### PR TITLE
fix: env-gated embedding throttle to prevent ETL embedding 429 (RPM)

### DIFF
--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -1,3 +1,6 @@
+import os
+import threading
+import time
 from functools import lru_cache
 
 from google import genai
@@ -7,13 +10,34 @@ from google.genai import types
 # defaults to 3072, so we must request 1536 explicitly.
 EMBEDDING_DIMENSIONS = 1536
 
+# Optional client-side pacing for the embedding endpoint, controlled by EMBED_MIN_INTERVAL (seconds
+# between cache-MISS embed calls; 0/unset = no throttle). The interactive recommendation path leaves
+# it unset, so live lookups pay zero added latency; the Flow-1 ETL sets a small value so a chunk's
+# embedding burst during persist stays under the Gemini embedding RPM instead of 429-ing mid-run
+# (the SDK retry in llm_retry.py can't outlast a sustained over-rate burst). lru_cache hits skip this.
+_EMBED_MIN_INTERVAL = float(os.environ.get("EMBED_MIN_INTERVAL", "0") or "0")
+_embed_lock = threading.Lock()
+_last_embed = 0.0
+
+
+def _throttle_embedding() -> None:
+    if _EMBED_MIN_INTERVAL <= 0:
+        return
+    global _last_embed
+    with _embed_lock:
+        wait = _EMBED_MIN_INTERVAL - (time.monotonic() - _last_embed)
+        if wait > 0:
+            time.sleep(wait)
+        _last_embed = time.monotonic()
+
 
 @lru_cache(maxsize=128)
 def get_cached_embedding(client: genai.Client, model_name: str, text: str) -> list[float]:
-    """Shared helper to safely cache embeddings without leaking 'self'. task_type
+    """Shared helper to safely cache embeddings without leaking self. task_type
     SEMANTIC_SIMILARITY keeps stored vectors and query vectors in one representation space:
     this is the single embed chokepoint for both ETL ingestion and the recommendation flow,
     so both sides match. Changing task_type invalidates previously-stored vectors."""
+    _throttle_embedding()
     response = client.models.embed_content(
         model=model_name,
         contents=text,

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -24,11 +24,16 @@ def _throttle_embedding() -> None:
     if _EMBED_MIN_INTERVAL <= 0:
         return
     global _last_embed
+    # Reserve the next wake-up slot atomically, then sleep OUTSIDE the lock so
+    # concurrent callers can schedule themselves immediately instead of
+    # serializing on the full sleep of whoever acquired the lock first.
+    now = time.monotonic()
     with _embed_lock:
-        wait = _EMBED_MIN_INTERVAL - (time.monotonic() - _last_embed)
-        if wait > 0:
-            time.sleep(wait)
-        _last_embed = time.monotonic()
+        scheduled = max(now, _last_embed + _EMBED_MIN_INTERVAL)
+        _last_embed = scheduled
+    wait = scheduled - now
+    if wait > 0:
+        time.sleep(wait)
 
 
 @lru_cache(maxsize=128)

--- a/test/unit/test_embed_throttle.py
+++ b/test/unit/test_embed_throttle.py
@@ -1,0 +1,50 @@
+"""Tests for the opt-in embedding throttle (_throttle_embedding) in scouts/utils.py."""
+
+import threading
+import time
+
+from agentic_librarian.scouts import utils
+
+
+def test_throttle_does_not_hold_lock_while_sleeping(monkeypatch):
+    """The lock only guards slot scheduling; the pacing sleep must happen outside it,
+    so concurrent callers can reserve their own slots instead of serializing on the
+    full sleep of whoever got there first."""
+    monkeypatch.setattr(utils, "_EMBED_MIN_INTERVAL", 0.5)
+    monkeypatch.setattr(utils, "_last_embed", time.monotonic())  # next call must wait the full interval
+
+    sleeper = threading.Thread(target=utils._throttle_embedding)
+    sleeper.start()
+    time.sleep(0.1)  # let the sleeper enter its pacing wait
+
+    acquired = utils._embed_lock.acquire(timeout=0.1)
+    if acquired:
+        utils._embed_lock.release()
+    sleeper.join()
+
+    assert acquired, "_embed_lock must be free while a caller sleeps out its pacing wait"
+
+
+def test_throttle_paces_consecutive_calls(monkeypatch):
+    """Two back-to-back cache-miss calls are spaced by at least the configured interval."""
+    monkeypatch.setattr(utils, "_EMBED_MIN_INTERVAL", 0.2)
+    monkeypatch.setattr(utils, "_last_embed", 0.0)
+
+    start = time.monotonic()
+    utils._throttle_embedding()  # first call: no prior embed recent enough -> no wait
+    utils._throttle_embedding()  # second call: must wait out the interval
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.2
+
+
+def test_throttle_noop_when_disabled(monkeypatch):
+    """Interval 0/unset means no pacing at all (the interactive path)."""
+    monkeypatch.setattr(utils, "_EMBED_MIN_INTERVAL", 0.0)
+    monkeypatch.setattr(utils, "_last_embed", time.monotonic())
+
+    start = time.monotonic()
+    utils._throttle_embedding()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.05


### PR DESCRIPTION
## Summary
The Flow-1 ETL embeds a chunk's tropes/styles in a tight burst during `vectorized_tropes` persist. Even on the **paid** embedding tier this burst can exceed the Gemini embedding **RPM** and return `429 RESOURCE_EXHAUSTED` (the rate-limit message, *not* credit depletion) — and the SDK retry backoff can't outlast a sustained over-rate burst. Observed live killing a chunk mid-persist during the production DB build.

## Fix
Adds an **opt-in** client-side pace in `get_cached_embedding`, controlled by `EMBED_MIN_INTERVAL` (seconds between cache-miss embeds; `0`/unset = no throttle):
- **Interactive recommendation path** leaves it unset → **zero added latency** (this is why the earlier blanket throttle was removed; this version is opt-in so it doesn't tax live lookups).
- **ETL** sets `EMBED_MIN_INTERVAL=0.15` (~280/min, ~50s per 15-book chunk) to stay under the RPM.
- `lru_cache` hits skip the throttle entirely.

## Verification
- 250-embed burst at `0.15s` completes with **no 429** (~284/min).
- `ruff check` + `ruff format --check` clean.

## Test Plan
- [ ] CI lint
- [ ] (covered by the in-progress full-DB rebuild, where the ETL now sets the interval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)