### PR TITLE
Mesh runtime foundation: run the agent mesh as a multi-turn conversation (ADR-035 Spec 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ GOOGLE_SEARCH_API_KEY=
 SEARCH_ENGINE_ID=
 # Optional: raises Google Books rate limits.
 GOOGLE_BOOKS_API_KEY=
+# ADK (recommendation mesh) authenticates Gemini via GOOGLE_API_KEY. Optional if
+# GOOGLE_SEARCH_API_KEY is set (the runtime falls back to it).
+# GOOGLE_API_KEY=
 # Generative model for the LLM scouts (StyleScout, LLMTropeScout, audiobook scouts).
 # Pick one your key's quota/billing allows — gemini-2.0-flash has no free-tier
 # quota on some keys. Defaults to gemini-2.5-flash-lite if unset.

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -388,3 +388,18 @@ This file documents key architectural decisions, their context, and trade-offs.
 - ENV-015 part 2 is scoped to Spec 2 (Explorer external discovery).
 - `search_strategies.py`'s A/B benchmark is decoupled from the live mesh (kept as an experiment or removed later).
 - Phase 3's "COMPLETED" status was component-level, not runnable-mesh-level; these four specs close that gap.
+
+### ADR-036: The Librarian is a Multi-Turn Conversational Agent (2026-05-30)
+**Context:**
+- The Librarian should feel like talking to a librarian who remembers the exchange and knows the user's reading history (use_cases.md Levels 4–6: follow-ups, "I already read that" corrections, social signals). A single prompt→response call is too restrictive, and responses may legitimately be a list of authors, authors + an example book, or specific titles depending on the request.
+
+**Decision:**
+- The recommendation runtime hosts the Librarian in an ADK `Runner` with a **reusable session**. The public abstraction is a multi-turn `LibrarianConversation` (`start_conversation` → `send` → `send` …) that reuses one `(user_id, session_id)` so the agent remembers prior turns. `run_recommendation(prompt)` remains a one-shot convenience over the same path.
+- **Two layers of memory:** *within-conversation memory* = the ADK session; *durable "knows everything you've read"* = the Postgres reading-history DB via the agents' tools, independent of any conversation.
+- **Response shape** (authors, authors + an example book, or specific books) is Librarian instruction/behavior decided per request — not constrained by the runtime.
+- Spec 1 uses `InMemorySessionService` (ephemeral conversations); `DatabaseSessionService` (Postgres, resumable conversations across restarts) is a deferred upgrade.
+
+**Consequences:**
+- Supports the Level 4–6 conversational use cases within a session; the durable user profile persists in the DB regardless of session lifetime.
+- Conversations are not resumable across app restarts until `DatabaseSessionService` is adopted.
+- Realized by ADR-035 Spec 1; design at `docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md`.

--- a/docs/superpowers/plans/2026-05-30-mesh-runtime-foundation.md
+++ b/docs/superpowers/plans/2026-05-30-mesh-runtime-foundation.md
@@ -1,0 +1,485 @@
+# Mesh Runtime Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the 4-agent recommendation mesh runnable as a multi-turn conversation: assign models to the agents and add `agents/runtime.py` with an ADK Runner, a `LibrarianConversation`, and a `run_recommendation` one-shot.
+
+**Architecture:** One ADK `Runner` hosts the existing `create_agent_mesh()` Librarian (root agent); LLM-driven `AgentTool` delegation drives Analyst/Explorer/Critic (ADR-019/020). A reusable ADK session gives conversational memory (ADR-036); `InMemorySessionService` for now.
+
+**Tech Stack:** `google-adk` (`Runner`, `InMemorySessionService`, `LlmAgent`), `google-genai` (`types.Content`/`types.Part`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md`
+
+### Running tests & committing (this environment)
+- Tests run in the dev container: `docker exec agentic_librarian_app sh -lc 'cd /app && <pytest cmd>'` (or `pytest ...` directly inside the container).
+- When committing from the **host**, prefix with `SKIP=pytest` (the host lacks the project deps for the pre-commit `pytest` hook). The explicit pytest runs in each task are the real verification. End commit messages with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/agentic_librarian/agents/services.py` (modify) | Assign a `model` to each `LlmAgent`. |
+| `src/agentic_librarian/agents/runtime.py` (create) | ADK Runner + credentials + `LibrarianConversation` + `start_conversation` + `run_recommendation`. |
+| `test/unit/test_agent_runtime.py` (create) | Offline (mocked) unit tests + one `api_dependent` live smoke test. |
+| `.env.example` (modify) | Document `GOOGLE_API_KEY`. |
+
+---
+
+## Task 1: Assign a model to every mesh agent
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/services.py`
+- Test: `test/unit/test_agent_runtime.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test_agent_runtime.py`:
+
+```python
+import os
+
+import pytest
+from google.genai import types
+
+from agentic_librarian.agents import runtime  # noqa: F401  (used by later tasks)
+from agentic_librarian.agents.services import create_agent_mesh
+
+
+@pytest.fixture(autouse=True)
+def _adk_key(monkeypatch, request):
+    """ADK's Gemini model reads GOOGLE_API_KEY. Set a dummy for offline tests so
+    agent/runner construction never needs a real key. Live tests opt out."""
+    if "api_dependent" not in request.keywords:
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-adk-key")
+
+
+def test_all_mesh_agents_have_a_model():
+    mesh = create_agent_mesh()
+    for name in ("librarian", "analyst", "explorer", "critic"):
+        assert mesh[name].model, f"{name} agent has no model"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py::test_all_mesh_agents_have_a_model -v'`
+Expected: FAIL — agents are constructed without a `model` (empty/None). (The `runtime` import also fails until Task 2; if collection errors on that import, temporarily comment the `from agentic_librarian.agents import runtime` line, or do Task 2's file creation first. Simplest: create an empty `src/agentic_librarian/agents/runtime.py` now so the import resolves.)
+
+- [ ] **Step 3: Add the model to each agent**
+
+In `src/agentic_librarian/agents/services.py`, add `import os` at the top, and a helper plus a `model=` argument on all four agents:
+
+```python
+import os
+
+from agentic_librarian.mcp.server import (
+    check_reading_history,
+    get_unacted_suggestions,
+    get_user_trope_preferences,
+    get_work_details,
+    log_suggestion,
+    search_internal_database,
+    update_reading_status,
+    update_suggestion_status,
+)
+from google.adk.agents import LlmAgent
+from google.adk.tools import AgentTool, FunctionTool
+
+
+def _model_name() -> str:
+    """Generative model for the mesh agents (configurable; matches the scouts)."""
+    return os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+```
+
+Then add `model=_model_name(),` as the first argument of each `super().__init__(...)` call — in `AnalystAgent`, `ExplorerAgent`, `CriticAgent`, and `LibrarianAgent`. For example, `ExplorerAgent`:
+
+```python
+class ExplorerAgent(LlmAgent):
+    """The Scout. Web-based discovery using search grounding."""
+
+    def __init__(self):
+        super().__init__(
+            model=_model_name(),
+            name="Explorer",
+            description="Discovers new books from the internet using search grounding.",
+            instruction="""
+            You are a book scout. Use your internal search grounding capabilities to find real books.
+            If a book is found, return its title, author, and a brief description.
+            Focus on discovery of titles NOT likely to be in a standard personal library.
+            """,
+            # Search tool is added in Spec 2 (ENV-015 part 2); model-only placeholder for now.
+        )
+```
+
+Do the same (`model=_model_name(),`) for `AnalystAgent`, `CriticAgent`, and `LibrarianAgent`, keeping their existing `tools=[...]` arguments.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py::test_all_mesh_agents_have_a_model -v'`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing agent tests to check for regressions**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_services.py -q'`
+Expected: PASS (adding a model string must not break existing construction tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/agents/services.py test/unit/test_agent_runtime.py
+SKIP=pytest git commit -m "feat(agents): assign GEMINI_MODEL to mesh agents"
+```
+
+---
+
+## Task 2: ADK credentials + `build_runner`
+
+**Files:**
+- Create: `src/agentic_librarian/agents/runtime.py`
+- Test: `test/unit/test_agent_runtime.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/unit/test_agent_runtime.py`:
+
+```python
+def test_ensure_adk_credentials_falls_back(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "fallback-key-123")
+    runtime._ensure_adk_credentials()
+    assert os.environ["GOOGLE_API_KEY"] == "fallback-key-123"
+
+
+def test_build_runner_constructs():
+    r = runtime.build_runner()
+    assert r is not None
+    assert r.app_name == runtime.APP_NAME
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -k "credentials or build_runner" -v'`
+Expected: FAIL — `runtime` has no `_ensure_adk_credentials`/`build_runner`/`APP_NAME` (AttributeError).
+
+- [ ] **Step 3: Implement `runtime.py` (this part)**
+
+Create `src/agentic_librarian/agents/runtime.py`:
+
+```python
+"""Runtime for the recommendation agent mesh: host the Librarian in an ADK Runner
+and expose a multi-turn conversation API (ADR-035 Spec 1, ADR-036)."""
+
+import asyncio
+import os
+import uuid
+
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+from agentic_librarian.agents.services import create_agent_mesh
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+APP_NAME = "agentic_librarian"
+
+
+def _ensure_adk_credentials() -> None:
+    """ADK's Gemini model authenticates via GOOGLE_API_KEY. Populate it from the
+    project's existing keys if it isn't set (GOOGLE_SEARCH_API_KEY has access to both
+    Custom Search and the Gemini API in this GCP project)."""
+    if not os.environ.get("GOOGLE_API_KEY"):
+        key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        if key:
+            os.environ["GOOGLE_API_KEY"] = key
+
+
+def build_runner() -> Runner:
+    """Build a Runner hosting the Librarian (root of the agent mesh)."""
+    _ensure_adk_credentials()
+    mesh = create_agent_mesh()
+    return Runner(
+        agent=mesh["librarian"],
+        app_name=APP_NAME,
+        session_service=InMemorySessionService(),
+    )
+```
+
+(If you created an empty `runtime.py` in Task 1, replace its contents with the above.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -k "credentials or build_runner" -v'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/runtime.py test/unit/test_agent_runtime.py
+SKIP=pytest git commit -m "feat(agents): ADK runner + credential reconciliation"
+```
+
+---
+
+## Task 3: `LibrarianConversation` + `start_conversation` (multi-turn)
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/runtime.py`
+- Test: `test/unit/test_agent_runtime.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/unit/test_agent_runtime.py` (the fakes let us test the conversation logic with no API/DB):
+
+```python
+class _FakeEvent:
+    def __init__(self, text: str):
+        self.content = types.Content(role="model", parts=[types.Part(text=text)])
+
+    def is_final_response(self) -> bool:
+        return True
+
+
+class _FakeSessionService:
+    def __init__(self):
+        self.created = []
+
+    async def create_session(self, app_name, user_id, session_id):
+        self.created.append((app_name, user_id, session_id))
+        return None
+
+
+class _FakeRunner:
+    def __init__(self, reply="Recommended: Dune"):
+        self.app_name = runtime.APP_NAME
+        self.session_service = _FakeSessionService()
+        self.calls = []
+        self._reply = reply
+
+    async def run_async(self, user_id, session_id, new_message):
+        self.calls.append((user_id, session_id, new_message.parts[0].text))
+        yield _FakeEvent(self._reply)
+
+
+def test_send_returns_final_response_text():
+    conv = runtime.LibrarianConversation(_FakeRunner(reply="Try Hyperion"), "u", "s")
+    assert conv.send("recommend sci-fi") == "Try Hyperion"
+
+
+def test_two_sends_reuse_the_same_session():
+    fake = _FakeRunner()
+    conv = runtime.LibrarianConversation(fake, "u", "sess-1")
+    conv.send("first")
+    conv.send("second")
+    assert [sid for (_, sid, _) in fake.calls] == ["sess-1", "sess-1"]
+    assert [msg for (_, _, msg) in fake.calls] == ["first", "second"]
+
+
+def test_start_conversation_creates_a_session():
+    fake = _FakeRunner()
+    conv = runtime.start_conversation(user_id="alice", runner=fake)
+    assert conv.user_id == "alice"
+    assert fake.session_service.created  # a session was created
+    assert fake.session_service.created[0][1] == "alice"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -k "send or start_conversation" -v'`
+Expected: FAIL — `runtime` has no `LibrarianConversation`/`start_conversation`.
+
+- [ ] **Step 3: Implement the conversation API**
+
+Append to `src/agentic_librarian/agents/runtime.py`:
+
+```python
+class LibrarianConversation:
+    """A multi-turn conversation with the Librarian. Reusing one session across
+    sends is what gives the agent conversational memory (ADR-036)."""
+
+    def __init__(self, runner: Runner, user_id: str, session_id: str):
+        self._runner = runner
+        self.user_id = user_id
+        self.session_id = session_id
+
+    async def asend(self, message: str) -> str:
+        content = types.Content(role="user", parts=[types.Part(text=message)])
+        final = ""
+        async for event in self._runner.run_async(
+            user_id=self.user_id, session_id=self.session_id, new_message=content
+        ):
+            if event.is_final_response() and event.content and event.content.parts:
+                final = event.content.parts[0].text or final
+        return final or "(no response)"
+
+    def send(self, message: str) -> str:
+        return asyncio.run(self.asend(message))
+
+
+async def astart_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
+    runner = runner or build_runner()
+    session_id = uuid.uuid4().hex
+    await runner.session_service.create_session(
+        app_name=APP_NAME, user_id=user_id, session_id=session_id
+    )
+    return LibrarianConversation(runner, user_id, session_id)
+
+
+def start_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
+    return asyncio.run(astart_conversation(user_id=user_id, runner=runner))
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -k "send or start_conversation" -v'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/runtime.py test/unit/test_agent_runtime.py
+SKIP=pytest git commit -m "feat(agents): multi-turn LibrarianConversation"
+```
+
+---
+
+## Task 4: `run_recommendation` one-shot
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/runtime.py`
+- Test: `test/unit/test_agent_runtime.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/test_agent_runtime.py`:
+
+```python
+def test_run_recommendation_one_shot(monkeypatch):
+    fake = _FakeRunner(reply="Recommended: Dune")
+    monkeypatch.setattr(runtime, "build_runner", lambda: fake)
+    assert runtime.run_recommendation("something like Dune") == "Recommended: Dune"
+    assert fake.calls[0][2] == "something like Dune"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py::test_run_recommendation_one_shot -v'`
+Expected: FAIL — `runtime` has no `run_recommendation`.
+
+- [ ] **Step 3: Implement `run_recommendation`**
+
+Append to `src/agentic_librarian/agents/runtime.py`:
+
+```python
+def run_recommendation(prompt: str, user_id: str = "local") -> str:
+    """One-shot convenience: start a conversation and send a single message."""
+
+    async def _once() -> str:
+        conv = await astart_conversation(user_id=user_id)
+        return await conv.asend(prompt)
+
+    return asyncio.run(_once())
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py::test_run_recommendation_one_shot -v'`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full unit file**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -q'`
+Expected: PASS (all offline tests; the `api_dependent` test from Task 5 is deselected by default).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/agents/runtime.py test/unit/test_agent_runtime.py
+SKIP=pytest git commit -m "feat(agents): run_recommendation one-shot entrypoint"
+```
+
+---
+
+## Task 5: Document `GOOGLE_API_KEY` + live smoke test
+
+**Files:**
+- Modify: `.env.example`
+- Test: `test/unit/test_agent_runtime.py`
+
+- [ ] **Step 1: Document the key**
+
+In `.env.example`, under the Google APIs section (after `GOOGLE_BOOKS_API_KEY`), add:
+
+```bash
+# ADK (recommendation mesh) authenticates Gemini via GOOGLE_API_KEY. Optional if
+# GOOGLE_SEARCH_API_KEY is set (the runtime falls back to it).
+# GOOGLE_API_KEY=
+```
+
+- [ ] **Step 2: Add the live smoke test (api_dependent — not run in CI)**
+
+Append to `test/unit/test_agent_runtime.py`:
+
+```python
+@pytest.mark.api_dependent
+def test_live_conversation_runs():
+    conv = runtime.start_conversation()
+    first = conv.send("Recommend a sci-fi novel like Dune in one sentence.")
+    assert isinstance(first, str) and first.strip()
+    # Second turn shares the session (memory).
+    second = conv.send("Actually, something more recent.")
+    assert isinstance(second, str) and second.strip()
+```
+
+- [ ] **Step 3: Confirm it is deselected by the CI marker filter**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py -m "not api_dependent and not slow" -q'`
+Expected: PASS, with `test_live_conversation_runs` deselected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example test/unit/test_agent_runtime.py
+SKIP=pytest git commit -m "docs(env): document GOOGLE_API_KEY; add live mesh smoke test"
+```
+
+---
+
+## Task 6: Full-suite regression check
+
+- [ ] **Step 1: Run the whole CI subset**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && pytest -m "not api_dependent and not slow" -q'`
+Expected: PASS, with a higher count than before (the new offline runtime tests added; the one `api_dependent` test deselected). No regressions.
+
+- [ ] **Step 2 (optional, with API quota): run the live smoke**
+
+Run only when you have a working key + DB and accept the API cost:
+`docker exec agentic_librarian_app sh -lc 'cd /app && pytest test/unit/test_agent_runtime.py::test_live_conversation_runs -v'`
+Expected: PASS — the Librarian runs and returns text for two turns. (On an empty/seed DB the recommendation content will be thin; that's expected — quality is Specs 2–4.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Models on all agents → Task 1. ✓
+- `agents/runtime.py` with `build_runner`, `LibrarianConversation` (`asend`/`send`), `start_conversation`, `run_recommendation` → Tasks 2–4. ✓
+- Auth reconciliation (`GOOGLE_API_KEY` ← `GEMINI_API_KEY`/`GOOGLE_SEARCH_API_KEY`) → Task 2. ✓
+- `.env.example` documents `GOOGLE_API_KEY` → Task 5. ✓
+- Mock unit tests (runner constructs; agents have models; conversation returns final text; two sends reuse session; one-shot) → Tasks 1–4. ✓
+- `api_dependent` live smoke (incl. two-turn) → Task 5. ✓
+- In-memory session, multi-turn memory via reused `session_id` → Task 3 (verified by `test_two_sends_reuse_the_same_session`). ✓
+
+**Placeholder scan:** No TBDs; every code step shows the full code. ✓
+
+**Type/name consistency:** `APP_NAME`, `_ensure_adk_credentials`, `build_runner`, `LibrarianConversation(.asend/.send)`, `astart_conversation`, `start_conversation`, `run_recommendation`, `_model_name`, `_FakeRunner/_FakeEvent/_FakeSessionService` are used consistently across tasks. ✓
+
+**Note for the implementer:** If ADK `LlmAgent` construction unexpectedly requires a real key (it shouldn't — model strings resolve lazily, and the existing `test_agent_services.py` constructs agents offline), the `_adk_key` autouse fixture already sets a dummy `GOOGLE_API_KEY` for non-`api_dependent` tests.

--- a/docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md
@@ -6,13 +6,16 @@
 
 ## Goal
 
-Make the existing 4-agent recommendation mesh actually **run**. Today none of the
-`LlmAgent`s have a model and there is no ADK Runner/entrypoint, so the mesh cannot
-execute at all. This spec adds the minimal runtime so the Librarian executes a user
-prompt and delegates to Analyst/Explorer/Critic, returning a final text response.
+Make the existing 4-agent recommendation mesh actually **run**, as a **multi-turn
+conversation** with the Librarian — the user talks to a librarian who remembers the
+exchange and knows their reading history. Today none of the `LlmAgent`s have a model and
+there is no ADK Runner/entrypoint, so the mesh cannot execute at all. This spec adds the
+minimal runtime: assign models, host the Librarian in an ADK Runner with a reusable
+session, and expose a conversation API that delegates to Analyst/Explorer/Critic.
 
-**Success = "runs & delegates" (smoke):** `run_recommendation(prompt)` returns a
-non-empty response without error. Recommendation *quality* is explicitly out of scope
+**Success = "runs & delegates" (smoke):** a conversation can be started and one or more
+messages sent, each returning a non-empty response without error, with the session
+remembering prior turns. Recommendation *quality* and response styling are out of scope
 (Specs 2–4).
 
 ## Approach
@@ -29,13 +32,21 @@ Rejected: (B) manual Python orchestration of the sub-agents and (C) ADK
 ### New module: `agents/runtime.py`
 - `build_runner() -> Runner` — calls `create_agent_mesh()`, wraps the Librarian in a
   `Runner(agent=librarian, app_name="agentic_librarian", session_service=InMemorySessionService())`.
-- `async def arun_recommendation(prompt, user_id="local", session_id=None) -> str` —
-  creates a session, calls
-  `runner.run_async(user_id, session_id, new_message=types.Content(role="user", parts=[types.Part(text=prompt)]))`,
-  iterates events, and returns the text of the `event.is_final_response()` event (or a
-  clear fallback string if there is none).
-- `def run_recommendation(prompt) -> str` — `asyncio.run(arun_recommendation(prompt))`;
-  the public synchronous entrypoint.
+- `class LibrarianConversation` — holds the `Runner` plus a fixed `(user_id, session_id)`:
+  - `async def asend(message) -> str` / `def send(message) -> str` — sends one turn via
+    `runner.run_async(user_id, session_id, new_message=types.Content(role="user", parts=[types.Part(text=message)]))`,
+    iterates events, returns the `event.is_final_response()` text (or a clear fallback if
+    none). **Reusing the same session across calls is what gives the Librarian
+    conversational memory.**
+- `async def start_conversation(user_id="local") -> LibrarianConversation` — creates the
+  session and returns a conversation handle.
+- `def run_recommendation(prompt) -> str` — one-shot convenience: start a conversation
+  and send a single message (`asyncio.run` wrapper). Handy for tests and simple queries.
+
+The `SessionService` is `InMemorySessionService` — conversations are remembered within a
+run, not across restarts. Durable "knows everything you've read" comes from the Postgres
+reading-history DB via the agents' tools, not the session. `DatabaseSessionService`
+(Postgres-backed, resumable conversations) is a deferred upgrade.
 
 ### Agent models (`agents/services.py`)
 - Each `LlmAgent` receives `model=os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")`
@@ -57,14 +68,17 @@ Rejected: (B) manual Python orchestration of the sub-agents and (C) ADK
 ## Data flow
 
 ```
-run_recommendation("something like Dune")
-  → InMemorySessionService.create_session(...)
-  → Runner.run_async(new_message=user prompt)
+conv = start_conversation(user_id="local")     # creates session S
+conv.send("something like The Way of Kings but grittier")
+  → Runner.run_async(session S, user prompt)
   → Librarian LLM runs, delegates via AgentTool to Analyst / Explorer / Critic
       (their DB FunctionTools query Postgres; on an empty/seed DB they return [] — ok)
-  → Librarian composes a final response
-  → return final_response text
+  → final response text returned
+conv.send("I already read The Blade Itself")    # same session S → Librarian recalls the prior turn
+  → ... → updated response
 ```
+
+`run_recommendation("...")` is the single-turn shortcut over the same path.
 
 ## Error handling
 - The entrypoint returns a clear message when there is no final response / no text parts.
@@ -76,14 +90,18 @@ run_recommendation("something like Dune")
 - **Mock unit tests** (run in CI, no API/DB):
   - `build_runner()` constructs a `Runner` without error.
   - Every agent in `create_agent_mesh()` has a non-empty `model`.
-  - `run_recommendation` returns the final text when `Runner.run_async` is mocked to
-    yield a final-response event.
+  - A conversation returns the final text when `Runner.run_async` is mocked to yield a
+    final-response event; two `send` calls reuse the same `session_id` (memory).
+  - `run_recommendation` returns the final text (one-shot path).
 - **`@pytest.mark.api_dependent` live smoke** (manual; needs a key + DB up):
   - `run_recommendation("something like Dune")` returns a non-empty string.
+  - A two-turn conversation works (the second turn can reference the first).
 
 ## Out of scope (later specs)
 - Explorer web-search grounding (Spec 2).
 - Seeded-DB internal retrieval quality (Spec 3).
-- Coherent end-to-end recommendation + Trope-RAG justification, e2e test (Spec 4).
-- Per-agent model tuning, response streaming, multi-turn conversation state beyond a
-  single session.
+- Coherent end-to-end recommendation, response styling (authors vs books vs
+  authors + an example book), and Trope-RAG justification; e2e test (Spec 4).
+- Per-agent model tuning, response streaming.
+- Persistent / resumable conversations across app restarts (`DatabaseSessionService`) —
+  a later upgrade; Spec 1 uses in-memory sessions.

--- a/docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-30-mesh-runtime-foundation-design.md
@@ -1,0 +1,89 @@
+# Spec 1 — Mesh Runtime Foundation
+
+**Date:** 2026-05-30
+**Status:** Approved design (pre-implementation)
+**Part of:** ADR-035 phased mesh delivery — spec 1 of 4.
+
+## Goal
+
+Make the existing 4-agent recommendation mesh actually **run**. Today none of the
+`LlmAgent`s have a model and there is no ADK Runner/entrypoint, so the mesh cannot
+execute at all. This spec adds the minimal runtime so the Librarian executes a user
+prompt and delegates to Analyst/Explorer/Critic, returning a final text response.
+
+**Success = "runs & delegates" (smoke):** `run_recommendation(prompt)` returns a
+non-empty response without error. Recommendation *quality* is explicitly out of scope
+(Specs 2–4).
+
+## Approach
+
+**Approach A (approved):** one ADK `Runner` over the existing `create_agent_mesh()`
+Librarian root agent; LLM-driven `AgentTool` delegation drives the specialists. Honors
+ADR-019 (4-agent mesh) and ADR-020 (ADK delegation).
+
+Rejected: (B) manual Python orchestration of the sub-agents and (C) ADK
+`SequentialAgent` workflow — both discard the committed agent-delegation design.
+
+## Components
+
+### New module: `agents/runtime.py`
+- `build_runner() -> Runner` — calls `create_agent_mesh()`, wraps the Librarian in a
+  `Runner(agent=librarian, app_name="agentic_librarian", session_service=InMemorySessionService())`.
+- `async def arun_recommendation(prompt, user_id="local", session_id=None) -> str` —
+  creates a session, calls
+  `runner.run_async(user_id, session_id, new_message=types.Content(role="user", parts=[types.Part(text=prompt)]))`,
+  iterates events, and returns the text of the `event.is_final_response()` event (or a
+  clear fallback string if there is none).
+- `def run_recommendation(prompt) -> str` — `asyncio.run(arun_recommendation(prompt))`;
+  the public synchronous entrypoint.
+
+### Agent models (`agents/services.py`)
+- Each `LlmAgent` receives `model=os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")`
+  (same env var as the scouts). A single model for all agents in this spec; per-agent
+  tuning is deferred.
+- The Explorer remains a model-only agent with **no search tool** in this spec (search
+  is Spec 2); it answers from training knowledge as a placeholder.
+
+### Auth reconciliation
+- ADK's Gemini model authenticates via `GOOGLE_API_KEY` (Gemini Developer API;
+  `GOOGLE_GENAI_USE_VERTEXAI` stays false/unset).
+- The project's `GOOGLE_SEARCH_API_KEY` is confirmed to have access to **both** the
+  Custom Search API and the Gemini API in the GCP project, so it can serve as the ADK
+  key.
+- `runtime.py` ensures `GOOGLE_API_KEY` is populated at import: if unset, fall back to
+  `GEMINI_API_KEY`, then `GOOGLE_SEARCH_API_KEY`.
+- `.env.example` documents `GOOGLE_API_KEY` (optional when `GOOGLE_SEARCH_API_KEY` is set).
+
+## Data flow
+
+```
+run_recommendation("something like Dune")
+  → InMemorySessionService.create_session(...)
+  → Runner.run_async(new_message=user prompt)
+  → Librarian LLM runs, delegates via AgentTool to Analyst / Explorer / Critic
+      (their DB FunctionTools query Postgres; on an empty/seed DB they return [] — ok)
+  → Librarian composes a final response
+  → return final_response text
+```
+
+## Error handling
+- The entrypoint returns a clear message when there is no final response / no text parts.
+- DB FunctionTools already return empties (not exceptions) on an empty DB.
+- A single failing sub-agent or tool should not abort the whole run; log and continue so
+  the Librarian still returns a response.
+
+## Testing
+- **Mock unit tests** (run in CI, no API/DB):
+  - `build_runner()` constructs a `Runner` without error.
+  - Every agent in `create_agent_mesh()` has a non-empty `model`.
+  - `run_recommendation` returns the final text when `Runner.run_async` is mocked to
+    yield a final-response event.
+- **`@pytest.mark.api_dependent` live smoke** (manual; needs a key + DB up):
+  - `run_recommendation("something like Dune")` returns a non-empty string.
+
+## Out of scope (later specs)
+- Explorer web-search grounding (Spec 2).
+- Seeded-DB internal retrieval quality (Spec 3).
+- Coherent end-to-end recommendation + Trope-RAG justification, e2e test (Spec 4).
+- Per-agent model tuning, response streaming, multi-turn conversation state beyond a
+  single session.

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -1,0 +1,38 @@
+"""Runtime for the recommendation agent mesh: host the Librarian in an ADK Runner
+and expose a multi-turn conversation API (ADR-035 Spec 1, ADR-036)."""
+
+import os
+
+from agentic_librarian.agents.services import create_agent_mesh
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+APP_NAME = "agentic_librarian"
+
+
+def _ensure_adk_credentials() -> None:
+    """ADK's Gemini model authenticates via GOOGLE_API_KEY. Populate it from the
+    project's existing keys if it isn't set (GOOGLE_SEARCH_API_KEY has access to both
+    Custom Search and the Gemini API in this GCP project)."""
+    if not os.environ.get("GOOGLE_API_KEY"):
+        key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        if key:
+            os.environ["GOOGLE_API_KEY"] = key
+
+
+def build_runner() -> Runner:
+    """Build a Runner hosting the Librarian (root of the agent mesh)."""
+    _ensure_adk_credentials()
+    mesh = create_agent_mesh()
+    return Runner(
+        agent=mesh["librarian"],
+        app_name=APP_NAME,
+        session_service=InMemorySessionService(),
+    )

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -73,3 +73,13 @@ async def astart_conversation(user_id: str = "local", runner: Runner | None = No
 
 def start_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
     return asyncio.run(astart_conversation(user_id=user_id, runner=runner))
+
+
+def run_recommendation(prompt: str, user_id: str = "local") -> str:
+    """One-shot convenience: start a conversation and send a single message."""
+
+    async def _once() -> str:
+        conv = await astart_conversation(user_id=user_id)
+        return await conv.asend(prompt)
+
+    return asyncio.run(_once())

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -1,11 +1,14 @@
 """Runtime for the recommendation agent mesh: host the Librarian in an ADK Runner
 and expose a multi-turn conversation API (ADR-035 Spec 1, ADR-036)."""
 
+import asyncio
 import os
+import uuid
 
 from agentic_librarian.agents.services import create_agent_mesh
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
+from google.genai import types
 
 try:
     from dotenv import load_dotenv
@@ -36,3 +39,37 @@ def build_runner() -> Runner:
         app_name=APP_NAME,
         session_service=InMemorySessionService(),
     )
+
+
+class LibrarianConversation:
+    """A multi-turn conversation with the Librarian. Reusing one session across
+    sends is what gives the agent conversational memory (ADR-036)."""
+
+    def __init__(self, runner: Runner, user_id: str, session_id: str):
+        self._runner = runner
+        self.user_id = user_id
+        self.session_id = session_id
+
+    async def asend(self, message: str) -> str:
+        content = types.Content(role="user", parts=[types.Part(text=message)])
+        final = ""
+        async for event in self._runner.run_async(
+            user_id=self.user_id, session_id=self.session_id, new_message=content
+        ):
+            if event.is_final_response() and event.content and event.content.parts:
+                final = event.content.parts[0].text or final
+        return final or "(no response)"
+
+    def send(self, message: str) -> str:
+        return asyncio.run(self.asend(message))
+
+
+async def astart_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
+    runner = runner or build_runner()
+    session_id = uuid.uuid4().hex
+    await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
+    return LibrarianConversation(runner, user_id, session_id)
+
+
+def start_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
+    return asyncio.run(astart_conversation(user_id=user_id, runner=runner))

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -57,7 +57,9 @@ class LibrarianConversation:
             user_id=self.user_id, session_id=self.session_id, new_message=content
         ):
             if event.is_final_response() and event.content and event.content.parts:
-                final = event.content.parts[0].text or final
+                parts_text = [p.text for p in event.content.parts if p.text]
+                if parts_text:
+                    final = "".join(parts_text)
         return final or "(no response)"
 
     def send(self, message: str) -> str:
@@ -75,11 +77,12 @@ def start_conversation(user_id: str = "local", runner: Runner | None = None) -> 
     return asyncio.run(astart_conversation(user_id=user_id, runner=runner))
 
 
+async def arun_recommendation(prompt: str, user_id: str = "local") -> str:
+    """Async one-shot convenience: start a conversation and send a single message."""
+    conv = await astart_conversation(user_id=user_id)
+    return await conv.asend(prompt)
+
+
 def run_recommendation(prompt: str, user_id: str = "local") -> str:
     """One-shot convenience: start a conversation and send a single message."""
-
-    async def _once() -> str:
-        conv = await astart_conversation(user_id=user_id)
-        return await conv.asend(prompt)
-
-    return asyncio.run(_once())
+    return asyncio.run(arun_recommendation(prompt, user_id))

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -1,3 +1,5 @@
+import os
+
 from agentic_librarian.mcp.server import (
     check_reading_history,
     get_unacted_suggestions,
@@ -11,6 +13,12 @@ from agentic_librarian.mcp.server import (
 from google.adk.agents import LlmAgent
 from google.adk.tools import AgentTool, FunctionTool
 
+
+def _model_name() -> str:
+    """Generative model for the mesh agents (configurable; matches the scouts)."""
+    return os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+
 # --- SPECIALIST AGENTS ---
 
 
@@ -19,6 +27,7 @@ class AnalystAgent(LlmAgent):
 
     def __init__(self):
         super().__init__(
+            model=_model_name(),
             name="Analyst",
             description="Specializes in extracting structured book attributes and analyzing user taste.",
             instruction="""
@@ -38,6 +47,7 @@ class ExplorerAgent(LlmAgent):
 
     def __init__(self):
         super().__init__(
+            model=_model_name(),
             name="Explorer",
             description="Discovers new books from the internet using search grounding.",
             instruction="""
@@ -55,6 +65,7 @@ class CriticAgent(LlmAgent):
 
     def __init__(self):
         super().__init__(
+            model=_model_name(),
             name="Critic",
             description="Ranks book candidates using vector similarity and ensures no duplicates in history.",
             instruction="""
@@ -86,6 +97,7 @@ class LibrarianAgent(LlmAgent):
 
     def __init__(self, analyst, explorer, critic):
         super().__init__(
+            model=_model_name(),
             name="Librarian",
             description="The entry point for users. Orchestrates the recommendation process.",
             instruction="""

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from agentic_librarian.agents import runtime  # noqa: F401  (used by later tasks)
 from agentic_librarian.agents.services import create_agent_mesh
@@ -15,3 +17,17 @@ def test_all_mesh_agents_have_a_model():
     mesh = create_agent_mesh()
     for name in ("librarian", "analyst", "explorer", "critic"):
         assert mesh[name].model, f"{name} agent has no model"
+
+
+def test_ensure_adk_credentials_falls_back(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "fallback-key-123")
+    runtime._ensure_adk_credentials()
+    assert os.environ["GOOGLE_API_KEY"] == "fallback-key-123"
+
+
+def test_build_runner_constructs():
+    r = runtime.build_runner()
+    assert r is not None
+    assert r.app_name == runtime.APP_NAME

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from agentic_librarian.agents import runtime  # noqa: F401  (used by later tasks)
+from agentic_librarian.agents import runtime
 from agentic_librarian.agents.services import create_agent_mesh
 from google.genai import types
 
@@ -66,6 +66,17 @@ class _FakeRunner:
 def test_send_returns_final_response_text():
     conv = runtime.LibrarianConversation(_FakeRunner(reply="Try Hyperion"), "u", "s")
     assert conv.send("recommend sci-fi") == "Try Hyperion"
+
+
+def test_asend_concatenates_multiple_text_parts():
+    class _MultiPartRunner(_FakeRunner):
+        async def run_async(self, user_id, session_id, new_message):
+            event = _FakeEvent("")
+            event.content = types.Content(role="model", parts=[types.Part(text="Hello "), types.Part(text="world")])
+            yield event
+
+    conv = runtime.LibrarianConversation(_MultiPartRunner(), "u", "s")
+    assert conv.send("hi") == "Hello world"
 
 
 def test_two_sends_reuse_the_same_session():

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -90,3 +90,13 @@ def test_run_recommendation_one_shot(monkeypatch):
     monkeypatch.setattr(runtime, "build_runner", lambda: fake)
     assert runtime.run_recommendation("something like Dune") == "Recommended: Dune"
     assert fake.calls[0][2] == "something like Dune"
+
+
+@pytest.mark.api_dependent
+def test_live_conversation_runs():
+    conv = runtime.start_conversation()
+    first = conv.send("Recommend a sci-fi novel like Dune in one sentence.")
+    assert isinstance(first, str) and first.strip()
+    # Second turn shares the session (memory).
+    second = conv.send("Actually, something more recent.")
+    assert isinstance(second, str) and second.strip()

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -83,3 +83,10 @@ def test_start_conversation_creates_a_session():
     assert conv.user_id == "alice"
     assert fake.session_service.created
     assert fake.session_service.created[0][1] == "alice"
+
+
+def test_run_recommendation_one_shot(monkeypatch):
+    fake = _FakeRunner(reply="Recommended: Dune")
+    monkeypatch.setattr(runtime, "build_runner", lambda: fake)
+    assert runtime.run_recommendation("something like Dune") == "Recommended: Dune"
+    assert fake.calls[0][2] == "something like Dune"

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from agentic_librarian.agents import runtime  # noqa: F401  (used by later tasks)
 from agentic_librarian.agents.services import create_agent_mesh
+from google.genai import types
 
 
 @pytest.fixture(autouse=True)
@@ -31,3 +32,54 @@ def test_build_runner_constructs():
     r = runtime.build_runner()
     assert r is not None
     assert r.app_name == runtime.APP_NAME
+
+
+class _FakeEvent:
+    def __init__(self, text: str):
+        self.content = types.Content(role="model", parts=[types.Part(text=text)])
+
+    def is_final_response(self) -> bool:
+        return True
+
+
+class _FakeSessionService:
+    def __init__(self):
+        self.created = []
+
+    async def create_session(self, app_name, user_id, session_id):
+        self.created.append((app_name, user_id, session_id))
+        return None
+
+
+class _FakeRunner:
+    def __init__(self, reply="Recommended: Dune"):
+        self.app_name = runtime.APP_NAME
+        self.session_service = _FakeSessionService()
+        self.calls = []
+        self._reply = reply
+
+    async def run_async(self, user_id, session_id, new_message):
+        self.calls.append((user_id, session_id, new_message.parts[0].text))
+        yield _FakeEvent(self._reply)
+
+
+def test_send_returns_final_response_text():
+    conv = runtime.LibrarianConversation(_FakeRunner(reply="Try Hyperion"), "u", "s")
+    assert conv.send("recommend sci-fi") == "Try Hyperion"
+
+
+def test_two_sends_reuse_the_same_session():
+    fake = _FakeRunner()
+    conv = runtime.LibrarianConversation(fake, "u", "sess-1")
+    conv.send("first")
+    conv.send("second")
+    assert [sid for (_, sid, _) in fake.calls] == ["sess-1", "sess-1"]
+    assert [msg for (_, _, msg) in fake.calls] == ["first", "second"]
+
+
+def test_start_conversation_creates_a_session():
+    fake = _FakeRunner()
+    conv = runtime.start_conversation(user_id="alice", runner=fake)
+    assert conv.user_id == "alice"
+    assert fake.session_service.created
+    assert fake.session_service.created[0][1] == "alice"

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -1,0 +1,17 @@
+import pytest
+from agentic_librarian.agents import runtime  # noqa: F401  (used by later tasks)
+from agentic_librarian.agents.services import create_agent_mesh
+
+
+@pytest.fixture(autouse=True)
+def _adk_key(monkeypatch, request):
+    """ADK's Gemini model reads GOOGLE_API_KEY. Set a dummy for offline tests so
+    agent/runner construction never needs a real key. Live tests opt out."""
+    if "api_dependent" not in request.keywords:
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-adk-key")
+
+
+def test_all_mesh_agents_have_a_model():
+    mesh = create_agent_mesh()
+    for name in ("librarian", "analyst", "explorer", "critic"):
+        assert mesh[name].model, f"{name} agent has no model"


### PR DESCRIPTION
## What
Spec 1 of the phased mesh delivery (ADR-035): make the 4-agent recommendation mesh actually **run**, as a **multi-turn conversation** with the Librarian (ADR-036). Previously none of the `LlmAgent`s had a model and there was no ADK Runner/entrypoint, so the mesh could not execute.

Includes the design doc, the implementation plan, ADR-036, and the implementation.

## Changes
- **`agents/services.py`** — assign `model=_model_name()` (env `GEMINI_MODEL`, default `gemini-2.5-flash-lite`) to all four agents. Explorer stays model-only (its search tool is Spec 2).
- **`agents/runtime.py`** (new) —
  - `build_runner()` → ADK `Runner` over the existing `create_agent_mesh()` Librarian with `InMemorySessionService`.
  - `LibrarianConversation` (`asend`/`send`) — multi-turn; reusing one session gives conversational memory.
  - `start_conversation()` / `astart_conversation()` and `run_recommendation()` one-shot convenience.
  - `_ensure_adk_credentials()` — populates `GOOGLE_API_KEY` from `GEMINI_API_KEY`/`GOOGLE_SEARCH_API_KEY` (that key has both Custom Search + Gemini access).
- **`.env.example`** — document `GOOGLE_API_KEY`.
- **Docs** — `docs/superpowers/specs/` design, `docs/superpowers/plans/` plan, and **ADR-036** (Librarian is multi-turn conversational).

## Architecture
One Runner hosts the Librarian root agent; LLM-driven `AgentTool` delegation drives Analyst/Explorer/Critic (ADR-019/020). Within-conversation memory = the ADK session; durable "knows what you've read" = the Postgres reading-history DB via the agents' tools.

## Tests
- Mock unit tests (`test/unit/test_agent_runtime.py`): runner constructs; all agents have a model; conversation returns final text; **two sends reuse the same session** (memory); one-shot path; credential fallback.
- `@pytest.mark.api_dependent` live two-turn smoke (excluded from CI).
- Verified in the dev container: **135 passed, 5 deselected**.

## Scope
Success = "runs & delegates" (smoke). Recommendation quality, the Explorer's web search (Spec 2), seeded-DB retrieval (Spec 3), and end-to-end Trope-RAG (Spec 4) are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)