### PR TITLE
fix: reset index after split_formats explode (InvalidIndexError)

### DIFF
--- a/src/agentic_librarian/etl/cleaning.py
+++ b/src/agentic_librarian/etl/cleaning.py
@@ -122,8 +122,10 @@ def split_authors(df: pd.DataFrame) -> pd.DataFrame:
     # Apply the logic to each row
     author_lists = df["Author"].apply(process_row)
 
-    # Convert lists to a DataFrame of numbered columns
-    author_splits = pd.DataFrame(author_lists.tolist())
+    # Convert lists to a DataFrame of numbered columns. Build it on df's own index —
+    # .tolist() discards it, and the axis=1 concat below aligns by label, so a default
+    # RangeIndex would silently misalign on any non-default input index (PR #32 review).
+    author_splits = pd.DataFrame(author_lists.tolist(), index=df.index)
     author_splits.columns = [f"Author_{i + 1}" for i in range(author_splits.shape[1])]
 
     # Merge back and drop original

--- a/src/agentic_librarian/etl/cleaning.py
+++ b/src/agentic_librarian/etl/cleaning.py
@@ -12,6 +12,9 @@ def split_formats(df: pd.DataFrame) -> pd.DataFrame:
     df["format"] = df["format"].str.split(",")
     df = df.explode("format")
     df["format"] = df["format"].str.strip()
+    # explode() duplicates index labels for multi-format rows; reset so the downstream column-wise
+    # concats in split_authors/split_narrators can align (a non-unique index raises InvalidIndexError).
+    df = df.reset_index(drop=True)
     return df
 
 

--- a/test/unit/test_cleaning.py
+++ b/test/unit/test_cleaning.py
@@ -98,3 +98,22 @@ def test_split_narrators():
     result = split_narrators(df)
     assert result.iloc[0]["Narrator_1"] == "Narrator 1"
     assert result.iloc[0]["Narrator_2"] == "Narrator 2"
+
+
+def test_split_authors_after_multiformat_explode():
+    # Regression: split_formats explodes multi-format rows, duplicating index labels. split_authors
+    # then concats author columns with axis=1, which raised InvalidIndexError on the non-unique index.
+    # split_formats now resets the index so the column-wise concat aligns.
+    df = pd.DataFrame(
+        {
+            "Title": ["Multi", "Single"],
+            "Author": ["Solo Author", "First Author and Second Author"],
+            "format": ["hardcover, audiobook", "ebook"],
+        }
+    )
+    result = split_authors(split_formats(df))
+    assert result.index.is_unique
+    assert len(result) == 3  # the multi-format row exploded into two
+    assert sorted(result["format"].tolist()) == ["audiobook", "ebook", "hardcover"]
+    single = result[result["Title"] == "Single"].iloc[0]
+    assert single["Author_1"] == "First Author" and single["Author_2"] == "Second Author"

--- a/test/unit/test_cleaning.py
+++ b/test/unit/test_cleaning.py
@@ -117,3 +117,23 @@ def test_split_authors_after_multiformat_explode():
     assert sorted(result["format"].tolist()) == ["audiobook", "ebook", "hardcover"]
     single = result[result["Title"] == "Single"].iloc[0]
     assert single["Author_1"] == "First Author" and single["Author_2"] == "Second Author"
+
+
+def test_split_authors_preserves_nondefault_index():
+    # Regression (PR #32 review, gemini-code-assist): split_authors built the Author_X frame with a
+    # default RangeIndex, discarding the input's index. On any non-default index (e.g. a filtered
+    # frame) the axis=1 concat then aligned by label and silently misaligned — NaN authors and
+    # phantom rows. The Author_X frame must be built with index=df.index.
+    df = pd.DataFrame(
+        {
+            "Title": ["Keep A", "Drop", "Keep B"],
+            "Author": ["Author One", "Author Two", "Author Three and Author Four"],
+        }
+    )
+    df = df[df["Title"] != "Drop"]  # filtered frame keeps index labels [0, 2]
+    result = split_authors(df)
+    assert len(result) == 2
+    assert list(result.index) == [0, 2]
+    assert result.loc[0, "Author_1"] == "Author One"
+    assert result.loc[2, "Author_1"] == "Author Three"
+    assert result.loc[2, "Author_2"] == "Author Four"


### PR DESCRIPTION
## Summary
`split_formats` explodes multi-format rows (`df.explode("format")`), which **duplicates index labels**. `split_authors` (and `split_narrators`) then add columns via `pd.concat(..., axis=1)`, and a non-unique index makes pandas raise:

> `InvalidIndexError: Reindexing only valid with uniquely valued Index objects`

Hit live during the production build on the first chunk containing a book listed in multiple formats (c18), failing the `raw_history` asset before any enrichment.

## Fix
Reset the index (`df.reset_index(drop=True)`) right after the explode in `split_formats`, so all downstream column-wise concats align. One-line root fix.

## Verification
- New test `test_split_authors_after_multiformat_explode` (multi-format + multi-author row → 3 rows, unique index, authors split correctly).
- Full cleaning suite: 22 passed.
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)