### PR TITLE
Claude-native enrichment scouts: GroundedLLM seam under AGENT_BACKEND (REC-024)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,10 @@ HARDCOVER_API_KEY=
 # recently released books outside the model's training data trigger a real web
 # search instead of being hallucinated; the scouts parse grounded responses robustly.
 USE_SEARCH_GROUNDING=1
+
+# Selects the LLM backend for BOTH the recommendation mesh AND the enrichment scouts (and therefore
+# the Flow-1 Dagster ETL, which uses the same scouts): 'adk' (default) = Gemini; 'claude' = the Claude
+# Agent SDK on your Max subscription (needs the in-container `claude` CLI authenticated). Embeddings
+# always stay on Gemini (gemini-embedding-001, separate higher quota). Set AGENT_BACKEND=claude to run
+# a full reading-history ETL off Claude instead of the Gemini free-tier daily cap.
+AGENT_BACKEND=adk

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -561,3 +561,23 @@ This file documents key architectural decisions, their context, and trade-offs.
   (`&` vs "and", articles) since matching is fuzzy. Two API calls per book instead of one (acceptable —
   priority-1 short-circuits the other scouts; Hardcover quota is generous). Companion/workbook hits are
   filtered heuristically; a future refinement could weight series/edition signals.
+
+### ADR-044: GroundedLLM Seam — Enrichment Scouts Follow AGENT_BACKEND (2026-06-02)
+**Context:**
+- ADR-041 made the recommendation mesh backend-selectable, but the enrichment LLM scouts stayed on
+  Gemini. An `AGENT_BACKEND=claude` run (and the Flow-1 ETL) still hit the Gemini free-tier
+  `generate_content` daily cap (20/day), stretching a full reading-history ingest into ~weeks (REC-024).
+
+**Decision:**
+- Introduce a `GroundedLLM` provider seam (`scouts/grounded_llm.py`: `generate(prompt, grounded=)`) with
+  `GeminiGroundedLLM` (google_search) and `ClaudeGroundedLLM` (Agent SDK WebSearch, run synchronously via
+  `asyncio.run`), chosen by `get_grounded_llm()` reading the SAME `AGENT_BACKEND` knob. `LLMScout` takes
+  the provider (injectable); all four scouts call `self._llm.generate(...)`. Prompts, JSON parsing, merge
+  and persistence are unchanged. Embeddings stay on Gemini (separate, higher quota — not the bottleneck).
+
+**Consequences:**
+- One knob flips the whole pipeline (recommendation + batch ETL) between Gemini and Claude; default is
+  byte-for-byte Gemini. Claude extraction quality vs Gemini grounding is validated by a live check.
+  `ClaudeGroundedLLM.generate` must be called from a synchronous context (it uses `asyncio.run`); scouts
+  always are. A full ETL on Claude issues many WebSearch calls — validate Agent SDK rate limits on a
+  small batch first.

--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -157,7 +157,7 @@ This file tracks work history and ticket references.
 - **Notes**: This is the defensive fix. The deeper issue (the Claude backend still depending on Gemini `generate_content` for enrichment) is REC-024.
 
 ### 2026-06-01 - REC-024: Claude backend's enrichment scouts still use Gemini (next spec)
-- **Status**: Open (next spec, after enrichment-hardening)
+- **Status**: Resolved (2026-06-02) — GroundedLLM seam (scouts/grounded_llm.py): GeminiGroundedLLM + ClaudeGroundedLLM chosen by AGENT_BACKEND, injected into LLMScout. All four LLM scouts route through it; AGENT_BACKEND=claude runs the scouts (recommendation + Flow-1 ETL) on the Max subscription. Embeddings stay Gemini. ADR-044.
 - **Description**: PR #23 / ADR-041 abstracted only the recommendation MESH (Analyst/Explorer/Critic) to Claude + shared MCP DB tools. The per-discovery `enrich_and_persist_work` still runs the shared Flow-1 `ScoutManager`, whose LLM scouts (StyleScout/LLMTropeScout/DirectKnowledgeScout) do **Gemini-native grounding** (`gemini-2.5-flash` via `GROUNDING_MODEL`) and whose trope/style dedup uses Gemini embeddings. So a Claude-backend run is NOT free of the Gemini `generate_content` free-tier daily cap — under that cap the grounding scouts 429 and contribute nothing (REC-023 keeps Hardcover/REST data; styles/tropes are still lost).
 - **URL**: N/A
 - **Notes**: Next spec: give StyleScout/LLMTropeScout/DirectKnowledgeScout backend-selectable **Claude variants** (Claude + WebSearch for grounding) so a Claude run's enrichment is off Gemini `generate_content`. Embeddings (`gemini-embedding-001`, separate low-volume quota) may stay on Gemini initially. Mirror the `RecommendationBackend` strategy seam (ADR-041) at the scout layer.

--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -119,7 +119,7 @@ This file tracks work history and ticket references.
       remains open — re-evaluate after a post-enrichment-hardening e2e.
 
 ### 2026-05-31 - REC-018: Spec 4 Follow-ups (Critic ranking + live e2e verification)
-- **Status**: Open (Spec 5 / next quota window)
+- **Status**: Item 2 **Resolved (2026-06-02)** — the full live chain ran end-to-end: the ADK backend (`test_recommendation_e2e`) and the Claude backend (`test_claude_e2e`) each produced a justified recommendation and logged a Suggestion (verified in the DB). Item 1 (explicit candidate ranking) remains **Open** as a recommendation-quality refinement.
 - **Description**: Refinements surfaced by the Spec 4 final review.
 - **URL**: N/A
 - **Notes**:

--- a/docs/superpowers/plans/2026-06-02-claude-enrichment-scouts.md
+++ b/docs/superpowers/plans/2026-06-02-claude-enrichment-scouts.md
@@ -1,0 +1,596 @@
+# Claude-Native Enrichment Scouts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the enrichment LLM scouts backend-selectable under the single `AGENT_BACKEND` knob, so `AGENT_BACKEND=claude` runs them (recommendation pipeline AND Flow-1 ETL) on the Claude Max subscription instead of the Gemini free-tier daily cap (REC-024).
+
+**Architecture:** Introduce a `GroundedLLM` provider seam (`scouts/grounded_llm.py`) with Gemini and Claude implementations chosen by a factory reading `AGENT_BACKEND`, and inject it into the `LLMScout` base class. The genai client + grounded-response text extraction move out of `LLMScout` into `GeminiGroundedLLM`; every scout method swaps its `generate_content(...) + _extract_text(...)` for `self._llm.generate(prompt, grounded=...)`. Scout prompts, JSON parsing (`_safe_extract_json`/`_flatten_style_map`), merge and persistence are unchanged. Embeddings stay on Gemini.
+
+**Tech Stack:** Python 3.11, google-genai, claude-agent-sdk (optional extra, lazy-imported), pytest. Tests run in the dev container: `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest ...'`. Commit with `SKIP=pytest git commit` (ruff/ruff-format run on commit; if ruff-format reformats, re-`git add -A` and re-commit). Lint authoritative via pre-commit, NOT bare `ruff check`. Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `src/agentic_librarian/scouts/grounded_llm.py` — **new**: `GroundedLLM` Protocol, module-level `_extract_text`, `GeminiGroundedLLM`, `ClaudeGroundedLLM` (lazy-imports `claude_agent_sdk`), `get_grounded_llm()` factory. (Task 1)
+- `src/agentic_librarian/scouts/metadata_scout.py` — **modify**: `LLMScout.__init__` injects a `GroundedLLM`; remove the `genai.Client` construction and the `_extract_text` method from `LLMScout`; rewrite the 7 scout call sites to use `self._llm.generate(...)`. (Task 2)
+- `test/unit/test_grounded_llm.py` — **new**: provider + factory unit tests. (Task 1)
+- `test/unit/test_style_scout.py`, `test/unit/test_trope_scout.py` — **modify**: migrate from patching `genai.Client` to injecting a fake `GroundedLLM`. (Task 2)
+- `test/unit/test_metadata_scout.py` — **modify**: the `_extract_text` test moves to import from `grounded_llm`. (Task 2)
+- `.env.example`, `docs/project_notes/decisions.md` (ADR-044), `docs/project_notes/issues.md` (REC-024 resolved) — **modify**. (Task 3)
+
+---
+
+## Task 1: GroundedLLM provider seam
+
+**Files:**
+- Create: `src/agentic_librarian/scouts/grounded_llm.py`
+- Test: `test/unit/test_grounded_llm.py`
+
+- [ ] **Step 1: Write the failing tests** in new file `test/unit/test_grounded_llm.py`
+
+```python
+from unittest.mock import MagicMock
+
+import agentic_librarian.scouts.grounded_llm as gl
+
+
+def test_extract_text_prefers_text_then_parts():
+    direct = MagicMock()
+    direct.text = "hello"
+    assert gl._extract_text(direct) == "hello"
+
+    grounded = MagicMock()
+    grounded.text = None
+    part = MagicMock()
+    part.text = '{"x": 1}'
+    grounded.candidates = [MagicMock(content=MagicMock(parts=[part]))]
+    assert gl._extract_text(grounded) == '{"x": 1}'
+
+    empty = MagicMock()
+    empty.text = None
+    empty.candidates = []
+    assert gl._extract_text(empty) is None
+
+
+def test_gemini_generate_grounded_and_plain(monkeypatch):
+    captured = {}
+
+    class FakeModels:
+        def generate_content(self, model, contents, config):
+            captured["model"] = model
+            captured["config"] = config
+            resp = MagicMock()
+            resp.text = "RESULT"
+            return resp
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(gl.genai, "Client", FakeClient)
+    monkeypatch.setenv("USE_SEARCH_GROUNDING", "1")
+    monkeypatch.setenv("GROUNDING_MODEL", "gemini-test")
+
+    llm = gl.GeminiGroundedLLM(api_key="k")
+    assert llm.generate("p", grounded=True) == "RESULT"
+    assert captured["config"]["tools"] == [{"google_search": {}}]
+    assert captured["model"] == "gemini-test"
+
+    # grounded=False -> no tools
+    llm.generate("p", grounded=False)
+    assert captured["config"]["tools"] == []
+
+
+def test_gemini_respects_use_search_grounding_flag(monkeypatch):
+    captured = {}
+
+    class FakeModels:
+        def generate_content(self, model, contents, config):
+            captured["config"] = config
+            resp = MagicMock()
+            resp.text = "x"
+            return resp
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(gl.genai, "Client", FakeClient)
+    monkeypatch.setenv("USE_SEARCH_GROUNDING", "0")
+    gl.GeminiGroundedLLM(api_key="k").generate("p", grounded=True)
+    assert captured["config"]["tools"] == []  # flag off -> no grounding even when grounded=True
+
+
+def test_factory_selects_backend(monkeypatch):
+    monkeypatch.setattr(gl.genai, "Client", lambda *a, **k: MagicMock())
+    monkeypatch.setenv("AGENT_BACKEND", "adk")
+    assert isinstance(gl.get_grounded_llm("k"), gl.GeminiGroundedLLM)
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    assert isinstance(gl.get_grounded_llm("k"), gl.GeminiGroundedLLM)
+    monkeypatch.setenv("AGENT_BACKEND", "claude")
+    assert isinstance(gl.get_grounded_llm("k"), gl.ClaudeGroundedLLM)
+
+
+def test_claude_generate_collects_result_and_sets_tools(monkeypatch):
+    captured = {}
+
+    class FakeMsg:
+        def __init__(self, result):
+            self.result = result
+
+    async def fake_query(prompt, options):
+        captured["allowed_tools"] = options.allowed_tools
+        captured["model"] = options.model
+        yield FakeMsg(None)
+        yield FakeMsg("CLAUDE_JSON")
+
+    fake_sdk = MagicMock()
+    fake_sdk.query = fake_query
+    fake_sdk.ClaudeAgentOptions = lambda **kw: MagicMock(**kw)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-test")
+
+    llm = gl.ClaudeGroundedLLM()
+    assert llm.generate("p", grounded=True) == "CLAUDE_JSON"
+    assert captured["allowed_tools"] == ["WebSearch"]
+    assert captured["model"] == "claude-test"
+    assert llm.generate("p", grounded=False) == "CLAUDE_JSON"
+    assert captured["allowed_tools"] == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest test/unit/test_grounded_llm.py -v'`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agentic_librarian.scouts.grounded_llm'`.
+
+- [ ] **Step 3: Create `src/agentic_librarian/scouts/grounded_llm.py`**
+
+```python
+"""Backend-selectable grounded-LLM provider for the enrichment scouts. The single AGENT_BACKEND knob
+(shared with the recommendation mesh) picks Gemini grounding (default) or Claude WebSearch, so an
+`AGENT_BACKEND=claude` run enriches off the Max subscription instead of the Gemini free-tier daily cap
+(REC-024). Embeddings stay on Gemini (separate, higher quota)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Protocol, runtime_checkable
+
+from agentic_librarian.llm_retry import genai_http_options
+from google import genai
+
+
+@runtime_checkable
+class GroundedLLM(Protocol):
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        """Return the model's text for `prompt`. When `grounded`, perform web-grounded generation."""
+        ...
+
+
+def _extract_text(response) -> str | None:
+    """Return response text, falling back to concatenated candidate parts. Grounded/multi-part
+    responses can leave ``response.text`` empty even though the answer is in the candidate parts."""
+    if getattr(response, "text", None):
+        return response.text
+    try:
+        parts = response.candidates[0].content.parts or []
+    except (AttributeError, IndexError, TypeError):
+        return None
+    texts = [p.text for p in parts if getattr(p, "text", None)]
+    return "".join(texts) if texts else None
+
+
+class GeminiGroundedLLM:
+    """Grounded generation via Gemini's google_search tool — the prior scout behavior, relocated."""
+
+    def __init__(self, api_key: str | None = None, model_name: str | None = None):
+        self.api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        self.model_name = (
+            model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
+        )
+        self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        use_grounding = grounded and os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
+        response = self._client.models.generate_content(
+            model=self.model_name,
+            contents=prompt,
+            config={"tools": [{"google_search": {}}] if use_grounding else []},
+        )
+        return _extract_text(response) or ""
+
+
+class ClaudeGroundedLLM:
+    """Grounded generation via the Claude Agent SDK (WebSearch tool), Max-subscription quota."""
+
+    _SYSTEM = (
+        "You are a book-metadata extraction assistant. Use web search to verify facts; never invent "
+        "details. Return ONLY the raw JSON object the user's instructions specify — no prose, no code fences."
+    )
+
+    def __init__(self, model: str | None = None):
+        self.model = model or os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return asyncio.run(self._agenerate(prompt, grounded))
+
+    async def _agenerate(self, prompt: str, grounded: bool) -> str:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+
+        options = ClaudeAgentOptions(
+            system_prompt=self._SYSTEM,
+            model=self.model,
+            allowed_tools=["WebSearch"] if grounded else [],
+        )
+        text = ""
+        async for message in query(prompt=prompt, options=options):
+            result_val = getattr(message, "result", None)
+            if result_val and isinstance(result_val, str):
+                text = result_val
+        return text
+
+
+def get_grounded_llm(api_key: str | None = None) -> GroundedLLM:
+    """Pick the grounding-LLM provider from AGENT_BACKEND (default/'adk' -> Gemini; 'claude' -> Claude)."""
+    choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
+    if choice == "claude":
+        return ClaudeGroundedLLM()
+    return GeminiGroundedLLM(api_key)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest test/unit/test_grounded_llm.py -v'`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/scouts/grounded_llm.py test/unit/test_grounded_llm.py
+SKIP=pytest git commit -m "feat: GroundedLLM seam (Gemini/Claude) selected by AGENT_BACKEND (REC-024)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Route LLMScout through the seam
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/metadata_scout.py` (`LLMScout` + the 4 scout classes)
+- Modify: `test/unit/test_style_scout.py`, `test/unit/test_trope_scout.py`, `test/unit/test_metadata_scout.py`
+
+### 2a. LLMScout base: inject the provider, drop the client + `_extract_text`
+
+- [ ] **Step 1: Add the import.** At the top of `metadata_scout.py`, add to the first-party imports:
+
+```python
+from agentic_librarian.scouts.grounded_llm import GroundedLLM, get_grounded_llm
+```
+
+- [ ] **Step 2: Rewrite `LLMScout.__init__`.** Replace the current body:
+
+```python
+    def __init__(self, api_key: str = None, model_name: str = None, llm: GroundedLLM | None = None):
+        # Fallback to GOOGLE_SEARCH_API_KEY if no specific key provided (also used by AudiobookScout's
+        # Custom Search and by the Gemini provider/embeddings).
+        key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        if not key:
+            raise ValueError(f"{self.__class__.__name__} requires a Google API key.")
+        super().__init__(key)
+        # Backend-selectable grounding LLM (Gemini default; Claude when AGENT_BACKEND=claude). Injectable
+        # for tests. model_name kept for back-compat; the Gemini provider owns the model (GROUNDING_MODEL).
+        self.model_name = (
+            model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
+        )
+        self._llm = llm or get_grounded_llm(self.api_key)
+```
+
+This removes the `self._client = genai.Client(...)` line.
+
+- [ ] **Step 3: Delete the `_extract_text` method from `LLMScout`** (it now lives in `grounded_llm.py`). Keep `_safe_extract_json` exactly as-is.
+
+### 2b. Rewrite the scout call sites (7 of them)
+
+- [ ] **Step 4: StyleScout — `scout_work_style`.** Replace the `use_grounding = ...` + `generate_content(...)` block and the final return so the method ends with:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Work Style", title))
+```
+
+(Delete the `use_grounding = os.environ.get(...)` line and the `response = self._client.models.generate_content(...)` call.)
+
+- [ ] **Step 5: StyleScout — `scout_author_style`.** Same change; method ends with:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Author Style", name))
+```
+
+- [ ] **Step 6: StyleScout — `scout_narrator_style`.** Same change; method ends with:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Narrator Style", name))
+```
+
+- [ ] **Step 7: AudiobookScout — `extract_metadata_with_gemini`.** This is **plain** extraction (no grounding). Replace the two `generate_content` calls:
+
+```python
+        text = self._llm.generate(prompt, grounded=False)
+        data = self._safe_extract_json(text, title, author)
+        if data is None:
+            text = self._llm.generate(prompt + "\nJSON ONLY.", grounded=False)
+            data = self._safe_extract_json(text, title, author, retry_count=1)
+```
+
+(Keep the key-normalization block below it unchanged.)
+
+- [ ] **Step 8: DirectKnowledgeScout — `scout_audiobook`.** Replace the `use_grounding` + two `generate_content` calls:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        data = self._safe_extract_json(text, title, author)
+        if data is None:
+            prompt += "\n\nSTRICT: Return valid JSON ONLY."
+            text = self._llm.generate(prompt, grounded=True)
+            data = self._safe_extract_json(text, title, author, retry_count=1)
+```
+
+(Keep whatever return/normalization follows.)
+
+- [ ] **Step 9: LLMTropeScout — `search`.** Replace the `use_grounding` + `generate_content` so the method ends with:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        return self._safe_extract_json(text, "Tropes", title) or {"tropes": []}
+```
+
+- [ ] **Step 10: Remove the now-unused genai import.** The scouts no longer construct a client, so `from google import genai` in `metadata_scout.py` is unused (ruff will flag F401 and fail the commit). Delete that import line. (Verify `genai` isn't referenced elsewhere in the file first — it should only have been used by the deleted `LLMScout` client.)
+
+- [ ] **Step 11: Sanity-check no stragglers.** Run:
+
+`docker exec agentic_librarian_app sh -lc 'cd /app && grep -nE "_client\.models\.generate_content|self\._extract_text|self\._client|google import genai" src/agentic_librarian/scouts/metadata_scout.py'`
+Expected: **no output** (all generate_content / _client / _extract_text uses and the genai import are gone from the scouts file).
+
+### 2c. Migrate the scout unit tests to inject a fake provider
+
+- [ ] **Step 12: Rewrite `test/unit/test_style_scout.py`** to inject a fake `GroundedLLM` instead of patching `genai.Client`:
+
+```python
+from unittest.mock import patch
+
+from agentic_librarian.scouts.metadata_scout import StyleScout
+
+
+class _FakeLLM:
+    """A GroundedLLM stub returning a fixed JSON string for every call."""
+
+    def __init__(self, text: str):
+        self._text = text
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return self._text
+
+
+def test_scout_author_style():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM('{"pacing": "fast", "tone": "cynical", "style": "minimalist"}'))
+    style = scout.scout_author_style("Ernest Hemingway")
+    assert style["pacing"] == "fast"
+    assert style["tone"] == "cynical"
+    assert style["style"] == "minimalist"
+
+
+def test_scout_narrator_style():
+    scout = StyleScout(
+        api_key="fake-key",
+        llm=_FakeLLM('{"pacing": "steady", "voice_differentiation": "excellent", "emotional_range": "wide"}'),
+    )
+    style = scout.scout_narrator_style("Jefferson Mays")
+    assert style["pacing"] == "steady"
+    assert style["voice_differentiation"] == "excellent"
+    assert style["emotional_range"] == "wide"
+
+
+def test_style_scout_search_mode():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM('{"pacing": "fast"}'))
+    res = scout.search("The Expanse", "James S.A. Corey", narrators=["Jefferson Mays"])
+    assert "author_style" in res
+    assert "narrator_styles" in res
+    assert "Jefferson Mays" in res["narrator_styles"]
+    assert res["author_style"]["pacing"] == "fast"
+
+
+def test_work_style_baseline_falls_back_to_scouted_author_style():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM("{}"))
+    with (
+        patch.object(scout, "scout_author_style", return_value={"pacing": "fast"}),
+        patch.object(scout, "scout_work_style", return_value={}) as m_work,
+        patch.object(scout, "scout_narrator_style", return_value={}),
+    ):
+        scout.search("Book", "Author")
+    assert m_work.call_args.kwargs["author_baseline"] == {"pacing": "fast"}
+
+
+def test_work_style_baseline_prefers_db_baseline_when_provided():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM("{}"))
+    with (
+        patch.object(scout, "scout_author_style", return_value={"pacing": "fast"}),
+        patch.object(scout, "scout_work_style", return_value={}) as m_work,
+    ):
+        scout.search("Book", "Author", author_styles={"tone": "dark"})
+    assert m_work.call_args.kwargs["author_baseline"] == {"tone": "dark"}
+```
+
+- [ ] **Step 13: Rewrite `test/unit/test_trope_scout.py`** the same way:
+
+```python
+from agentic_librarian.scouts.metadata_scout import LLMTropeScout
+
+
+class _FakeLLM:
+    def __init__(self, text: str):
+        self._text = text
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return self._text
+
+
+def test_llm_trope_scout():
+    payload = """
+    {
+        "tropes": [
+            {
+                "trope_name": "Found Family",
+                "description": "A group of people who are not related by blood but form a deep familial bond.",
+                "relevance_score": 0.9,
+                "justification": "The crew of the Rocinante forms a tight-knit family unit throughout the series."
+            }
+        ]
+    }
+    """
+    scout = LLMTropeScout(api_key="fake-key", llm=_FakeLLM(payload))
+    res = scout.search("Leviathan Wakes", "James S.A. Corey")
+    assert "tropes" in res
+    assert len(res["tropes"]) == 1
+    assert res["tropes"][0]["trope_name"] == "Found Family"
+    assert res["tropes"][0]["relevance_score"] == 0.9
+```
+
+- [ ] **Step 14: Update the `_extract_text` test in `test/unit/test_metadata_scout.py`.** That test currently calls `scout._extract_text(...)`, which no longer exists on the scout. Replace `test_extract_text_falls_back_to_candidate_parts` with a version that exercises the relocated function:
+
+```python
+def test_extract_text_falls_back_to_candidate_parts():
+    """When response.text is empty (grounded responses), text comes from the candidate parts."""
+    from unittest.mock import MagicMock
+
+    from agentic_librarian.scouts.grounded_llm import _extract_text
+
+    direct = MagicMock()
+    direct.text = "hello"
+    assert _extract_text(direct) == "hello"
+
+    grounded = MagicMock()
+    grounded.text = None
+    part = MagicMock()
+    part.text = '{"x": 1}'
+    grounded.candidates = [MagicMock(content=MagicMock(parts=[part]))]
+    assert _extract_text(grounded) == '{"x": 1}'
+```
+
+(Leave `test_safe_extract_json_handles_fences_prose_and_none` as-is — `_safe_extract_json` still lives on `LLMScout`, and constructing `LLMTropeScout(api_key="fake-key")` is offline-safe.)
+
+- [ ] **Step 15: Run the scout tests**
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest test/unit/test_style_scout.py test/unit/test_trope_scout.py test/unit/test_metadata_scout.py -o addopts="" -m "not api_dependent" -v 2>&1 | tail -25'`
+Expected: all PASS (the migrated scout tests + the relocated `_extract_text` test).
+
+- [ ] **Step 16: Run the full offline suite** to confirm nothing else broke (the `LLMScout` change affects every scout):
+
+Run: `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest -q -p no:cacheprovider -m "not api_dependent and not db_integration"'`
+Expected: all pass.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add src/agentic_librarian/scouts/metadata_scout.py test/unit/test_style_scout.py test/unit/test_trope_scout.py test/unit/test_metadata_scout.py
+SKIP=pytest git commit -m "refactor: route LLMScout through the GroundedLLM seam (REC-024)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: ETL audit, config, ADR, and a live Claude-scout check
+
+**Files:**
+- Modify: `.env.example`, `docs/project_notes/decisions.md`, `docs/project_notes/issues.md`
+- Test: `test/unit/test_metadata_scout.py` (one `api_dependent` live test)
+
+- [ ] **Step 1: Audit for genai usage outside the seam on the scout/ETL path.** Run:
+
+`docker exec agentic_librarian_app sh -lc 'cd /app && grep -rnE "genai\.Client|generate_content" src/agentic_librarian/scouts/ src/agentic_librarian/orchestration/'`
+Expected: the only `genai.Client` matches are in `grounded_llm.py` (the seam), `trope_manager.py`, and `style_manager.py` (embeddings — intentionally Gemini). No `generate_content` in `orchestration/`. If any scout/ETL generation path still constructs a client directly, route it through `get_grounded_llm()` the same way. Record the audit result in the commit message.
+
+- [ ] **Step 2: Update `.env.example`.** Find the `AGENT_BACKEND` line (added in the pluggable-backend work) and expand its comment; if absent, add it near the model config:
+
+```
+# Selects the LLM backend for BOTH the recommendation mesh AND the enrichment scouts (and therefore
+# the Flow-1 Dagster ETL, which uses the same scouts): 'adk' (default) = Gemini; 'claude' = the Claude
+# Agent SDK on your Max subscription (needs the in-container `claude` CLI authenticated). Embeddings
+# always stay on Gemini (gemini-embedding-001, separate higher quota). Set AGENT_BACKEND=claude to run
+# a full reading-history ETL off Claude instead of the Gemini free-tier daily cap.
+AGENT_BACKEND=adk
+```
+
+- [ ] **Step 3: Append ADR-044** to the end of `docs/project_notes/decisions.md`:
+
+```markdown
+
+### ADR-044: GroundedLLM Seam — Enrichment Scouts Follow AGENT_BACKEND (2026-06-02)
+**Context:**
+- ADR-041 made the recommendation mesh backend-selectable, but the enrichment LLM scouts stayed on
+  Gemini. An `AGENT_BACKEND=claude` run (and the Flow-1 ETL) still hit the Gemini free-tier
+  `generate_content` daily cap (20/day), stretching a full reading-history ingest into ~weeks (REC-024).
+
+**Decision:**
+- Introduce a `GroundedLLM` provider seam (`scouts/grounded_llm.py`: `generate(prompt, grounded=)`) with
+  `GeminiGroundedLLM` (google_search) and `ClaudeGroundedLLM` (Agent SDK WebSearch, run synchronously via
+  `asyncio.run`), chosen by `get_grounded_llm()` reading the SAME `AGENT_BACKEND` knob. `LLMScout` takes
+  the provider (injectable); all four scouts call `self._llm.generate(...)`. Prompts, JSON parsing, merge
+  and persistence are unchanged. Embeddings stay on Gemini (separate, higher quota — not the bottleneck).
+
+**Consequences:**
+- One knob flips the whole pipeline (recommendation + batch ETL) between Gemini and Claude; default is
+  byte-for-byte Gemini. Claude extraction quality vs Gemini grounding is validated by a live check.
+  `ClaudeGroundedLLM.generate` must be called from a synchronous context (it uses `asyncio.run`); scouts
+  always are. A full ETL on Claude issues many WebSearch calls — validate Agent SDK rate limits on a
+  small batch first.
+```
+
+- [ ] **Step 4: Resolve REC-024** in `docs/project_notes/issues.md` — set its `- **Status**:` line to:
+
+```
+- **Status**: Resolved (2026-06-02) — GroundedLLM seam (scouts/grounded_llm.py): GeminiGroundedLLM + ClaudeGroundedLLM chosen by AGENT_BACKEND, injected into LLMScout. All four LLM scouts route through it; AGENT_BACKEND=claude runs the scouts (recommendation + Flow-1 ETL) on the Max subscription. Embeddings stay Gemini. ADR-044.
+```
+
+- [ ] **Step 5: Add an `api_dependent` live Claude-scout test** to `test/unit/test_metadata_scout.py`:
+
+```python
+@pytest.mark.api_dependent
+def test_claude_grounded_scouts_produce_styles_and_tropes(monkeypatch):
+    """Live (needs an authenticated claude CLI): AGENT_BACKEND=claude yields usable style/trope JSON."""
+    monkeypatch.setenv("AGENT_BACKEND", "claude")
+    from agentic_librarian.scouts.metadata_scout import LLMTropeScout, StyleScout
+
+    tropes = LLMTropeScout(api_key="x").search("The Way of Kings", "Brandon Sanderson")
+    assert tropes.get("tropes"), "expected non-empty tropes from the Claude LLMTropeScout"
+    style = StyleScout(api_key="x").scout_author_style("Brandon Sanderson")
+    assert style, "expected non-empty author style from the Claude StyleScout"
+```
+
+- [ ] **Step 6: (Manual) run the live test** once the `claude` CLI is authenticated and you want to spend Claude quota:
+
+Run: `docker exec -e AGENT_BACKEND=claude agentic_librarian_app sh -lc 'cd /app && python -m pytest test/unit/test_metadata_scout.py::test_claude_grounded_scouts_produce_styles_and_tropes -o addopts="" -m api_dependent -v -s'`
+Expected: PASS (non-empty tropes + style). If the output is empty or malformed, do NOT hack the test — report it; the scout prompts may need light tuning for Claude (a separate follow-up, noted in the spec's Risks).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .env.example docs/project_notes/decisions.md docs/project_notes/issues.md test/unit/test_metadata_scout.py
+SKIP=pytest git commit -m "docs+test: ADR-044, AGENT_BACKEND env docs, resolve REC-024, live Claude-scout test
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] **Full offline suite:** `docker exec agentic_librarian_app sh -lc 'cd /app && python -m pytest -q -p no:cacheprovider -m "not api_dependent and not db_integration"'` — all pass (prior count + the new grounded_llm tests; the migrated scout tests still pass).
+- [ ] **pre-commit clean:** `docker exec agentic_librarian_app sh -lc 'cd /app && pre-commit run --all-files'` (or rely on the per-commit hooks) — ruff + ruff-format pass.
+- [ ] **Default path unchanged:** confirm that with `AGENT_BACKEND` unset, the scouts still construct a `GeminiGroundedLLM` (the `test_factory_selects_backend` test covers this).
+- [ ] Use **superpowers:finishing-a-development-branch** to open the PR. (Live Claude-scout verification — Task 3 Step 6 — and a Claude-backed ETL smoke can follow on quota, like prior specs.)

--- a/docs/superpowers/specs/2026-06-02-claude-enrichment-scouts-design.md
+++ b/docs/superpowers/specs/2026-06-02-claude-enrichment-scouts-design.md
@@ -1,0 +1,144 @@
+# Claude-Native Enrichment Scouts (REC-024) — Design
+
+**Date:** 2026-06-02
+**Branch:** `spec/claude-enrichment-scouts` (off `main` after PR #25 merged)
+**Status:** Approved design — ready for implementation plan
+
+## Context
+
+PR #23 (ADR-041) made the recommendation **mesh** (Analyst/Explorer/Critic) backend-selectable via
+`AGENT_BACKEND`, but the **enrichment scouts** stayed hardwired to Gemini. So a `AGENT_BACKEND=claude`
+run still calls Gemini `generate_content` during `enrich_and_persist_work` — the LLM scouts
+(StyleScout, LLMTropeScout, DirectKnowledgeScout, AudiobookScout) do Gemini-native grounding, and that
+hits the free-tier daily cap (20 `generate_content`/day on `gemini-2.5-flash`). The same scouts power
+the Flow-1 Dagster **ETL** (batch CSV → reading history + enrichment), where the daily cap stretches a
+full reading-history ingest into ~weeks. REC-023 made `ScoutManager.enrich` tolerate a scout failing,
+but the enrichment still produces nothing useful for styles/tropes under the cap.
+
+This spec makes the enrichment LLM calls **backend-selectable** under the *same* `AGENT_BACKEND` knob,
+so setting `AGENT_BACKEND=claude` runs the scouts (and therefore both the recommendation pipeline and
+the batch ETL) on the Claude Max subscription instead of the Gemini free tier. Embeddings stay on
+Gemini (`gemini-embedding-001` is a separate, much higher quota — never the bottleneck).
+
+## Goals / Non-goals
+
+**Goals**
+1. One knob (`AGENT_BACKEND`) selects the grounding-LLM backend for **all** LLM scouts.
+2. `AGENT_BACKEND=claude` makes the recommendation pipeline AND the Flow-1 ETL enrich off Claude.
+3. No duplication of scout prompt/parse logic across backends (one seam, like `prompts.py` for the mesh).
+4. Default (`AGENT_BACKEND` unset / `adk`) preserves current Gemini behavior exactly.
+
+**Non-goals (YAGNI / deferred)**
+- Moving embeddings off Gemini (separate high quota; stays Gemini).
+- A separate per-scout or per-flow backend knob (single `AGENT_BACKEND` only).
+- Changing scout prompts, the merge logic, or the persistence contract.
+- Audiobook-specific quality work (AudiobookScout is included mechanically but its scrape pathway is unchanged).
+
+## Design
+
+### Component 1 — `GroundedLLM` provider seam (`scouts/grounded_llm.py`, new)
+
+A small Protocol the scouts call instead of touching a genai client directly:
+
+```python
+class GroundedLLM(Protocol):
+    def generate(self, prompt: str, grounded: bool = True) -> str: ...
+```
+
+- `grounded=True` → the provider performs web-grounded generation (Gemini `google_search` / Claude
+  `WebSearch`). `grounded=False` → plain generation, no tools (AudiobookScout extracts from already-
+  scraped Audible text).
+- Returns the model's **text** (the provider does any response-part extraction internally).
+
+Two implementations:
+
+- **`GeminiGroundedLLM`** — owns a `genai.Client(http_options=genai_http_options())` (the REC-020
+  retry), calls `client.models.generate_content(model=GROUNDING_MODEL, contents=prompt, config={"tools":
+  [{"google_search": {}}]} if grounded and USE_SEARCH_GROUNDING else {"tools": []})`, and returns text
+  via the existing `_extract_text` logic (moved here from `LLMScout`). This is the current behavior,
+  byte-for-byte, just relocated.
+- **`ClaudeGroundedLLM`** — a **synchronous** wrapper over the Claude Agent SDK: runs `query(prompt=...,
+  options=ClaudeAgentOptions(system_prompt=<generic extractor instruction>, model=CLAUDE_MODEL,
+  allowed_tools=["WebSearch"] if grounded else []))` via `asyncio.run`, collects the `ResultMessage`
+  text, and returns it. Output is JSON-as-text (the scout prompts already say "Return ONLY a raw JSON
+  object"), parsed downstream by the unchanged `_safe_extract_json`.
+
+Factory (mirrors `agents/backends.get_backend`):
+
+```python
+def get_grounded_llm(api_key: str | None = None) -> GroundedLLM:
+    choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
+    if choice == "claude":
+        return ClaudeGroundedLLM()
+    return GeminiGroundedLLM(api_key)  # 'adk'/default/anything-else -> Gemini (back-compat)
+```
+
+(`adk` maps to Gemini here — `AGENT_BACKEND` already uses `adk` to mean "the Gemini path".)
+
+### Component 2 — `LLMScout` refactor (`scouts/metadata_scout.py`)
+
+- `LLMScout.__init__(api_key=None, model_name=None, llm: GroundedLLM | None = None)`: resolve
+  `self._llm = llm or get_grounded_llm(self.api_key)`. The `genai.Client` construction moves out of
+  `LLMScout` into `GeminiGroundedLLM`; `_extract_text` moves to `GeminiGroundedLLM`. `model_name` stays
+  for back-compat but the model is owned by the provider (the Gemini provider reads `GROUNDING_MODEL`).
+- Each scout method changes from
+  `response = self._client.models.generate_content(...); data = self._safe_extract_json(self._extract_text(response), ...)`
+  to
+  `text = self._llm.generate(prompt, grounded=use_grounding); data = self._safe_extract_json(text, ...)`.
+  Applies uniformly to `StyleScout` (3 methods), `LLMTropeScout`, `DirectKnowledgeScout`, and
+  `AudiobookScout` (`grounded=False` for its extraction). `_safe_extract_json` / `_flatten_style_map`
+  are unchanged.
+
+### Component 3 — ETL respects the knob (no code change expected)
+
+The Dagster Flow-1 enrichment goes through `create_scout_manager()` → the same `LLMScout` subclasses,
+which now resolve their backend from `AGENT_BACKEND`. So `AGENT_BACKEND=claude dagster ...` runs the
+batch on Claude with no orchestration changes. Implementation step: **audit** `orchestration/` and
+`scouts/` for any direct `genai.Client`/`generate_content` use outside the seam and confirm none remain
+on the scout path (embeddings via `TropeManager`/`StyleManager` are intentionally excluded).
+
+### Component 4 — Config & docs
+
+- `.env.example`: document that `AGENT_BACKEND` now governs the mesh **and** the enrichment scouts
+  **and** the Flow-1 ETL (claude → Max quota; default/adk → Gemini). Note embeddings stay Gemini.
+- New ADR-044 recording the GroundedLLM seam + single-knob decision.
+
+## Testing
+
+Offline (CI):
+- `GeminiGroundedLLM.generate` returns text for a mocked `genai.Client` (grounded and plain configs).
+- `ClaudeGroundedLLM.generate` returns the result text for a mocked `query()` async generator; assert
+  `WebSearch` is in `allowed_tools` when `grounded=True` and absent when `grounded=False`.
+- `get_grounded_llm()` returns `ClaudeGroundedLLM` for `AGENT_BACKEND=claude`, `GeminiGroundedLLM`
+  otherwise.
+- `LLMScout` subclasses parse correctly with an **injected fake** `GroundedLLM` returning canned JSON
+  (e.g. StyleScout → `_flatten_style_map` output; LLMTropeScout → tropes list). Existing scout tests
+  migrate from patching `genai.Client` to injecting a fake provider.
+
+Live (`api_dependent`, manual):
+- With `AGENT_BACKEND=claude`, a StyleScout + LLMTropeScout call for a known book returns non-empty,
+  well-formed style/trope JSON (validates Claude `WebSearch` grounding ≈ `google_search` for extraction).
+
+## Success criteria
+
+- `AGENT_BACKEND=claude` runs the scouts on Claude (recommendation + ETL); default stays Gemini, with
+  current behavior byte-for-byte.
+- All four LLM scouts route through the seam; no per-scout duplication; parse/merge/persist unchanged.
+- Embeddings remain Gemini.
+- Offline suite green; one live Claude-scout check confirms usable extraction.
+
+## Risks
+
+- **Extraction quality on Claude `WebSearch`** is unverified vs Gemini `google_search` — the live check
+  gates it; if weak, the prompts may need light tuning (separate follow-up, not this spec).
+- **Async-in-sync:** `ClaudeGroundedLLM.generate` uses `asyncio.run`; safe only when called from a
+  thread without a running loop. Scouts are always invoked synchronously (`ScoutManager.enrich` is sync;
+  the pipeline wraps it in `asyncio.to_thread`). Documented as a constraint; a guard/`anyio` fallback can
+  be added if a running-loop caller ever appears.
+- **Throughput/cost:** a Claude run issues several `WebSearch` calls per book; a full ETL batch makes
+  many. Validate the Agent SDK's own rate limits on a small batch before a full reading-history ingest.
+
+## Issue tracking
+
+Resolves REC-024. Builds on ADR-041 (RecommendationBackend seam) and REC-023 (per-scout isolation).
+New ADR-044 for the GroundedLLM seam.

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -89,4 +89,7 @@ def get_grounded_llm(api_key: str | None = None, model_name: str | None = None) 
     choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
     if choice == "claude":
         return ClaudeGroundedLLM()
+    if choice not in ("adk", ""):
+        # Fail loudly on a typo rather than silently defaulting to Gemini (matches agents.get_backend).
+        raise ValueError(f"Unknown AGENT_BACKEND={choice!r} (expected 'adk' or 'claude').")
     return GeminiGroundedLLM(api_key, model_name)

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -1,0 +1,91 @@
+"""Backend-selectable grounded-LLM provider for the enrichment scouts. The single AGENT_BACKEND knob
+(shared with the recommendation mesh) picks Gemini grounding (default) or Claude WebSearch, so an
+`AGENT_BACKEND=claude` run enriches off the Max subscription instead of the Gemini free-tier daily cap
+(REC-024). Embeddings stay on Gemini (separate, higher quota)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Protocol, runtime_checkable
+
+from agentic_librarian.llm_retry import genai_http_options
+from google import genai
+
+
+@runtime_checkable
+class GroundedLLM(Protocol):
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        """Return the model's text for `prompt`. When `grounded`, perform web-grounded generation."""
+        ...
+
+
+def _extract_text(response) -> str | None:
+    """Return response text, falling back to concatenated candidate parts. Grounded/multi-part
+    responses can leave ``response.text`` empty even though the answer is in the candidate parts."""
+    if getattr(response, "text", None):
+        return response.text
+    try:
+        parts = response.candidates[0].content.parts or []
+    except (AttributeError, IndexError, TypeError):
+        return None
+    texts = [p.text for p in parts if getattr(p, "text", None)]
+    return "".join(texts) if texts else None
+
+
+class GeminiGroundedLLM:
+    """Grounded generation via Gemini's google_search tool — the prior scout behavior, relocated."""
+
+    def __init__(self, api_key: str | None = None, model_name: str | None = None):
+        self.api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        self.model_name = (
+            model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
+        )
+        self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        use_grounding = grounded and os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
+        response = self._client.models.generate_content(
+            model=self.model_name,
+            contents=prompt,
+            config={"tools": [{"google_search": {}}] if use_grounding else []},
+        )
+        return _extract_text(response) or ""
+
+
+class ClaudeGroundedLLM:
+    """Grounded generation via the Claude Agent SDK (WebSearch tool), Max-subscription quota."""
+
+    _SYSTEM = (
+        "You are a book-metadata extraction assistant. Use web search to verify facts; never invent "
+        "details. Return ONLY the raw JSON object the user's instructions specify — no prose, no code fences."
+    )
+
+    def __init__(self, model: str | None = None):
+        self.model = model or os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return asyncio.run(self._agenerate(prompt, grounded))
+
+    async def _agenerate(self, prompt: str, grounded: bool) -> str:
+        from claude_agent_sdk import ClaudeAgentOptions, query
+
+        options = ClaudeAgentOptions(
+            system_prompt=self._SYSTEM,
+            model=self.model,
+            allowed_tools=["WebSearch"] if grounded else [],
+        )
+        text = ""
+        async for message in query(prompt=prompt, options=options):
+            result_val = getattr(message, "result", None)
+            if result_val and isinstance(result_val, str):
+                text = result_val
+        return text
+
+
+def get_grounded_llm(api_key: str | None = None) -> GroundedLLM:
+    """Pick the grounding-LLM provider from AGENT_BACKEND (default/'adk' -> Gemini; 'claude' -> Claude)."""
+    choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
+    if choice == "claude":
+        return ClaudeGroundedLLM()
+    return GeminiGroundedLLM(api_key)

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -65,7 +65,17 @@ class ClaudeGroundedLLM:
         self.model = model or os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
 
     def generate(self, prompt: str, grounded: bool = True) -> str:
-        return asyncio.run(self._agenerate(prompt, grounded))
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop (the normal synchronous scout path) — drive the coroutine directly.
+            return asyncio.run(self._agenerate(prompt, grounded))
+        # Called from within a running event loop (async test runner / framework): asyncio.run can't
+        # run inside one, so offload to a worker thread that gets its own loop.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(self._agenerate(prompt, grounded))).result()
 
     async def _agenerate(self, prompt: str, grounded: bool) -> str:
         from claude_agent_sdk import ClaudeAgentOptions, query

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -83,9 +83,10 @@ class ClaudeGroundedLLM:
         return text
 
 
-def get_grounded_llm(api_key: str | None = None) -> GroundedLLM:
-    """Pick the grounding-LLM provider from AGENT_BACKEND (default/'adk' -> Gemini; 'claude' -> Claude)."""
+def get_grounded_llm(api_key: str | None = None, model_name: str | None = None) -> GroundedLLM:
+    """Pick the grounding-LLM provider from AGENT_BACKEND (default/'adk' -> Gemini; 'claude' -> Claude).
+    `model_name` applies only to the Gemini provider; the Claude provider uses CLAUDE_MODEL."""
     choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
     if choice == "claude":
         return ClaudeGroundedLLM()
-    return GeminiGroundedLLM(api_key)
+    return GeminiGroundedLLM(api_key, model_name)

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -7,9 +7,8 @@ from abc import ABC, abstractmethod
 from contextlib import suppress
 
 import requests
-from agentic_librarian.llm_retry import genai_http_options
+from agentic_librarian.scouts.grounded_llm import GroundedLLM, get_grounded_llm
 from bs4 import BeautifulSoup
-from google import genai
 from googleapiclient.discovery import build
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -94,36 +93,19 @@ class APIScout(BaseScout):
 class LLMScout(BaseScout):
     """Abstract base class for scouts using LLMs for unstructured data."""
 
-    def __init__(self, api_key: str = None, model_name: str = None):
-        # Fallback to GOOGLE_SEARCH_API_KEY if no specific key provided
+    def __init__(self, api_key: str = None, model_name: str = None, llm: GroundedLLM | None = None):
+        # Fallback to GOOGLE_SEARCH_API_KEY if no specific key provided (also used by AudiobookScout's
+        # Custom Search and by the Gemini provider/embeddings).
         key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         if not key:
             raise ValueError(f"{self.__class__.__name__} requires a Google API key.")
         super().__init__(key)
-        # http_options carries the shared transient-error retry so grounded calls ride through
-        # 429/5xx demand spikes instead of crashing the run (REC-020).
-        self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
-        # These scouts use Gemini-native Search grounding ({"google_search": {}}), so they need a
-        # grounding-capable model. Defaults to gemini-2.5-flash (reliable free-tier grounding);
-        # GROUNDING_MODEL/EXPLORER_MODEL override it. (Non-grounding mesh agents use GEMINI_MODEL.)
+        # Backend-selectable grounding LLM (Gemini default; Claude when AGENT_BACKEND=claude). Injectable
+        # for tests. model_name kept for back-compat; the Gemini provider owns the model (GROUNDING_MODEL).
         self.model_name = (
             model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
         )
-
-    def _extract_text(self, response) -> str | None:
-        """Return the response text, falling back to concatenated candidate parts.
-
-        Grounded / multi-part responses can leave ``response.text`` empty even though
-        the answer is present in the candidate parts.
-        """
-        if getattr(response, "text", None):
-            return response.text
-        try:
-            parts = response.candidates[0].content.parts or []
-        except (AttributeError, IndexError, TypeError):
-            return None
-        texts = [p.text for p in parts if getattr(p, "text", None)]
-        return "".join(texts) if texts else None
+        self._llm = llm or get_grounded_llm(self.api_key)
 
     def _safe_extract_json(self, response_text: str, title: str, author: str, retry_count: int = 0) -> dict | None:
         """Cleans and parses LLM JSON output with descriptive error logging."""
@@ -388,11 +370,11 @@ class AudiobookScout(LLMScout):
         CRITICAL: If the information is not present in the text, return an empty object {{}}.
         DO NOT hallucinate or guess.
         """
-        response = self._client.models.generate_content(model=self.model_name, contents=prompt)
-        data = self._safe_extract_json(self._extract_text(response), title, author)
+        text = self._llm.generate(prompt, grounded=False)
+        data = self._safe_extract_json(text, title, author)
         if data is None:
-            response = self._client.models.generate_content(model=self.model_name, contents=prompt + "\nJSON ONLY.")
-            data = self._safe_extract_json(self._extract_text(response), title, author, retry_count=1)
+            text = self._llm.generate(prompt + "\nJSON ONLY.", grounded=False)
+            data = self._safe_extract_json(text, title, author, retry_count=1)
 
         # Normalize keys
         if data and "narrators" in data:
@@ -426,23 +408,12 @@ class DirectKnowledgeScout(LLMScout):
         DO NOT guess or provide info from your internal memory if it is not verified by search.
         """
 
-        use_grounding = os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
-
-        response = self._client.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-            config={"tools": [{"google_search": {}}] if use_grounding else []},
-        )
-
-        data = self._safe_extract_json(self._extract_text(response), title, author)
+        text = self._llm.generate(prompt, grounded=True)
+        data = self._safe_extract_json(text, title, author)
         if data is None:
             prompt += "\n\nSTRICT: Return valid JSON ONLY."
-            response = self._client.models.generate_content(
-                model=self.model_name,
-                contents=prompt,
-                config={"tools": [{"google_search": {}}] if use_grounding else []},
-            )
-            data = self._safe_extract_json(self._extract_text(response), title, author, retry_count=1)
+            text = self._llm.generate(prompt, grounded=True)
+            data = self._safe_extract_json(text, title, author, retry_count=1)
 
         if data and "narrators" in data:
             data["narrator_names"] = data.pop("narrators")
@@ -515,13 +486,8 @@ class StyleScout(LLMScout):
         Return ONLY a raw JSON object with these keys.
         If an attribute is identical to the author's general baseline, omit it from the JSON.
         """
-        use_grounding = os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
-        response = self._client.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-            config={"tools": [{"google_search": {}}] if use_grounding else []},
-        )
-        return _flatten_style_map(self._safe_extract_json(self._extract_text(response), "Work Style", title))
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Work Style", title))
 
     def scout_author_style(self, name: str) -> dict:
         """Extracts style attributes for an author."""
@@ -541,13 +507,8 @@ class StyleScout(LLMScout):
         Return ONLY a raw JSON object with these nine keys.
         If unknown, return empty strings for those keys.
         """
-        use_grounding = os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
-        response = self._client.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-            config={"tools": [{"google_search": {}}] if use_grounding else []},
-        )
-        return _flatten_style_map(self._safe_extract_json(self._extract_text(response), "Author Style", name))
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Author Style", name))
 
     def scout_narrator_style(self, name: str) -> dict:
         """Extracts performance attributes for an audiobook narrator."""
@@ -566,13 +527,8 @@ class StyleScout(LLMScout):
         Return ONLY a raw JSON object with these keys. Use short descriptive phrases (3-5 words max).
         If unknown, return empty strings for those keys.
         """
-        use_grounding = os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
-        response = self._client.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-            config={"tools": [{"google_search": {}}] if use_grounding else []},
-        )
-        return _flatten_style_map(self._safe_extract_json(self._extract_text(response), "Narrator Style", name))
+        text = self._llm.generate(prompt, grounded=True)
+        return _flatten_style_map(self._safe_extract_json(text, "Narrator Style", name))
 
 
 class LLMTropeScout(LLMScout):
@@ -594,13 +550,8 @@ class LLMTropeScout(LLMScout):
         CRITICAL: Focus on narrative devices and archetypes. Avoid broad genres (Fantasy, Sci-Fi) or simple moods.
         Return ONLY a raw JSON object with a 'tropes' key containing a list of these trope objects.
         """
-        use_grounding = os.environ.get("USE_SEARCH_GROUNDING", "1") == "1"
-        response = self._client.models.generate_content(
-            model=self.model_name,
-            contents=prompt,
-            config={"tools": [{"google_search": {}}] if use_grounding else []},
-        )
-        return self._safe_extract_json(self._extract_text(response), "Tropes", title) or {"tropes": []}
+        text = self._llm.generate(prompt, grounded=True)
+        return self._safe_extract_json(text, "Tropes", title) or {"tropes": []}
 
 
 # --- THE MANAGER ---

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -330,7 +330,7 @@ class AudiobookScout(LLMScout):
     """Scouts audiobook metadata from Audible using LLM extraction."""
 
     def search(self, title: str, author: str, **kwargs) -> dict:
-        return self.extract_metadata_with_gemini(title, author)
+        return self._extract_metadata_from_page(title, author)
 
     def search_audible_link(self, title: str) -> str | None:
         search_engine_id = os.environ.get("SEARCH_ENGINE_ID")
@@ -358,7 +358,7 @@ class AudiobookScout(LLMScout):
             script.extract()
         return soup.get_text()
 
-    def extract_metadata_with_gemini(self, title: str, author: str = "Unknown") -> dict:
+    def _extract_metadata_from_page(self, title: str, author: str = "Unknown") -> dict:
         text_content = self.fetch_page_content(title)
         prompt = f"""
         Extract the following fields from the text. Return ONLY a raw JSON object.

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -101,11 +101,11 @@ class LLMScout(BaseScout):
             raise ValueError(f"{self.__class__.__name__} requires a Google API key.")
         super().__init__(key)
         # Backend-selectable grounding LLM (Gemini default; Claude when AGENT_BACKEND=claude). Injectable
-        # for tests. model_name kept for back-compat; the Gemini provider owns the model (GROUNDING_MODEL).
+        # for tests. model_name is threaded into the Gemini provider (so it isn't silently ignored).
         self.model_name = (
             model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
         )
-        self._llm = llm or get_grounded_llm(self.api_key)
+        self._llm = llm or get_grounded_llm(self.api_key, model_name=self.model_name)
 
     def _safe_extract_json(self, response_text: str, title: str, author: str, retry_count: int = 0) -> dict | None:
         """Cleans and parses LLM JSON output with descriptive error logging."""

--- a/test/unit/test_grounded_llm.py
+++ b/test/unit/test_grounded_llm.py
@@ -79,6 +79,13 @@ def test_factory_selects_backend(monkeypatch):
     assert isinstance(gl.get_grounded_llm("k"), gl.ClaudeGroundedLLM)
 
 
+def test_factory_threads_model_name_to_gemini(monkeypatch):
+    monkeypatch.setattr(gl.genai, "Client", lambda *a, **k: MagicMock())
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    llm = gl.get_grounded_llm("k", model_name="gemini-custom")
+    assert llm.model_name == "gemini-custom"  # not silently ignored
+
+
 def test_claude_generate_collects_result_and_sets_tools(monkeypatch):
     captured = {}
 

--- a/test/unit/test_grounded_llm.py
+++ b/test/unit/test_grounded_llm.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+
+import agentic_librarian.scouts.grounded_llm as gl
+
+
+def test_extract_text_prefers_text_then_parts():
+    direct = MagicMock()
+    direct.text = "hello"
+    assert gl._extract_text(direct) == "hello"
+
+    grounded = MagicMock()
+    grounded.text = None
+    part = MagicMock()
+    part.text = '{"x": 1}'
+    grounded.candidates = [MagicMock(content=MagicMock(parts=[part]))]
+    assert gl._extract_text(grounded) == '{"x": 1}'
+
+    empty = MagicMock()
+    empty.text = None
+    empty.candidates = []
+    assert gl._extract_text(empty) is None
+
+
+def test_gemini_generate_grounded_and_plain(monkeypatch):
+    captured = {}
+
+    class FakeModels:
+        def generate_content(self, model, contents, config):
+            captured["model"] = model
+            captured["config"] = config
+            resp = MagicMock()
+            resp.text = "RESULT"
+            return resp
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(gl.genai, "Client", FakeClient)
+    monkeypatch.setenv("USE_SEARCH_GROUNDING", "1")
+    monkeypatch.setenv("GROUNDING_MODEL", "gemini-test")
+
+    llm = gl.GeminiGroundedLLM(api_key="k")
+    assert llm.generate("p", grounded=True) == "RESULT"
+    assert captured["config"]["tools"] == [{"google_search": {}}]
+    assert captured["model"] == "gemini-test"
+
+    llm.generate("p", grounded=False)
+    assert captured["config"]["tools"] == []
+
+
+def test_gemini_respects_use_search_grounding_flag(monkeypatch):
+    captured = {}
+
+    class FakeModels:
+        def generate_content(self, model, contents, config):
+            captured["config"] = config
+            resp = MagicMock()
+            resp.text = "x"
+            return resp
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.models = FakeModels()
+
+    monkeypatch.setattr(gl.genai, "Client", FakeClient)
+    monkeypatch.setenv("USE_SEARCH_GROUNDING", "0")
+    gl.GeminiGroundedLLM(api_key="k").generate("p", grounded=True)
+    assert captured["config"]["tools"] == []
+
+
+def test_factory_selects_backend(monkeypatch):
+    monkeypatch.setattr(gl.genai, "Client", lambda *a, **k: MagicMock())
+    monkeypatch.setenv("AGENT_BACKEND", "adk")
+    assert isinstance(gl.get_grounded_llm("k"), gl.GeminiGroundedLLM)
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    assert isinstance(gl.get_grounded_llm("k"), gl.GeminiGroundedLLM)
+    monkeypatch.setenv("AGENT_BACKEND", "claude")
+    assert isinstance(gl.get_grounded_llm("k"), gl.ClaudeGroundedLLM)
+
+
+def test_claude_generate_collects_result_and_sets_tools(monkeypatch):
+    captured = {}
+
+    class FakeMsg:
+        def __init__(self, result):
+            self.result = result
+
+    async def fake_query(prompt, options):
+        captured["allowed_tools"] = options.allowed_tools
+        captured["model"] = options.model
+        yield FakeMsg(None)
+        yield FakeMsg("CLAUDE_JSON")
+
+    fake_sdk = MagicMock()
+    fake_sdk.query = fake_query
+    fake_sdk.ClaudeAgentOptions = lambda **kw: MagicMock(**kw)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-test")
+
+    llm = gl.ClaudeGroundedLLM()
+    assert llm.generate("p", grounded=True) == "CLAUDE_JSON"
+    assert captured["allowed_tools"] == ["WebSearch"]
+    assert captured["model"] == "claude-test"
+    assert llm.generate("p", grounded=False) == "CLAUDE_JSON"
+    assert captured["allowed_tools"] == []

--- a/test/unit/test_grounded_llm.py
+++ b/test/unit/test_grounded_llm.py
@@ -86,6 +86,14 @@ def test_factory_threads_model_name_to_gemini(monkeypatch):
     assert llm.model_name == "gemini-custom"  # not silently ignored
 
 
+def test_factory_raises_on_unknown_backend(monkeypatch):
+    import pytest
+
+    monkeypatch.setenv("AGENT_BACKEND", "gemni")  # typo
+    with pytest.raises(ValueError, match="Unknown AGENT_BACKEND"):
+        gl.get_grounded_llm("k")
+
+
 def test_claude_generate_collects_result_and_sets_tools(monkeypatch):
     captured = {}
 

--- a/test/unit/test_grounded_llm.py
+++ b/test/unit/test_grounded_llm.py
@@ -119,3 +119,25 @@ def test_claude_generate_collects_result_and_sets_tools(monkeypatch):
     assert captured["model"] == "claude-test"
     assert llm.generate("p", grounded=False) == "CLAUDE_JSON"
     assert captured["allowed_tools"] == []
+
+
+def test_claude_generate_works_inside_running_loop(monkeypatch):
+    import asyncio
+
+    class FakeMsg:
+        def __init__(self, result):
+            self.result = result
+
+    async def fake_query(prompt, options):
+        yield FakeMsg("CLAUDE_JSON")
+
+    fake_sdk = MagicMock()
+    fake_sdk.query = fake_query
+    fake_sdk.ClaudeAgentOptions = lambda **kw: MagicMock(**kw)
+    monkeypatch.setitem(__import__("sys").modules, "claude_agent_sdk", fake_sdk)
+
+    async def driver():
+        # generate() is sync but invoked from within a running loop — must offload, not raise.
+        return gl.ClaudeGroundedLLM().generate("p", grounded=True)
+
+    assert asyncio.run(driver()) == "CLAUDE_JSON"

--- a/test/unit/test_metadata_scout.py
+++ b/test/unit/test_metadata_scout.py
@@ -144,19 +144,20 @@ def test_safe_extract_json_handles_fences_prose_and_none():
 
 
 def test_extract_text_falls_back_to_candidate_parts():
-    """When response.text is empty (grounded responses), text comes from the parts."""
-    scout = md_scout.LLMTropeScout(api_key="fake-key")
+    """When response.text is empty (grounded responses), text comes from the candidate parts."""
+
+    from agentic_librarian.scouts.grounded_llm import _extract_text
 
     direct = MagicMock()
     direct.text = "hello"
-    assert scout._extract_text(direct) == "hello"
+    assert _extract_text(direct) == "hello"
 
     grounded = MagicMock()
     grounded.text = None
     part = MagicMock()
     part.text = '{"x": 1}'
     grounded.candidates = [MagicMock(content=MagicMock(parts=[part]))]
-    assert scout._extract_text(grounded) == '{"x": 1}'
+    assert _extract_text(grounded) == '{"x": 1}'
 
 
 @pytest.mark.api_dependent

--- a/test/unit/test_metadata_scout.py
+++ b/test/unit/test_metadata_scout.py
@@ -360,3 +360,15 @@ def test_flatten_style_map_hoists_nested_and_drops_nonstrings():
         "tone": "darker",
     }
     assert _flatten_style_map("not a dict") == {}
+
+
+@pytest.mark.api_dependent
+def test_claude_grounded_scouts_produce_styles_and_tropes(monkeypatch):
+    """Live (needs an authenticated claude CLI): AGENT_BACKEND=claude yields usable style/trope JSON."""
+    monkeypatch.setenv("AGENT_BACKEND", "claude")
+    from agentic_librarian.scouts.metadata_scout import LLMTropeScout, StyleScout
+
+    tropes = LLMTropeScout(api_key="x").search("The Way of Kings", "Brandon Sanderson")
+    assert tropes.get("tropes"), "expected non-empty tropes from the Claude LLMTropeScout"
+    style = StyleScout(api_key="x").scout_author_style("Brandon Sanderson")
+    assert style, "expected non-empty author style from the Claude StyleScout"

--- a/test/unit/test_style_scout.py
+++ b/test/unit/test_style_scout.py
@@ -1,85 +1,62 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import pytest
 from agentic_librarian.scouts.metadata_scout import StyleScout
 
 
-@pytest.fixture
-def mock_genai_client():
-    with patch("agentic_librarian.scouts.metadata_scout.genai.Client") as mock:
-        client_inst = mock.return_value
-        yield client_inst
+class _FakeLLM:
+    """A GroundedLLM stub returning a fixed JSON string for every call."""
+
+    def __init__(self, text: str):
+        self._text = text
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return self._text
 
 
-def test_scout_author_style(mock_genai_client):
-    scout = StyleScout(api_key="fake-key")
-
-    # Mock LLM response
-    mock_response = MagicMock()
-    mock_response.text = '{"pacing": "fast", "tone": "cynical", "style": "minimalist"}'
-    mock_genai_client.models.generate_content.return_value = mock_response
-
+def test_scout_author_style():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM('{"pacing": "fast", "tone": "cynical", "style": "minimalist"}'))
     style = scout.scout_author_style("Ernest Hemingway")
-
     assert style["pacing"] == "fast"
     assert style["tone"] == "cynical"
     assert style["style"] == "minimalist"
 
 
-def test_scout_narrator_style(mock_genai_client):
-    scout = StyleScout(api_key="fake-key")
-
-    # Mock LLM response
-    mock_response = MagicMock()
-    mock_response.text = '{"pacing": "steady", "voice_differentiation": "excellent", "emotional_range": "wide"}'
-    mock_genai_client.models.generate_content.return_value = mock_response
-
+def test_scout_narrator_style():
+    scout = StyleScout(
+        api_key="fake-key",
+        llm=_FakeLLM('{"pacing": "steady", "voice_differentiation": "excellent", "emotional_range": "wide"}'),
+    )
     style = scout.scout_narrator_style("Jefferson Mays")
-
     assert style["pacing"] == "steady"
     assert style["voice_differentiation"] == "excellent"
     assert style["emotional_range"] == "wide"
 
 
-def test_style_scout_search_mode(mock_genai_client):
-    scout = StyleScout(api_key="fake-key")
-
-    # Mock both calls
-    mock_response = MagicMock()
-    mock_response.text = '{"pacing": "fast"}'
-    mock_genai_client.models.generate_content.return_value = mock_response
-
+def test_style_scout_search_mode():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM('{"pacing": "fast"}'))
     res = scout.search("The Expanse", "James S.A. Corey", narrators=["Jefferson Mays"])
-
     assert "author_style" in res
     assert "narrator_styles" in res
     assert "Jefferson Mays" in res["narrator_styles"]
     assert res["author_style"]["pacing"] == "fast"
 
 
-def test_work_style_baseline_falls_back_to_scouted_author_style(mock_genai_client):
-    """New author: no DB baseline is supplied, so work-style scouting should use the
-    freshly scouted author style as the baseline (Informed Scouting, ADR-023)."""
-    scout = StyleScout(api_key="fake-key")
-
+def test_work_style_baseline_falls_back_to_scouted_author_style():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM("{}"))
     with (
         patch.object(scout, "scout_author_style", return_value={"pacing": "fast"}),
         patch.object(scout, "scout_work_style", return_value={}) as m_work,
         patch.object(scout, "scout_narrator_style", return_value={}),
     ):
-        scout.search("Book", "Author")  # no author_styles kwarg
-
+        scout.search("Book", "Author")
     assert m_work.call_args.kwargs["author_baseline"] == {"pacing": "fast"}
 
 
-def test_work_style_baseline_prefers_db_baseline_when_provided(mock_genai_client):
-    """Existing author: the DB baseline passed via author_styles wins over a fresh scout."""
-    scout = StyleScout(api_key="fake-key")
-
+def test_work_style_baseline_prefers_db_baseline_when_provided():
+    scout = StyleScout(api_key="fake-key", llm=_FakeLLM("{}"))
     with (
         patch.object(scout, "scout_author_style", return_value={"pacing": "fast"}),
         patch.object(scout, "scout_work_style", return_value={}) as m_work,
     ):
         scout.search("Book", "Author", author_styles={"tone": "dark"})
-
     assert m_work.call_args.kwargs["author_baseline"] == {"tone": "dark"}

--- a/test/unit/test_trope_scout.py
+++ b/test/unit/test_trope_scout.py
@@ -1,22 +1,16 @@
-from unittest.mock import MagicMock, patch
-
-import pytest
 from agentic_librarian.scouts.metadata_scout import LLMTropeScout
 
 
-@pytest.fixture
-def mock_genai_client():
-    with patch("agentic_librarian.scouts.metadata_scout.genai.Client") as mock:
-        client_inst = mock.return_value
-        yield client_inst
+class _FakeLLM:
+    def __init__(self, text: str):
+        self._text = text
+
+    def generate(self, prompt: str, grounded: bool = True) -> str:
+        return self._text
 
 
-def test_llm_trope_scout(mock_genai_client):
-    scout = LLMTropeScout(api_key="fake-key")
-
-    # Mock LLM response
-    mock_response = MagicMock()
-    mock_response.text = """
+def test_llm_trope_scout():
+    payload = """
     {
         "tropes": [
             {
@@ -28,10 +22,8 @@ def test_llm_trope_scout(mock_genai_client):
         ]
     }
     """
-    mock_genai_client.models.generate_content.return_value = mock_response
-
+    scout = LLMTropeScout(api_key="fake-key", llm=_FakeLLM(payload))
     res = scout.search("Leviathan Wakes", "James S.A. Corey")
-
     assert "tropes" in res
     assert len(res["tropes"]) == 1
     assert res["tropes"][0]["trope_name"] == "Found Family"


### PR DESCRIPTION
## Summary
Makes the enrichment LLM scouts backend-selectable under the **same `AGENT_BACKEND` knob** as the recommendation mesh, so `AGENT_BACKEND=claude` runs them — the recommendation pipeline **and** the Flow-1 Dagster ETL — on the Claude Max subscription instead of the Gemini free-tier `generate_content` daily cap (20/day). Closes the gap from PR #23/ADR-041, where only the mesh was backend-selectable. **Embeddings stay on Gemini** (`gemini-embedding-001`, separate higher quota — never the bottleneck).

Motivation: a full reading-history ETL on the Gemini free tier is a ~weeks-long crawl; on Claude (already-paid-for quota) it's hours.

## How — a `GroundedLLM` provider seam
- **New `scouts/grounded_llm.py`:** `GroundedLLM` Protocol (`generate(prompt, grounded=)`), `GeminiGroundedLLM` (`google_search`, carries the REC-020 retry `http_options`), `ClaudeGroundedLLM` (Agent SDK `WebSearch`, run synchronously via `asyncio.run`, lazy-imports the SDK), and a `get_grounded_llm()` factory reading `AGENT_BACKEND` (default/`adk` → Gemini, `claude` → Claude; **raises** on an unknown value, matching `agents.get_backend`).
- **`scouts/metadata_scout.py`:** `LLMScout` injects a `GroundedLLM` (injectable for tests); all four scouts (StyleScout ×3 methods, LLMTropeScout, DirectKnowledgeScout, AudiobookScout) call `self._llm.generate(prompt, grounded=…)`. The genai client + `_extract_text` + now-unused imports were removed; `_extract_text` moved into the seam. Prompts, JSON parsing, merge, and persistence are unchanged.
- **ETL:** no orchestration change — `create_scout_manager()` builds fresh scouts that resolve the backend at construction.

## Default-path safety
`AGENT_BACKEND` unset ⇒ **byte-for-byte the prior Gemini path**: same model resolution (`GROUNDING_MODEL`→`EXPLORER_MODEL`→`gemini-2.5-flash`), same `USE_SEARCH_GROUNDING` gating, same retry `http_options`. The whole-implementation review verified this explicitly.

## Test plan
- [x] Offline suite green: **177 passed, 23 deselected**.
- [x] New `test_grounded_llm.py`: both providers, factory selection + unknown-backend error + `model_name` threading, Claude async/tool gating, `_extract_text` fallback.
- [x] Scout tests migrated from patching `genai.Client` to injecting a fake `GroundedLLM`.
- [ ] **Live (deferred, `api_dependent`):** `AGENT_BACKEND=claude` Style/Trope scout for a known book returns usable JSON (validates Claude `WebSearch` ≈ `google_search` for extraction) — gates trusting Claude extraction quality; if weak, light prompt tuning is a follow-up.

## Docs
ADR-044; `.env.example` documents `AGENT_BACKEND`'s expanded reach; REC-024 resolved. Spec + plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)