### PR TITLE
fix: skip contributors with null/blank name in persist

### DIFF
--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -70,6 +70,12 @@ def persist_enriched_work(
             if name and not pd.isna(name):
                 raw_contributors.append({"name": name, "role": "Author"})
 
+    # Drop contributors without a usable name: malformed scout output can yield {"name": None} (or
+    # blank/NaN), which violates the authors.name NOT NULL constraint on insert.
+    raw_contributors = [
+        c for c in raw_contributors if isinstance(c, dict) and isinstance(c.get("name"), str) and c["name"].strip()
+    ]
+
     if not raw_contributors:
         return None
 
@@ -78,8 +84,8 @@ def persist_enriched_work(
     author_style_data = row.get("author_style", {})
 
     for c_data in raw_contributors:
-        name = c_data["name"]
-        role = c_data["role"]
+        name = c_data["name"].strip()
+        role = c_data.get("role") or "Author"
         author = session.query(Author).filter(Author.name == name).first()
         if not author:
             author = Author(name=name)

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -85,7 +85,10 @@ def persist_enriched_work(
 
     for c_data in raw_contributors:
         name = c_data["name"].strip()
-        role = c_data.get("role") or "Author"
+        # A whitespace-only role is truthy and a non-string role would persist as-is; both
+        # must fall back to "Author" (PR #30 review). Valid roles keep their stripped value.
+        role = c_data.get("role")
+        role = role.strip() if isinstance(role, str) and role.strip() else "Author"
         author = session.query(Author).filter(Author.name == name).first()
         if not author:
             author = Author(name=name)

--- a/test/integration/test_persist_enriched.py
+++ b/test/integration/test_persist_enriched.py
@@ -96,3 +96,32 @@ def test_persist_tolerates_nan_enrichment_fields(db_url, monkeypatch):
         # Scalars coerced to NULL, not NaN.
         assert work.original_publication_year is None
         assert work.genres == []
+
+
+@pytest.mark.db_integration
+def test_persist_skips_nameless_contributors(db_url, monkeypatch):
+    # Regression: malformed scout output can include a contributor with a None/blank name. Inserting
+    # it violates the authors.name NOT NULL constraint and crashes the partition. Persist must skip
+    # nameless contributors and still create the work from the valid ones.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    dbm = DatabaseManager(db_url)
+    with dbm.get_session() as session:
+        tm = TropeManager(session=session)
+        sm = StyleManager(session=session)
+        row = {
+            "Title": "Nameless Contributor Book",
+            "Author_1": "Real Author",
+            "format": "audiobook",
+            "skip_enrichment": True,
+            "date_completed": None,
+            "contributors": [
+                {"name": None, "role": "Author"},
+                {"name": "Real Author", "role": "Author"},
+                {"name": "   ", "role": "Narrator"},
+            ],
+        }
+        work = persist_enriched_work(session, row, tm, sm)
+        session.flush()
+        assert work is not None and work.title == "Nameless Contributor Book"
+        names = [c.author.name for c in work.contributors]
+        assert names == ["Real Author"]  # the None and blank contributors are skipped

--- a/test/integration/test_persist_enriched.py
+++ b/test/integration/test_persist_enriched.py
@@ -125,3 +125,37 @@ def test_persist_skips_nameless_contributors(db_url, monkeypatch):
         assert work is not None and work.title == "Nameless Contributor Book"
         names = [c.author.name for c in work.contributors]
         assert names == ["Real Author"]  # the None and blank contributors are skipped
+
+
+@pytest.mark.db_integration
+def test_persist_defaults_blank_or_invalid_role_to_author(db_url, monkeypatch):
+    # Regression (PR #30 review, gemini-code-assist): a whitespace-only role is truthy, so
+    # `role or "Author"` would persist it as-is — a malformed role value in work_contributors.
+    # Non-string roles from malformed scout output must also fall back to "Author"; a valid
+    # role keeps its stripped value.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    dbm = DatabaseManager(db_url)
+    with dbm.get_session() as session:
+        tm = TropeManager(session=session)
+        sm = StyleManager(session=session)
+        row = {
+            "Title": "Blank Role Book",
+            "Author_1": "Whitespace Role Author",
+            "format": "ebook",
+            "skip_enrichment": True,
+            "date_completed": None,
+            "contributors": [
+                {"name": "Whitespace Role Author", "role": "   "},
+                {"name": "Padded Role Editor", "role": " Editor "},
+                {"name": "Numeric Role Author", "role": 7},
+            ],
+        }
+        work = persist_enriched_work(session, row, tm, sm)
+        session.flush()
+        assert work is not None and work.title == "Blank Role Book"
+        roles = {c.author.name: c.role for c in work.contributors}
+        assert roles == {
+            "Whitespace Role Author": "Author",
+            "Padded Role Editor": "Editor",
+            "Numeric Role Author": "Author",
+        }


### PR DESCRIPTION
## Summary
During the production build, an audiobook's enrichment produced a contributor like `{"name": None}`. Persist passed it straight to `Author(name=None)`, which violates the `authors.name` NOT NULL constraint → `IntegrityError` that rolls back the whole partition (killed chunk c13 at persist after enriching 14/15 books).

## Fix
- Filters `raw_contributors` to entries with a non-blank **string** name before resolving authors (covers `None`, blank, and non-string/NaN). Falls through to the existing "no contributors → return None" path if none remain.
- Hardens the loop: `name.strip()`, and `role` defaults to `"Author"` if missing/null.
- Adds `test_persist_skips_nameless_contributors` (a contributor list with a `None` name and a blank `"  "` name alongside a valid one → persists, only the valid author is linked).

## Verification
- New test passes; inline run confirmed only the valid author persists.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)