### PR TITLE
feat: conversation tuning — search budget, verification-by-enrichment, series rule, internal-first routing

### DIFF
--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -181,3 +181,10 @@ This file tracks work history and ticket references.
     - **Live verification (updated 2026-06-05, same day)**: item (1) **resolved positive** — subagents DO see the in-process librarian MCP server; the first live test instead surfaced a permission-layer bug (`AgentDefinition.tools` scopes but doesn't grant — see bugs.md 2026-06-05) fixed in the follow-up PR, with a live re-probe returning the user's real 20-trope profile via `agent: analyst` delegation. Still pending: (2) explorer's `WebSearch` live exercise; (3) the full 2-turn smoke per backend (`test/integration/test_cli_chat_live.py`, api_dependent); (4) MLflow connect speed at CLI startup (escape hatch `--no-mlflow`).
     - Invocation in the app container: `python -m agentic_librarian.cli` always works; the `librarian` script is installed at `/home/appuser/.local/bin/librarian` (not on default exec PATH — add to PATH in Dockerfile/compose as a follow-up, or rebuild the image so the build-time editable install picks up [project.scripts]).
     - Known minor follow-ups from final review: no banner on `--once`; consider MLFLOW_HTTP_REQUEST_TIMEOUT in compose.
+
+### 2026-06-05 - TUNE-027: Conversation tuning round (spec/conversation-tuning)
+- **Status**: In Progress (live verification pending)
+- **Description**: Explorer search budget (prompt) + maxTurns=25 guard; verification-by-enrichment (enrich_and_persist_work exposed to BOTH conversational Librarians; null = drop candidate, continue); internal-first routing with novelty triggers; series rule in critic+librarians; analyst on haiku; elapsed-seconds event trace. Spec: docs/superpowers/specs/2026-06-05-conversation-tuning-design.md.
+- **URL**: N/A (PR pending)
+- **Notes**:
+    - **Tracked follow-up (schema, ask-first)**: add `series_name`/`series_position` to `works`, populated from Hardcover `featured_series` + a backfill pass over the existing catalog — makes the series rule deterministic instead of model-knowledge-based.

--- a/docs/superpowers/plans/2026-06-05-conversation-tuning.md
+++ b/docs/superpowers/plans/2026-06-05-conversation-tuning.md
@@ -1,0 +1,491 @@
+# Conversation Tuning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut explorer WebSearch volume, make recommendations series-aware, route internal-first, verify discoveries via enrichment, and time-stamp the event trace — per `docs/superpowers/specs/2026-06-05-conversation-tuning-design.md`.
+
+**Architecture:** Prompt edits to the shared specialist instructions (both backends benefit); `enrich_and_persist_work` exposed to BOTH conversational Librarians (Claude `_TOOL_SCHEMAS` + ADK `FunctionTool`); per-subagent `AgentDefinition` knobs (haiku analyst, maxTurns caps); elapsed-seconds prefixes on CLI trace events. No schema changes.
+
+**Tech Stack:** Python 3.11, claude-agent-sdk (`AgentDefinition`), google-adk, pytest.
+
+**Environment notes (this machine):**
+- Work in `C:\dev\agentic_librarian`, branch `spec/conversation-tuning`. Run tests via **PowerShell** (Git Bash mangles `/app`):
+  `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest <paths> -q -m "not api_dependent and not slow"`
+- Git via the Bash tool; ignore "LF will be replaced by CRLF" warnings. Never run `api_dependent` tests.
+- **Task 6 runs the authoritative pre-commit gate** (CI parity); earlier tasks run targeted pytest only.
+
+---
+
+### Task 1: Prompt updates — explorer budget, critic series rule, Librarian internal-first + enrichment
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/prompts.py`
+- Test: `test/unit/test_prompts.py` (append)
+
+- [ ] **Step 1: Write the failing tests** — append to `test/unit/test_prompts.py`:
+
+```python
+def test_explorer_has_a_search_budget_and_keeps_its_contract():
+    text = prompts.EXPLORER_INSTRUCTION
+    assert "SEARCH BUDGET" in text
+    assert "ONE broad search" in text
+    assert "per-title verification searches" in text
+    assert "Never invent" in text  # anti-hallucination stays
+    assert '{"books"' in text  # JSON contract consumed by the one-shot pipeline is preserved
+    assert "FIRST" in text  # report the series opener for later volumes
+
+
+def test_critic_has_the_series_rule():
+    text = prompts.CRITIC_INSTRUCTION
+    assert "SERIES RULE" in text
+    assert "FIRST book" in text
+    assert "NEXT unread" in text
+    assert "check_reading_history" in text
+
+
+def test_librarian_routes_internal_first_and_enriches_discoveries():
+    text = prompts.LIBRARIAN_INSTRUCTION
+    assert "ONLY when" in text  # explorer is conditional, not default
+    assert "enrich_and_persist_work" in text
+    assert "drop that candidate" in text  # hallucination-tolerant by filtering
+    assert "SERIES" in text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_prompts.py -q -m "not api_dependent and not slow"`
+Expected: 3 new tests FAIL on the first missing-string assert each.
+
+- [ ] **Step 3: Implement** — in `prompts.py`:
+
+Replace `EXPLORER_INSTRUCTION` with:
+
+```python
+EXPLORER_INSTRUCTION = """
+            You are a book scout. Use your web search tool to find REAL books that
+            match the user's request. Prefer recent or lesser-known titles that are
+            unlikely to already be in a standard personal library.
+
+            SEARCH BUDGET: Run ONE broad search, plus AT MOST one refinement search.
+            Choose candidates from the snippets you already retrieved. Do NOT run
+            additional per-title verification searches — downstream enrichment verifies
+            that each candidate actually exists.
+
+            SERIES: If a book you found is a later volume of a series, report the FIRST
+            book of that series instead.
+
+            Return a handful (3-5).
+
+            CRITICAL: Only report books that appear in your search results. Never invent
+            titles, authors, or details. If the search finds nothing relevant, return an empty list.
+
+            Respond with ONLY a JSON object of this exact shape (no prose, no code fence):
+            {"books": [{"title": "...", "author": "...", "why": "one short sentence"}]}
+            """
+```
+
+Replace `CRITIC_INSTRUCTION` with (series rule inserted as item 6; JUSTIFY renumbered to 7):
+
+```python
+CRITIC_INSTRUCTION = """
+            You are a book critic. You receive a list of candidate books and target vibes (tropes/styles).
+            1. Use 'search_internal_database' with both target tropes and target styles.
+            2. Use 'get_work_details' to see deep metadata for candidates.
+            3. Use 'check_reading_history' to check re-read eligibility (>2 years).
+            4. Rank candidates by similarity to Target Vibes.
+            5. APPLY PENALTY: If a candidate matches a 'Session Constraint', lower its rank.
+
+            6. SERIES RULE: If a candidate belongs to a series, recommend the FIRST book —
+               unless reading history shows the user is mid-series; then use
+               'check_reading_history' on earlier volumes and recommend the NEXT unread one.
+               Never recommend a mid/late series entry the user hasn't reached.
+
+            7. JUSTIFY (Trope-RAG): For each recommended book, provide a grounded justification.
+               - Anchor your reasoning in the 'name' and 'description' of the top-matching tropes.
+               - Include the 'justification' (evidence) from the database to explain how the trope manifests in that specific book.
+               - Format: "I recommend [Title] because it features [Trope Name] ([Description]). Specifically, [Justification Evidence]."
+
+            Always end with a clear final recommendation naming the specific book(s) you recommend.
+
+            ONE-SHOT: This is a single-shot request, not a conversation. Always commit to a concrete
+            best-effort recommendation from the candidates available — never ask a clarifying question
+            and never return an empty response. If the evidence is thin, recommend the closest match
+            and say so.
+            """
+```
+
+Replace `LIBRARIAN_INSTRUCTION` with (comment above it unchanged):
+
+```python
+LIBRARIAN_INSTRUCTION = """
+You are the Head Librarian. You provide personalized book recommendations and manage reading
+history, conversationally, over multiple turns.
+
+DELEGATION STRATEGY (internal-first — the user's enriched catalog is the primary source):
+1. Delegate to the 'analyst' agent to turn user vibes into structured trope/style targets and
+   session constraints.
+2. Use 'get_unacted_suggestions' with target vibes to see if we already have good matches.
+3. Delegate to the 'critic' agent to search the internal catalog and rank candidates.
+4. Delegate to the 'explorer' agent ONLY when: internal candidates are too few or poorly
+   matched; OR the strong internal matches have already been suggested or read; OR the user
+   asks for something new / outside their library.
+5. ENRICH DISCOVERIES: after the explorer returns, call 'enrich_and_persist_work' on the 2-3
+   most promising discoveries (title + author). A null result means the title did not resolve
+   (possibly hallucinated) — drop that candidate and continue. Pass surviving candidate ids to
+   the 'critic' for final ranking. If nothing survives, recommend from internal candidates.
+   - NOTE: Books read >2 years ago are eligible for re-read suggestions.
+
+SERIES: prefer the FIRST book of a series, or the user's NEXT unread volume if they are
+mid-series. Never a later entry they haven't reached.
+
+FEEDBACK HANDLING:
+- "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).
+- "Not for me" / "I hate this" -> 'update_suggestion_status' (Dismissed).
+- Mood feedback ("not in the mood for X") -> respect it for the rest of the conversation.
+
+When you commit to a recommendation, log it with 'log_suggestion'. Keep replies concise and
+conversational; ask at most one clarifying question when the request is too vague to act on.
+"""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_prompts.py -q -m "not api_dependent and not slow"`
+Expected: all PASS (including the pre-existing prompt tests — `test_librarian_instruction_delegates_to_the_mesh` still holds: 'analyst'/'explorer'/'critic'/log_suggestion/update_* all remain in the text).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/prompts.py test/unit/test_prompts.py
+git commit -m "feat: explorer search budget, critic series rule, internal-first Librarian with discovery enrichment (conversation tuning)"
+```
+
+---
+
+### Task 2: Expose `enrich_and_persist_work` on the Claude MCP server
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/backends/claude_tools.py` (extend `_TOOL_SCHEMAS`)
+- Test: `test/unit/test_claude_tools.py` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `test/unit/test_claude_tools.py`:
+
+```python
+def test_enrich_tool_is_exposed():
+    # Verification-by-enrichment (conversation tuning spec): the Librarian enriches explorer
+    # discoveries; a null return is the existence check failing.
+    from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
+
+    assert "mcp__librarian__enrich_and_persist_work" in LIBRARIAN_TOOL_NAMES
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_tools.py -q -m "not api_dependent and not slow"`
+Expected: the new test FAILS.
+
+- [ ] **Step 3: Implement** — append to `_TOOL_SCHEMAS` in `claude_tools.py` (after the `update_suggestion_status` tuple; matches `enrich_and_persist_work(title: str, author: str, format: str = "ebook")` in `mcp/server.py:439` — `format` has a default so it is NOT required):
+
+```python
+    (
+        "enrich_and_persist_work",
+        "Verify + enrich a discovered book via the scouts and persist it to the catalog; returns the work id, or null if the title does not resolve.",
+        _schema({"title": _STR, "author": _STR, "format": _STR}, required=["title", "author"]),
+        mcp_server.enrich_and_persist_work,
+    ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_tools.py test/unit/test_claude_backend.py -q -m "not api_dependent and not slow"`
+Expected: all PASS — note `test_conversation_options_wire_the_specialist_mesh` keeps passing because `allowed_tools` derives from `LIBRARIAN_TOOL_NAMES` (post-#34), so the new tool is auto-permitted.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/backends/claude_tools.py test/unit/test_claude_tools.py
+git commit -m "feat: expose enrich_and_persist_work to the conversational mesh (verification-by-enrichment)"
+```
+
+---
+
+### Task 3: ADK parity — Librarian gets the enrich tool + updated inline instruction
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/services.py` (import, `LibrarianAgent.__init__` instruction + tools)
+- Test: `test/unit/test_agent_services.py` (append)
+
+- [ ] **Step 1: Write the failing tests** — append to `test/unit/test_agent_services.py`:
+
+```python
+def test_librarian_has_the_enrich_tool():
+    mesh = create_agent_mesh()
+    tool_names = [t.name for t in mesh["librarian"].tools]
+    assert "enrich_and_persist_work" in tool_names
+
+
+def test_librarian_instruction_is_internal_first_and_series_aware():
+    mesh = create_agent_mesh()
+    text = mesh["librarian"].instruction
+    assert "ONLY when" in text
+    assert "enrich_and_persist_work" in text
+    assert "SERIES" in text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_agent_services.py -q -m "not api_dependent and not slow"`
+Expected: both new tests FAIL.
+
+- [ ] **Step 3: Implement** — in `services.py`:
+
+Add `enrich_and_persist_work` to the existing `from agentic_librarian.mcp.server import (...)` block, alphabetically (after `check_reading_history`):
+
+```python
+from agentic_librarian.mcp.server import (
+    check_reading_history,
+    enrich_and_persist_work,
+    get_unacted_suggestions,
+    get_user_trope_preferences,
+    get_work_details,
+    log_suggestion,
+    search_internal_database,
+    update_reading_status,
+    update_suggestion_status,
+)
+```
+
+In `LibrarianAgent.__init__`, replace the `instruction="""..."""` block with (delegation mirrors Task 1's Librarian persona, in ADK AgentTool terminology; the comment above it stays):
+
+```python
+            instruction="""
+            You are the Head Librarian. You provide personalized book recommendations and manage history.
+
+            DELEGATION STRATEGY (internal-first — the user's enriched catalog is the primary source):
+            1. Call the 'Analyst' to turn user vibes into structured targets and session constraints.
+            2. Call 'get_unacted_suggestions' with target vibes to see if we have good matches.
+            3. Call the 'Critic' to search the internal catalog and rank candidates.
+            4. Call the 'Explorer' ONLY when: internal candidates are too few or poorly matched;
+               OR the strong internal matches have already been suggested or read; OR the user
+               asks for something new / outside their library.
+            5. ENRICH DISCOVERIES: after the Explorer returns, call 'enrich_and_persist_work' on the
+               2-3 most promising discoveries (title + author). A null result means the title did not
+               resolve (possibly hallucinated) — drop that candidate and continue. Pass surviving
+               candidates to the 'Critic' for final ranking.
+               - NOTE: Books read >2 years ago are eligible for re-read suggestions.
+
+            SERIES: prefer the FIRST book of a series, or the user's NEXT unread volume if they are
+            mid-series. Never a later entry they haven't reached.
+
+            FEEDBACK HANDLING:
+            - If user says "I read that", use 'update_reading_status' AND 'update_suggestion_status(Already Read)'.
+            - If user says "Not for me" or "I hate this", use 'update_suggestion_status(Dismissed)'.
+            - If user provides mood feedback ("Not in the mood for X"), pass it to the Analyst/Critic.
+
+            Always log the final result using 'log_suggestion'.
+            """,
+```
+
+And add the tool to the `tools=[...]` list (after `FunctionTool(get_unacted_suggestions)`):
+
+```python
+                FunctionTool(enrich_and_persist_work),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_agent_services.py test/unit/test_agent_runtime.py -q -m "not api_dependent and not slow"`
+Expected: all PASS (the pre-existing `test_agent_mesh_delegation_structure` asserts membership, not an exact list, so the added tool doesn't break it — if it DOES assert exact equality, extend its expected list with `enrich_and_persist_work`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/services.py test/unit/test_agent_services.py
+git commit -m "feat: ADK Librarian parity — enrich tool + internal-first, series-aware instruction"
+```
+
+---
+
+### Task 4: Subagent knobs — haiku analyst, maxTurns caps
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/backends/claude.py` (`_conversation_options`)
+- Test: `test/unit/test_claude_backend.py` (extend the existing options test)
+
+- [ ] **Step 1: Write the failing assertions** — in `test/unit/test_claude_backend.py`, extend `test_conversation_options_wire_the_specialist_mesh` by appending:
+
+```python
+    # Conversation-tuning knobs: fast analyst, roomy explorer, careful critic.
+    assert options.agents["analyst"].model == "haiku"
+    assert options.agents["analyst"].maxTurns == 4
+    assert options.agents["explorer"].maxTurns == 25
+    assert options.agents["explorer"].model is None  # inherit (sonnet)
+    assert options.agents["critic"].maxTurns == 8
+    assert options.agents["critic"].model is None  # inherit (sonnet)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_backend.py -q -m "not api_dependent and not slow"`
+Expected: FAIL on `options.agents["analyst"].model == "haiku"` (currently None).
+
+- [ ] **Step 3: Implement** — in `_conversation_options()` in `claude.py`, add the knobs to the three `AgentDefinition`s:
+
+```python
+        "analyst": AgentDefinition(
+            description="Turns user vibes into structured trope/style targets and constraints.",
+            prompt=prompts.ANALYST_INSTRUCTION,
+            tools=["mcp__librarian__get_user_trope_preferences"],
+            mcpServers=["librarian"],
+            model="haiku",  # easy structured extraction — large latency win (tuning spec)
+            maxTurns=4,
+        ),
+        "explorer": AgentDefinition(
+            description="Discovers new candidate books on the web.",
+            prompt=prompts.EXPLORER_INSTRUCTION,
+            tools=["WebSearch"],
+            maxTurns=25,  # runaway guard only — the search BUDGET lives in the prompt
+        ),
+        "critic": AgentDefinition(
+            description="Ranks candidates and writes a grounded Trope-RAG justification.",
+            prompt=prompts.CRITIC_INSTRUCTION,
+            tools=[
+                "mcp__librarian__search_internal_database",
+                "mcp__librarian__get_work_details",
+                "mcp__librarian__check_reading_history",
+            ],
+            mcpServers=["librarian"],
+            maxTurns=8,
+        ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_claude_backend.py test/unit/test_backends.py -q -m "not api_dependent and not slow"`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/agents/backends/claude.py test/unit/test_claude_backend.py
+git commit -m "feat: subagent knobs — haiku analyst (4 turns), explorer cap 25, critic cap 8"
+```
+
+---
+
+### Task 5: CLI event timestamps
+
+**Files:**
+- Modify: `src/agentic_librarian/cli.py` (`_run_repl`)
+- Test: `test/unit/test_cli.py` (update two assertions + one new test)
+
+- [ ] **Step 1: Write/adjust the failing tests** — in `test/unit/test_cli.py`:
+
+Add a new test:
+
+```python
+def test_events_carry_elapsed_seconds_prefix(monkeypatch, capsys, no_mlflow_dir):
+    import re
+
+    fake = _FakeBackend(replies=("ok",))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hi", "/quit"])
+    cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    # "  · 0.0s tool: search_internal_database" — elapsed-seconds-into-turn prefix (tuning spec)
+    assert re.search(r"· \d+\.\ds tool: search_internal_database", out)
+```
+
+And update the two existing assertions that will change shape:
+- In `test_repl_two_turns_then_quit`: replace `assert "· tool: search_internal_database" in out` with `assert "tool: search_internal_database" in out`.
+- In `test_quiet_suppresses_event_trace_but_still_records`: replace `assert record["events"] == ["tool: search_internal_database"]` with:
+
+```python
+    assert len(record["events"]) == 1
+    assert record["events"][0].endswith("tool: search_internal_database")  # carries elapsed prefix
+```
+
+- [ ] **Step 2: Run tests to verify the new one fails**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_cli.py -q -m "not api_dependent and not slow"`
+Expected: `test_events_carry_elapsed_seconds_prefix` FAILS (no elapsed prefix yet); the two updated tests still pass (their loosened assertions hold on current output).
+
+- [ ] **Step 3: Implement** — in `cli.py` `_run_repl`, replace the `turn_events`/`on_event` block and the per-turn `t0` line:
+
+```python
+    turn_events: list[str] = []
+    turn_t0 = [time.monotonic()]  # mutable holder: on_event reads the CURRENT turn's start
+
+    def on_event(kind: str, detail: str) -> None:
+        entry = f"{time.monotonic() - turn_t0[0]:.1f}s {kind}: {detail}"
+        turn_events.append(entry)
+        if not args.quiet:
+            print(f"  · {entry}")
+```
+
+and inside the loop, where `t0 = time.monotonic()` is set for the turn, change to:
+
+```python
+            t0 = time.monotonic()
+            turn_t0[0] = t0
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit/test_cli.py -q -m "not api_dependent and not slow"`
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/cli.py test/unit/test_cli.py
+git commit -m "feat: elapsed-seconds prefixes on CLI trace events (latency observability)"
+```
+
+---
+
+### Task 6: Follow-up log + full gates
+
+**Files:**
+- Modify: `docs/project_notes/issues.md` (append entry)
+
+- [ ] **Step 1: Append to `docs/project_notes/issues.md`** (after the CLI-026 entry):
+
+```markdown
+### 2026-06-05 - TUNE-027: Conversation tuning round (spec/conversation-tuning)
+- **Status**: In Progress (live verification pending)
+- **Description**: Explorer search budget (prompt) + maxTurns=25 guard; verification-by-enrichment (enrich_and_persist_work exposed to BOTH conversational Librarians; null = drop candidate, continue); internal-first routing with novelty triggers; series rule in critic+librarians; analyst on haiku; elapsed-seconds event trace. Spec: docs/superpowers/specs/2026-06-05-conversation-tuning-design.md.
+- **URL**: N/A (PR pending)
+- **Notes**:
+    - **Tracked follow-up (schema, ask-first)**: add `series_name`/`series_position` to `works`, populated from Hardcover `featured_series` + a backfill pass over the existing catalog — makes the series rule deterministic instead of model-knowledge-based.
+```
+
+- [ ] **Step 2: Run the FULL fast suite**
+
+Run: `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest python -m pytest test/unit -q -m "not api_dependent and not slow"`
+Expected: ALL PASS (baseline 208 + ~7 new).
+
+- [ ] **Step 3: Run the authoritative pre-commit gate** (CI parity — the pinned ruff differs from the container's bare ruff):
+
+Run (PowerShell): `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app agentic_librarian-app:latest bash -c "git config --global --add safe.directory /app; pip install -q --user pre-commit 2>/dev/null; export PATH=$PATH:~/.local/bin; SKIP=pytest pre-commit run --all-files"`
+Expected: all hooks Passed. **If hooks auto-fix files**: the in-container run rewrites mounted files to LF — afterwards only `git diff --stat` shows true content changes; `git add` those, `git checkout -- .` the rest, and include them in the commit below.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/project_notes/issues.md
+git commit -m "docs: log TUNE-027 conversation tuning round + series-schema follow-up"
+```
+
+- [ ] **Step 5 (manual, user-gated): live verification**
+
+After merge + clone sync, one conversation via `docker exec -it agentic_librarian_app python -m agentic_librarian.cli --backend claude`, expecting: (a) far fewer `WebSearch` events; (b) an internal-only turn that's visibly faster (timestamps now show it); (c) series-opener bias in recs; (d) if the explorer ran, surviving discoveries appear in the DB (`SELECT title FROM works ORDER BY created_at DESC LIMIT 5` — check the column exists first; otherwise verify via `get_work_details`).
+
+---
+
+## Definition of done
+
+- All unit tests green; pre-commit gate clean (CI parity).
+- Both backends carry the same behavioral rules (prompts shared; enrich tool on both Librarians).
+- Live verification (user-gated) shows fewer searches, faster internal turns, series-aware recs.
+- `issues.md` TUNE-027 entry tracks the series-schema follow-up.

--- a/docs/superpowers/specs/2026-06-05-conversation-tuning-design.md
+++ b/docs/superpowers/specs/2026-06-05-conversation-tuning-design.md
@@ -1,0 +1,127 @@
+# Conversation Tuning — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstormed with user after first live CLI sessions)
+**Branch:** `spec/conversation-tuning`
+
+## Problem (from live use of the `librarian` CLI, PR #33/#34)
+
+Three observations from real conversations:
+1. **The explorer burns an enormous number of WebSearch calls.** Its instruction
+   ("only report books that appear in your search results") incentivizes one verification
+   search per candidate on top of the broad query, with no stated budget and no cap.
+2. **Series-blind recommendations.** A rec was book #4 of a series. The schema has no
+   series fields, and no prompt mentions series order.
+3. **Recommendations are slow.** Every request can fan out to web discovery (the slowest
+   path), the analyst runs on sonnet for easy structured extraction, and there is no
+   per-stage timing to show where seconds go.
+
+Also: in the **conversational** mesh, explorer discoveries reach the critic as bare
+title/author text — unlike the one-shot pipeline (ADR-040), no enrichment step exists, so
+the critic ranks discoveries on model priors, not data.
+
+## User decisions (brainstorm)
+
+1. **Verification = enrichment** ("enrichment is the existence proof"): expose
+   `enrich_and_persist_work` to the conversation; the flow must keep working when a
+   title fails to resolve (hallucination-tolerant by filtering, not by trusting).
+2. **Internal-first routing**, with an explicit novelty guarantee — new works must keep
+   surfacing.
+3. **Knobs**: explorer `maxTurns=25` (high — runaway guard only; the budget lives in the
+   prompt), sonnet. Analyst `model="haiku"`, `maxTurns=4`. Critic sonnet, `maxTurns=8`.
+
+## Design
+
+### 1. Explorer search budget (`prompts.EXPLORER_INSTRUCTION` — shared by both backends)
+
+- Explicit budget: ONE broad search, at most one refinement; choose candidates from the
+  snippets already retrieved; do **not** run per-title verification searches —
+  downstream enrichment verifies existence.
+- Keep the anti-hallucination rule ("only report books that appear in your search
+  results; never invent") — it shapes honesty; the system no longer *depends* on it.
+- Series note: when a found book is a later volume of a series, report the series opener
+  instead.
+- Claude side: `AgentDefinition(maxTurns=25)`. (ADK explorer has no equivalent cap; the
+  prompt budget applies to both.)
+
+### 2. Verification-by-enrichment (conversation reaches pipeline parity)
+
+- Add `enrich_and_persist_work` to `claude_tools._TOOL_SCHEMAS` (schema:
+  `{title: str, author: str, format: str}`, required `["title", "author"]` — `format`
+  defaults to "ebook"). Post-#34, `LIBRARIAN_TOOL_NAMES` membership auto-permits it.
+- ADK parity: add `FunctionTool(enrich_and_persist_work)` to the ADK Librarian's tools
+  (`services.py`).
+- `LIBRARIAN_INSTRUCTION` (and the ADK inline instruction) gains an enrichment step:
+  after the explorer returns, call `enrich_and_persist_work` on the **2–3 most
+  promising** discoveries (not all — each enrichment includes LLM scouts, so cap the
+  cost); a **null return means the title didn't resolve (possibly hallucinated): drop
+  that candidate and continue**; pass surviving candidate ids to the critic. If nothing
+  survives, recommend from internal candidates only.
+- Side effect (desired): every surviving discovery persists with tropes/styles/
+  embeddings — the catalog grows through conversation, and the critic ranks discoveries
+  on real data.
+
+### 3. Internal-first routing with novelty triggers (`LIBRARIAN_INSTRUCTION` + ADK inline)
+
+Delegate to the explorer only when:
+(a) internal candidates (unacted suggestions + the critic's catalog search) are too few
+or poorly matched; **or**
+(b) the strong internal matches have already been suggested or read — the suggestions
+log makes this self-balancing: repeated chats exhaust obvious internal picks and tip
+back toward discovery; **or**
+(c) the user signals novelty ("something new / I haven't heard of").
+
+### 4. Series rule (`CRITIC_INSTRUCTION` — shared, so one-shot + conversation, both backends)
+
+> If a candidate belongs to a series, recommend the FIRST book — unless reading history
+> shows the user is mid-series; then use `check_reading_history` on earlier volumes and
+> recommend the NEXT unread one. Never recommend a mid/late series entry the user
+> hasn't reached.
+
+Echoed briefly in the Librarian instructions.
+
+### 5. Subagent knobs (`claude.py _conversation_options`)
+
+| Agent | model | maxTurns |
+|---|---|---|
+| analyst | `"haiku"` | 4 |
+| explorer | inherit (sonnet) | 25 |
+| critic | inherit (sonnet) | 8 |
+
+### 6. Observability: event timestamps
+
+`cli.py`'s `on_event` prefixes each event with elapsed seconds into the turn
+(`"  · 12.3s agent: explorer"`), and the recorded transcript event strings carry the
+same prefix — so future latency questions start from data. (Recorder schema unchanged:
+events remain a list of strings.)
+
+### 7. Tracked follow-up (NOT built now)
+
+`series_name`/`series_position` columns on `works`, populated from Hardcover's
+`featured_series` during enrichment + a backfill pass for the existing 326 works —
+makes the series rule deterministic. Logged in `issues.md`; schema changes are
+ask-first per project boundaries.
+
+## Error handling
+
+- Enrichment failure for a discovery: drop the candidate, continue (REC-023 posture);
+  total failure → internal-only recommendation. Never crash the turn.
+- All prompt changes preserve the explorer's JSON output contract
+  (`{"books": [...]}`) consumed by the one-shot pipeline.
+
+## Testing
+
+1. Offline (TDD where behavior changes): options assertions (knobs per subagent, enrich
+   tool exposure in `LIBRARIAN_TOOL_NAMES` and Claude `_conversation_options`; ADK
+   Librarian tool list), prompt-content assertions (budget wording, series rule,
+   enrichment step, internal-first), CLI event-timestamp format.
+2. Existing suites stay green (explorer JSON contract untouched).
+3. Live verification (user-gated): one conversation expecting (a) far fewer searches,
+   (b) series-opener bias, (c) faster internal-only turn, (d) a surviving discovery
+   visible in the DB afterward.
+
+## Out of scope
+
+- Series schema columns + backfill (tracked follow-up).
+- `--solo` fast mode (revisit only if latency still hurts after this round).
+- MLflow startup timeout, `--once` banner (known minor follow-ups from PR #33).

--- a/src/agentic_librarian/agents/backends/claude.py
+++ b/src/agentic_librarian/agents/backends/claude.py
@@ -109,11 +109,14 @@ def _conversation_options() -> ClaudeAgentOptions:
             prompt=prompts.ANALYST_INSTRUCTION,
             tools=["mcp__librarian__get_user_trope_preferences"],
             mcpServers=["librarian"],
+            model="haiku",  # easy structured extraction — large latency win (tuning spec)
+            maxTurns=4,
         ),
         "explorer": AgentDefinition(
             description="Discovers new candidate books on the web.",
             prompt=prompts.EXPLORER_INSTRUCTION,
             tools=["WebSearch"],
+            maxTurns=25,  # runaway guard only — the search BUDGET lives in the prompt
         ),
         "critic": AgentDefinition(
             description="Ranks candidates and writes a grounded Trope-RAG justification.",
@@ -124,6 +127,7 @@ def _conversation_options() -> ClaudeAgentOptions:
                 "mcp__librarian__check_reading_history",
             ],
             mcpServers=["librarian"],
+            maxTurns=8,
         ),
     }
     return ClaudeAgentOptions(

--- a/src/agentic_librarian/agents/backends/claude_tools.py
+++ b/src/agentic_librarian/agents/backends/claude_tools.py
@@ -82,6 +82,12 @@ _TOOL_SCHEMAS: list[tuple[str, str, dict[str, Any], Any]] = [
         _schema({"work_id": _STR, "status": _STR}, required=["work_id", "status"]),
         mcp_server.update_suggestion_status,
     ),
+    (
+        "enrich_and_persist_work",
+        "Verify + enrich a discovered book via the scouts and persist it to the catalog; returns the work id, or null if the title does not resolve.",
+        _schema({"title": _STR, "author": _STR, "format": _STR}, required=["title", "author"]),
+        mcp_server.enrich_and_persist_work,
+    ),
 ]
 
 LIBRARIAN_TOOL_NAMES = [f"mcp__{_SERVER_NAME}__{short}" for short, _, _, _ in _TOOL_SCHEMAS]

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -18,6 +18,14 @@ EXPLORER_INSTRUCTION = """
             match the user's request. Prefer recent or lesser-known titles that are
             unlikely to already be in a standard personal library.
 
+            SEARCH BUDGET: Run ONE broad search, plus AT MOST one refinement search.
+            Choose candidates from the snippets you already retrieved. Do NOT run
+            additional per-title verification searches — downstream enrichment verifies
+            that each candidate actually exists.
+
+            SERIES: If a book you found is a later volume of a series, report the FIRST
+            book of that series instead.
+
             Return a handful (3-5).
 
             CRITICAL: Only report books that appear in your search results. Never invent
@@ -35,7 +43,12 @@ CRITIC_INSTRUCTION = """
             4. Rank candidates by similarity to Target Vibes.
             5. APPLY PENALTY: If a candidate matches a 'Session Constraint', lower its rank.
 
-            6. JUSTIFY (Trope-RAG): For each recommended book, provide a grounded justification.
+            6. SERIES RULE: If a candidate belongs to a series, recommend the FIRST book —
+               unless reading history shows the user is mid-series; then use
+               'check_reading_history' on earlier volumes and recommend the NEXT unread one.
+               Never recommend a mid/late series entry the user hasn't reached.
+
+            7. JUSTIFY (Trope-RAG): For each recommended book, provide a grounded justification.
                - Anchor your reasoning in the 'name' and 'description' of the top-matching tropes.
                - Include the 'justification' (evidence) from the database to explain how the trope manifests in that specific book.
                - Format: "I recommend [Title] because it features [Trope Name] ([Description]). Specifically, [Justification Evidence]."
@@ -55,14 +68,22 @@ LIBRARIAN_INSTRUCTION = """
 You are the Head Librarian. You provide personalized book recommendations and manage reading
 history, conversationally, over multiple turns.
 
-DELEGATION STRATEGY:
+DELEGATION STRATEGY (internal-first — the user's enriched catalog is the primary source):
 1. Delegate to the 'analyst' agent to turn user vibes into structured trope/style targets and
    session constraints.
 2. Use 'get_unacted_suggestions' with target vibes to see if we already have good matches.
-3. If new discovery is needed, delegate to the 'explorer' agent.
-4. Delegate all candidates, targets, and session constraints to the 'critic' agent for final
-   ranking and a grounded justification.
+3. Delegate to the 'critic' agent to search the internal catalog and rank candidates.
+4. Delegate to the 'explorer' agent ONLY when: internal candidates are too few or poorly
+   matched; OR the strong internal matches have already been suggested or read; OR the user
+   asks for something new / outside their library.
+5. ENRICH DISCOVERIES: after the explorer returns, call 'enrich_and_persist_work' on the 2-3
+   most promising discoveries (title + author). A null result means the title did not resolve
+   (possibly hallucinated) — drop that candidate and continue. Pass surviving candidate ids to
+   the 'critic' for final ranking. If nothing survives, recommend from internal candidates.
    - NOTE: Books read >2 years ago are eligible for re-read suggestions.
+
+SERIES: prefer the FIRST book of a series, or the user's NEXT unread volume if they are
+mid-series. Never a later entry they haven't reached.
 
 FEEDBACK HANDLING:
 - "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -5,6 +5,7 @@ from agentic_librarian.agents.schemas import Targets
 from agentic_librarian.llm_retry import RETRY_OPTIONS
 from agentic_librarian.mcp.server import (
     check_reading_history,
+    enrich_and_persist_work,
     get_unacted_suggestions,
     get_user_trope_preferences,
     get_work_details,
@@ -112,12 +113,21 @@ class LibrarianAgent(LlmAgent):
             instruction="""
             You are the Head Librarian. You provide personalized book recommendations and manage history.
 
-            DELEGATION STRATEGY:
+            DELEGATION STRATEGY (internal-first — the user's enriched catalog is the primary source):
             1. Call the 'Analyst' to turn user vibes into structured targets and session constraints.
             2. Call 'get_unacted_suggestions' with target vibes to see if we have good matches.
-            3. If new discovery is needed, call the 'Explorer'.
-            4. Pass all candidates, targets, and session constraints to the 'Critic' for final ranking.
+            3. Call the 'Critic' to search the internal catalog and rank candidates.
+            4. Call the 'Explorer' ONLY when: internal candidates are too few or poorly matched;
+               OR the strong internal matches have already been suggested or read; OR the user
+               asks for something new / outside their library.
+            5. ENRICH DISCOVERIES: after the Explorer returns, call 'enrich_and_persist_work' on the
+               2-3 most promising discoveries (title + author). A null result means the title did not
+               resolve (possibly hallucinated) — drop that candidate and continue. Pass surviving
+               candidates to the 'Critic' for final ranking.
                - NOTE: Books read >2 years ago are eligible for re-read suggestions.
+
+            SERIES: prefer the FIRST book of a series, or the user's NEXT unread volume if they are
+            mid-series. Never a later entry they haven't reached.
 
             FEEDBACK HANDLING:
             - If user says "I read that", use 'update_reading_status' AND 'update_suggestion_status(Already Read)'.
@@ -131,6 +141,7 @@ class LibrarianAgent(LlmAgent):
                 AgentTool(explorer),
                 AgentTool(critic),
                 FunctionTool(get_unacted_suggestions),
+                FunctionTool(enrich_and_persist_work),
                 FunctionTool(update_reading_status),
                 FunctionTool(update_suggestion_status),
                 FunctionTool(log_suggestion),

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -69,11 +69,13 @@ def _run_once(backend, args, recorder) -> int:
 
 def _run_repl(backend, args, recorder) -> int:
     turn_events: list[str] = []
+    turn_t0 = [time.monotonic()]  # mutable holder: on_event reads the CURRENT turn's start
 
     def on_event(kind: str, detail: str) -> None:
-        turn_events.append(f"{kind}: {detail}")
+        entry = f"{time.monotonic() - turn_t0[0]:.1f}s {kind}: {detail}"
+        turn_events.append(entry)
         if not args.quiet:
-            print(f"  · {kind}: {detail}")
+            print(f"  · {entry}")
 
     try:
         conversation = backend.start_conversation(user_id=args.user_id, on_event=on_event)
@@ -99,6 +101,7 @@ def _run_repl(backend, args, recorder) -> int:
                 break
             turn_events.clear()
             t0 = time.monotonic()
+            turn_t0[0] = t0
             try:
                 reply = conversation.send(line)
             except KeyboardInterrupt:

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -69,10 +69,10 @@ def _run_once(backend, args, recorder) -> int:
 
 def _run_repl(backend, args, recorder) -> int:
     turn_events: list[str] = []
-    turn_t0 = [time.monotonic()]  # mutable holder: on_event reads the CURRENT turn's start
+    turn_t0 = time.monotonic()  # on_event reads the enclosing scope's current value (closure cell)
 
     def on_event(kind: str, detail: str) -> None:
-        entry = f"{time.monotonic() - turn_t0[0]:.1f}s {kind}: {detail}"
+        entry = f"{time.monotonic() - turn_t0:.1f}s {kind}: {detail}"
         turn_events.append(entry)
         if not args.quiet:
             print(f"  · {entry}")
@@ -101,7 +101,7 @@ def _run_repl(backend, args, recorder) -> int:
                 break
             turn_events.clear()
             t0 = time.monotonic()
-            turn_t0[0] = t0
+            turn_t0 = t0
             try:
                 reply = conversation.send(line)
             except KeyboardInterrupt:

--- a/test/unit/test_agent_services.py
+++ b/test/unit/test_agent_services.py
@@ -32,3 +32,17 @@ def test_critic_tool_assignment():
     tool_names = [t.name for t in critic.tools]
     assert "search_internal_database" in tool_names
     assert "check_reading_history" in tool_names
+
+
+def test_librarian_has_the_enrich_tool():
+    mesh = create_agent_mesh()
+    tool_names = [t.name for t in mesh["librarian"].tools]
+    assert "enrich_and_persist_work" in tool_names
+
+
+def test_librarian_instruction_is_internal_first_and_series_aware():
+    mesh = create_agent_mesh()
+    text = mesh["librarian"].instruction
+    assert "ONLY when" in text
+    assert "enrich_and_persist_work" in text
+    assert "SERIES" in text

--- a/test/unit/test_claude_backend.py
+++ b/test/unit/test_claude_backend.py
@@ -143,6 +143,14 @@ def test_conversation_options_wire_the_specialist_mesh():
     assert "Agent" in options.allowed_tools
     assert options.system_prompt == prompts.LIBRARIAN_INSTRUCTION
 
+    # Conversation-tuning knobs: fast analyst, roomy explorer, careful critic.
+    assert options.agents["analyst"].model == "haiku"
+    assert options.agents["analyst"].maxTurns == 4
+    assert options.agents["explorer"].maxTurns == 25
+    assert options.agents["explorer"].model is None  # inherit (sonnet)
+    assert options.agents["critic"].maxTurns == 8
+    assert options.agents["critic"].model is None  # inherit (sonnet)
+
 
 def test_claude_conversation_close_is_idempotent():
     from agentic_librarian.agents.backends.claude import ClaudeConversation

--- a/test/unit/test_claude_tools.py
+++ b/test/unit/test_claude_tools.py
@@ -18,3 +18,11 @@ def test_feedback_tools_are_exposed():
 
     assert "mcp__librarian__update_reading_status" in LIBRARIAN_TOOL_NAMES
     assert "mcp__librarian__update_suggestion_status" in LIBRARIAN_TOOL_NAMES
+
+
+def test_enrich_tool_is_exposed():
+    # Verification-by-enrichment (conversation tuning spec): the Librarian enriches explorer
+    # discoveries; a null return is the existence check failing.
+    from agentic_librarian.agents.backends.claude_tools import LIBRARIAN_TOOL_NAMES
+
+    assert "mcp__librarian__enrich_and_persist_work" in LIBRARIAN_TOOL_NAMES

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -67,7 +67,7 @@ def test_repl_two_turns_then_quit(monkeypatch, capsys, no_mlflow_dir):
     assert rc == 0
     assert "librarian> first reply" in out
     assert "librarian> second reply" in out
-    assert "· tool: search_internal_database" in out  # event trace
+    assert "tool: search_internal_database" in out  # event trace
     assert fake.conversation.closed
 
 
@@ -94,7 +94,8 @@ def test_quiet_suppresses_event_trace_but_still_records(tmp_path, monkeypatch, c
     transcripts = list(tmp_path.glob("*.jsonl"))
     assert len(transcripts) == 1
     record = json.loads(transcripts[0].read_text(encoding="utf-8").splitlines()[0])
-    assert record["events"] == ["tool: search_internal_database"]  # recorded even when not printed
+    assert len(record["events"]) == 1
+    assert record["events"][0].endswith("tool: search_internal_database")  # carries elapsed prefix
 
 
 def test_backend_flag_sets_env(monkeypatch, capsys, no_mlflow_dir):
@@ -115,3 +116,15 @@ def test_unknown_backend_fails_fast(monkeypatch, capsys, no_mlflow_dir):
     rc = cli.main(["--once", "x", "--no-mlflow"])
     assert rc == 2
     assert "Unknown AGENT_BACKEND" in capsys.readouterr().err
+
+
+def test_events_carry_elapsed_seconds_prefix(monkeypatch, capsys, no_mlflow_dir):
+    import re
+
+    fake = _FakeBackend(replies=("ok",))
+    monkeypatch.setattr(cli, "get_backend", lambda: fake)
+    _feed_stdin(monkeypatch, ["hi", "/quit"])
+    cli.main(["--no-mlflow"])
+    out = capsys.readouterr().out
+    # "  · 0.0s tool: search_internal_database" — elapsed-seconds-into-turn prefix (tuning spec)
+    assert re.search(r"· \d+\.\ds tool: search_internal_database", out)

--- a/test/unit/test_prompts.py
+++ b/test/unit/test_prompts.py
@@ -35,3 +35,29 @@ def test_librarian_instruction_delegates_to_the_mesh():
     assert "update_suggestion_status" in text
     assert "update_reading_status" in text
     assert "get_unacted_suggestions" in text
+
+
+def test_explorer_has_a_search_budget_and_keeps_its_contract():
+    text = prompts.EXPLORER_INSTRUCTION
+    assert "SEARCH BUDGET" in text
+    assert "ONE broad search" in text
+    assert "per-title verification searches" in text
+    assert "Never invent" in text  # anti-hallucination stays
+    assert '{"books"' in text  # JSON contract consumed by the one-shot pipeline is preserved
+    assert "FIRST" in text  # report the series opener for later volumes
+
+
+def test_critic_has_the_series_rule():
+    text = prompts.CRITIC_INSTRUCTION
+    assert "SERIES RULE" in text
+    assert "FIRST book" in text
+    assert "NEXT unread" in text
+    assert "check_reading_history" in text
+
+
+def test_librarian_routes_internal_first_and_enriches_discoveries():
+    text = prompts.LIBRARIAN_INSTRUCTION
+    assert "ONLY when" in text  # explorer is conditional, not default
+    assert "enrich_and_persist_work" in text
+    assert "drop that candidate" in text  # hallucination-tolerant by filtering
+    assert "SERIES" in text


### PR DESCRIPTION
## Summary

Tuning round from the first live `librarian` chats (spec: `docs/superpowers/specs/2026-06-05-conversation-tuning-design.md`):

- **Explorer search budget**: ONE broad search + at most one refinement, candidates from snippets already retrieved, NO per-title verification searches (`AgentDefinition(maxTurns=25)` as runaway guard). Anti-hallucination rule stays — the system just no longer depends on it, because…
- **Verification-by-enrichment**: `enrich_and_persist_work` exposed to BOTH conversational Librarians (Claude `_TOOL_SCHEMAS` + ADK `FunctionTool`). Enrichment IS the existence proof — a hallucinated title returns null and is dropped (flow continues); survivors persist with tropes/styles/embeddings so the critic ranks discoveries on real data and the catalog grows through conversation. Brings the conversation to parity with the one-shot pipeline (ADR-040).
- **Internal-first routing**: the explorer runs ONLY when internal candidates are weak, the strong matches were already suggested/read, or the user asks for novelty — the suggestions log makes this self-balancing.
- **Series rule** (shared `CRITIC_INSTRUCTION` + both Librarians): first book of a series, or the user's next unread volume if mid-series; never an unreached later entry. (Deterministic series schema columns tracked as TUNE-027 follow-up.)
- **Knobs**: analyst → haiku/maxTurns 4; explorer → sonnet/25; critic → sonnet/8.
- **Observability**: CLI trace events carry elapsed-seconds-into-turn prefixes (`· 12.3s agent: explorer`), recorded in transcripts.

## Verification

- Full fast suite: **215 passed, 0 failed**. TDD red→green per task; per-task spec + quality reviews; final integration review verified all tool wiring reachable on both backends and proved the nested-LLM enrichment path safe (scout calls run on a no-running-loop worker thread → `asyncio.run` path in `ClaudeGroundedLLM.generate`).
- Pre-commit gate run in-container (CI parity): all hooks pass.
- Explorer JSON contract (`{"books": [...]}`) preserved — asserted against the real parser.
- Live verification checklist (user-gated, quota): fewer searches, internal-only fast path, enrichment null-tolerance, DB growth, series bias — listed in TUNE-027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)