### PR TITLE
spec: product roadmap — walking skeleton → multi-user → front end → productization (ADR-046)

### DIFF
--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -639,6 +639,19 @@ This file documents key architectural decisions, their context, and trade-offs.
 - Shared catalog / per-user history. MLflow+Dagster stay dev-only. DEBT-001: bulk
   enrichment remains operator-run local Dagster until demand justifies a Cloud Run Job.
 
+**Alternatives Considered:**
+- FE-first, GCP last (big-bang deploy) -> Rejected: saves the unfamiliar infra for the end
+  where it is hardest to debug, and friends need auth before anything is shareable — so
+  multi-user had to precede the beta regardless; skeleton-first converts deployment into
+  continuous delivery from week one.
+- FE before the multi-user foundation -> Rejected: would build the FE twice (once
+  single-user, once against the auth'd contract).
+- Claude API in prod now -> Deferred: ~5-15x flash-tier Gemini per conversation plus a
+  second vendor to meter before any revenue; kept one config-change away via the
+  AGENT_BACKEND seam.
+- Both-LLM user-selectable tier at launch -> Rejected: dual metering and parity
+  maintenance before product-market fit.
+
 **Consequences:**
 - Deployment becomes continuous from week one instead of a big-bang finale; the FE is
   built once against the auth'd contract; the most invasive work (schema) happens while

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -617,3 +617,30 @@ This file documents key architectural decisions, their context, and trade-offs.
 - The conversational piece becomes testable on both quota pools, and ADK-vs-Claude conversations are
   comparable in the MLflow UI. The Claude one-shot pipeline is untouched. The new protocol method is
   additive (existing callers unaffected).
+
+### ADR-046: Product Roadmap — Walking Skeleton First, Gemini-First Prod, BYOK-Ready Schema (2026-06-05)
+**Context:**
+- Three heavy lifts loomed unordered: web front end (Phase 4), GCP deployment, multi-user
+  support. Target: friends/family soon, then open signup with a cost-recovery subscription.
+  Couplings: the Claude backend's Max OAuth doesn't deploy; auth-provider choice is
+  GCP-informed; multi-user expires security.md's single-user assumptions.
+  Spec: docs/superpowers/specs/2026-06-05-product-roadmap-design.md.
+
+**Decision:**
+- Sequence: (0) GCP walking skeleton (Cloud Run + Cloud SQL/pgvector + CD, existing FastAPI
+  scaffold, catalog restored, access-gated) → (1) multi-user foundation (users + user_id +
+  default-user migration, Firebase Auth, usage metering keyed by user and key-source,
+  KMS-encrypted user_credentials placeholder) → (2) front end → friends/family beta →
+  (3) productization (Stripe, quotas, BYOK feature, Claude prod enablement, security
+  re-review) → open signup.
+- Prod LLM: Gemini-first; AGENT_BACKEND stays env-configurable in prod so Claude-via-API
+  (viable per the cited mid-June 2026 Anthropic billing change) is config + container +
+  metering, not architecture. BYOK: schema-ready in Lift 1, feature in Lift 3.
+- Shared catalog / per-user history. MLflow+Dagster stay dev-only. DEBT-001: bulk
+  enrichment remains operator-run local Dagster until demand justifies a Cloud Run Job.
+
+**Consequences:**
+- Deployment becomes continuous from week one instead of a big-bang finale; the FE is
+  built once against the auth'd contract; the most invasive work (schema) happens while
+  the surface is smallest. Each lift gets its own spec/plan cycle; security.md must be
+  formally re-reviewed before open signup.

--- a/docs/superpowers/specs/2026-06-05-product-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-05-product-roadmap-design.md
@@ -1,0 +1,92 @@
+# Product Roadmap — Web App, GCP, Multi-User Sequencing
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstormed with user)
+**Branch:** `spec/product-roadmap`
+
+This is a SEQUENCING spec: it decomposes three heavy lifts into ordered sub-projects and
+locks the cross-cutting decisions. Each lift gets its own spec → plan → implementation
+cycle when it starts. Nothing here is an implementation plan.
+
+## Vision (user)
+
+Start with friends & family soon; move to open signup with a subscription model that
+covers tokens + hosting (maybe a small margin if popular). Users can BYO API key for a
+much cheaper tier, or use the app's key at a higher price.
+
+## The three lifts and their couplings
+
+1. **Front end (Phase 4)** — FastAPI + web UI. The FastAPI surface is the contract the
+   deployment ships and the multi-user boundary enforces. A scaffold exists
+   (`13-phase-4-web-interface-and-analysis` branch: FastAPI app + `GET /history`).
+2. **GCP deployment** — Cloud Run + Cloud SQL (pgvector supported). Coupling: the Claude
+   backend's Max-subscription OAuth does NOT deploy; production Claude means
+   `ANTHROPIC_API_KEY` (see LLM strategy). MLflow/Dagster are dev tools and do not deploy.
+3. **Multi-user** — the most invasive: schema (`user_id`), identity, isolation — and it
+   expires the "single-user system" assumptions recorded in `security.md` (SEC-001/002
+   residual-risk reasoning, no rate limiting, no transport auth). Coupling: the auth
+   provider choice is GCP-informed, so multi-user design follows platform contact.
+
+## The sequence
+
+| # | Lift | Delivers | Why this position |
+|---|------|----------|-------------------|
+| 0 | **Walking skeleton** — GCP project, Cloud Run service running the existing FastAPI scaffold, Cloud SQL Postgres+pgvector with the catalog restored from pg_dump, Secret Manager, GitHub Actions CD, access-gated (IAP or app-level gate — Lift-0 spec decides) | A real URL serving the enriched catalog | Learn ALL the unfamiliar GCP plumbing on a system too small to hide bugs; converts deployment from a finale into continuous delivery |
+| 1 | **Multi-user foundation** — users table, `user_id` on reading_history/suggestions with a default-user migration (existing 331 history rows → user #1), Firebase Auth on the FastAPI layer, per-user scoping through the MCP tools, `usage` metering table (keyed by user AND key-source), `user_credentials` placeholder (KMS-encrypted, BYOK-ready, feature later) | Friends can sign in; data isolated; usage recorded from day one | The invasive schema work while the surface is small; auth must precede any sharing, so it precedes the FE |
+| 2 | **Front end** — chat UI over the conversational Librarian via FastAPI, history/analysis views, add-book form (completion-date field AUTO-FILLED with today, visible+editable, per IMP-028) | 🎯 **Friends & family beta** | Built once against the real auth'd contract; framework choice (Vite SPA vs Next.js) decided in this lift's spec |
+| 3 | **Productization** — per-user token metering enforcement + quotas, Stripe subscription, **BYOK feature** (key validation, per-key routing; pricing tiers: BYOK ≈ hosting-only, app-key ≈ tokens + margin), **Claude prod enablement** (see LLM strategy), **security posture re-review** (single-user assumptions formally expire), observability, cost tuning | 🎯 **Open signup** | The business layer, after real usage data exists |
+
+## Cross-cutting decisions (locked)
+
+- **Infrastructure: Cloud Run** (user decision) — scale-to-zero economics fit the
+  project's stage; Cloud SQL Postgres with pgvector (schema ports cleanly).
+- **Prod LLM: Gemini-first** (paid tier; the ADK backend is live-proven; cheapest
+  per-conversation; one vendor to meter). **Claude-readiness is a standing constraint,
+  not a later rewrite**: per the Anthropic billing change the user cites (paid users'
+  Agent SDK usage moves to a monthly credit that exhausts before other billing,
+  ~mid-June 2026), Agent-SDK-with-API-key becomes viable. The SDK already honors
+  `ANTHROPIC_API_KEY`, so Claude prod enablement ≈ env config + bundled-CLI-in-container
+  verification + second-vendor metering. Therefore: **Lift 0 keeps `AGENT_BACKEND`
+  env-configurable in prod config**, and the enablement task sits in Lift 3 (may pull
+  earlier once the billing change lands).
+- **BYOK** (user decision): users may bring their own API key (cost drops to ~hosting)
+  or use the app's key (higher tier). Schema accommodates it from Lift 1
+  (`user_credentials`, encrypted at rest via Cloud KMS — never plaintext, never logged;
+  security.md gains the handling rule); the FEATURE lands in Lift 3 with metering
+  attribution by key source.
+- **Auth: Firebase Auth in Lift 1.** (Clarified: Firebase Authentication and Identity
+  Platform are distinct tiers of the SAME underlying Google identity service — Identity
+  Platform adds enterprise features (SAML/OIDC, multi-tenancy, SLA) with per-MAU
+  billing, and upgrading a project is an in-place toggle, not a migration. Start
+  consumer-tier; the upgrade path is preserved.)
+- **Shared catalog, per-user history.** Works/editions/tropes/styles are communal — one
+  user's enrichment grows the library for everyone; reading_history/suggestions/usage
+  are per-user. (The 326-work enriched catalog seeds the product.)
+- **MLflow + Dagster stay local/dev.** They do not deploy.
+- **Claude backend remains a local/dev capability** on the Max subscription until the
+  Lift-3 enablement; the conversation recorder's MLflow capture is dev-only.
+
+## Accepted technical debt
+
+- **DEBT-001: Bulk enrichment service.** Bulk imports stay operator-run local Dagster
+  (near term: friends send the operator a CSV). Future shape when user-facing bulk
+  import earns its keep: a Cloud Run Job + queue running the same partition flow. Not
+  designed now (user decision).
+
+## What each lift's spec must decide (deferred, not forgotten)
+
+- Lift 0: IAP vs app-level gate; GCP project/region/budget alarms; CD shape; how the
+  pg_dump restore is performed and verified.
+- Lift 1: exact user model; default-user migration mechanics; per-user scoping seam in
+  the MCP tools (parameter vs context); Firebase Auth integration pattern on FastAPI;
+  usage-table schema.
+- Lift 2: FE framework (Vite SPA vs Next.js); hosting (static vs Cloud Run); chat
+  transport (SSE/websocket vs request-response); which analysis views ship in beta.
+- Lift 3: pricing numbers; Stripe integration shape; quota policy; rate limiting; the
+  security re-review scope; Claude enablement verification.
+
+## Out of scope (this roadmap)
+
+- Mobile apps, A2A external mesh (ADR-035 deferral stands), series schema columns
+  (separate tracked follow-up), the Explorer citation surfacing (pairs with a future
+  security pass).


### PR DESCRIPTION
## Summary

Docs-only: the sequencing spec for the three heavy lifts (web front end, GCP deployment, multi-user) plus ADR-046.

**Sequence**: (0) GCP walking skeleton — Cloud Run + Cloud SQL/pgvector + CD, existing FastAPI scaffold, catalog restored, access-gated → (1) multi-user foundation — users/user_id + default-user migration, Firebase Auth, usage metering by user and key-source, KMS-encrypted `user_credentials` placeholder → (2) front end → 🎯 friends/family beta → (3) productization — Stripe, quotas, BYOK feature, Claude prod enablement, security re-review → 🎯 open signup.

**Locked decisions**: Cloud Run; Gemini-first prod with `AGENT_BACKEND` staying env-configurable (Claude-via-API becomes config + container + metering once the cited mid-June 2026 Anthropic Agent-SDK billing change lands); BYOK schema-ready in Lift 1, feature in Lift 3; Firebase Auth (Identity Platform = in-place upgrade of the same service); shared catalog / per-user history; MLflow + Dagster stay dev-only; DEBT-001 bulk enrichment stays operator-run local Dagster for now.

Each lift gets its own spec → plan → implementation cycle; per-lift unknowns are explicitly deferred in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)