### PR TITLE
Fix run-blocking bugs found running the stack (follow-up to #15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Add both possible uv install locations to PATH
 ENV PATH="/root/.cargo/bin:/root/.local/bin:$PATH"
 
-# Copy pyproject.toml first for better caching
+# Copy pyproject.toml first so the heavy dependency layer stays cached.
 COPY pyproject.toml .
 
-# Install Python dependencies with uv
+# Install dependencies. The local 'agentic_librarian' package can't be
+# registered yet (its source isn't present), but this caches the expensive
+# dependency layer.
 RUN uv pip install --system -e ".[dev]"
 
-# Copy the rest of the application
+# Copy the rest of the application.
 COPY . .
+
+# Re-run the editable install now that src/ is present, so 'agentic_librarian'
+# is actually importable. Dependencies are already satisfied, so this is fast.
+RUN uv pip install --system -e ".[dev]"
 
 # Install and configure en_US.UTF-8 locale
 RUN apt-get update && apt-get install -y locales \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
 
   db:
-    image: pgvector/pgvector:16-pg16
+    image: pgvector/pgvector:pg16
     container_name: agentic_librarian_db
     restart: always
     environment:

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -346,3 +346,25 @@ This file documents key architectural decisions, their context, and trade-offs.
 **Consequences:**
 - Pros: Massive reduction in database round-trips; improved response time for the Librarian agent.
 - Cons: Slightly more complex query definitions.
+
+### ADR-034: Isolated Database for `db_integration` Tests (2026-05-30)
+**Status:** Accepted — implementation pending (tracked as tech debt).
+
+**Context:**
+- The `db_integration` suite had never been executed before the stack ran under Docker on a single machine. Once it ran, several isolation problems surfaced:
+  - Tests run against the **same** database the application uses (`POSTGRES_DB=agentic_librarian`), so they pollute real data.
+  - There is **no cleanup** between tests, so rows accumulate across runs. This caused non-deterministic passes (e.g. `search_internal_database` returned results from a *previous* test's committed rows rather than the current test's seed).
+  - The MCP tools intentionally open their own independent sessions and commit (coarse-grained design, ADR-013), so a single outer transaction cannot wrap a test for rollback — the tools' commits escape it.
+
+**Decision:**
+- Run `db_integration` tests against a **dedicated test database** (e.g. `agentic_librarian_test` via a `TEST_POSTGRES_DB` / `DATABASE_URL` override), never the application database.
+- Reset state with a **function-scoped autouse fixture that truncates all tables** before each `db_integration` test (the session-scoped fixture from the schema-creation work continues to create the schema + `vector` extension once).
+
+**Alternatives Considered:**
+- Per-test transactional rollback (bind the session to a SAVEPOINT) → rejected: the MCP tools open new sessions on the engine and commit, so their writes bypass and survive the test's transaction.
+- `drop_all` + `create_all` per test → rejected: slower than `TRUNCATE`, and still unsafe against the app DB without a separate database.
+- Status quo (shared DB, commit seed before tool calls — the stopgap applied in commit 43ed411) → insufficient: it makes the current assertions pass but leaves data pollution and run-to-run drift.
+
+**Consequences:**
+- Pros: Deterministic, repeatable integration tests; no risk to application/dev data; aligns with the Dual-Verification mandate (ADR-018).
+- Cons: Requires provisioning a separate database in local/compose/CI environments and a truncation fixture; marginally more setup per test run.

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -348,7 +348,7 @@ This file documents key architectural decisions, their context, and trade-offs.
 - Cons: Slightly more complex query definitions.
 
 ### ADR-034: Isolated Database for `db_integration` Tests (2026-05-30)
-**Status:** Accepted — implementation pending (tracked as tech debt).
+**Status:** Accepted and implemented (2026-05-30) in `test/conftest.py` — a dedicated `*_test` database is auto-created and all tables are truncated before each `db_integration` test.
 
 **Context:**
 - The `db_integration` suite had never been executed before the stack ran under Docker on a single machine. Once it ran, several isolation problems surfaced:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ line-ending = "lf"
 testpaths = [
     "test"
 ]
+# Make the src/ layout importable for tests regardless of editable-install state.
+pythonpath = [
+    "src"
+]
 python_files = [
     "test_*.py"
 ]

--- a/src/agentic_librarian/scouts/style_manager.py
+++ b/src/agentic_librarian/scouts/style_manager.py
@@ -15,7 +15,7 @@ class StyleManager:
         if not self._api_key:
             raise ValueError("Google API key not set for StyleManager.")
         self.client = genai.Client(api_key=self._api_key)
-        self.model_name = "text-embedding-004"
+        self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
 
     def _get_embedding(self, text: str) -> list[float]:
         """Fetch embedding from Gemini. Uses shared module-level cache."""

--- a/src/agentic_librarian/scouts/trope_manager.py
+++ b/src/agentic_librarian/scouts/trope_manager.py
@@ -15,7 +15,7 @@ class TropeManager:
         if not self._api_key:
             raise ValueError("Google API key not set for TropeManager.")
         self.client = genai.Client(api_key=self._api_key)
-        self.model_name = "text-embedding-004"  # Standard Gemini embedding model
+        self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
 
     def _get_embedding(self, text: str) -> list[float]:
         """Fetch embedding from Gemini. Uses shared module-level cache."""

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -1,10 +1,19 @@
 from functools import lru_cache
 
 from google import genai
+from google.genai import types
+
+# Match the pgvector column dimension (Vector(1536) on Style/Trope). gemini-embedding-001
+# defaults to 3072, so we must request 1536 explicitly.
+EMBEDDING_DIMENSIONS = 1536
 
 
 @lru_cache(maxsize=128)
 def get_cached_embedding(client: genai.Client, model_name: str, text: str) -> list[float]:
     """Shared helper to safely cache embeddings without leaking 'self'."""
-    response = client.models.embed_content(model=model_name, contents=text)
+    response = client.models.embed_content(
+        model=model_name,
+        contents=text,
+        config=types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIMENSIONS),
+    )
     return response.embeddings[0].values

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -16,4 +16,6 @@ def get_cached_embedding(client: genai.Client, model_name: str, text: str) -> li
         contents=text,
         config=types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIMENSIONS),
     )
+    if not response or not response.embeddings:
+        raise ValueError(f"Embedding generation returned no result for text: {text!r}")
     return response.embeddings[0].values

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,27 +2,42 @@ import os
 
 import pytest
 from dotenv import load_dotenv
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 load_dotenv()
 
 
+def _server_components():
+    user = os.getenv("POSTGRES_USER", "librarian")
+    password = os.getenv("POSTGRES_PASSWORD", "librarian_secret_password")
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    return user, password, host, port
+
+
+def _test_db_name():
+    """Dedicated test database, isolated from the application database (ADR-034)."""
+    return os.getenv("TEST_POSTGRES_DB") or f"{os.getenv('POSTGRES_DB', 'agentic_librarian')}_test"
+
+
+def _server_url(db_name="postgres"):
+    user, password, host, port = _server_components()
+    return f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
+
+
+def _test_db_url():
+    override = os.getenv("TEST_DATABASE_URL")
+    if override:
+        return override
+    return _server_url(_test_db_name())
+
+
 def is_db_reachable():
-    """Check if the database is reachable."""
+    """Check whether the Postgres *server* is reachable (not a specific database)."""
     if os.getenv("SKIP_DB_TESTS"):
         return False
-
-    db_url = os.getenv("DATABASE_URL")
-    if not db_url:
-        user = os.getenv("POSTGRES_USER", "librarian")
-        password = os.getenv("POSTGRES_PASSWORD", "librarian_secret_password")
-        host = os.getenv("POSTGRES_HOST", "localhost")
-        port = os.getenv("POSTGRES_PORT", "5432")
-        db_name = os.getenv("POSTGRES_DB", "agentic_librarian")
-        db_url = f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
-
     try:
-        engine = create_engine(db_url)
+        engine = create_engine(_server_url())
         with engine.connect():
             return True
     except Exception:
@@ -31,38 +46,52 @@ def is_db_reachable():
 
 @pytest.fixture(scope="session")
 def db_url():
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        user = os.getenv("POSTGRES_USER", "librarian")
-        password = os.getenv("POSTGRES_PASSWORD", "librarian_secret_password")
-        host = os.getenv("POSTGRES_HOST", "localhost")
-        port = os.getenv("POSTGRES_PORT", "5432")
-        db_name = os.getenv("POSTGRES_DB", "agentic_librarian")
-        url = f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
-    return url
+    """URL of the dedicated test database (never the application database)."""
+    return _test_db_url()
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _create_schema(db_url):
-    """Create the ORM schema in the live database for db_integration tests.
-
-    Runs once per session when a database is reachable (otherwise a no-op, since
-    those tests are skipped). The pgvector extension is ensured first because the
-    Style and Trope models declare Vector columns.
-    """
+def _create_test_database():
+    """Create the dedicated test database, extension, and schema once per session (ADR-034)."""
     if not is_db_reachable():
         yield
         return
 
-    from agentic_librarian.db.models import Base
-    from sqlalchemy import text
+    # 1. Create the test database if it does not exist (CREATE DATABASE needs autocommit).
+    db_name = _test_db_name()
+    server_engine = create_engine(_server_url(), isolation_level="AUTOCOMMIT")
+    with server_engine.connect() as conn:
+        exists = conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :n"), {"n": db_name}).scalar()
+        if not exists:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    server_engine.dispose()
 
-    engine = create_engine(db_url)
+    # 2. Ensure the pgvector extension and ORM schema exist in the test database.
+    from agentic_librarian.db.models import Base
+
+    engine = create_engine(_test_db_url())
     with engine.begin() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
     Base.metadata.create_all(engine)
-    yield
     engine.dispose()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_db_tables(request):
+    """Truncate all tables before each db_integration test for deterministic isolation (ADR-034)."""
+    if "db_integration" not in request.keywords or not is_db_reachable():
+        yield
+        return
+
+    from agentic_librarian.db.models import Base
+
+    engine = create_engine(_test_db_url())
+    tables = ", ".join(f'"{t.name}"' for t in Base.metadata.sorted_tables)
+    with engine.begin() as conn:
+        conn.execute(text(f"TRUNCATE {tables} RESTART IDENTITY CASCADE"))
+    engine.dispose()
+    yield
 
 
 def pytest_configure(config):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -86,8 +86,13 @@ def _clean_db_tables(request):
 
     from agentic_librarian.db.models import Base
 
+    sorted_tables = Base.metadata.sorted_tables
+    if not sorted_tables:
+        yield
+        return
+
     engine = create_engine(_test_db_url())
-    tables = ", ".join(f'"{t.name}"' for t in Base.metadata.sorted_tables)
+    tables = ", ".join(f'"{t.name}"' for t in sorted_tables)
     with engine.begin() as conn:
         conn.execute(text(f"TRUNCATE {tables} RESTART IDENTITY CASCADE"))
     engine.dispose()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,29 @@ def db_url():
     return url
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _create_schema(db_url):
+    """Create the ORM schema in the live database for db_integration tests.
+
+    Runs once per session when a database is reachable (otherwise a no-op, since
+    those tests are skipped). The pgvector extension is ensured first because the
+    Style and Trope models declare Vector columns.
+    """
+    if not is_db_reachable():
+        yield
+        return
+
+    from agentic_librarian.db.models import Base
+    from sqlalchemy import text
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    Base.metadata.create_all(engine)
+    yield
+    engine.dispose()
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "db_integration: mark test as requiring a live database (e.g. Docker)")
 

--- a/test/integration/test_mcp_tools.py
+++ b/test/integration/test_mcp_tools.py
@@ -51,6 +51,10 @@ def test_mcp_discovery_and_filtering_real_db(db_url, standard_books):
                 wt = WorkTrope(work=work, trope=trope)
                 session.add(wt)
 
+        # Commit the seed: the MCP tools open their own independent sessions
+        # (coarse-grained, ADR-013), so they can only see committed data.
+        session.commit()
+
         # 2. Verify search_internal_database
         with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", return_value=[0.1] * 1536):
             results = search_internal_database(target_tropes=["any"])
@@ -83,6 +87,10 @@ def test_suggestion_persistence_real_db(db_url, standard_books):
         wc = WorkContributor(work=work, author=author, role="Author")
         session.add(wc)
         session.flush()
+
+        # Commit the seed: log_suggestion opens its own session and references
+        # work_id as an FK, so the work must be committed first.
+        session.commit()
 
         # Log it
         log_suggestion(work_id=str(work.id), context="Vibe", justification="Logic")


### PR DESCRIPTION
## Context
PR #15 was merged when the branch was at `6a1f2bd` (devcontainer wiring + reviewer fixes). The commits below were pushed to the same branch **after** that merge while bringing the stack up for the first time under Docker, so they are **not yet in `main`**. A fresh clone of `main` would hit all of these.

## Bugs fixed (each only surfaced once the stack actually ran)
| Commit | Fix | Layer |
|---|---|---|
| `b7df936` | `pgvector/pgvector:16-pg16` tag doesn't exist → `pg16` | compose |
| `25986f0` | Dockerfile installed the editable package before copying source → `ModuleNotFoundError: agentic_librarian`; re-run install after `COPY . .`, add `pythonpath=["src"]` | build / pytest |
| `7b1fb11` | `db_integration` tests had no schema; add a fixture that ensures `vector` + `create_all()` | test infra |
| `43ed411` | tests seeded data the MCP tools (independent sessions, ADR-013) couldn't see; commit the seed first | test |
| `6811649` | embedding model `text-embedding-004` not found → `gemini-embedding-001`, with `output_dimensionality=1536` to match `Vector(1536)` | **app code** |
| `f491415` / `67be54d` | ADR-034: isolate `db_integration` tests in a dedicated `*_test` DB + truncate-between-tests | test infra / docs |

## Verification
Run inside the devcontainer:
```
pytest -m "not api_dependent and not slow"  →  122 passed, 3 deselected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)