### PR TITLE
fix: Lift 0 live-run learnings — import as librarian, runbook corrections, prod facts, LF pin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must check out LF everywhere — a CRLF working copy breaks bash
+# (classic symptom: "syntax error: unexpected end of file"). The infra/ scripts are
+# run from the WSL clone, but this protects any checkout.
+*.sh text eol=lf

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -57,6 +57,25 @@ This file tracks important project configuration, constants, and environment det
   still go through the CSV/Dagster path. Reading history is a log of READ EVENTS: a
   re-read inserts a new row (re-read count = rows per work).
 
+## Production (GCP — Lift 0, live 2026-06-06)
+- **Project**: `agentic-librarian-prod` (us-central1); ADR-047; runbook
+  `docs/runbooks/gcp-walking-skeleton.md`; provisioning scripts in `infra/`.
+- **Service URL**: <https://librarian-api-hnucndzntq-uc.a.run.app> — Cloud Run
+  `librarian-api`, IAM-gated (`--no-allow-unauthenticated`); call with
+  `Authorization: Bearer $(gcloud auth print-identity-token)` or
+  `gcloud run services proxy librarian-api --region us-central1`.
+- **Endpoints**: `/health`, `/health/db`, `/history` (unpaginated, INF-029), `/works`
+  (paginated, limit 1–200).
+- **Database**: Cloud SQL Postgres 16 `librarian-sql` (db-f1-micro, 10GB SSD) +
+  pgvector; restored 2026-06-06 from `agentic_librarian_FINAL_20260605_014912.sql.gz`
+  and verified (326 works / 335 editions / 331 reading_history / 230 authors; 556
+  tropes + 508 styles fully embedded). App connects via the `librarian-db-url` secret
+  (full `DATABASE_URL`, Cloud SQL unix socket).
+- **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
+  `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
+  the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.
+- **Cost guardrail**: $25/mo budget, email alerts at 50/90/100% (~$12–16/mo expected).
+
 ## Security Guidelines
 - **DO NOT** store real passwords or secrets here.
 - **DO NOT** store PII.

--- a/docs/runbooks/gcp-walking-skeleton.md
+++ b/docs/runbooks/gcp-walking-skeleton.md
@@ -210,9 +210,10 @@ a fresh clone does NOT have it. If the WSL clone is missing it, copy from the Wi
 clone first:
 
 ```bash
-mkdir -p ~/agentic_librarian/data/backups
+# From the WSL clone root (adjust the source if your Windows clone lives elsewhere):
+mkdir -p data/backups
 cp /mnt/c/dev/agentic_librarian/data/backups/agentic_librarian_FINAL_20260605_014912.sql.gz \
-   ~/agentic_librarian/data/backups/
+   data/backups/
 ```
 
 ### Pre-flight: confirm the vector extension is in the dump
@@ -337,7 +338,7 @@ manual password copying needed):
 ```bash
 URL=$(gcloud secrets versions access latest --secret=librarian-db-url)
 DBURL=$(echo "$URL" | sed 's#@/agentic_librarian?host=.*#@host.docker.internal:5433/agentic_librarian#')
-docker run --rm -e DATABASE_URL="$DBURL" -v ~/agentic_librarian:/app -w /app \
+docker run --rm -e DATABASE_URL="$DBURL" -v "$PWD":/app -w /app \
   agentic_librarian-app:latest python infra/verify_restore.py
 ```
 

--- a/docs/runbooks/gcp-walking-skeleton.md
+++ b/docs/runbooks/gcp-walking-skeleton.md
@@ -18,7 +18,7 @@ Install the Google Cloud CLI in WSL following the Debian/Ubuntu apt repository
 instructions at <https://cloud.google.com/sdk/docs/install#deb>. The short version:
 
 ```bash
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
   | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
 sudo apt update && sudo apt install -y google-cloud-cli
@@ -200,8 +200,20 @@ that silently targets the wrong project.
 
 The restore script uploads `data/backups/agentic_librarian_FINAL_20260605_014912.sql.gz`
 to the GCS bucket, grants the Cloud SQL service agent read access to the bucket, and
-runs `gcloud sql import sql` to load it into the database. Run this from the WSL dev
-clone — a fresh clone does not have the dump (it is gitignored).
+runs `gcloud sql import sql` to load it into the database **as the `librarian` user**
+(`--user` — the default import user cannot `SET ROLE "librarian"` on PG16, which aborts
+the import at the dump's first `OWNER TO librarian` statement; importing as the owner
+makes those statements no-ops).
+
+Run this from a clone that actually holds the dump — `data/backups/` is gitignored, so
+a fresh clone does NOT have it. If the WSL clone is missing it, copy from the Windows
+clone first:
+
+```bash
+mkdir -p ~/agentic_librarian/data/backups
+cp /mnt/c/dev/agentic_librarian/data/backups/agentic_librarian_FINAL_20260605_014912.sql.gz \
+   ~/agentic_librarian/data/backups/
+```
 
 ### Pre-flight: confirm the vector extension is in the dump
 
@@ -282,14 +294,25 @@ curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/clou
 chmod +x cloud-sql-proxy
 ```
 
+**Set up Application Default Credentials** (one-time — distinct from `gcloud auth
+login`, which only authenticates the CLI; the proxy and Google client libraries read
+ADC):
+
+```bash
+gcloud auth application-default login   # browser flow, like gcloud init
+```
+
+(Alternative without ADC: add `--gcloud-auth` to the proxy command to borrow the CLI's
+credentials.)
+
 **Start the proxy** (replace `<CONNECTION_NAME>` with the value from step 2 or 5):
 
 ```bash
 ./cloud-sql-proxy <CONNECTION_NAME> --port 5433 &
 ```
 
-The `&` runs it in the background. You will see a line like
-`Listening on 127.0.0.1:5433` when it is ready.
+The `&` runs it in the background. The proxy prints `Listening on 127.0.0.1:5433` over
+your prompt — press Enter to get the prompt back; it's still running (`jobs` shows it).
 
 **Read the password from Secret Manager** — the secret stores the full DATABASE_URL,
 so you can paste it and change only the host:
@@ -305,6 +328,17 @@ gcloud secrets versions access latest --secret=librarian-db-url
 ```bash
 DATABASE_URL="postgresql://librarian:<hex-password>@localhost:5433/agentic_librarian" \
   python infra/verify_restore.py
+```
+
+WSL's bare `python3` has neither pip nor sqlalchemy — route through the app container
+instead (the container reaches the WSL-hosted proxy via `host.docker.internal`; no
+manual password copying needed):
+
+```bash
+URL=$(gcloud secrets versions access latest --secret=librarian-db-url)
+DBURL=$(echo "$URL" | sed 's#@/agentic_librarian?host=.*#@host.docker.internal:5433/agentic_librarian#')
+docker run --rm -e DATABASE_URL="$DBURL" -v ~/agentic_librarian:/app -w /app \
+  agentic_librarian-app:latest python infra/verify_restore.py
 ```
 
 All checks must pass before the first deploy. Expected passing output:

--- a/infra/06-restore.sh
+++ b/infra/06-restore.sh
@@ -5,8 +5,10 @@
 #   If 'CREATE EXTENSION ... vector' is NOT in the dump, create it first via:
 #   gcloud sql connect librarian-sql --user=postgres --database=agentic_librarian
 #   then: CREATE EXTENSION IF NOT EXISTS vector;
-# The 'librarian' role must already exist (03-db-user-secret.sh) — the dump's
-# ALTER ... OWNER TO librarian statements fail without it.
+# The 'librarian' role must already exist (03-db-user-secret.sh) — the import runs AS
+# that role (--user) so the dump's ALTER ... OWNER TO librarian statements are no-ops.
+# (Live-run lesson 2026-06-06: the default import user can't SET ROLE "librarian" on
+# PG16, which aborts the import at the first ownership statement.)
 set -euo pipefail
 source "$(dirname "$0")/00-config.sh"
 
@@ -21,6 +23,6 @@ SQL_SA="$(gcloud sql instances describe "${SQL_INSTANCE}" --format='value(servic
 gcloud storage buckets add-iam-policy-binding "${BUCKET}" \
   --member="serviceAccount:${SQL_SA}" --role="roles/storage.objectViewer"
 
-gcloud sql import sql "${SQL_INSTANCE}" "${BUCKET}/${DUMP_FILE}" --database="${DB_NAME}" --quiet
+gcloud sql import sql "${SQL_INSTANCE}" "${BUCKET}/${DUMP_FILE}" --database="${DB_NAME}" --user="${DB_USER}" --quiet
 
 echo "Import complete. Now verify: infra/verify_restore.py (runbook §7)."


### PR DESCRIPTION
## Summary

Patches from the **2026-06-06 live provisioning run** (Task 12 — now complete: Cloud SQL restored + verified, first deploy green, budget armed). Each change fixes something the run actually hit:

- **`infra/06-restore.sh`**: import runs `--user="${DB_USER}"` — the default Cloud SQL import user cannot `SET ROLE "librarian"` on PG16, so the dump's first `OWNER TO librarian` statement aborted the import. Importing *as* the owner makes those statements no-ops. (This was the one live failure; recovered with the documented drop-and-recreate + this flag.)
- **Runbook**:
  - §0: `gpg --yes` (re-runs hit an "overwrite?" prompt the doc didn't cover)
  - §6: dump-copy-to-WSL-clone instructions (`data/backups/` is gitignored and did not survive the re-clone)
  - §7: ADC note — `gcloud auth application-default login` is distinct from `gcloud auth login`; the Auth Proxy reads ADC (or use `--gcloud-auth`). Plus the container-routed verify command (WSL's bare python3 has no pip) and a "press Enter, it's still running" note for the backgrounded proxy.
- **`key_facts.md`**: new Production section — service URL, project, DB, deploy mechanism, budget guardrail.
- **`.gitattributes`**: `*.sh text eol=lf` — a CRLF Windows working tree breaks `bash` with "unexpected end of file"; scripts now check out LF everywhere.

## Test Plan
- [x] `bash -n` on the committed `06-restore.sh` blob (LF, syntax OK)
- [x] The `--user` import path is exactly what succeeded live (run manually during recovery)
- [x] Verification + count checks all green against the restored Cloud SQL instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)