### PR TITLE
fix: set embedding task_type=SEMANTIC_SIMILARITY for retrieval quality

### DIFF
--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -10,11 +10,17 @@ EMBEDDING_DIMENSIONS = 1536
 
 @lru_cache(maxsize=128)
 def get_cached_embedding(client: genai.Client, model_name: str, text: str) -> list[float]:
-    """Shared helper to safely cache embeddings without leaking 'self'."""
+    """Shared helper to safely cache embeddings without leaking 'self'. task_type
+    SEMANTIC_SIMILARITY keeps stored vectors and query vectors in one representation space:
+    this is the single embed chokepoint for both ETL ingestion and the recommendation flow,
+    so both sides match. Changing task_type invalidates previously-stored vectors."""
     response = client.models.embed_content(
         model=model_name,
         contents=text,
-        config=types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIMENSIONS),
+        config=types.EmbedContentConfig(
+            task_type="SEMANTIC_SIMILARITY",
+            output_dimensionality=EMBEDDING_DIMENSIONS,
+        ),
     )
     if not response or not response.embeddings:
         raise ValueError(f"Embedding generation returned no result for text: {text!r}")


### PR DESCRIPTION
## Summary
Sets `task_type="SEMANTIC_SIMILARITY"` on the embedding call in `get_cached_embedding`.

This function is the **single embed chokepoint** for both:
- Flow-1 ETL ingestion (stored trope/style/work vectors), and
- the recommendation flow (query vectors for pgvector similarity search).

Setting `task_type` on this one function keeps stored and query vectors in the **same representation space** — the condition required for the flag to actually improve similarity search. We were previously passing no `task_type`, leaving retrieval quality on the table.

## Why now
Surfaced while building the production reading-history DB: the embedding step was being reworked for quota reasons anyway, and `gemini-embedding-001` already supports the flag, so it's a one-line, no-cost quality win to adopt before the catalog is populated.

## Important: vector invalidation
Changing `task_type` changes the vector representation, so any **previously-stored vectors become invalid** (you can't mix them in a similarity search). This is safe here because the catalog is being **rebuilt fresh** (the only prior rows were 13 disposable test works) — every vector in the new DB is generated with this flag, so all are consistent.

## Verification
- Live call against the API accepted the config and returned a 1536-dim vector (`task_type` field valid for the installed `google-genai`).
- `ruff check` + `ruff format --check` clean.

## Test Plan
- [ ] CI lint passes
- [ ] (covered by the in-progress full-DB rebuild, which generates all vectors with this flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)