### PR TITLE
chore: gitignore database dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ mlruns/
 
 # uv
 .uv/
+
+# Database dumps / snapshots (use pg_dump; never commit DB backups)
+data/backups/
+*.dump
+*.sql.gz


### PR DESCRIPTION
## Summary
Ignores local `pg_dump` snapshots so DB backups never get committed:

```
data/backups/
*.dump
*.sql.gz
```

Scoped deliberately — **no blanket `*.sql`**, so the tracked `scripts/init-db.sql` (used by the compose `db` init) stays in git. Verified `git check-ignore` ignores `data/backups/*.sql.gz` and does *not* ignore `scripts/init-db.sql`.

Context: took a snapshot of the in-progress production DB as a portable safety net outside the Docker VHDX; this keeps that artifact (and future ones) out of version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)