### PR TITLE
Fix: ETL persist crash on NaN narrator_names (blocks DB build)

### DIFF
--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -36,6 +36,17 @@ def _iter_style_items(style_data: dict | None, owner_label: str):
             print(f"Warning: skipping non-string style '{attr_type}'={type(style_name).__name__} for {owner_label}")
 
 
+def _nan_to_none(value):
+    """Coerce a pandas NaN/NaT scalar to None so it inserts as SQL NULL. Enrichment/CSV columns
+    arrive via pandas, which fills missing scalars with NaN (a float); inserting that into a typed
+    column (date/int) raises DatatypeMismatch. Real values — including strings — pass through, and a
+    non-scalar (list/dict) is returned unchanged rather than raising on pd.isna."""
+    try:
+        return None if pd.isna(value) else value
+    except (TypeError, ValueError):
+        return value
+
+
 def persist_enriched_work(
     session: Session, row: dict, trope_manager: TropeManager, style_manager: StyleManager
 ) -> Work | None:
@@ -161,14 +172,22 @@ def persist_enriched_work(
 
         narrator_objs.append(narrator)
 
+    # Coerce pandas NaN -> None so typed columns (date/int) receive SQL NULL, not a float NaN.
+    # Without this a missing publication_date/page_count/audio_minutes raises DatatypeMismatch on
+    # INSERT, and in the update branch `nan or edition.x` would keep the NaN (NaN is truthy).
+    isbn_13 = _nan_to_none(row.get("isbn_13"))
+    page_count = _nan_to_none(row.get("page_count"))
+    audio_minutes = _nan_to_none(row.get("audio_minutes"))
+    publication_date = _nan_to_none(row.get("publication_date"))
+
     if not edition:
         edition = Edition(
             work=work,
-            isbn_13=row.get("isbn_13"),
+            isbn_13=isbn_13,
             format=row.get("format"),
-            page_count=row.get("page_count"),
-            audio_minutes=row.get("audio_minutes"),
-            publication_date=row.get("publication_date"),
+            page_count=page_count,
+            audio_minutes=audio_minutes,
+            publication_date=publication_date,
             narrators=narrator_objs,
         )
         session.add(edition)
@@ -176,9 +195,9 @@ def persist_enriched_work(
     else:
         if not row.get("skip_enrichment"):
             # Update existing edition if new metadata found
-            edition.isbn_13 = row.get("isbn_13") or edition.isbn_13
-            edition.page_count = row.get("page_count") or edition.page_count
-            edition.audio_minutes = row.get("audio_minutes") or edition.audio_minutes
+            edition.isbn_13 = isbn_13 or edition.isbn_13
+            edition.page_count = page_count or edition.page_count
+            edition.audio_minutes = audio_minutes or edition.audio_minutes
 
         # Update narrators if needed
         if narrator_objs:

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -128,10 +128,16 @@ def persist_enriched_work(
     # 3. Edition & Narrators
     edition = session.query(Edition).filter_by(work_id=work.id, format=row["format"]).first()
 
-    # Resolve Narrators
+    # Resolve Narrators. A row may carry narrator_names/styles as NaN (float) — pandas fills the
+    # column with NaN for rows that lack it (e.g. skip_enrichment rows mixed with audiobook rows in
+    # the same partition DataFrame). Coerce non-list/dict to empty so persist never crashes on it.
     narrator_objs = []
-    narrator_names = row.get("narrator_names", [])
-    narrator_styles = row.get("narrator_styles", {})
+    narrator_names = row.get("narrator_names")
+    if not isinstance(narrator_names, list):
+        narrator_names = []
+    narrator_styles = row.get("narrator_styles")
+    if not isinstance(narrator_styles, dict):
+        narrator_styles = {}
 
     for n_name in narrator_names:
         narrator = session.query(Narrator).filter(Narrator.name == n_name).first()

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -47,6 +47,12 @@ def _nan_to_none(value):
         return value
 
 
+def _nan_to_list(value):
+    """Return value if it is a list, else [] — so an enrichment column that pandas filled with NaN
+    (a float) or None doesn't crash downstream iteration/set() with 'float object is not iterable'."""
+    return value if isinstance(value, list) else []
+
+
 def persist_enriched_work(
     session: Session, row: dict, trope_manager: TropeManager, style_manager: StyleManager
 ) -> Work | None:
@@ -94,6 +100,22 @@ def persist_enriched_work(
 
         work_contributors_list.append(WorkContributor(author=author, role=role))
 
+    # Coerce every enrichment/CSV field that pandas may deliver as NaN before it reaches the ORM.
+    # Scalars -> None (SQL NULL); list-typed fields -> [] so downstream iteration/set() can't crash
+    # on a float NaN. This single pass is the guard against both 'float object is not iterable' and
+    # DatatypeMismatch (NaN into an Integer/Date column) across the whole persist path.
+    original_publication_year = _nan_to_none(row.get("original_publication_year"))
+    description = _nan_to_none(row.get("description"))
+    genres = _nan_to_list(row.get("genres"))
+    moods = _nan_to_list(row.get("moods"))
+    enriched_tropes = _nan_to_list(row.get("enriched_tropes"))
+    user_rating = _nan_to_none(row.get("user_rating"))
+    user_notes = _nan_to_none(row.get("user_notes"))
+    isbn_13 = _nan_to_none(row.get("isbn_13"))
+    page_count = _nan_to_none(row.get("page_count"))
+    audio_minutes = _nan_to_none(row.get("audio_minutes"))
+    publication_date = _nan_to_none(row.get("publication_date"))
+
     # 2. Work. no_autoflush: the not-yet-added WorkContributor objects above must not be
     # cascaded by this query's autoflush (raises a SAWarning and could flush incomplete rows).
     with session.no_autoflush:
@@ -109,19 +131,19 @@ def persist_enriched_work(
         work = Work(
             title=row["Title"],
             contributors=work_contributors_list,
-            original_publication_year=row.get("original_publication_year"),
-            description=row.get("description"),
-            genres=row.get("genres"),
-            moods=row.get("moods"),
+            original_publication_year=original_publication_year,
+            description=description,
+            genres=genres,
+            moods=moods,
         )
         session.add(work)
         session.flush()
     elif not row.get("skip_enrichment"):
         # Update existing work if new metadata found
-        work.original_publication_year = row.get("original_publication_year") or work.original_publication_year
-        work.description = row.get("description") or work.description
-        work.genres = row.get("genres") or work.genres
-        work.moods = row.get("moods") or work.moods
+        work.original_publication_year = original_publication_year or work.original_publication_year
+        work.description = description or work.description
+        work.genres = genres or work.genres
+        work.moods = moods or work.moods
 
     # 2.5 Work Styles
     work_style_data = row.get("work_style", {})
@@ -172,14 +194,6 @@ def persist_enriched_work(
 
         narrator_objs.append(narrator)
 
-    # Coerce pandas NaN -> None so typed columns (date/int) receive SQL NULL, not a float NaN.
-    # Without this a missing publication_date/page_count/audio_minutes raises DatatypeMismatch on
-    # INSERT, and in the update branch `nan or edition.x` would keep the NaN (NaN is truthy).
-    isbn_13 = _nan_to_none(row.get("isbn_13"))
-    page_count = _nan_to_none(row.get("page_count"))
-    audio_minutes = _nan_to_none(row.get("audio_minutes"))
-    publication_date = _nan_to_none(row.get("publication_date"))
-
     if not edition:
         edition = Edition(
             work=work,
@@ -218,20 +232,16 @@ def persist_enriched_work(
             history_entry = ReadingHistory(
                 edition=edition,
                 date_completed=date_completed,
-                user_rating=row.get("user_rating"),
-                user_notes=row.get("user_notes"),
+                user_rating=user_rating,
+                user_notes=user_notes,
             )
             session.add(history_entry)
 
-    # 5. Tropes (Only if enriched)
+    # 5. Tropes (Only if enriched). enriched_tropes/genres/moods were NaN-coerced to lists above,
+    # so the truthy check and set() iteration below are safe even when pandas filled them with NaN.
     if not row.get("skip_enrichment"):
-        # Handle Enriched Tropes (LLMTropeScout)
-        enriched_tropes = row.get("enriched_tropes", [])
-
         # Handle Fallback Tags (Moods/Genres)
-        raw_genres = row.get("genres", [])
-        raw_moods = row.get("moods", [])
-        all_fallback_tags = set(raw_genres) | set(raw_moods)
+        all_fallback_tags = set(genres) | set(moods)
 
         if enriched_tropes:
             for t_data in enriched_tropes:

--- a/test/integration/test_persist_enriched.py
+++ b/test/integration/test_persist_enriched.py
@@ -62,3 +62,37 @@ def test_persist_tolerates_nan_narrator_fields(db_url, monkeypatch):
         work = persist_enriched_work(session, row, tm, sm)
         session.flush()
         assert work is not None and work.title == "NaN Narrator Book"
+
+
+@pytest.mark.db_integration
+def test_persist_tolerates_nan_enrichment_fields(db_url, monkeypatch):
+    # Regression (PR #27 review, gemini-code-assist): with skip_enrichment=False, the enrichment
+    # columns enriched_tropes/genres/moods arriving as pandas NaN (float) must not crash with
+    # 'float object is not iterable', and the scalar columns original_publication_year/user_rating/
+    # publication_date/page_count as NaN must not raise DatatypeMismatch on the typed columns.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    dbm = DatabaseManager(db_url)
+    with dbm.get_session() as session:
+        tm = TropeManager(session=session)
+        sm = StyleManager(session=session)
+        row = {
+            "Title": "NaN Enrichment Book",
+            "Author_1": "Nan Enrich Author",
+            "format": "ebook",
+            "skip_enrichment": False,
+            "date_completed": None,
+            "contributors": [{"name": "Nan Enrich Author", "role": "Author"}],
+            "enriched_tropes": float("nan"),
+            "genres": float("nan"),
+            "moods": float("nan"),
+            "original_publication_year": float("nan"),
+            "user_rating": float("nan"),
+            "publication_date": float("nan"),
+            "page_count": float("nan"),
+        }
+        work = persist_enriched_work(session, row, tm, sm)
+        session.flush()
+        assert work is not None and work.title == "NaN Enrichment Book"
+        # Scalars coerced to NULL, not NaN.
+        assert work.original_publication_year is None
+        assert work.genres == []

--- a/test/integration/test_persist_enriched.py
+++ b/test/integration/test_persist_enriched.py
@@ -37,3 +37,28 @@ def test_persist_tolerates_dict_style_value(db_url, monkeypatch):
         attr_types = {ws.attribute_type for ws in session.query(WorkStyle).filter_by(work_id=work.id).all()}
         assert "perspective" in attr_types
         assert "differences" not in attr_types
+
+
+@pytest.mark.db_integration
+def test_persist_tolerates_nan_narrator_fields(db_url, monkeypatch):
+    # Regression: pandas fills narrator_names/narrator_styles with NaN (float) for rows that lack them
+    # (e.g. a skip_enrichment row mixed with audiobook rows in the same partition DataFrame). Persist
+    # must coerce non-list/dict to empty rather than crash on `for n_name in narrator_names`.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    dbm = DatabaseManager(db_url)
+    with dbm.get_session() as session:
+        tm = TropeManager(session=session)
+        sm = StyleManager(session=session)
+        row = {
+            "Title": "NaN Narrator Book",
+            "Author_1": "Nan Author",
+            "format": "hardcover",
+            "skip_enrichment": True,
+            "date_completed": None,
+            "contributors": [{"name": "Nan Author", "role": "Author"}],
+            "narrator_names": float("nan"),
+            "narrator_styles": float("nan"),
+        }
+        work = persist_enriched_work(session, row, tm, sm)
+        session.flush()
+        assert work is not None and work.title == "NaN Narrator Book"


### PR DESCRIPTION
## Summary
Fixes a crash in `persist_enriched_work` that **rolled back an entire ETL chunk** during the first real database build.

**Root cause:** when a partition's enriched DataFrame mixes `skip_enrichment` rows (existing editions, which carry no enrichment columns) with audiobook rows (which carry `narrator_names`/`narrator_styles`), pandas fills the missing cells with **`NaN` (a float)**. `persist.py` then did `for n_name in narrator_names:` → `TypeError: 'float' object is not iterable`, which propagated out of the `vectorized_tropes` asset and rolled back the whole chunk's persist (losing all of that chunk's enrichment work).

It didn't surface in the smoke test because those 3 rows were all freshly-enriched (uniform columns, no NaN); it bit the first 60-book chunk because its leading rows were already-seen books marked `skip_enrichment`.

**Fix:** coerce `narrator_names`/`narrator_styles` to empty when they aren't a `list`/`dict` (same defensive shape as the REC-021 style-value guard).

## Test plan
- [x] New db_integration regression `test_persist_tolerates_nan_narrator_fields` — a `skip_enrichment` row with `narrator_names=NaN` / `narrator_styles=NaN` now persists without crashing (it crashed before the fix).
- [x] Existing `test_persist_tolerates_dict_style_value` still passes.

Unblocks the chunked Claude-backed reading-history ETL build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)