### PR TITLE
feat: librarian CLI chat harness — multi-turn conversations on both backends + MLflow capture (ADR-045)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ mlruns/
 data/backups/
 *.dump
 *.sql.gz
+
+# CLI chat harness local transcripts (MLflow holds the durable copy)
+.chat_logs/

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -594,9 +594,17 @@ This file documents key architectural decisions, their context, and trade-offs.
   (`send`/`close`), so multi-turn means the SAME thing on both backends: a stateful Librarian session
   calling DB/web tools on demand. ADK wraps the existing `LibrarianConversation` (+ optional event
   callback in `asend`); Claude gains a true conversational mode via a persistent `ClaudeSDKClient`
-  session (LIBRARIAN_INSTRUCTION + full librarian MCP toolset + WebSearch) on a background event-loop
-  thread (PR #26 async precedent). Rejected: CLI-managed transcript replay over the one-shot pipeline
-  (re-runs the full pipeline per turn: slow, quota-hungry, logs a spurious Suggestion per turn).
+  session on a background event-loop thread (PR #26 async precedent). Rejected: CLI-managed transcript
+  replay over the one-shot pipeline (re-runs the full pipeline per turn: slow, quota-hungry, logs a
+  spurious Suggestion per turn).
+- **Full mesh parity on Claude** (amended same day, user decision): the Claude conversational
+  Librarian delegates to the SAME specialist mesh as ADK via programmatic SDK subagents
+  (`ClaudeAgentOptions(agents={"analyst"/"explorer"/"critic": AgentDefinition(prompt=<specialist
+  instruction>, tools=<scoped like the ADK mesh>)})`, invoked through the `Task` tool — the analogue
+  of ADK's `AgentTool`). A single-agent variant was rejected: it doesn't exercise the specialist
+  prompts, and ADK-vs-Claude conversation comparisons would conflate backend with architecture.
+  Cost accepted: slower turns / more Max quota per turn. VERIFY live (REC-019 pattern): subagent
+  visibility of the in-process MCP server via `AgentDefinition.mcpServers=["librarian"]`.
 - New `librarian` console script (argparse REPL; `--once`, `--backend`, `--quiet`, `--no-mlflow`)
   printing replies plus a compact key-event trace (`on_event(kind, detail)`).
 - Each conversation is one MLflow run (experiment `librarian_conversations`: params backend/model/

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -581,3 +581,31 @@ This file documents key architectural decisions, their context, and trade-offs.
   `ClaudeGroundedLLM.generate` must be called from a synchronous context (it uses `asyncio.run`); scouts
   always are. A full ETL on Claude issues many WebSearch calls — validate Agent SDK rate limits on a
   small batch first.
+
+### ADR-045: Conversation Seam on the Backend Protocol + CLI Chat Harness (2026-06-05)
+**Context:**
+- No command-line way to exercise the conversational piece. `RecommendationBackend` (ADR-041) is
+  one-shot only; multi-turn (`LibrarianConversation`, ADR-036) exists only on ADK, and the Claude
+  backend is a fixed pipeline of independent `query()` calls (ADR-040) with no conversational mode.
+  Spec: docs/superpowers/specs/2026-06-05-cli-chat-design.md.
+
+**Decision:**
+- Extend the strategy seam with `start_conversation(user_id, on_event) -> BackendConversation`
+  (`send`/`close`), so multi-turn means the SAME thing on both backends: a stateful Librarian session
+  calling DB/web tools on demand. ADK wraps the existing `LibrarianConversation` (+ optional event
+  callback in `asend`); Claude gains a true conversational mode via a persistent `ClaudeSDKClient`
+  session (LIBRARIAN_INSTRUCTION + full librarian MCP toolset + WebSearch) on a background event-loop
+  thread (PR #26 async precedent). Rejected: CLI-managed transcript replay over the one-shot pipeline
+  (re-runs the full pipeline per turn: slow, quota-hungry, logs a spurious Suggestion per turn).
+- New `librarian` console script (argparse REPL; `--once`, `--backend`, `--quiet`, `--no-mlflow`)
+  printing replies plus a compact key-event trace (`on_event(kind, detail)`).
+- Each conversation is one MLflow run (experiment `librarian_conversations`: params backend/model/
+  mode, per-turn latency metrics, `transcript.jsonl` artifact) owned by the CLI-layer
+  `ConversationRecorder` — backends stay pure. Degradation posture: MLflow failures warn once and
+  never block the chat; transcript falls back to a local gitignored `.chat_logs/<ts>.jsonl`
+  (informed by the 2026-05-31 MLflow 403 bug).
+
+**Consequences:**
+- The conversational piece becomes testable on both quota pools, and ADK-vs-Claude conversations are
+  comparable in the MLflow UI. The Claude one-shot pipeline is untouched. The new protocol method is
+  additive (existing callers unaffected).

--- a/docs/superpowers/plans/2026-06-05-cli-chat.md
+++ b/docs/superpowers/plans/2026-06-05-cli-chat.md
@@ -1,0 +1,1127 @@
+# CLI Chat Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `librarian` console-script REPL giving multi-turn Librarian conversations on BOTH backends (ADK + Claude), with key-event tracing and MLflow conversation capture.
+
+**Architecture:** Extend the `RecommendationBackend` strategy seam (ADR-041) with `start_conversation() -> BackendConversation`. ADK wraps the existing `LibrarianConversation` (plus an event callback); the Claude backend gains a true conversational mode via a persistent `ClaudeSDKClient` session on a background event-loop thread. A CLI-layer `ConversationRecorder` logs each conversation as one MLflow run with a never-block degradation posture. Spec: `docs/superpowers/specs/2026-06-05-cli-chat-design.md`, ADR-045.
+
+**Tech Stack:** Python 3.11, argparse (no new deps), `claude-agent-sdk` (`ClaudeSDKClient`), google-adk 2.1.0, MLflow, pytest.
+
+**Environment notes (this machine):**
+- Work in `C:\dev\agentic_librarian` (git clone). Run tests in a throwaway container via **PowerShell** (Git Bash mangles `/app`):
+  `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest <paths> -q`
+  None of these tasks need the DB network.
+- Lint: bare `ruff check` in the container FALSE-flags I001 on `agentic_librarian` import ordering (editable-install first-party artifact). Sort imports alphabetically inline among third-party (match `mcp/server.py`); ignore container-only I001 on that pattern. `ruff format` diffs that are only line-endings can be ignored (git normalizes).
+- Do NOT run `api_dependent` tests except where Task 9 says so (real quota).
+
+---
+
+### Task 1: Conversational Librarian prompt for the Claude backend
+
+The ADK Librarian's instruction is deliberately inline in `services.py` (it is delegation-specific: "Call the 'Analyst'..."). The Claude conversation has no sub-agents — it has direct MCP tools + WebSearch — so it needs its own persona constant. The ADK inline instruction stays untouched.
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/prompts.py` (append constant)
+- Test: `test/unit/test_prompts.py` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `test/unit/test_prompts.py`:
+
+```python
+def test_librarian_instruction_is_tool_direct():
+    # The Claude conversational Librarian has no sub-agents: its instruction must reference
+    # the direct MCP tools, not ADK delegation ("Call the 'Analyst'").
+    text = prompts.LIBRARIAN_INSTRUCTION
+    assert "search_internal_database" in text
+    assert "log_suggestion" in text
+    assert "update_suggestion_status" in text
+    assert "Analyst" not in text
+```
+
+(If `test_prompts.py` does not already import `prompts`, add `from agentic_librarian.agents import prompts` at the top, matching the file's existing imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_prompts.py -q`
+Expected: FAIL with `AttributeError: ... has no attribute 'LIBRARIAN_INSTRUCTION'`
+
+- [ ] **Step 3: Implement** — append to `src/agentic_librarian/agents/prompts.py`:
+
+```python
+# Conversational Librarian persona for backends whose conversation mode calls tools DIRECTLY
+# (no Analyst/Explorer/Critic sub-agents — cf. the ADK-only delegation instruction inline in
+# services.py). Used by the Claude backend's ClaudeConversation (ADR-045).
+LIBRARIAN_INSTRUCTION = """
+You are the Head Librarian. You provide personalized book recommendations and manage reading
+history, conversationally, over multiple turns.
+
+TOOL STRATEGY:
+1. Use 'get_user_trope_preferences' to understand the user's tastes when their request is vague.
+2. Use 'get_unacted_suggestions' with target tropes/styles to surface existing good matches first.
+3. Use 'search_internal_database' for vector search over the user's enriched catalog.
+4. If new discovery is needed, use your web search tool, then 'check_reading_history' to avoid
+   re-recommending something already read (books read >2 years ago are eligible for re-reads).
+5. Use 'get_work_details' to ground justifications in the work's actual tropes and styles.
+
+FEEDBACK HANDLING:
+- "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).
+- "Not for me" / "I hate this" -> 'update_suggestion_status' (Dismissed).
+- Mood feedback ("not in the mood for X") -> respect it for the rest of the conversation.
+
+When you commit to a recommendation, log it with 'log_suggestion'. Keep replies concise and
+conversational; ask at most one clarifying question when the request is too vague to act on.
+"""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_prompts.py -q`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/prompts.py test/unit/test_prompts.py
+git commit -m "feat: LIBRARIAN_INSTRUCTION — direct-tool conversational persona (ADR-045)"
+```
+
+---
+
+### Task 2: Feedback tools on the Claude MCP server
+
+The conversational Librarian handles "I read that" / "not for me" via `update_reading_status` and `update_suggestion_status` (see the ADK Librarian's tools, `services.py:133-136`). The Claude in-process server (`claude_tools._TOOL_SCHEMAS`) exposes only 6 tools — add these 2.
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/backends/claude_tools.py` (extend `_TOOL_SCHEMAS`)
+- Test: `test/unit/test_claude_tools.py` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `test/unit/test_claude_tools.py`:
+
+```python
+def test_feedback_tools_are_exposed():
+    # The conversational Librarian (ADR-045) needs the feedback tools the ADK Librarian has.
+    from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
+
+    assert "mcp__librarian__update_reading_status" in LIBRARIAN_TOOL_NAMES
+    assert "mcp__librarian__update_suggestion_status" in LIBRARIAN_TOOL_NAMES
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_tools.py -q`
+Expected: FAIL on the first assert
+
+- [ ] **Step 3: Implement** — in `claude_tools.py`, append two entries to `_TOOL_SCHEMAS` (after the `log_suggestion` tuple, matching signatures `update_reading_status(title, author, status, notes=None)` and `update_suggestion_status(work_id, status)` in `mcp/server.py`):
+
+```python
+    (
+        "update_reading_status",
+        "Update reading history from user feedback (e.g. 'I read that').",
+        _schema(
+            {"title": _STR, "author": _STR, "status": _STR, "notes": _STR},
+            required=["title", "author", "status"],
+        ),
+        mcp_server.update_reading_status,
+    ),
+    (
+        "update_suggestion_status",
+        "Update a suggestion's status (Accepted / Dismissed / Already Read).",
+        _schema({"work_id": _STR, "status": _STR}, required=["work_id", "status"]),
+        mcp_server.update_suggestion_status,
+    ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_tools.py test/unit/test_claude_backend.py -q`
+Expected: all PASS (the existing one-shot pipeline hand-lists its `allowed_tools` per step, so it is unaffected)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/backends/claude_tools.py test/unit/test_claude_tools.py
+git commit -m "feat: expose update_reading_status/update_suggestion_status on the Claude MCP server"
+```
+
+---
+
+### Task 3: Protocol extension — `BackendConversation` + `start_conversation`
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/backends/__init__.py`
+- Test: `test/unit/test_backends.py` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `test/unit/test_backends.py`:
+
+```python
+def test_backend_conversation_protocol_is_runtime_checkable():
+    from agentic_librarian.agents.backends import BackendConversation
+
+    class _Conv:
+        def send(self, message: str) -> str:
+            return "ok"
+
+        def close(self) -> None:
+            pass
+
+    class _NotConv:
+        pass
+
+    assert isinstance(_Conv(), BackendConversation)
+    assert not isinstance(_NotConv(), BackendConversation)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_backends.py -q`
+Expected: FAIL with `ImportError: cannot import name 'BackendConversation'`
+
+- [ ] **Step 3: Implement** — in `backends/__init__.py`, change the imports line and add the protocols (the file currently imports `from typing import Protocol, runtime_checkable`):
+
+```python
+from typing import Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BackendConversation(Protocol):
+    """A stateful multi-turn Librarian session (ADR-045)."""
+
+    def send(self, message: str) -> str:
+        """Send one user message; return the Librarian's reply for this turn."""
+        ...
+
+    def close(self) -> None:
+        """Release session resources. Idempotent."""
+        ...
+
+
+@runtime_checkable
+class RecommendationBackend(Protocol):
+    name: str
+
+    def run_recommendation(self, prompt: str, user_id: str = "local") -> str:
+        """Run the one-shot recommendation pipeline and return the recommendation text."""
+        ...
+
+    def start_conversation(
+        self,
+        user_id: str = "local",
+        on_event: Callable[[str, str], None] | None = None,
+    ) -> BackendConversation:
+        """Open a multi-turn conversation. `on_event(kind, detail)` receives key events
+        (e.g. ("tool", "search_internal_database"), ("agent", "Explorer"))."""
+        ...
+```
+
+(Keep the existing `get_backend()` unchanged below.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_backends.py -q`
+Expected: all PASS (note: existing `isinstance(..., RecommendationBackend)` assertions, if any, still pass — `runtime_checkable` only checks method presence, and Tasks 4–5 add the method to both backends; if an existing conformance test fails here because a backend lacks `start_conversation`, that is the expected RED for Tasks 4–5 — note it and proceed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/backends/__init__.py test/unit/test_backends.py
+git commit -m "feat: BackendConversation protocol + start_conversation on the backend seam (ADR-045)"
+```
+
+---
+
+### Task 4: ADK conversation events + `ADKBackend.start_conversation`
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/runtime.py` (`LibrarianConversation`, `astart_conversation`, `start_conversation`)
+- Modify: `src/agentic_librarian/agents/backends/adk.py`
+- Test: `test/unit/test_agent_runtime.py`, `test/unit/test_backends.py` (append)
+
+- [ ] **Step 1: Write the failing tests** — append to `test/unit/test_agent_runtime.py` (reuses the file's existing `_FakeRunner`/`_FakeEvent`):
+
+```python
+class _FakeFunctionCall:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeToolEvent(_FakeEvent):
+    """An intermediate event carrying tool calls from a named agent."""
+
+    def __init__(self, author, tool_names):
+        super().__init__("")
+        self.author = author
+        self._tool_names = tool_names
+
+    def is_final_response(self) -> bool:
+        return False
+
+    def get_function_calls(self):
+        return [_FakeFunctionCall(n) for n in self._tool_names]
+
+
+def test_asend_fires_on_event_for_tools_and_agents():
+    class _EventfulRunner(_FakeRunner):
+        async def run_async(self, user_id, session_id, new_message):
+            yield _FakeToolEvent("Librarian", ["get_unacted_suggestions"])
+            yield _FakeToolEvent("Explorer", ["google_search"])
+            final = _FakeEvent("Try Hyperion")
+            final.author = "Librarian"
+            yield final
+
+    seen = []
+    conv = runtime.LibrarianConversation(
+        _EventfulRunner(), "u", "s", on_event=lambda kind, detail: seen.append((kind, detail))
+    )
+    assert conv.send("recommend sci-fi") == "Try Hyperion"
+    assert ("tool", "get_unacted_suggestions") in seen
+    assert ("tool", "google_search") in seen
+    assert ("agent", "Explorer") in seen
+
+
+def test_asend_without_on_event_is_unchanged():
+    conv = runtime.LibrarianConversation(_FakeRunner(reply="Try Dune"), "u", "s")
+    assert conv.send("recommend sci-fi") == "Try Dune"
+    assert conv.close() is None  # close() exists and is a no-op
+```
+
+And append to `test/unit/test_backends.py`:
+
+```python
+def test_adk_backend_start_conversation_satisfies_protocol():
+    from agentic_librarian.agents.backends import BackendConversation
+    from agentic_librarian.agents.backends.adk import ADKBackend
+    from test.unit.test_agent_runtime import _FakeRunner
+
+    conv = ADKBackend().start_conversation(user_id="u", runner=_FakeRunner(reply="ok"))
+    assert isinstance(conv, BackendConversation)
+    assert conv.send("hi") == "ok"
+    conv.close()
+```
+
+(If importing from `test.unit.test_agent_runtime` fails in this repo's pytest config, define a local 6-line copy of `_FakeRunner`/`_FakeEvent` in `test_backends.py` instead — same code as in `test_agent_runtime.py:37-63`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_agent_runtime.py test/unit/test_backends.py -q`
+Expected: FAIL — `LibrarianConversation.__init__() got an unexpected keyword argument 'on_event'`, missing `close`, missing `ADKBackend.start_conversation`
+
+- [ ] **Step 3: Implement** — in `runtime.py`, replace the `LibrarianConversation` class and the two start functions:
+
+```python
+class LibrarianConversation:
+    """A multi-turn conversation with the Librarian. Reusing one session across
+    sends is what gives the agent conversational memory (ADR-036)."""
+
+    def __init__(self, runner: Runner, user_id: str, session_id: str, on_event=None):
+        self._runner = runner
+        self.user_id = user_id
+        self.session_id = session_id
+        # Optional visibility hook (ADR-045): on_event(kind, detail) for ("tool", name) /
+        # ("agent", author). Duck-typed event introspection so unit-test fakes keep working.
+        self.on_event = on_event
+
+    async def asend(self, message: str) -> str:
+        content = types.Content(role="user", parts=[types.Part(text=message)])
+        final = ""
+        last_author = None
+        async for event in self._runner.run_async(
+            user_id=self.user_id, session_id=self.session_id, new_message=content
+        ):
+            if self.on_event:
+                author = getattr(event, "author", None)
+                if author and author != last_author:
+                    self.on_event("agent", author)
+                    last_author = author
+                get_calls = getattr(event, "get_function_calls", None)
+                for fc in (get_calls() if callable(get_calls) else []) or []:
+                    name = getattr(fc, "name", None)
+                    if name:
+                        self.on_event("tool", name)
+            if event.is_final_response() and event.content and event.content.parts:
+                parts_text = [p.text for p in event.content.parts if p.text]
+                if parts_text:
+                    final = "".join(parts_text)
+        return final or "(no response)"
+
+    def send(self, message: str) -> str:
+        return asyncio.run(self.asend(message))
+
+    def close(self) -> None:
+        """No session resources to release (InMemorySessionService); exists for
+        BackendConversation conformance (ADR-045)."""
+
+
+async def astart_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None
+) -> LibrarianConversation:
+    runner = runner or build_runner()
+    session_id = uuid.uuid4().hex
+    await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
+    return LibrarianConversation(runner, user_id, session_id, on_event=on_event)
+
+
+def start_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None
+) -> LibrarianConversation:
+    return asyncio.run(astart_conversation(user_id=user_id, runner=runner, on_event=on_event))
+```
+
+In `backends/adk.py`, extend the runtime import and add the method to `ADKBackend`:
+
+```python
+from agentic_librarian.agents.runtime import APP_NAME, _ensure_adk_credentials, start_conversation
+```
+
+```python
+    def start_conversation(self, user_id: str = "local", on_event=None, runner=None):
+        """Multi-turn conversational Librarian (the mesh dispatcher, ADR-036/ADR-045).
+        `runner` is injectable for tests; default builds the mesh runner."""
+        return start_conversation(user_id=user_id, runner=runner, on_event=on_event)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_agent_runtime.py test/unit/test_backends.py test/unit/test_backend_dispatch.py -q`
+Expected: all PASS (existing conversation tests unchanged — `on_event` defaults to `None`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/runtime.py src/agentic_librarian/agents/backends/adk.py test/unit/test_agent_runtime.py test/unit/test_backends.py
+git commit -m "feat: ADK conversation events + ADKBackend.start_conversation (ADR-045)"
+```
+
+---
+
+### Task 5: `ClaudeConversation` — persistent SDK session
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/backends/claude.py`
+- Test: `test/unit/test_claude_backend.py` (append)
+
+- [ ] **Step 1: Write the failing tests** — append to `test/unit/test_claude_backend.py`:
+
+```python
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeToolUseBlock:
+    def __init__(self, name):
+        self.name = name
+        self.input = {}
+
+
+class _FakeAssistantMessage:
+    def __init__(self, blocks):
+        self.content = blocks
+
+
+class _FakeResultMessage:
+    def __init__(self, result):
+        self.result = result
+        self.content = []
+
+
+class _FakeSDKClient:
+    """Duck-typed ClaudeSDKClient: connect/query/receive_response/disconnect."""
+
+    def __init__(self):
+        self.connected = False
+        self.disconnected = False
+        self.queries = []
+
+    async def connect(self):
+        self.connected = True
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        yield _FakeAssistantMessage(
+            [_FakeToolUseBlock("mcp__librarian__search_internal_database"), _FakeTextBlock("thinking...")]
+        )
+        yield _FakeResultMessage(f"reply-{len(self.queries)}")
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def test_claude_conversation_reuses_one_session_and_fires_events():
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    fake = _FakeSDKClient()
+    seen = []
+    conv = ClaudeConversation(on_event=lambda k, d: seen.append((k, d)), client_factory=lambda: fake)
+    try:
+        assert conv.send("first") == "reply-1"
+        assert conv.send("second") == "reply-2"
+    finally:
+        conv.close()
+    assert fake.queries == ["first", "second"]  # ONE client, one session, two turns
+    assert ("tool", "mcp__librarian__search_internal_database") in seen
+    assert fake.disconnected
+
+
+def test_claude_conversation_close_is_idempotent():
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    conv = ClaudeConversation(client_factory=_FakeSDKClient)
+    conv.close()
+    conv.close()  # second close must not raise
+
+
+def test_claude_backend_start_conversation_satisfies_protocol():
+    from agentic_librarian.agents.backends import BackendConversation
+    from agentic_librarian.agents.backends.claude import ClaudeBackend
+
+    conv = ClaudeBackend().start_conversation(client_factory=_FakeSDKClient)
+    try:
+        assert isinstance(conv, BackendConversation)
+        assert conv.send("hi") == "reply-1"
+    finally:
+        conv.close()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_backend.py -q`
+Expected: FAIL with `ImportError: cannot import name 'ClaudeConversation'`
+
+- [ ] **Step 3: Implement** — in `claude.py`: add `import threading` to the imports, and add (above `class ClaudeBackend`):
+
+```python
+class ClaudeConversation:
+    """Multi-turn conversational Librarian on a persistent ClaudeSDKClient session (ADR-045).
+    The SDK is async and the REPL is sync, and the session must outlive each send — so the
+    client lives on a dedicated background event-loop thread (cf. the running-loop constraint
+    ClaudeGroundedLLM solved in PR #26; asyncio.run per send would tear down the session)."""
+
+    def __init__(self, user_id: str = "local", on_event=None, client_factory=None):
+        self.user_id = user_id
+        self.on_event = on_event
+        self._client_factory = client_factory or self._default_client
+        self._client = None
+        self._closed = False
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._run(self._connect())
+
+    @staticmethod
+    def _default_client():
+        from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
+        from claude_agent_sdk import ClaudeSDKClient
+
+        options = ClaudeAgentOptions(
+            system_prompt=prompts.LIBRARIAN_INSTRUCTION,
+            model=_model(),
+            mcp_servers={"librarian": build_librarian_mcp_server()},
+            # Every tool registered on the librarian server, plus Claude Code's web search.
+            allowed_tools=[*LIBRARIAN_TOOL_NAMES, "WebSearch"],
+        )
+        return ClaudeSDKClient(options=options)
+
+    def _run(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    async def _connect(self):
+        self._client = self._client_factory()
+        await self._client.connect()
+
+    async def _asend(self, message: str) -> str:
+        await self._client.query(message)
+        text_parts: list[str] = []
+        result_text = ""
+        async for msg in self._client.receive_response():
+            # ResultMessage carries the authoritative turn result (same duck-typing as _ask).
+            result_val = getattr(msg, "result", None)
+            if result_val and isinstance(result_val, str):
+                result_text = result_val
+            for block in getattr(msg, "content", None) or []:
+                block_text = getattr(block, "text", None)
+                if isinstance(block_text, str):
+                    text_parts.append(block_text)
+                tool_name = getattr(block, "name", None)
+                if tool_name and hasattr(block, "input") and self.on_event:
+                    self.on_event("tool", str(tool_name))
+        return result_text or "".join(text_parts) or "(no response)"
+
+    def send(self, message: str) -> str:
+        return self._run(self._asend(message))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._client is not None:
+                self._run(self._client.disconnect())
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+```
+
+And add the method to `ClaudeBackend`:
+
+```python
+    def start_conversation(self, user_id: str = "local", on_event=None, client_factory=None):
+        """Multi-turn conversational Librarian on a persistent SDK session (ADR-045).
+        `client_factory` is injectable for tests."""
+        return ClaudeConversation(user_id=user_id, on_event=on_event, client_factory=client_factory)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_backend.py test/unit/test_backends.py -q`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/backends/claude.py test/unit/test_claude_backend.py
+git commit -m "feat: ClaudeConversation — persistent SDK session conversational mode (ADR-045)"
+```
+
+---
+
+### Task 6: `ConversationRecorder` — MLflow capture with degradation
+
+**Files:**
+- Create: `src/agentic_librarian/chat_recorder.py`
+- Create: `test/unit/test_chat_recorder.py`
+
+- [ ] **Step 1: Write the failing tests** — create `test/unit/test_chat_recorder.py`:
+
+```python
+import json
+
+from agentic_librarian.chat_recorder import ConversationRecorder
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_transcript_written_without_mlflow(tmp_path):
+    rec = ConversationRecorder("adk", "m", "u", "chat", use_mlflow=False, log_dir=str(tmp_path))
+    rec.record_turn("hi", "hello", ["tool: x"], 1.25)
+    rec.record_turn("bye", "", [], 0.5, error="boom")
+    rec.close()
+    records = _read_jsonl(rec.transcript_path)
+    assert len(records) == 2
+    assert records[0] == {"turn": 0, "user": "hi", "reply": "hello", "events": ["tool: x"], "latency_s": 1.25, "error": None}
+    assert records[1]["error"] == "boom"
+    assert rec.run_id is None
+
+
+def test_mlflow_run_captured_with_file_store(tmp_path, monkeypatch):
+    import mlflow
+
+    uri = (tmp_path / "mlruns").as_uri()
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", uri)
+    mlflow.set_tracking_uri(uri)
+    rec = ConversationRecorder("claude", "claude-sonnet-4-6", "u", "chat", log_dir=str(tmp_path / "logs"))
+    assert rec.run_id
+    rec.record_turn("hi", "hello", [], 2.0)
+    rec.close()
+    run = mlflow.get_run(rec.run_id)
+    assert run.data.params["backend"] == "claude"
+    assert run.data.metrics["turns"] == 1.0
+    assert run.info.status == "FINISHED"
+
+
+def test_unreachable_mlflow_degrades_to_local_jsonl(tmp_path, monkeypatch, capsys):
+    import mlflow
+
+    monkeypatch.setenv("MLFLOW_HTTP_REQUEST_MAX_RETRIES", "0")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:9")
+    mlflow.set_tracking_uri("http://127.0.0.1:9")
+    rec = ConversationRecorder("adk", "m", "u", "chat", log_dir=str(tmp_path))
+    rec.record_turn("hi", "hello", [], 1.0)
+    rec.close()  # must not raise
+    assert rec.run_id is None
+    assert len(_read_jsonl(rec.transcript_path)) == 1
+    assert "mlflow capture disabled" in capsys.readouterr().out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_chat_recorder.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agentic_librarian.chat_recorder'`
+
+- [ ] **Step 3: Implement** — create `src/agentic_librarian/chat_recorder.py`:
+
+```python
+"""MLflow conversation capture for the CLI chat harness (ADR-045). One conversation = one
+MLflow run. Degradation posture (cf. the 2026-05-31 MLflow 403 bug): MLflow must NEVER block
+or kill a chat — every MLflow call is guarded with warn-and-continue, and the transcript is
+always written to a local jsonl regardless."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+_EXPERIMENT = "librarian_conversations"
+
+
+class ConversationRecorder:
+    def __init__(
+        self,
+        backend: str,
+        model: str,
+        user_id: str,
+        mode: str,
+        use_mlflow: bool = True,
+        log_dir: str = ".chat_logs",
+    ):
+        self._t0 = time.monotonic()
+        self._turns = 0
+        self._mlflow = None
+        self.run_id: str | None = None
+        path_dir = Path(log_dir)
+        path_dir.mkdir(parents=True, exist_ok=True)
+        self.transcript_path = path_dir / f"{datetime.now():%Y%m%d_%H%M%S}_{backend}.jsonl"
+        if use_mlflow:
+            try:
+                import mlflow
+
+                mlflow.set_experiment(_EXPERIMENT)
+                run = mlflow.start_run(run_name=f"{backend}-{mode}")
+                mlflow.log_params({"backend": backend, "model": model, "user_id": user_id, "mode": mode})
+                self._mlflow = mlflow
+                self.run_id = run.info.run_id
+            except Exception as e:  # degradation posture: warn once, never block the chat
+                print(f"warning: mlflow capture disabled ({type(e).__name__}: {e})")
+
+    def record_turn(
+        self,
+        user_text: str,
+        reply: str,
+        events: list[str],
+        latency_s: float,
+        error: str | None = None,
+    ) -> None:
+        record = {
+            "turn": self._turns,
+            "user": user_text,
+            "reply": reply,
+            "events": events,
+            "latency_s": round(latency_s, 3),
+            "error": error,
+        }
+        with self.transcript_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        if self._mlflow:
+            try:
+                self._mlflow.log_metric("latency_s", latency_s, step=self._turns)
+            except Exception as e:
+                print(f"warning: mlflow log_metric failed ({type(e).__name__}: {e})")
+        self._turns += 1
+
+    def close(self, status: str = "FINISHED") -> None:
+        if not self._mlflow:
+            return
+        try:
+            self._mlflow.log_metric("turns", self._turns)
+            self._mlflow.log_metric("duration_s", time.monotonic() - self._t0)
+            if self.transcript_path.exists():
+                self._mlflow.log_artifact(str(self.transcript_path))
+            self._mlflow.end_run(status=status)
+        except Exception as e:
+            print(f"warning: mlflow close failed ({type(e).__name__}: {e})")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_chat_recorder.py -q`
+Expected: 3 PASS (the unreachable test should fail FAST thanks to `MLFLOW_HTTP_REQUEST_MAX_RETRIES=0`; if it hangs >60s, check that env var is read by the installed mlflow version)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/chat_recorder.py test/unit/test_chat_recorder.py
+git commit -m "feat: ConversationRecorder — MLflow conversation capture with never-block degradation (ADR-045)"
+```
+
+---
+
+### Task 7: The CLI — REPL + `--once`
+
+**Files:**
+- Create: `src/agentic_librarian/cli.py`
+- Create: `test/unit/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests** — create `test/unit/test_cli.py`:
+
+```python
+import builtins
+
+import pytest
+from agentic_librarian import cli
+
+
+class _FakeConversation:
+    def __init__(self, replies, on_event=None):
+        self._replies = list(replies)
+        self.on_event = on_event
+        self.sent = []
+        self.closed = False
+
+    def send(self, message):
+        self.sent.append(message)
+        if self.on_event:
+            self.on_event("tool", "search_internal_database")
+        reply = self._replies.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeBackend:
+    name = "fake"
+
+    def __init__(self, replies=("a reply",)):
+        self._replies = replies
+        self.conversation = None
+
+    def run_recommendation(self, prompt, user_id="local"):
+        return f"one-shot: {prompt}"
+
+    def start_conversation(self, user_id="local", on_event=None):
+        self.conversation = _FakeConversation(self._replies, on_event)
+        return self.conversation
+
+
+@pytest.fixture
+def no_mlflow_dir(tmp_path, monkeypatch):
+    # Keep transcripts inside tmp and never touch MLflow in CLI tests.
+    monkeypatch.setattr(cli, "_LOG_DIR", str(tmp_path))
+
+
+def _feed_stdin(monkeypatch, lines):
+    it = iter(lines)
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(it))
+
+
+def test_once_prints_recommendation(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend()
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    rc = cli.main(["--once", "heist novel", "--no-mlflow"])
+    assert rc == 0
+    assert "one-shot: heist novel" in capsys.readouterr().out
+
+
+def test_repl_two_turns_then_quit(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=("first reply", "second reply"))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hello", "more", "/quit"])
+    rc = cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "librarian> first reply" in out
+    assert "librarian> second reply" in out
+    assert "· tool: search_internal_database" in out  # event trace
+    assert fake.conversation.closed
+
+
+def test_repl_survives_a_failed_turn(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=(RuntimeError("boom"), "recovered"))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["explode", "again", "/quit"])
+    rc = cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "error: RuntimeError: boom" in out
+    assert "librarian> recovered" in out
+
+
+def test_quiet_suppresses_event_trace(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=("ok",))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hi", "/quit"])
+    cli.main(["--no-mlflow", "--quiet"])
+    assert "· tool:" not in capsys.readouterr().out
+
+
+def test_backend_flag_sets_env(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend()
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    cli.main(["--once", "x", "--no-mlflow", "--backend", "claude"])
+    import os
+
+    assert os.environ["AGENT_BACKEND"] == "claude"
+
+
+def test_unknown_backend_fails_fast(monkeypatch, capsys, no_mlflow_dir):
+    def _boom():
+        raise ValueError("Unknown AGENT_BACKEND='nope'")
+
+    monkeypatch.setattr(cli, "get_backend", _boom)
+    rc = cli.main(["--once", "x", "--no-mlflow"])
+    assert rc == 2
+    assert "Unknown AGENT_BACKEND" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_cli.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'agentic_librarian.cli'`
+
+- [ ] **Step 3: Implement** — create `src/agentic_librarian/cli.py`:
+
+```python
+"""`librarian` CLI — multi-turn chat REPL + one-shot recommendation test harness (ADR-045).
+Run inside the app container: `docker exec -it agentic_librarian_app librarian`."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+from agentic_librarian.agents.backends import get_backend
+from agentic_librarian.chat_recorder import ConversationRecorder
+
+_LOG_DIR = ".chat_logs"
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(prog="librarian", description="Chat with the Librarian recommendation agent.")
+    parser.add_argument("--once", metavar="PROMPT", help="one-shot recommendation (pipeline), then exit")
+    parser.add_argument("--backend", choices=["adk", "claude"], help="override AGENT_BACKEND for this run")
+    parser.add_argument("--user-id", default="local", help="user id for sessions and history (default: local)")
+    parser.add_argument("--quiet", action="store_true", help="suppress the key-event trace")
+    parser.add_argument("--no-mlflow", action="store_true", help="disable MLflow conversation capture")
+    return parser.parse_args(argv)
+
+
+def _model_label(backend_name: str) -> str:
+    if backend_name == "claude":
+        return os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
+    return os.environ.get("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    if args.backend:
+        os.environ["AGENT_BACKEND"] = args.backend
+    try:
+        backend = get_backend()
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    recorder = ConversationRecorder(
+        backend.name,
+        _model_label(backend.name),
+        args.user_id,
+        "one-shot" if args.once else "chat",
+        use_mlflow=not args.no_mlflow,
+        log_dir=_LOG_DIR,
+    )
+    if args.once:
+        return _run_once(backend, args, recorder)
+    return _run_repl(backend, args, recorder)
+
+
+def _run_once(backend, args, recorder) -> int:
+    t0 = time.monotonic()
+    try:
+        reply = backend.run_recommendation(args.once, user_id=args.user_id)
+    except Exception as e:
+        recorder.record_turn(args.once, "", [], time.monotonic() - t0, error=f"{type(e).__name__}: {e}")
+        recorder.close(status="FAILED")
+        print(f"error: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    print(reply)
+    recorder.record_turn(args.once, reply, [], time.monotonic() - t0)
+    recorder.close()
+    return 0
+
+
+def _run_repl(backend, args, recorder) -> int:
+    turn_events: list[str] = []
+
+    def on_event(kind: str, detail: str) -> None:
+        turn_events.append(f"{kind}: {detail}")
+        if not args.quiet:
+            print(f"  · {kind}: {detail}")
+
+    try:
+        conversation = backend.start_conversation(user_id=args.user_id, on_event=on_event)
+    except Exception as e:
+        recorder.close(status="FAILED")
+        print(f"error: could not start conversation: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"librarian chat — backend: {backend.name} ({_model_label(backend.name)})"
+        f" | mlflow: {recorder.run_id or 'off'} | /quit to exit"
+    )
+    try:
+        while True:
+            try:
+                line = input("you> ")
+            except (EOFError, KeyboardInterrupt, StopIteration):
+                print()
+                break
+            line = line.strip()
+            if not line:
+                continue
+            if line in ("/quit", "/exit"):
+                break
+            turn_events.clear()
+            t0 = time.monotonic()
+            try:
+                reply = conversation.send(line)
+            except KeyboardInterrupt:
+                print("(turn aborted)")
+                recorder.record_turn(line, "", list(turn_events), time.monotonic() - t0, error="aborted")
+                continue
+            except Exception as e:
+                print(f"error: {type(e).__name__}: {e}")
+                recorder.record_turn(
+                    line, "", list(turn_events), time.monotonic() - t0, error=f"{type(e).__name__}: {e}"
+                )
+                continue
+            print(f"librarian> {reply}")
+            recorder.record_turn(line, reply, list(turn_events), time.monotonic() - t0)
+    finally:
+        try:
+            conversation.close()
+        except Exception as e:
+            print(f"warning: close failed ({type(e).__name__}: {e})")
+        recorder.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+(Note: `StopIteration` in the `input` catch exists because tests feed stdin from an iterator; live `input()` raises `EOFError`, which is also caught.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_cli.py -q`
+Expected: 6 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/cli.py test/unit/test_cli.py
+git commit -m "feat: librarian CLI — chat REPL with event trace + --once one-shot (ADR-045)"
+```
+
+---
+
+### Task 8: Packaging — console script + gitignore
+
+**Files:**
+- Modify: `pyproject.toml` (add `[project.scripts]`)
+- Modify: `.gitignore` (add `.chat_logs/`)
+
+- [ ] **Step 1: Add the console script** — in `pyproject.toml`, after the `[project]` table (before `[project.optional-dependencies]`), add:
+
+```toml
+[project.scripts]
+librarian = "agentic_librarian.cli:main"
+```
+
+- [ ] **Step 2: Add `.chat_logs/` to `.gitignore`** — append:
+
+```
+# CLI chat harness local transcripts (MLflow holds the durable copy)
+.chat_logs/
+```
+
+- [ ] **Step 3: Verify the entry point resolves and module invocation works**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m agentic_librarian.cli --help`
+Expected: usage text showing `--once`, `--backend`, `--user-id`, `--quiet`, `--no-mlflow`
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest bash -c "pip install -q -e . 2>/dev/null; librarian --help"`
+Expected: same usage text (proves the console script wiring; the throwaway container discards the reinstall). If `pip install` fails on container-user permissions, the `python -m` verification above is sufficient — the durable install happens later in the app container (Task 9 Step 4).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml .gitignore
+git commit -m "feat: librarian console script + ignore .chat_logs (ADR-045)"
+```
+
+---
+
+### Task 9: Live smoke + final verification
+
+**Files:**
+- Create: `test/integration/test_cli_chat_live.py`
+
+- [ ] **Step 1: Create the live smoke test** (api_dependent — NOT run in CI/pre-commit):
+
+```python
+"""Live 2-turn conversation smoke for the conversation seam (ADR-045). Run manually, once per
+backend, when quota allows:
+  AGENT_BACKEND=adk    pytest test/integration/test_cli_chat_live.py -m api_dependent -s
+  AGENT_BACKEND=claude pytest test/integration/test_cli_chat_live.py -m api_dependent -s
+(inside the app container — the claude backend additionally needs the authed `claude` CLI)."""
+
+import pytest
+from agentic_librarian.agents.backends import get_backend
+
+
+@pytest.mark.api_dependent
+def test_two_turn_conversation_live():
+    events = []
+    backend = get_backend()
+    conv = backend.start_conversation(on_event=lambda kind, detail: events.append((kind, detail)))
+    try:
+        first = conv.send("Recommend one fantasy book from my catalog with found-family vibes.")
+        second = conv.send("Why did you pick that one over other options?")
+    finally:
+        conv.close()
+    print(f"\n[{backend.name}] events: {events}\nfirst: {first}\nsecond: {second}")
+    assert first.strip() and first != "(no response)"
+    assert second.strip() and second != "(no response)"
+    assert events, "expected at least one tool/agent event in a real conversation"
+```
+
+- [ ] **Step 2: Run the full fast suite (offline regression gate)**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit -q -m "not api_dependent and not slow"`
+Expected: all PASS, 0 failures (baseline before this work: 179 passed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/integration/test_cli_chat_live.py
+git commit -m "test: live 2-turn conversation smoke for both backends (ADR-045)"
+```
+
+- [ ] **Step 4 (manual, user-gated): live verification**
+
+Ask the user before burning quota. Inside the running app container (after syncing the WSL clone with `git pull` and re-running `pip install -e .` there once for the console script):
+
+```bash
+docker exec -it agentic_librarian_app librarian --backend claude
+docker exec -it agentic_librarian_app librarian --backend adk
+```
+
+Verify: banner shows backend/model/run-id; events stream during turns; second turn is context-aware; MLflow UI (http://localhost:5000) shows the `librarian_conversations` run with the transcript artifact.
+
+---
+
+## Definition of done
+
+- All unit tests green (`test/unit`, fast suite) — including the pre-existing 179.
+- `python -m agentic_librarian.cli --help` works; console script resolves after editable install.
+- Live smoke passes on both backends (manual, quota-gated).
+- ADR-045 and the spec describe what was actually built (update if implementation diverged).

--- a/docs/superpowers/plans/2026-06-05-cli-chat.md
+++ b/docs/superpowers/plans/2026-06-05-cli-chat.md
@@ -4,7 +4,7 @@
 
 **Goal:** A `librarian` console-script REPL giving multi-turn Librarian conversations on BOTH backends (ADK + Claude), with key-event tracing and MLflow conversation capture.
 
-**Architecture:** Extend the `RecommendationBackend` strategy seam (ADR-041) with `start_conversation() -> BackendConversation`. ADK wraps the existing `LibrarianConversation` (plus an event callback); the Claude backend gains a true conversational mode via a persistent `ClaudeSDKClient` session on a background event-loop thread. A CLI-layer `ConversationRecorder` logs each conversation as one MLflow run with a never-block degradation posture. Spec: `docs/superpowers/specs/2026-06-05-cli-chat-design.md`, ADR-045.
+**Architecture:** Extend the `RecommendationBackend` strategy seam (ADR-041) with `start_conversation() -> BackendConversation`. ADK wraps the existing `LibrarianConversation` (plus an event callback); the Claude backend gains a true conversational mode via a persistent `ClaudeSDKClient` session on a background event-loop thread, delegating to the SAME specialist mesh as ADK via programmatic SDK subagents (analyst/explorer/critic `AgentDefinition`s invoked through the `Task` tool — mesh parity, ADR-045). A CLI-layer `ConversationRecorder` logs each conversation as one MLflow run with a never-block degradation posture. Spec: `docs/superpowers/specs/2026-06-05-cli-chat-design.md`, ADR-045.
 
 **Tech Stack:** Python 3.11, argparse (no new deps), `claude-agent-sdk` (`ClaudeSDKClient`), google-adk 2.1.0, MLflow, pytest.
 
@@ -19,7 +19,7 @@
 
 ### Task 1: Conversational Librarian prompt for the Claude backend
 
-The ADK Librarian's instruction is deliberately inline in `services.py` (it is delegation-specific: "Call the 'Analyst'..."). The Claude conversation has no sub-agents — it has direct MCP tools + WebSearch — so it needs its own persona constant. The ADK inline instruction stays untouched.
+The ADK Librarian's instruction is deliberately inline in `services.py` and references ADK `AgentTool` names ("Call the 'Analyst'..."). The Claude conversation delegates to SDK subagents named `analyst`/`explorer`/`critic` (mesh parity, ADR-045), so it needs its own delegation persona constant. The ADK inline instruction stays untouched.
 
 **Files:**
 - Modify: `src/agentic_librarian/agents/prompts.py` (append constant)
@@ -28,14 +28,15 @@ The ADK Librarian's instruction is deliberately inline in `services.py` (it is d
 - [ ] **Step 1: Write the failing test** — append to `test/unit/test_prompts.py`:
 
 ```python
-def test_librarian_instruction_is_tool_direct():
-    # The Claude conversational Librarian has no sub-agents: its instruction must reference
-    # the direct MCP tools, not ADK delegation ("Call the 'Analyst'").
+def test_librarian_instruction_delegates_to_the_mesh():
+    # The Claude conversational Librarian delegates to the SAME specialist mesh as ADK
+    # (SDK subagents named analyst/explorer/critic) and keeps the feedback/logging tools direct.
     text = prompts.LIBRARIAN_INSTRUCTION
-    assert "search_internal_database" in text
+    assert "'analyst'" in text
+    assert "'explorer'" in text
+    assert "'critic'" in text
     assert "log_suggestion" in text
     assert "update_suggestion_status" in text
-    assert "Analyst" not in text
 ```
 
 (If `test_prompts.py` does not already import `prompts`, add `from agentic_librarian.agents import prompts` at the top, matching the file's existing imports.)
@@ -48,20 +49,21 @@ Expected: FAIL with `AttributeError: ... has no attribute 'LIBRARIAN_INSTRUCTION
 - [ ] **Step 3: Implement** — append to `src/agentic_librarian/agents/prompts.py`:
 
 ```python
-# Conversational Librarian persona for backends whose conversation mode calls tools DIRECTLY
-# (no Analyst/Explorer/Critic sub-agents — cf. the ADK-only delegation instruction inline in
-# services.py). Used by the Claude backend's ClaudeConversation (ADR-045).
+# Conversational Librarian persona for the Claude backend (ADR-045, mesh parity). Mirrors the
+# ADK Librarian's delegation strategy (inline in services.py), but addresses SDK subagents
+# (analyst/explorer/critic AgentDefinitions invoked via the Task tool) instead of AgentTools.
 LIBRARIAN_INSTRUCTION = """
 You are the Head Librarian. You provide personalized book recommendations and manage reading
 history, conversationally, over multiple turns.
 
-TOOL STRATEGY:
-1. Use 'get_user_trope_preferences' to understand the user's tastes when their request is vague.
-2. Use 'get_unacted_suggestions' with target tropes/styles to surface existing good matches first.
-3. Use 'search_internal_database' for vector search over the user's enriched catalog.
-4. If new discovery is needed, use your web search tool, then 'check_reading_history' to avoid
-   re-recommending something already read (books read >2 years ago are eligible for re-reads).
-5. Use 'get_work_details' to ground justifications in the work's actual tropes and styles.
+DELEGATION STRATEGY:
+1. Delegate to the 'analyst' agent to turn user vibes into structured trope/style targets and
+   session constraints.
+2. Use 'get_unacted_suggestions' with target vibes to see if we already have good matches.
+3. If new discovery is needed, delegate to the 'explorer' agent.
+4. Delegate all candidates, targets, and session constraints to the 'critic' agent for final
+   ranking and a grounded justification.
+   - NOTE: Books read >2 years ago are eligible for re-read suggestions.
 
 FEEDBACK HANDLING:
 - "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).
@@ -393,7 +395,11 @@ git commit -m "feat: ADK conversation events + ADKBackend.start_conversation (AD
 
 ---
 
-### Task 5: `ClaudeConversation` — persistent SDK session
+### Task 5: `ClaudeConversation` — persistent SDK session with the specialist mesh
+
+The conversational Librarian delegates to the SAME specialist mesh as ADK via programmatic SDK
+subagents (`ClaudeAgentOptions(agents={...: AgentDefinition(...)})`, invoked through the `Task`
+tool). Subagents reuse the specialist prompts verbatim, tool-scoped like the ADK mesh.
 
 **Files:**
 - Modify: `src/agentic_librarian/agents/backends/claude.py`
@@ -439,8 +445,14 @@ class _FakeSDKClient:
         self.queries.append(prompt)
 
     async def receive_response(self):
+        task_block = _FakeToolUseBlock("Task")
+        task_block.input = {"subagent_type": "explorer", "prompt": "find books"}
         yield _FakeAssistantMessage(
-            [_FakeToolUseBlock("mcp__librarian__search_internal_database"), _FakeTextBlock("thinking...")]
+            [
+                task_block,
+                _FakeToolUseBlock("mcp__librarian__get_unacted_suggestions"),
+                _FakeTextBlock("thinking..."),
+            ]
         )
         yield _FakeResultMessage(f"reply-{len(self.queries)}")
 
@@ -460,8 +472,25 @@ def test_claude_conversation_reuses_one_session_and_fires_events():
     finally:
         conv.close()
     assert fake.queries == ["first", "second"]  # ONE client, one session, two turns
-    assert ("tool", "mcp__librarian__search_internal_database") in seen
+    assert ("agent", "explorer") in seen  # Task delegation maps to an agent event (ADK parity)
+    assert ("tool", "mcp__librarian__get_unacted_suggestions") in seen
     assert fake.disconnected
+
+
+def test_conversation_options_wire_the_specialist_mesh():
+    from agentic_librarian.agents import prompts
+    from agentic_librarian.agents.backends.claude import _conversation_options
+
+    options = _conversation_options()
+    assert set(options.agents) == {"analyst", "explorer", "critic"}
+    assert options.agents["analyst"].prompt == prompts.ANALYST_INSTRUCTION
+    assert options.agents["explorer"].prompt == prompts.EXPLORER_INSTRUCTION
+    assert options.agents["explorer"].tools == ["WebSearch"]
+    assert options.agents["critic"].prompt == prompts.CRITIC_INSTRUCTION
+    assert "mcp__librarian__search_internal_database" in options.agents["critic"].tools
+    assert "Task" in options.allowed_tools  # the Librarian delegates via the Task tool
+    assert "mcp__librarian__log_suggestion" in options.allowed_tools
+    assert options.system_prompt == prompts.LIBRARIAN_INSTRUCTION
 
 
 def test_claude_conversation_close_is_idempotent():
@@ -489,9 +518,55 @@ def test_claude_backend_start_conversation_satisfies_protocol():
 Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_backend.py -q`
 Expected: FAIL with `ImportError: cannot import name 'ClaudeConversation'`
 
-- [ ] **Step 3: Implement** — in `claude.py`: add `import threading` to the imports, and add (above `class ClaudeBackend`):
+- [ ] **Step 3: Implement** — in `claude.py`: add `import threading` to the imports, extend the SDK import to `from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, query`, and add (above `class ClaudeBackend`):
 
 ```python
+def _conversation_options() -> ClaudeAgentOptions:
+    """Options for the conversational Librarian (ADR-045): the SAME specialist mesh as ADK,
+    as programmatic SDK subagents invoked via the Task tool (the analogue of ADK's AgentTool).
+    Specialist prompts are reused verbatim; tools are scoped like the ADK mesh. VERIFY on the
+    first live run (REC-019 pattern): subagents must see the in-process 'librarian' MCP server
+    via mcpServers=["librarian"]; if not, rescope those tools onto the Librarian itself."""
+    agents = {
+        "analyst": AgentDefinition(
+            description="Turns user vibes into structured trope/style targets and constraints.",
+            prompt=prompts.ANALYST_INSTRUCTION,
+            tools=["mcp__librarian__get_user_trope_preferences"],
+            mcpServers=["librarian"],
+        ),
+        "explorer": AgentDefinition(
+            description="Discovers new candidate books on the web.",
+            prompt=prompts.EXPLORER_INSTRUCTION,
+            tools=["WebSearch"],
+        ),
+        "critic": AgentDefinition(
+            description="Ranks candidates and writes a grounded Trope-RAG justification.",
+            prompt=prompts.CRITIC_INSTRUCTION,
+            tools=[
+                "mcp__librarian__search_internal_database",
+                "mcp__librarian__get_work_details",
+                "mcp__librarian__check_reading_history",
+            ],
+            mcpServers=["librarian"],
+        ),
+    }
+    return ClaudeAgentOptions(
+        system_prompt=prompts.LIBRARIAN_INSTRUCTION,
+        model=_model(),
+        mcp_servers={"librarian": build_librarian_mcp_server()},
+        agents=agents,
+        # Task = subagent delegation; the rest are the Librarian's DIRECT tools (mirrors the
+        # ADK Librarian's FunctionTools in services.py).
+        allowed_tools=[
+            "Task",
+            "mcp__librarian__get_unacted_suggestions",
+            "mcp__librarian__update_reading_status",
+            "mcp__librarian__update_suggestion_status",
+            "mcp__librarian__log_suggestion",
+        ],
+    )
+
+
 class ClaudeConversation:
     """Multi-turn conversational Librarian on a persistent ClaudeSDKClient session (ADR-045).
     The SDK is async and the REPL is sync, and the session must outlive each send — so the
@@ -511,17 +586,9 @@ class ClaudeConversation:
 
     @staticmethod
     def _default_client():
-        from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
         from claude_agent_sdk import ClaudeSDKClient
 
-        options = ClaudeAgentOptions(
-            system_prompt=prompts.LIBRARIAN_INSTRUCTION,
-            model=_model(),
-            mcp_servers={"librarian": build_librarian_mcp_server()},
-            # Every tool registered on the librarian server, plus Claude Code's web search.
-            allowed_tools=[*LIBRARIAN_TOOL_NAMES, "WebSearch"],
-        )
-        return ClaudeSDKClient(options=options)
+        return ClaudeSDKClient(options=_conversation_options())
 
     def _run(self, coro):
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
@@ -529,6 +596,17 @@ class ClaudeConversation:
     async def _connect(self):
         self._client = self._client_factory()
         await self._client.connect()
+
+    def _emit_block_event(self, block) -> None:
+        """Map a ToolUseBlock to the trace: Task delegations -> ("agent", subagent), everything
+        else -> ("tool", name) — matching the ADK event shape."""
+        tool_name = getattr(block, "name", None)
+        if not (tool_name and hasattr(block, "input") and self.on_event):
+            return
+        if tool_name == "Task":
+            self.on_event("agent", (block.input or {}).get("subagent_type", "subagent"))
+        else:
+            self.on_event("tool", str(tool_name))
 
     async def _asend(self, message: str) -> str:
         await self._client.query(message)
@@ -543,9 +621,7 @@ class ClaudeConversation:
                 block_text = getattr(block, "text", None)
                 if isinstance(block_text, str):
                     text_parts.append(block_text)
-                tool_name = getattr(block, "name", None)
-                if tool_name and hasattr(block, "input") and self.on_event:
-                    self.on_event("tool", str(tool_name))
+                self._emit_block_event(block)
         return result_text or "".join(text_parts) or "(no response)"
 
     def send(self, message: str) -> str:
@@ -581,7 +657,7 @@ Expected: all PASS
 
 ```bash
 git add src/agentic_librarian/agents/backends/claude.py test/unit/test_claude_backend.py
-git commit -m "feat: ClaudeConversation — persistent SDK session conversational mode (ADR-045)"
+git commit -m "feat: ClaudeConversation — persistent SDK session with the specialist mesh (ADR-045)"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-05-cli-chat-design.md
+++ b/docs/superpowers/specs/2026-06-05-cli-chat-design.md
@@ -65,19 +65,37 @@ The only `runtime.py` change: `LibrarianConversation.asend` gains an optional ev
 callback, fired from the `run_async` event stream it already iterates (function calls /
 agent-author transitions). Default `None` — zero behavior change for existing callers.
 
-### 3. Claude conversation — `agents/backends/claude.py`
+### 3. Claude conversation — `agents/backends/claude.py` (full mesh parity)
 
 New `ClaudeConversation` holding one persistent `ClaudeSDKClient` session
 (verified current via Context7 `/anthropics/claude-agent-sdk-python`: each
 `client.query()` continues the same session; `receive_response()` yields messages
-until the turn's `ResultMessage`):
+until the turn's `ResultMessage`).
 
-- `system_prompt=LIBRARIAN_INSTRUCTION`, the existing in-process librarian MCP server
-  (`build_librarian_mcp_server()`), `allowed_tools` = **every** tool registered on that
-  server (enumerated from the server definition, `mcp__librarian__<name>`) +
-  `"WebSearch"`, model from `CLAUDE_MODEL` (default `claude-sonnet-4-6`).
-- `send()` = `query()` + collect `TextBlock`s from `receive_response()`; each
-  `ToolUseBlock` fires `on_event`.
+**Mesh parity (user decision, 2026-06-05):** the conversational Librarian delegates to
+the SAME specialist mesh ADK uses, via programmatic SDK subagents
+(`ClaudeAgentOptions(agents={...: AgentDefinition(...)})`, invoked through the `Task`
+tool — the direct analogue of ADK's `AgentTool`). A single-agent variant was rejected:
+it can do the same tasks but doesn't exercise the specialist prompts, and cross-backend
+MLflow comparisons would conflate backend with architecture.
+
+- Subagents reuse the specialist prompts verbatim, tool-scoped like the ADK mesh:
+  `analyst` (ANALYST_INSTRUCTION; `get_user_trope_preferences`), `explorer`
+  (EXPLORER_INSTRUCTION; `WebSearch`), `critic` (CRITIC_INSTRUCTION;
+  `search_internal_database`, `get_work_details`, `check_reading_history`).
+- The Librarian session: `system_prompt=LIBRARIAN_INSTRUCTION` (delegation-flavored,
+  mirroring the ADK Librarian's inline instruction), the in-process librarian MCP
+  server (`build_librarian_mcp_server()`), `allowed_tools` = `"Task"` + the Librarian's
+  direct tools (`get_unacted_suggestions`, `update_reading_status`,
+  `update_suggestion_status`, `log_suggestion`), model from `CLAUDE_MODEL`
+  (default `claude-sonnet-4-6`).
+- `send()` = `query()` + collect the turn result from `receive_response()`; each
+  `ToolUseBlock` fires `on_event` — a `Task` block maps to `("agent",
+  <subagent_type>)`, everything else to `("tool", <name>)`, matching the ADK trace.
+- **VERIFY on first live run** (REC-019 pattern): subagents see the parent's
+  in-process MCP server via `AgentDefinition.mcpServers=["librarian"]` — if the
+  in-process server is not visible to subagents, fall back to scoping those tools on
+  the Librarian and letting the critic receive tool RESULTS in its Task prompt.
 - The SDK is async; the REPL is sync. The session lives on a **background event-loop
   thread** (the same running-loop constraint `ClaudeGroundedLLM.generate` solved in
   PR #26 — follow that precedent; `asyncio.run` per send would tear down the session).

--- a/docs/superpowers/specs/2026-06-05-cli-chat-design.md
+++ b/docs/superpowers/specs/2026-06-05-cli-chat-design.md
@@ -1,0 +1,161 @@
+# CLI Chat Harness — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstormed with user)
+**Branch:** `spec/cli-chat`
+
+## Problem
+
+There is no command-line way to exercise the conversational piece of the recommendation
+system. Today's options are: a one-shot `run_recommendation()` via `python -c`, an
+interactive-Python session around `LibrarianConversation` (ADK only), or the
+`api_dependent` e2e tests. None of them give a usable multi-turn chat, and the Claude
+backend has no conversational mode at all — its `RecommendationBackend` protocol is
+one-shot only, implemented as a fixed Analyst→Explorer→Critic pipeline of independent
+`query()` calls.
+
+## Goals (user decisions)
+
+1. **Multi-turn chat on BOTH backends** (ADK and Claude), plus the existing one-shot
+   pipeline behind a flag. The Claude backend gains a true conversational mode.
+2. **Visibility**: print final replies plus a compact trace of key events (tool calls,
+   agent delegations) — a hollow run must look different from a real one.
+3. **Invocation**: a `librarian` console script (`[project.scripts]`), runnable as
+   `docker exec -it agentic_librarian_app librarian ...`.
+4. **MLflow conversation capture**: each conversation is an MLflow run, with a
+   graceful-degradation posture (logging must never block or kill a chat).
+
+## Approach (chosen: A)
+
+Extend the `RecommendationBackend` strategy seam (ADR-041) with a conversation method,
+so "multi-turn" means the same thing on both backends: a stateful Librarian session that
+calls DB/web tools on demand. Rejected alternatives: (B) CLI-managed transcript replay
+over the one-shot pipeline — re-runs the full pipeline every turn (slow, quota-hungry,
+logs a spurious Suggestion per turn, simulated rather than real conversation); (C) hybrid
+with transcript-replay only on Claude — two different conversation semantics muddies what
+the harness tests.
+
+## Architecture
+
+### 1. Protocol extension — `agents/backends/__init__.py`
+
+```python
+@runtime_checkable
+class BackendConversation(Protocol):
+    def send(self, message: str) -> str: ...
+    def close(self) -> None: ...
+
+class RecommendationBackend(Protocol):
+    name: str
+    def run_recommendation(self, prompt: str, user_id: str = "local") -> str: ...
+    def start_conversation(
+        self, user_id: str = "local",
+        on_event: Callable[[str, str], None] | None = None,
+    ) -> BackendConversation: ...
+```
+
+`on_event(kind, detail)` is the visibility hook — e.g. `("tool",
+"search_internal_database")`, `("agent", "Explorer")`. Structured-but-minimal; the CLI
+owns formatting.
+
+### 2. ADK adapter — `agents/backends/adk.py` + small `agents/runtime.py` touch
+
+`ADKBackend.start_conversation` wraps the existing `LibrarianConversation` (ADR-036).
+The only `runtime.py` change: `LibrarianConversation.asend` gains an optional event
+callback, fired from the `run_async` event stream it already iterates (function calls /
+agent-author transitions). Default `None` — zero behavior change for existing callers.
+
+### 3. Claude conversation — `agents/backends/claude.py`
+
+New `ClaudeConversation` holding one persistent `ClaudeSDKClient` session
+(verified current via Context7 `/anthropics/claude-agent-sdk-python`: each
+`client.query()` continues the same session; `receive_response()` yields messages
+until the turn's `ResultMessage`):
+
+- `system_prompt=LIBRARIAN_INSTRUCTION`, the existing in-process librarian MCP server
+  (`build_librarian_mcp_server()`), `allowed_tools` = **every** tool registered on that
+  server (enumerated from the server definition, `mcp__librarian__<name>`) +
+  `"WebSearch"`, model from `CLAUDE_MODEL` (default `claude-sonnet-4-6`).
+- `send()` = `query()` + collect `TextBlock`s from `receive_response()`; each
+  `ToolUseBlock` fires `on_event`.
+- The SDK is async; the REPL is sync. The session lives on a **background event-loop
+  thread** (the same running-loop constraint `ClaudeGroundedLLM.generate` solved in
+  PR #26 — follow that precedent; `asyncio.run` per send would tear down the session).
+- `close()` disconnects the client and stops the loop thread.
+- The existing one-shot pipeline (`_arun`) is untouched.
+
+### 4. CLI — new `src/agentic_librarian/cli.py` + `[project.scripts]`
+
+argparse only (no new dependencies). `librarian = "agentic_librarian.cli:main"`.
+
+```
+librarian                          # REPL (multi-turn, configured backend)
+librarian --once "find me ..."     # one-shot pipeline (run_recommendation)
+librarian --backend adk|claude     # override AGENT_BACKEND for this run
+librarian --user-id NAME           # default "local"
+librarian --quiet                  # replies only, no event trace
+librarian --no-mlflow              # disable conversation capture
+```
+
+Data flow: CLI → `get_backend()` → conversation/one-shot; event lines print dimmed as
+they arrive; the reply prints when the turn completes. Startup banner states backend,
+model, and MLflow run id (self-documenting test runs). Commands: `/quit` (also
+Ctrl-D / Ctrl-C at prompt). No `/history`, no `/save` — capture handles that (YAGNI).
+
+### 5. MLflow conversation capture — `ConversationRecorder` in `src/agentic_librarian/chat_recorder.py`
+
+- **One conversation = one MLflow run**, experiment `librarian_conversations`;
+  `--once` logs the same way with `mode=one-shot`.
+- **Params**: backend, model, user_id, mode. **Metrics**: `turns`, per-turn
+  `latency_s` (step-indexed), total duration. **Artifacts**: `transcript.jsonl`
+  (per turn: user text, reply, event trace, latency), uploaded at close; buffered
+  locally during the chat so a crash keeps what's written.
+- **Ownership**: CLI layer only — the CLI already sees every message, reply, and event
+  via `on_event`; backends stay pure.
+- **Degradation posture** (the in-container MLflow server has bitten us before —
+  DNS-rebinding 403, bugs.md 2026-05-31): tracking server unreachable → one warning
+  line, chat continues, transcript still written to a local fallback
+  `.chat_logs/<timestamp>.jsonl` (gitignored). MLflow errors mid-run are caught and
+  warned, never raised into the REPL.
+
+## Error handling
+
+- **A failed turn never kills the REPL**: backend exception → `error: <type>: <msg>`
+  printed, recorded in the transcript, prompt continues. (Transient Gemini 5xx are
+  already retried inside via `llm_retry`.)
+- **Ctrl-C during a turn** aborts the turn, not the session; Ctrl-C/Ctrl-D at the
+  prompt exits cleanly.
+- **Clean shutdown** (`finally`): `conversation.close()` → recorder flush → MLflow run
+  ended with status.
+- **Startup failures fail fast**: unknown backend (existing `ValueError`), missing
+  `claude` CLI auth, DB unreachable → clear message, nonzero exit, no broken REPL.
+
+## Testing (TDD; offline-deterministic except the live smoke)
+
+1. **Protocol conformance**: both backends satisfy the extended protocol
+   (mirrors `test_backends.py`).
+2. **ADK adapter**: fake runner yielding scripted events → `on_event` fires for tool
+   calls/agent transfers; final text returned (extends `test_agent_runtime.py` fakes).
+3. **ClaudeConversation**: duck-typed fake SDK client (pattern from
+   `test_claude_backend.py`) → session reused across two `send()`s, ToolUseBlock →
+   event mapping, clean `close()`.
+4. **CLI**: injected stdin/stdout + fake backend → REPL loop, `--once`, `--backend`
+   override, `--quiet`, error-turn survival.
+5. **Recorder**: local file-store MLflow (the `local_mlflow_tracking` fixture pattern)
+   → params/metrics/artifact written; unreachable-server path degrades to local jsonl.
+6. **Live smoke** (`api_dependent`, manual): 2-turn conversation per backend asserting
+   a non-empty, contextually-aware second reply.
+
+## Out of scope
+
+- Changing the Claude one-shot pipeline (ADR-040 semantics stay).
+- Streaming token-by-token output, `/history`-style REPL commands, transcript replay.
+- The Phase-4 web UI (this harness is the stopgap until then).
+- Embeddings remain Gemini regardless of backend (ADR-044).
+
+## References
+
+ADR-036 (conversational Librarian), ADR-040 (one-shot pipeline), ADR-041 (backend
+strategy seam), ADR-044 (GroundedLLM seam / PR #26 async precedent), REC-019
+(`WebSearch` tool name verified live), bugs.md 2026-05-31 (MLflow 403 / degradation
+rationale).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "psycopg2-binary>=2.9.11"
 ]
 
+[project.scripts]
+librarian = "agentic_librarian.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "pre-commit>=4.5.1",

--- a/src/agentic_librarian/agents/backends/__init__.py
+++ b/src/agentic_librarian/agents/backends/__init__.py
@@ -5,7 +5,20 @@ quota) is selectable with AGENT_BACKEND=claude."""
 from __future__ import annotations
 
 import os
-from typing import Protocol, runtime_checkable
+from typing import Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BackendConversation(Protocol):
+    """A stateful multi-turn Librarian session (ADR-045)."""
+
+    def send(self, message: str) -> str:
+        """Send one user message; return the Librarian's reply for this turn."""
+        ...
+
+    def close(self) -> None:
+        """Release session resources. Idempotent."""
+        ...
 
 
 @runtime_checkable
@@ -14,6 +27,15 @@ class RecommendationBackend(Protocol):
 
     def run_recommendation(self, prompt: str, user_id: str = "local") -> str:
         """Run the one-shot recommendation pipeline and return the recommendation text."""
+        ...
+
+    def start_conversation(
+        self,
+        user_id: str = "local",
+        on_event: Callable[[str, str], None] | None = None,
+    ) -> BackendConversation:
+        """Open a multi-turn conversation. `on_event(kind, detail)` receives key events
+        (e.g. ("tool", "search_internal_database"), ("agent", "Explorer"))."""
         ...
 
 

--- a/src/agentic_librarian/agents/backends/adk.py
+++ b/src/agentic_librarian/agents/backends/adk.py
@@ -6,7 +6,7 @@ import asyncio
 import uuid
 
 from agentic_librarian.agents.pipeline import create_recommendation_pipeline
-from agentic_librarian.agents.runtime import APP_NAME, _ensure_adk_credentials
+from agentic_librarian.agents.runtime import APP_NAME, _ensure_adk_credentials, start_conversation as _runtime_start_conversation
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -35,3 +35,8 @@ class ADKBackend:
 
     def run_recommendation(self, prompt: str, user_id: str = "local") -> str:
         return asyncio.run(self.arun(prompt, user_id))
+
+    def start_conversation(self, user_id: str = "local", on_event=None, runner=None):
+        """Multi-turn conversational Librarian (the mesh dispatcher, ADR-036/ADR-045).
+        `runner` is injectable for tests; default builds the mesh runner."""
+        return _runtime_start_conversation(user_id=user_id, runner=runner, on_event=on_event)

--- a/src/agentic_librarian/agents/backends/claude.py
+++ b/src/agentic_librarian/agents/backends/claude.py
@@ -158,7 +158,13 @@ class ClaudeConversation:
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
         self._thread.start()
-        self._run(self._connect())
+        try:
+            self._run(self._connect())
+        except BaseException:
+            # Don't leak the loop thread when the client can't connect (e.g. no `claude` auth).
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+            raise
 
     @staticmethod
     def _default_client():
@@ -167,6 +173,8 @@ class ClaudeConversation:
         return ClaudeSDKClient(options=_conversation_options())
 
     def _run(self, coro):
+        # Blocks the calling (REPL) thread until the turn completes; Ctrl-C in the main
+        # thread interrupts the wait (the CLI maps it to "turn aborted").
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
     async def _connect(self):
@@ -210,6 +218,10 @@ class ClaudeConversation:
         try:
             if self._client is not None:
                 self._run(self._client.disconnect())
+        except Exception as e:
+            # A failed disconnect must not mask the caller's exception path; the session is
+            # over either way. Warn for visibility (matches the project's no-silent-except rule).
+            print(f"warning: claude conversation disconnect failed ({type(e).__name__}: {e})")
         finally:
             self._loop.call_soon_threadsafe(self._loop.stop)
             self._thread.join(timeout=5)

--- a/src/agentic_librarian/agents/backends/claude.py
+++ b/src/agentic_librarian/agents/backends/claude.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 
 from agentic_librarian.agents import prompts
 from agentic_librarian.agents.backends.claude_tools import build_librarian_mcp_server
 from agentic_librarian.agents.candidates import coerce_schema_value, extract_candidate_ids, extract_discovery_pairs
 from agentic_librarian.mcp.server import enrich_and_persist_work, log_suggestion
-from claude_agent_sdk import ClaudeAgentOptions, query
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, query
 
 
 def _model() -> str:
@@ -96,8 +97,131 @@ async def _arun(prompt: str) -> str:
     return recommendation
 
 
+def _conversation_options() -> ClaudeAgentOptions:
+    """Options for the conversational Librarian (ADR-045): the SAME specialist mesh as ADK,
+    as programmatic SDK subagents invoked via the Task tool (the analogue of ADK's AgentTool).
+    Specialist prompts are reused verbatim; tools are scoped like the ADK mesh. VERIFY on the
+    first live run (REC-019 pattern): subagents must see the in-process 'librarian' MCP server
+    via mcpServers=["librarian"]; if not, rescope those tools onto the Librarian itself."""
+    agents = {
+        "analyst": AgentDefinition(
+            description="Turns user vibes into structured trope/style targets and constraints.",
+            prompt=prompts.ANALYST_INSTRUCTION,
+            tools=["mcp__librarian__get_user_trope_preferences"],
+            mcpServers=["librarian"],
+        ),
+        "explorer": AgentDefinition(
+            description="Discovers new candidate books on the web.",
+            prompt=prompts.EXPLORER_INSTRUCTION,
+            tools=["WebSearch"],
+        ),
+        "critic": AgentDefinition(
+            description="Ranks candidates and writes a grounded Trope-RAG justification.",
+            prompt=prompts.CRITIC_INSTRUCTION,
+            tools=[
+                "mcp__librarian__search_internal_database",
+                "mcp__librarian__get_work_details",
+                "mcp__librarian__check_reading_history",
+            ],
+            mcpServers=["librarian"],
+        ),
+    }
+    return ClaudeAgentOptions(
+        system_prompt=prompts.LIBRARIAN_INSTRUCTION,
+        model=_model(),
+        mcp_servers={"librarian": build_librarian_mcp_server()},
+        agents=agents,
+        # Task = subagent delegation; the rest are the Librarian's DIRECT tools (mirrors the
+        # ADK Librarian's FunctionTools in services.py).
+        allowed_tools=[
+            "Task",
+            "mcp__librarian__get_unacted_suggestions",
+            "mcp__librarian__update_reading_status",
+            "mcp__librarian__update_suggestion_status",
+            "mcp__librarian__log_suggestion",
+        ],
+    )
+
+
+class ClaudeConversation:
+    """Multi-turn conversational Librarian on a persistent ClaudeSDKClient session (ADR-045).
+    The SDK is async and the REPL is sync, and the session must outlive each send — so the
+    client lives on a dedicated background event-loop thread (cf. the running-loop constraint
+    ClaudeGroundedLLM solved in PR #26; asyncio.run per send would tear down the session)."""
+
+    def __init__(self, user_id: str = "local", on_event=None, client_factory=None):
+        self.user_id = user_id
+        self.on_event = on_event
+        self._client_factory = client_factory or self._default_client
+        self._client = None
+        self._closed = False
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._run(self._connect())
+
+    @staticmethod
+    def _default_client():
+        from claude_agent_sdk import ClaudeSDKClient
+
+        return ClaudeSDKClient(options=_conversation_options())
+
+    def _run(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    async def _connect(self):
+        self._client = self._client_factory()
+        await self._client.connect()
+
+    def _emit_block_event(self, block) -> None:
+        """Map a ToolUseBlock to the trace: Task delegations -> ("agent", subagent), everything
+        else -> ("tool", name) — matching the ADK event shape."""
+        tool_name = getattr(block, "name", None)
+        if not (tool_name and hasattr(block, "input") and self.on_event):
+            return
+        if tool_name == "Task":
+            self.on_event("agent", (block.input or {}).get("subagent_type", "subagent"))
+        else:
+            self.on_event("tool", str(tool_name))
+
+    async def _asend(self, message: str) -> str:
+        await self._client.query(message)
+        text_parts: list[str] = []
+        result_text = ""
+        async for msg in self._client.receive_response():
+            # ResultMessage carries the authoritative turn result (same duck-typing as _ask).
+            result_val = getattr(msg, "result", None)
+            if result_val and isinstance(result_val, str):
+                result_text = result_val
+            for block in getattr(msg, "content", None) or []:
+                block_text = getattr(block, "text", None)
+                if isinstance(block_text, str):
+                    text_parts.append(block_text)
+                self._emit_block_event(block)
+        return result_text or "".join(text_parts) or "(no response)"
+
+    def send(self, message: str) -> str:
+        return self._run(self._asend(message))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._client is not None:
+                self._run(self._client.disconnect())
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+
+
 class ClaudeBackend:
     name = "claude"
 
     def run_recommendation(self, prompt: str, user_id: str = "local") -> str:
         return asyncio.run(_arun(prompt))
+
+    def start_conversation(self, user_id: str = "local", on_event=None, client_factory=None):
+        """Multi-turn conversational Librarian on a persistent SDK session (ADR-045).
+        `client_factory` is injectable for tests."""
+        return ClaudeConversation(user_id=user_id, on_event=on_event, client_factory=client_factory)

--- a/src/agentic_librarian/agents/backends/claude.py
+++ b/src/agentic_librarian/agents/backends/claude.py
@@ -162,8 +162,7 @@ class ClaudeConversation:
             self._run(self._connect())
         except BaseException:
             # Don't leak the loop thread when the client can't connect (e.g. no `claude` auth).
-            self._loop.call_soon_threadsafe(self._loop.stop)
-            self._thread.join(timeout=5)
+            self._teardown_loop()
             raise
 
     @staticmethod
@@ -211,6 +210,15 @@ class ClaudeConversation:
     def send(self, message: str) -> str:
         return self._run(self._asend(message))
 
+    def _teardown_loop(self) -> None:
+        """Stop the background loop, join its thread, then close the loop so selector
+        resources are released (PR #33 review). Close only once the thread is gone —
+        closing a still-running loop raises RuntimeError."""
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+        if not self._thread.is_alive():
+            self._loop.close()
+
     def close(self) -> None:
         if self._closed:
             return
@@ -223,8 +231,7 @@ class ClaudeConversation:
             # over either way. Warn for visibility (matches the project's no-silent-except rule).
             print(f"warning: claude conversation disconnect failed ({type(e).__name__}: {e})")
         finally:
-            self._loop.call_soon_threadsafe(self._loop.stop)
-            self._thread.join(timeout=5)
+            self._teardown_loop()
 
 
 class ClaudeBackend:

--- a/src/agentic_librarian/agents/backends/claude_tools.py
+++ b/src/agentic_librarian/agents/backends/claude_tools.py
@@ -67,6 +67,21 @@ _TOOL_SCHEMAS: list[tuple[str, str, dict[str, Any], Any]] = [
         ),
         mcp_server.log_suggestion,
     ),
+    (
+        "update_reading_status",
+        "Update reading history from user feedback (e.g. 'I read that').",
+        _schema(
+            {"title": _STR, "author": _STR, "status": _STR, "notes": _STR},
+            required=["title", "author", "status"],
+        ),
+        mcp_server.update_reading_status,
+    ),
+    (
+        "update_suggestion_status",
+        "Update a suggestion's status (Accepted / Dismissed / Already Read).",
+        _schema({"work_id": _STR, "status": _STR}, required=["work_id", "status"]),
+        mcp_server.update_suggestion_status,
+    ),
 ]
 
 LIBRARIAN_TOOL_NAMES = [f"mcp__{_SERVER_NAME}__{short}" for short, _, _, _ in _TOOL_SCHEMAS]

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -1,6 +1,7 @@
 """Shared instruction text for the three specialist agents (Analyst/Explorer/Critic), used by both
-the ADK and Claude backends so the two never drift. The Librarian orchestrator's instruction stays
-inline in services.py — it is part of the ADK-only conversational path, not a portable backend prompt."""
+the ADK and Claude backends so the two never drift. The ADK Librarian orchestrator's instruction
+stays inline in services.py (ADK-only AgentTool terminology); the Claude backend's conversational
+Librarian uses LIBRARIAN_INSTRUCTION below (SDK subagent/Task-tool terminology, ADR-045)."""
 
 ANALYST_INSTRUCTION = """
             You are a literary analyst. Your job is to extract semantic concepts from user requests.

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -46,3 +46,28 @@ CRITIC_INSTRUCTION = """
             and never return an empty response. If the evidence is thin, recommend the closest match
             and say so.
             """
+
+# Conversational Librarian persona for the Claude backend (ADR-045, mesh parity). Mirrors the
+# ADK Librarian's delegation strategy (inline in services.py), but addresses SDK subagents
+# (analyst/explorer/critic AgentDefinitions invoked via the Task tool) instead of AgentTools.
+LIBRARIAN_INSTRUCTION = """
+You are the Head Librarian. You provide personalized book recommendations and manage reading
+history, conversationally, over multiple turns.
+
+DELEGATION STRATEGY:
+1. Delegate to the 'analyst' agent to turn user vibes into structured trope/style targets and
+   session constraints.
+2. Use 'get_unacted_suggestions' with target vibes to see if we already have good matches.
+3. If new discovery is needed, delegate to the 'explorer' agent.
+4. Delegate all candidates, targets, and session constraints to the 'critic' agent for final
+   ranking and a grounded justification.
+   - NOTE: Books read >2 years ago are eligible for re-read suggestions.
+
+FEEDBACK HANDLING:
+- "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).
+- "Not for me" / "I hate this" -> 'update_suggestion_status' (Dismissed).
+- Mood feedback ("not in the mood for X") -> respect it for the rest of the conversation.
+
+When you commit to a recommendation, log it with 'log_suggestion'. Keep replies concise and
+conversational; ask at most one clarifying question when the request is too vague to act on.
+"""

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -46,17 +46,31 @@ class LibrarianConversation:
     """A multi-turn conversation with the Librarian. Reusing one session across
     sends is what gives the agent conversational memory (ADR-036)."""
 
-    def __init__(self, runner: Runner, user_id: str, session_id: str):
+    def __init__(self, runner: Runner, user_id: str, session_id: str, on_event=None):
         self._runner = runner
         self.user_id = user_id
         self.session_id = session_id
+        # Optional visibility hook (ADR-045): on_event(kind, detail) for ("tool", name) /
+        # ("agent", author). Duck-typed event introspection so unit-test fakes keep working.
+        self.on_event = on_event
 
     async def asend(self, message: str) -> str:
         content = types.Content(role="user", parts=[types.Part(text=message)])
         final = ""
+        last_author = None
         async for event in self._runner.run_async(
             user_id=self.user_id, session_id=self.session_id, new_message=content
         ):
+            if self.on_event:
+                author = getattr(event, "author", None)
+                if author and author != last_author:
+                    self.on_event("agent", author)
+                    last_author = author
+                get_calls = getattr(event, "get_function_calls", None)
+                for fc in (get_calls() if callable(get_calls) else []) or []:
+                    name = getattr(fc, "name", None)
+                    if name:
+                        self.on_event("tool", name)
             if event.is_final_response() and event.content and event.content.parts:
                 parts_text = [p.text for p in event.content.parts if p.text]
                 if parts_text:
@@ -66,16 +80,24 @@ class LibrarianConversation:
     def send(self, message: str) -> str:
         return asyncio.run(self.asend(message))
 
+    def close(self) -> None:
+        """No session resources to release (InMemorySessionService); exists for
+        BackendConversation conformance (ADR-045)."""
 
-async def astart_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
+
+async def astart_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None
+) -> LibrarianConversation:
     runner = runner or build_runner()
     session_id = uuid.uuid4().hex
     await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
-    return LibrarianConversation(runner, user_id, session_id)
+    return LibrarianConversation(runner, user_id, session_id, on_event=on_event)
 
 
-def start_conversation(user_id: str = "local", runner: Runner | None = None) -> LibrarianConversation:
-    return asyncio.run(astart_conversation(user_id=user_id, runner=runner))
+def start_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None
+) -> LibrarianConversation:
+    return asyncio.run(astart_conversation(user_id=user_id, runner=runner, on_event=on_event))
 
 
 def run_recommendation(prompt: str, user_id: str = "local") -> str:

--- a/src/agentic_librarian/chat_recorder.py
+++ b/src/agentic_librarian/chat_recorder.py
@@ -75,6 +75,11 @@ class ConversationRecorder:
             self._mlflow.log_metric("duration_s", time.monotonic() - self._t0)
             if self.transcript_path.exists():
                 self._mlflow.log_artifact(str(self.transcript_path))
-            self._mlflow.end_run(status=status)
         except Exception as e:
             print(f"warning: mlflow close failed ({type(e).__name__}: {e})")
+        # end_run gets its own guard so a failed metric/artifact upload can't leave the
+        # run stuck in RUNNING (mlflow's active run is process-global).
+        try:
+            self._mlflow.end_run(status=status)
+        except Exception as e:
+            print(f"warning: mlflow end_run failed ({type(e).__name__}: {e})")

--- a/src/agentic_librarian/chat_recorder.py
+++ b/src/agentic_librarian/chat_recorder.py
@@ -1,0 +1,80 @@
+"""MLflow conversation capture for the CLI chat harness (ADR-045). One conversation = one
+MLflow run. Degradation posture (cf. the 2026-05-31 MLflow 403 bug): MLflow must NEVER block
+or kill a chat — every MLflow call is guarded with warn-and-continue, and the transcript is
+always written to a local jsonl regardless."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+_EXPERIMENT = "librarian_conversations"
+
+
+class ConversationRecorder:
+    def __init__(
+        self,
+        backend: str,
+        model: str,
+        user_id: str,
+        mode: str,
+        use_mlflow: bool = True,
+        log_dir: str = ".chat_logs",
+    ):
+        self._t0 = time.monotonic()
+        self._turns = 0
+        self._mlflow = None
+        self.run_id: str | None = None
+        path_dir = Path(log_dir)
+        path_dir.mkdir(parents=True, exist_ok=True)
+        self.transcript_path = path_dir / f"{datetime.now():%Y%m%d_%H%M%S}_{backend}.jsonl"
+        if use_mlflow:
+            try:
+                import mlflow
+
+                mlflow.set_experiment(_EXPERIMENT)
+                run = mlflow.start_run(run_name=f"{backend}-{mode}")
+                mlflow.log_params({"backend": backend, "model": model, "user_id": user_id, "mode": mode})
+                self._mlflow = mlflow
+                self.run_id = run.info.run_id
+            except Exception as e:  # degradation posture: warn once, never block the chat
+                print(f"warning: mlflow capture disabled ({type(e).__name__}: {e})")
+
+    def record_turn(
+        self,
+        user_text: str,
+        reply: str,
+        events: list[str],
+        latency_s: float,
+        error: str | None = None,
+    ) -> None:
+        record = {
+            "turn": self._turns,
+            "user": user_text,
+            "reply": reply,
+            "events": events,
+            "latency_s": round(latency_s, 3),
+            "error": error,
+        }
+        with self.transcript_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        if self._mlflow:
+            try:
+                self._mlflow.log_metric("latency_s", latency_s, step=self._turns)
+            except Exception as e:
+                print(f"warning: mlflow log_metric failed ({type(e).__name__}: {e})")
+        self._turns += 1
+
+    def close(self, status: str = "FINISHED") -> None:
+        if not self._mlflow:
+            return
+        try:
+            self._mlflow.log_metric("turns", self._turns)
+            self._mlflow.log_metric("duration_s", time.monotonic() - self._t0)
+            if self.transcript_path.exists():
+                self._mlflow.log_artifact(str(self.transcript_path))
+            self._mlflow.end_run(status=status)
+        except Exception as e:
+            print(f"warning: mlflow close failed ({type(e).__name__}: {e})")

--- a/src/agentic_librarian/chat_recorder.py
+++ b/src/agentic_librarian/chat_recorder.py
@@ -36,11 +36,20 @@ class ConversationRecorder:
 
                 mlflow.set_experiment(_EXPERIMENT)
                 run = mlflow.start_run(run_name=f"{backend}-{mode}")
-                mlflow.log_params({"backend": backend, "model": model, "user_id": user_id, "mode": mode})
                 self._mlflow = mlflow
                 self.run_id = run.info.run_id
+                mlflow.log_params({"backend": backend, "model": model, "user_id": user_id, "mode": mode})
             except Exception as e:  # degradation posture: warn once, never block the chat
                 print(f"warning: mlflow capture disabled ({type(e).__name__}: {e})")
+                if self._mlflow:
+                    # A run was already started: end it FAILED so it can't leak in RUNNING state
+                    # (mlflow's active run is process-global).
+                    try:
+                        self._mlflow.end_run(status="FAILED")
+                    except Exception as end_err:
+                        print(f"warning: failed to end leaked mlflow run ({type(end_err).__name__}: {end_err})")
+                    self._mlflow = None
+                    self.run_id = None
 
     def record_turn(
         self,

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -1,0 +1,126 @@
+"""`librarian` CLI — multi-turn chat REPL + one-shot recommendation test harness (ADR-045).
+Run inside the app container: `docker exec -it agentic_librarian_app librarian`."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+from agentic_librarian.agents.backends import get_backend
+from agentic_librarian.chat_recorder import ConversationRecorder
+
+_LOG_DIR = ".chat_logs"
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(prog="librarian", description="Chat with the Librarian recommendation agent.")
+    parser.add_argument("--once", metavar="PROMPT", help="one-shot recommendation (pipeline), then exit")
+    parser.add_argument("--backend", choices=["adk", "claude"], help="override AGENT_BACKEND for this run")
+    parser.add_argument("--user-id", default="local", help="user id for sessions and history (default: local)")
+    parser.add_argument("--quiet", action="store_true", help="suppress the key-event trace")
+    parser.add_argument("--no-mlflow", action="store_true", help="disable MLflow conversation capture")
+    return parser.parse_args(argv)
+
+
+def _model_label(backend_name: str) -> str:
+    if backend_name == "claude":
+        return os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
+    return os.environ.get("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    if args.backend:
+        os.environ["AGENT_BACKEND"] = args.backend
+    try:
+        backend = get_backend()
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    recorder = ConversationRecorder(
+        backend.name,
+        _model_label(backend.name),
+        args.user_id,
+        "one-shot" if args.once else "chat",
+        use_mlflow=not args.no_mlflow,
+        log_dir=_LOG_DIR,
+    )
+    if args.once:
+        return _run_once(backend, args, recorder)
+    return _run_repl(backend, args, recorder)
+
+
+def _run_once(backend, args, recorder) -> int:
+    t0 = time.monotonic()
+    try:
+        reply = backend.run_recommendation(args.once, user_id=args.user_id)
+    except Exception as e:
+        recorder.record_turn(args.once, "", [], time.monotonic() - t0, error=f"{type(e).__name__}: {e}")
+        recorder.close(status="FAILED")
+        print(f"error: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    print(reply)
+    recorder.record_turn(args.once, reply, [], time.monotonic() - t0)
+    recorder.close()
+    return 0
+
+
+def _run_repl(backend, args, recorder) -> int:
+    turn_events: list[str] = []
+
+    def on_event(kind: str, detail: str) -> None:
+        turn_events.append(f"{kind}: {detail}")
+        if not args.quiet:
+            print(f"  · {kind}: {detail}")
+
+    try:
+        conversation = backend.start_conversation(user_id=args.user_id, on_event=on_event)
+    except Exception as e:
+        recorder.close(status="FAILED")
+        print(f"error: could not start conversation: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"librarian chat — backend: {backend.name} ({_model_label(backend.name)})"
+        f" | mlflow: {recorder.run_id or 'off'} | /quit to exit"
+    )
+    try:
+        while True:
+            try:
+                line = input("you> ")
+            except (EOFError, KeyboardInterrupt, StopIteration):
+                print()
+                break
+            line = line.strip()
+            if not line:
+                continue
+            if line in ("/quit", "/exit"):
+                break
+            turn_events.clear()
+            t0 = time.monotonic()
+            try:
+                reply = conversation.send(line)
+            except KeyboardInterrupt:
+                print("(turn aborted)")
+                recorder.record_turn(line, "", list(turn_events), time.monotonic() - t0, error="aborted")
+                continue
+            except Exception as e:
+                print(f"error: {type(e).__name__}: {e}")
+                recorder.record_turn(
+                    line, "", list(turn_events), time.monotonic() - t0, error=f"{type(e).__name__}: {e}"
+                )
+                continue
+            print(f"librarian> {reply}")
+            recorder.record_turn(line, reply, list(turn_events), time.monotonic() - t0)
+    finally:
+        try:
+            conversation.close()
+        except Exception as e:
+            print(f"warning: close failed ({type(e).__name__}: {e})")
+        recorder.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_cli_chat_live.py
+++ b/test/integration/test_cli_chat_live.py
@@ -1,0 +1,24 @@
+"""Live 2-turn conversation smoke for the conversation seam (ADR-045). Run manually, once per
+backend, when quota allows:
+  AGENT_BACKEND=adk    pytest test/integration/test_cli_chat_live.py -m api_dependent -s
+  AGENT_BACKEND=claude pytest test/integration/test_cli_chat_live.py -m api_dependent -s
+(inside the app container — the claude backend additionally needs the authed `claude` CLI)."""
+
+import pytest
+from agentic_librarian.agents.backends import get_backend
+
+
+@pytest.mark.api_dependent
+def test_two_turn_conversation_live():
+    events = []
+    backend = get_backend()
+    conv = backend.start_conversation(on_event=lambda kind, detail: events.append((kind, detail)))
+    try:
+        first = conv.send("Recommend one fantasy book from my catalog with found-family vibes.")
+        second = conv.send("Why did you pick that one over other options?")
+    finally:
+        conv.close()
+    print(f"\n[{backend.name}] events: {events}\nfirst: {first}\nsecond: {second}")
+    assert first.strip() and first != "(no response)"
+    assert second.strip() and second != "(no response)"
+    assert events, "expected at least one tool/agent event in a real conversation"

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -169,6 +169,51 @@ def test_explorer_has_a_google_search_tool():
     assert any("GoogleSearch" in name for name in tool_types), tool_types
 
 
+class _FakeFunctionCall:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeToolEvent(_FakeEvent):
+    """An intermediate event carrying tool calls from a named agent."""
+
+    def __init__(self, author, tool_names):
+        super().__init__("")
+        self.author = author
+        self._tool_names = tool_names
+
+    def is_final_response(self) -> bool:
+        return False
+
+    def get_function_calls(self):
+        return [_FakeFunctionCall(n) for n in self._tool_names]
+
+
+def test_asend_fires_on_event_for_tools_and_agents():
+    class _EventfulRunner(_FakeRunner):
+        async def run_async(self, user_id, session_id, new_message):
+            yield _FakeToolEvent("Librarian", ["get_unacted_suggestions"])
+            yield _FakeToolEvent("Explorer", ["google_search"])
+            final = _FakeEvent("Try Hyperion")
+            final.author = "Librarian"
+            yield final
+
+    seen = []
+    conv = runtime.LibrarianConversation(
+        _EventfulRunner(), "u", "s", on_event=lambda kind, detail: seen.append((kind, detail))
+    )
+    assert conv.send("recommend sci-fi") == "Try Hyperion"
+    assert ("tool", "get_unacted_suggestions") in seen
+    assert ("tool", "google_search") in seen
+    assert ("agent", "Explorer") in seen
+
+
+def test_asend_without_on_event_is_unchanged():
+    conv = runtime.LibrarianConversation(_FakeRunner(reply="Try Dune"), "u", "s")
+    assert conv.send("recommend sci-fi") == "Try Dune"
+    assert conv.close() is None  # close() exists and is a no-op
+
+
 @pytest.mark.api_dependent
 def test_explorer_discovers_real_books():
     # The Explorer in isolation: its grounded google_search should return a

--- a/test/unit/test_backends.py
+++ b/test/unit/test_backends.py
@@ -18,3 +18,20 @@ def test_unknown_backend_raises(monkeypatch):
     monkeypatch.setenv("AGENT_BACKEND", "bogus")
     with pytest.raises(ValueError, match="Unknown AGENT_BACKEND"):
         get_backend()
+
+
+def test_backend_conversation_protocol_is_runtime_checkable():
+    from agentic_librarian.agents.backends import BackendConversation
+
+    class _Conv:
+        def send(self, message: str) -> str:
+            return "ok"
+
+        def close(self) -> None:
+            pass
+
+    class _NotConv:
+        pass
+
+    assert isinstance(_Conv(), BackendConversation)
+    assert not isinstance(_NotConv(), BackendConversation)

--- a/test/unit/test_backends.py
+++ b/test/unit/test_backends.py
@@ -35,3 +35,14 @@ def test_backend_conversation_protocol_is_runtime_checkable():
 
     assert isinstance(_Conv(), BackendConversation)
     assert not isinstance(_NotConv(), BackendConversation)
+
+
+def test_adk_backend_start_conversation_satisfies_protocol():
+    from agentic_librarian.agents.backends import BackendConversation
+    from agentic_librarian.agents.backends.adk import ADKBackend
+    from test.unit.test_agent_runtime import _FakeRunner
+
+    conv = ADKBackend().start_conversation(user_id="u", runner=_FakeRunner(reply="ok"))
+    assert isinstance(conv, BackendConversation)
+    assert conv.send("hi") == "ok"
+    conv.close()

--- a/test/unit/test_chat_recorder.py
+++ b/test/unit/test_chat_recorder.py
@@ -1,0 +1,50 @@
+import json
+
+from agentic_librarian.chat_recorder import ConversationRecorder
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_transcript_written_without_mlflow(tmp_path):
+    rec = ConversationRecorder("adk", "m", "u", "chat", use_mlflow=False, log_dir=str(tmp_path))
+    rec.record_turn("hi", "hello", ["tool: x"], 1.25)
+    rec.record_turn("bye", "", [], 0.5, error="boom")
+    rec.close()
+    records = _read_jsonl(rec.transcript_path)
+    assert len(records) == 2
+    assert records[0] == {"turn": 0, "user": "hi", "reply": "hello", "events": ["tool: x"], "latency_s": 1.25, "error": None}
+    assert records[1]["error"] == "boom"
+    assert rec.run_id is None
+
+
+def test_mlflow_run_captured_with_file_store(tmp_path, monkeypatch):
+    import mlflow
+
+    uri = (tmp_path / "mlruns").as_uri()
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", uri)
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")  # MLflow 3.x requires opt-in
+    mlflow.set_tracking_uri(uri)
+    rec = ConversationRecorder("claude", "claude-sonnet-4-6", "u", "chat", log_dir=str(tmp_path / "logs"))
+    assert rec.run_id
+    rec.record_turn("hi", "hello", [], 2.0)
+    rec.close()
+    run = mlflow.get_run(rec.run_id)
+    assert run.data.params["backend"] == "claude"
+    assert run.data.metrics["turns"] == 1.0
+    assert run.info.status == "FINISHED"
+
+
+def test_unreachable_mlflow_degrades_to_local_jsonl(tmp_path, monkeypatch, capsys):
+    import mlflow
+
+    monkeypatch.setenv("MLFLOW_HTTP_REQUEST_MAX_RETRIES", "0")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:9")
+    mlflow.set_tracking_uri("http://127.0.0.1:9")
+    rec = ConversationRecorder("adk", "m", "u", "chat", log_dir=str(tmp_path))
+    rec.record_turn("hi", "hello", [], 1.0)
+    rec.close()  # must not raise
+    assert rec.run_id is None
+    assert len(_read_jsonl(rec.transcript_path)) == 1
+    assert "mlflow capture disabled" in capsys.readouterr().out

--- a/test/unit/test_chat_recorder.py
+++ b/test/unit/test_chat_recorder.py
@@ -48,3 +48,17 @@ def test_unreachable_mlflow_degrades_to_local_jsonl(tmp_path, monkeypatch, capsy
     assert rec.run_id is None
     assert len(_read_jsonl(rec.transcript_path)) == 1
     assert "mlflow capture disabled" in capsys.readouterr().out
+
+
+def test_close_ends_run_even_when_artifact_upload_fails(tmp_path, monkeypatch):
+    import mlflow
+
+    uri = (tmp_path / "mlruns").as_uri()
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", uri)
+    mlflow.set_tracking_uri(uri)
+    rec = ConversationRecorder("adk", "m", "u", "chat", log_dir=str(tmp_path / "logs"))
+    rec.record_turn("hi", "hello", [], 1.0)
+    monkeypatch.setattr(rec._mlflow, "log_artifact", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("upload failed")))
+    rec.close()  # must not raise, and must still end the run
+    assert mlflow.get_run(rec.run_id).info.status == "FINISHED"

--- a/test/unit/test_chat_recorder.py
+++ b/test/unit/test_chat_recorder.py
@@ -62,3 +62,19 @@ def test_close_ends_run_even_when_artifact_upload_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(rec._mlflow, "log_artifact", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("upload failed")))
     rec.close()  # must not raise, and must still end the run
     assert mlflow.get_run(rec.run_id).info.status == "FINISHED"
+
+
+def test_init_ends_run_when_param_logging_fails(tmp_path, monkeypatch, capsys):
+    import mlflow
+
+    uri = (tmp_path / "mlruns").as_uri()
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", uri)
+    mlflow.set_tracking_uri(uri)
+    monkeypatch.setattr(
+        mlflow, "log_params", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("params failed"))
+    )
+    rec = ConversationRecorder("adk", "m", "u", "chat", log_dir=str(tmp_path / "logs"))
+    assert rec.run_id is None
+    assert mlflow.active_run() is None  # no leaked RUNNING run polluting process-global state
+    assert "mlflow capture disabled" in capsys.readouterr().out

--- a/test/unit/test_claude_backend.py
+++ b/test/unit/test_claude_backend.py
@@ -178,3 +178,31 @@ def test_claude_conversation_close_survives_disconnect_error(capsys):
     conv = ClaudeConversation(client_factory=_ExplodingDisconnectClient)
     conv.close()  # must not raise
     assert "disconnect failed" in capsys.readouterr().out
+
+
+def test_claude_conversation_close_closes_the_loop():
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    conv = ClaudeConversation(client_factory=_FakeSDKClient)
+    loop = conv._loop
+    conv.close()
+    assert loop.is_closed()  # selector resources released, not just stopped (PR #33 review)
+
+
+def test_claude_conversation_connect_failure_closes_the_loop(monkeypatch):
+    import asyncio as _asyncio
+
+    from agentic_librarian.agents.backends import claude as claude_mod
+
+    created = []
+    real_new_event_loop = _asyncio.new_event_loop
+
+    def _capturing_new_event_loop():
+        loop = real_new_event_loop()
+        created.append(loop)
+        return loop
+
+    monkeypatch.setattr(claude_mod.asyncio, "new_event_loop", _capturing_new_event_loop)
+    with pytest.raises(RuntimeError, match="no auth"):
+        claude_mod.ClaudeConversation(client_factory=lambda: (_ for _ in ()).throw(RuntimeError("no auth")))
+    assert created and created[0].is_closed()

--- a/test/unit/test_claude_backend.py
+++ b/test/unit/test_claude_backend.py
@@ -49,3 +49,108 @@ def test_claude_backend_sequences_pipeline_and_returns_recommendation():
     assert "recommend" in out.lower()
     assert calls["i"] == 3  # Analyst, Explorer, Critic each queried once
     mock_log.assert_called_once()  # the top candidate was logged
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeToolUseBlock:
+    def __init__(self, name):
+        self.name = name
+        self.input = {}
+
+
+class _FakeAssistantMessage:
+    def __init__(self, blocks):
+        self.content = blocks
+
+
+class _FakeResultMessage:
+    def __init__(self, result):
+        self.result = result
+        self.content = []
+
+
+class _FakeSDKClient:
+    """Duck-typed ClaudeSDKClient: connect/query/receive_response/disconnect."""
+
+    def __init__(self):
+        self.connected = False
+        self.disconnected = False
+        self.queries = []
+
+    async def connect(self):
+        self.connected = True
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        task_block = _FakeToolUseBlock("Task")
+        task_block.input = {"subagent_type": "explorer", "prompt": "find books"}
+        yield _FakeAssistantMessage(
+            [
+                task_block,
+                _FakeToolUseBlock("mcp__librarian__get_unacted_suggestions"),
+                _FakeTextBlock("thinking..."),
+            ]
+        )
+        yield _FakeResultMessage(f"reply-{len(self.queries)}")
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def test_claude_conversation_reuses_one_session_and_fires_events():
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    fake = _FakeSDKClient()
+    seen = []
+    conv = ClaudeConversation(on_event=lambda k, d: seen.append((k, d)), client_factory=lambda: fake)
+    try:
+        assert conv.send("first") == "reply-1"
+        assert conv.send("second") == "reply-2"
+    finally:
+        conv.close()
+    assert fake.queries == ["first", "second"]  # ONE client, one session, two turns
+    assert ("agent", "explorer") in seen  # Task delegation maps to an agent event (ADK parity)
+    assert ("tool", "mcp__librarian__get_unacted_suggestions") in seen
+    assert fake.disconnected
+
+
+def test_conversation_options_wire_the_specialist_mesh():
+    from agentic_librarian.agents import prompts
+    from agentic_librarian.agents.backends.claude import _conversation_options
+
+    options = _conversation_options()
+    assert set(options.agents) == {"analyst", "explorer", "critic"}
+    assert options.agents["analyst"].prompt == prompts.ANALYST_INSTRUCTION
+    assert options.agents["explorer"].prompt == prompts.EXPLORER_INSTRUCTION
+    assert options.agents["explorer"].tools == ["WebSearch"]
+    assert options.agents["critic"].prompt == prompts.CRITIC_INSTRUCTION
+    assert "mcp__librarian__search_internal_database" in options.agents["critic"].tools
+    assert "Task" in options.allowed_tools  # the Librarian delegates via the Task tool
+    assert "mcp__librarian__log_suggestion" in options.allowed_tools
+    assert options.system_prompt == prompts.LIBRARIAN_INSTRUCTION
+
+
+def test_claude_conversation_close_is_idempotent():
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    conv = ClaudeConversation(client_factory=_FakeSDKClient)
+    conv.close()
+    conv.close()  # second close must not raise
+
+
+def test_claude_backend_start_conversation_satisfies_protocol():
+    from agentic_librarian.agents.backends import BackendConversation
+    from agentic_librarian.agents.backends.claude import ClaudeBackend
+
+    conv = ClaudeBackend().start_conversation(client_factory=_FakeSDKClient)
+    try:
+        assert isinstance(conv, BackendConversation)
+        assert conv.send("hi") == "reply-1"
+    finally:
+        conv.close()

--- a/test/unit/test_claude_backend.py
+++ b/test/unit/test_claude_backend.py
@@ -154,3 +154,27 @@ def test_claude_backend_start_conversation_satisfies_protocol():
         assert conv.send("hi") == "reply-1"
     finally:
         conv.close()
+
+
+def test_claude_conversation_connect_failure_stops_loop_thread():
+    import threading
+
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    before = {t.ident for t in threading.enumerate()}
+    with pytest.raises(RuntimeError, match="no auth"):
+        ClaudeConversation(client_factory=lambda: (_ for _ in ()).throw(RuntimeError("no auth")))
+    leaked = [t for t in threading.enumerate() if t.ident not in before and t.is_alive()]
+    assert not leaked, f"connect failure leaked loop thread(s): {leaked}"
+
+
+def test_claude_conversation_close_survives_disconnect_error(capsys):
+    from agentic_librarian.agents.backends.claude import ClaudeConversation
+
+    class _ExplodingDisconnectClient(_FakeSDKClient):
+        async def disconnect(self):
+            raise RuntimeError("socket gone")
+
+    conv = ClaudeConversation(client_factory=_ExplodingDisconnectClient)
+    conv.close()  # must not raise
+    assert "disconnect failed" in capsys.readouterr().out

--- a/test/unit/test_claude_tools.py
+++ b/test/unit/test_claude_tools.py
@@ -10,3 +10,11 @@ def test_build_librarian_mcp_server_exposes_tools():
     assert server is not None
     for short in ("search_internal_database", "get_work_details", "get_user_trope_preferences", "log_suggestion"):
         assert f"mcp__librarian__{short}" in LIBRARIAN_TOOL_NAMES
+
+
+def test_feedback_tools_are_exposed():
+    # The conversational Librarian (ADR-045) needs the feedback tools the ADK Librarian has.
+    from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
+
+    assert "mcp__librarian__update_reading_status" in LIBRARIAN_TOOL_NAMES
+    assert "mcp__librarian__update_suggestion_status" in LIBRARIAN_TOOL_NAMES

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,0 +1,110 @@
+import builtins
+
+import pytest
+from agentic_librarian import cli
+
+
+class _FakeConversation:
+    def __init__(self, replies, on_event=None):
+        self._replies = list(replies)
+        self.on_event = on_event
+        self.sent = []
+        self.closed = False
+
+    def send(self, message):
+        self.sent.append(message)
+        if self.on_event:
+            self.on_event("tool", "search_internal_database")
+        reply = self._replies.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeBackend:
+    name = "fake"
+
+    def __init__(self, replies=("a reply",)):
+        self._replies = replies
+        self.conversation = None
+
+    def run_recommendation(self, prompt, user_id="local"):
+        return f"one-shot: {prompt}"
+
+    def start_conversation(self, user_id="local", on_event=None):
+        self.conversation = _FakeConversation(self._replies, on_event)
+        return self.conversation
+
+
+@pytest.fixture
+def no_mlflow_dir(tmp_path, monkeypatch):
+    # Keep transcripts inside tmp and never touch MLflow in CLI tests.
+    monkeypatch.setattr(cli, "_LOG_DIR", str(tmp_path))
+
+
+def _feed_stdin(monkeypatch, lines):
+    it = iter(lines)
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(it))
+
+
+def test_once_prints_recommendation(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend()
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    rc = cli.main(["--once", "heist novel", "--no-mlflow"])
+    assert rc == 0
+    assert "one-shot: heist novel" in capsys.readouterr().out
+
+
+def test_repl_two_turns_then_quit(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=("first reply", "second reply"))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hello", "more", "/quit"])
+    rc = cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "librarian> first reply" in out
+    assert "librarian> second reply" in out
+    assert "· tool: search_internal_database" in out  # event trace
+    assert fake.conversation.closed
+
+
+def test_repl_survives_a_failed_turn(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=(RuntimeError("boom"), "recovered"))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["explode", "again", "/quit"])
+    rc = cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "error: RuntimeError: boom" in out
+    assert "librarian> recovered" in out
+
+
+def test_quiet_suppresses_event_trace(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend(replies=("ok",))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hi", "/quit"])
+    cli.main(["--no-mlflow", "--quiet"])
+    assert "· tool:" not in capsys.readouterr().out
+
+
+def test_backend_flag_sets_env(monkeypatch, capsys, no_mlflow_dir):
+    fake = _FakeBackend()
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+    cli.main(["--once", "x", "--no-mlflow", "--backend", "claude"])
+    import os
+
+    assert os.environ["AGENT_BACKEND"] == "claude"
+
+
+def test_unknown_backend_fails_fast(monkeypatch, capsys, no_mlflow_dir):
+    def _boom():
+        raise ValueError("Unknown AGENT_BACKEND='nope'")
+
+    monkeypatch.setattr(cli, "get_backend", _boom)
+    rc = cli.main(["--once", "x", "--no-mlflow"])
+    assert rc == 2
+    assert "Unknown AGENT_BACKEND" in capsys.readouterr().err

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -82,12 +82,19 @@ def test_repl_survives_a_failed_turn(monkeypatch, capsys, no_mlflow_dir):
     assert "librarian> recovered" in out
 
 
-def test_quiet_suppresses_event_trace(monkeypatch, capsys, no_mlflow_dir):
+def test_quiet_suppresses_event_trace_but_still_records(tmp_path, monkeypatch, capsys):
+    import json
+
+    monkeypatch.setattr(cli, "_LOG_DIR", str(tmp_path))
     fake = _FakeBackend(replies=("ok",))
     monkeypatch.setattr(cli, "get_backend", lambda: fake)
     _feed_stdin(monkeypatch, ["hi", "/quit"])
     cli.main(["--no-mlflow", "--quiet"])
     assert "· tool:" not in capsys.readouterr().out
+    transcripts = list(tmp_path.glob("*.jsonl"))
+    assert len(transcripts) == 1
+    record = json.loads(transcripts[0].read_text(encoding="utf-8").splitlines()[0])
+    assert record["events"] == ["tool: search_internal_database"]  # recorded even when not printed
 
 
 def test_backend_flag_sets_env(monkeypatch, capsys, no_mlflow_dir):

--- a/test/unit/test_prompts.py
+++ b/test/unit/test_prompts.py
@@ -22,3 +22,14 @@ def test_services_use_shared_prompts(monkeypatch):
     assert mesh["analyst"].instruction == prompts.ANALYST_INSTRUCTION
     assert mesh["explorer"].instruction == prompts.EXPLORER_INSTRUCTION
     assert mesh["critic"].instruction == prompts.CRITIC_INSTRUCTION
+
+
+def test_librarian_instruction_delegates_to_the_mesh():
+    # The Claude conversational Librarian delegates to the SAME specialist mesh as ADK
+    # (SDK subagents named analyst/explorer/critic) and keeps the feedback/logging tools direct.
+    text = prompts.LIBRARIAN_INSTRUCTION
+    assert "'analyst'" in text
+    assert "'explorer'" in text
+    assert "'critic'" in text
+    assert "log_suggestion" in text
+    assert "update_suggestion_status" in text

--- a/test/unit/test_prompts.py
+++ b/test/unit/test_prompts.py
@@ -33,3 +33,5 @@ def test_librarian_instruction_delegates_to_the_mesh():
     assert "'critic'" in text
     assert "log_suggestion" in text
     assert "update_suggestion_status" in text
+    assert "update_reading_status" in text
+    assert "get_unacted_suggestions" in text


### PR DESCRIPTION
## Summary

Adds a `librarian` console-script test harness for the conversational piece, with **multi-turn conversations on BOTH backends** (spec: `docs/superpowers/specs/2026-06-05-cli-chat-design.md`, ADR-045):

- **Backend seam extension (ADR-041)**: `RecommendationBackend.start_conversation(user_id, on_event) -> BackendConversation` (`send`/`close`), so multi-turn means the same thing on both backends — a stateful Librarian session calling tools on demand.
- **ADK**: wraps the existing `LibrarianConversation` (ADR-036); `asend` gains an optional event callback firing `("agent", author)` / `("tool", name)` from the event stream (duck-typed; zero behavior change when unset).
- **Claude — full mesh parity**: new `ClaudeConversation` on a persistent `ClaudeSDKClient` session (background event-loop thread, PR #26 precedent), delegating to the SAME specialist mesh as ADK via programmatic SDK subagents (`analyst`/`explorer`/`critic` `AgentDefinition`s reusing the specialist prompts verbatim, invoked through the `Task` tool — the analogue of ADK's `AgentTool`). `Task` delegations map to `("agent", subagent)` trace events. Lifecycle hardened: no thread leak on connect failure; `close()` idempotent and survives disconnect errors. The one-shot pipeline (ADR-040) is untouched.
- **MLflow conversation capture**: `ConversationRecorder` — one conversation = one run in `librarian_conversations` (params backend/model/user_id/mode, per-turn latency metrics, `transcript.jsonl` artifact). Degradation posture per the 2026-05-31 MLflow-403 bug: failures warn-and-continue, never block the chat; transcript always lands in a local gitignored `.chat_logs/` jsonl; `end_run` has its own guard so runs can't leak in RUNNING state.
- **CLI**: `librarian` (REPL) / `--once PROMPT` / `--backend adk|claude` / `--user-id` / `--quiet` / `--no-mlflow`. Compact event trace as turns execute; failed turns never kill the REPL; Ctrl-C aborts the turn, not the session.
- Feedback tools (`update_reading_status`, `update_suggestion_status`) added to the Claude in-process MCP server for conversational parity with the ADK Librarian.

## Verification

- Full fast suite: **203 passed, 0 failed** (was 179 before the branch; +24 from this feature, all red→green TDD).
- Per-task spec-compliance + code-quality reviews, plus a final integration review.
- **Live-run items (user-gated, documented in code + ADR-045)**: subagent visibility of the in-process MCP server (`mcpServers=["librarian"]`, REC-019 pattern — fallback documented); live 2-turn smoke per backend (`test/integration/test_cli_chat_live.py`, api_dependent).

## Test Plan
- [ ] CI lint
- [ ] Live 2-turn smoke per backend when quota allows (`AGENT_BACKEND=adk|claude pytest test/integration/test_cli_chat_live.py -m api_dependent -s`)
- [ ] First interactive run: `docker exec -it agentic_librarian_app librarian --backend claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)