### PR TITLE
fix: Lift 1 live-run learnings — token-signing prerequisites + runbook corrections

### DIFF
--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -57,7 +57,7 @@ This file tracks important project configuration, constants, and environment det
   still go through the CSV/Dagster path. Reading history is a log of READ EVENTS: a
   re-read inserts a new row (re-read count = rows per work).
 
-## Production (GCP — Lift 0, live 2026-06-06)
+## Production (GCP — Lift 0 live 2026-06-06; Lift 1 multi-user live 2026-06-07)
 - **Project**: `agentic-librarian-prod` (us-central1); ADR-047; runbook
   `docs/runbooks/gcp-walking-skeleton.md`; provisioning scripts in `infra/`.
 - **Service URL**: <https://librarian-api-hnucndzntq-uc.a.run.app> — Cloud Run
@@ -67,7 +67,9 @@ This file tracks important project configuration, constants, and environment det
 - **Endpoints**: `/health` (open); `/health/db`, `/history` (caller-scoped), `/works`
   (shared catalog) — all Firebase-gated (Lift 1, ADR-048). `SIGNUP_MODE=invite` on the
   service; invites via `librarian user invite <email>` (runbook
-  `docs/runbooks/lift1-multi-user-rollout.md`).
+  `docs/runbooks/lift1-multi-user-rollout.md`). Operator account (user #1,
+  `jaydee829@gmail.com`) claimed via Google sign-in 2026-06-07; token-minting for
+  live tests needs `FIREBASE_WEB_API_KEY` + `FIREBASE_SERVICE_ACCOUNT_ID` (runbook §1).
 - **Database**: Cloud SQL Postgres 16 `librarian-sql` (db-f1-micro, 10GB SSD) +
   pgvector; restored 2026-06-06 from `agentic_librarian_FINAL_20260605_014912.sql.gz`
   and verified (326 works / 335 editions / 331 reading_history / 230 authors; 556

--- a/docs/runbooks/lift1-multi-user-rollout.md
+++ b/docs/runbooks/lift1-multi-user-rollout.md
@@ -1,8 +1,19 @@
 # Runbook: Lift 1 multi-user rollout
 
-Operator-run, from the WSL clone (`~/agentic_librarian`), after PR approval but
-BEFORE merging (the migration must land before the auto-deploy). Lift 0's runbook
-(`gcp-walking-skeleton.md`) §7 has the proxy + ADC setup this reuses.
+Operator-run, after PR approval but BEFORE merging (the migration must land before
+the auto-deploy). Lift 0's runbook (`gcp-walking-skeleton.md`) §7 has the proxy + ADC
+setup this reuses. Executed live 2026-06-07; corrections from that run are folded in.
+
+**Where each section runs** (live-run lesson — the context changes per section):
+
+| Section | Runs in |
+|---|---|
+| §1 Firebase console + IAM | browser + plain WSL shell (gcloud) |
+| §2 dev rehearsal | dev container (alembic); psql via `docker exec` into the **db** container |
+| §3 prod migration | **plain WSL shell** — gcloud/proxy/sed host-side; alembic docker-wrapped |
+| §4 merge | GitHub |
+| §5 live verification | plain WSL shell (docker-wrapped token helper + curl) |
+| §6 invites | plain WSL shell, docker-wrapped |
 
 **No pre-migration backup for Lift 1** (spec §6): prod is byte-identical to
 `agentic_librarian_FINAL_20260605_014912.sql.gz` (the Lift 0 API is read-only) and that
@@ -16,27 +27,79 @@ before every migration.**
    project `agentic-librarian-prod` (Firebase is a console layer over the GCP project —
    no new project, no new billing).
 2. Build → **Authentication** → Get started → Sign-in method → enable **Google**.
-3. Project settings (gear) → General → note the **Web API Key** → export it in your
-   WSL shell: `export FIREBASE_WEB_API_KEY=<key>` (an identifier, not a secret — but
-   don't commit it).
+3. **Register a web app** (live-run lesson: the Web API key does NOT appear until an
+   app exists — and don't confuse it with Cloud Messaging's Web Push keys/sender ID):
+   Project settings (gear) → General → Your apps → **Add app** → Web (`</>`), any
+   nickname, skip Hosting. The shown `firebaseConfig.apiKey` (an `AIza...` string) is
+   the **Web API Key**; it also now appears on the General tab. Export it:
+   `export FIREBASE_WEB_API_KEY=<key>` (an identifier, not a secret — but don't
+   commit it; if you ever add API restrictions to it, keep Identity Toolkit allowed).
+4. **Token-minting prerequisites** (live-run lesson: `create_custom_token` must SIGN,
+   and user-credential ADC has no private key — the helper signs via the IAM
+   Credentials API as the firebase-adminsdk service account):
+
+    ```bash
+    gcloud services enable iamcredentials.googleapis.com --project agentic-librarian-prod
+    export FIREBASE_SERVICE_ACCOUNT_ID=firebase-adminsdk-fbsvc@agentic-librarian-prod.iam.gserviceaccount.com
+    gcloud iam service-accounts add-iam-policy-binding "$FIREBASE_SERVICE_ACCOUNT_ID" \
+      --member="user:jaydee829@gmail.com" --role="roles/iam.serviceAccountTokenCreator" \
+      --project agentic-librarian-prod
+    ```
+
+   (`serviceAccountTokenCreator` is deliberately excluded from Owner. Confirm the SA
+   email with `gcloud iam service-accounts list` — the suffix may differ. IAM grants
+   can take ~a minute to propagate.)
 
 ## §2 Rehearse the migration on the DEV database
 
-The dev DB carries the same data prod was restored from — a free rehearsal. From the
-dev container (or a throwaway app container on the compose network):
+The dev DB carries the same data prod was restored from — a free rehearsal. **Run
+from:** the dev container (or a throwaway app container on the compose network).
+
+**Orphaned `alembic_version` (live-run lesson):** the FINAL dump contains a stale
+`alembic_version` row (`7d34483879f0`, from a pre-dump-era experiment) — so BOTH the
+dev DB and anything restored from the dump (prod included) carry it, and `alembic
+stamp` fails with `Can't locate revision identified by '7d34483879f0'`. Clear it
+first (it is a one-row bookmark; deleting it is safe):
+
+```bash
+# from the dev container — for prod, run the same DELETE through the §3 docker wrapper
+python -c 'from sqlalchemy import create_engine, text; from agentic_librarian.db.session import resolve_database_url; e = create_engine(resolve_database_url()); c = e.connect(); t = c.begin(); r = c.execute(text("DELETE FROM alembic_version")); t.commit(); print("cleared", r.rowcount, "row(s)"); c.close()'
+```
+
+Then:
 
 ```bash
 alembic history                      # note the BASELINE revision id (the LAST entry — history prints newest first)
 alembic stamp <baseline-rev>         # dev DB already has the baseline schema
 alembic upgrade head
-# verify: psql → \dt shows users/usage/user_credentials; then:
-#   SELECT count(*) FROM reading_history WHERE user_id IS NULL;   -- must be 0
-#   SELECT email FROM users;                                      -- jaydee829@gmail.com
+```
+
+Verify — `psql` lives in the **db** container, not the app container:
+
+```bash
+# from a plain WSL shell (find the name with: docker ps --format '{{.Names}}' | grep db)
+docker exec -it agentic_librarian-db-1 psql -U librarian -d agentic_librarian -c '\dt' \
+  -c "SELECT count(*) AS null_user_rows FROM reading_history WHERE user_id IS NULL;" \
+  -c "SELECT email, firebase_uid, display_name FROM users;"
+# pass: users/usage/user_credentials listed; null_user_rows = 0; one row jaydee829@gmail.com
 ```
 
 ## §3 Migrate PROD
 
+**Run from:** a plain WSL shell at `~/agentic_librarian` (NOT the dev container —
+gcloud and the proxy binary live on the WSL host from the Lift 0 run).
+
 1. Start the proxy (Lift 0 runbook §7): `./cloud-sql-proxy --port 5433 <CONNECTION_NAME>`
+   — it sits on a blank line when serving. **Confirm it is actually listening**
+   (live-run lesson — "connection refused" from the containers means it isn't):
+
+    ```bash
+    ss -tln | grep 5433     # no output = proxy not running; 127.0.0.1:5433 = loopback-bound
+    ```
+
+   If containers still can't reach it, restart with `--address 0.0.0.0` (exposes the
+   port on your WSL interfaces for the session — Ctrl-C it when done; the proxy still
+   requires IAM auth behind it).
 2. Build the proxy-routed DATABASE_URL from the secret (same sed as Lift 0 §7,
    container-routed so the URL targets host.docker.internal):
 
@@ -58,6 +121,16 @@ alembic upgrade head
 4. The OLD deployed code keeps serving its read-only GETs against the migrated schema —
    no downtime window to manage.
 
+5. **Verify prod** (live-run lesson — this step was missing; same wrapper, python
+   instead of psql):
+
+    ```bash
+    docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+      -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest \
+      python -c 'from sqlalchemy import create_engine, text, inspect; from agentic_librarian.db.session import resolve_database_url; e = create_engine(resolve_database_url()); i = inspect(e); print("multi-user tables:", [t for t in ("users","usage","user_credentials") if t in i.get_table_names()]); c = e.connect(); print("null user_id rows:", c.execute(text("SELECT count(*) FROM reading_history WHERE user_id IS NULL")).scalar()); print("users:", c.execute(text("SELECT email, firebase_uid IS NULL FROM users")).fetchall()); c.close()'
+    # pass: all three tables; null user_id rows: 0; users: [('jaydee829@gmail.com', True)]
+    ```
+
 ## §4 Merge → auto-deploy
 
 Merge the PR. `.github/workflows/deploy.yml` deploys with `SIGNUP_MODE=invite` and
@@ -66,11 +139,14 @@ AND 401-enforcement on `/history`.
 
 ## §5 Verify live (the real-Firebase acceptance, spec §2)
 
+**Run from:** a plain WSL shell with `FIREBASE_WEB_API_KEY` and
+`FIREBASE_SERVICE_ACCOUNT_ID` (§1) exported — BOTH token commands need both vars.
+
 ```bash
 # ADC if not already done: gcloud auth application-default login
 TOKEN=$(docker run --rm -v "$PWD":/app -w /app \
   -v "$HOME/.config/gcloud:/home/appuser/.config/gcloud" \
-  -e GOOGLE_CLOUD_PROJECT=agentic-librarian-prod -e FIREBASE_WEB_API_KEY \
+  -e GOOGLE_CLOUD_PROJECT=agentic-librarian-prod -e FIREBASE_WEB_API_KEY -e FIREBASE_SERVICE_ACCOUNT_ID \
   agentic_librarian-app:latest python infra/get_firebase_token.py jaydee829@gmail.com)
 IAM="$(gcloud auth print-identity-token)"
 URL="https://librarian-api-hnucndzntq-uc.a.run.app"
@@ -81,7 +157,7 @@ curl -s -o /dev/null -w '%{http_code}\n' -H "X-Serverless-Authorization: Bearer 
 curl -s -H "X-Serverless-Authorization: Bearer $IAM" -H "Authorization: Bearer $TOKEN" "$URL/history" | head -c 400
 # 3. a non-invited account → 403
 TOKEN2=$(docker run --rm -v "$PWD":/app -w /app -v "$HOME/.config/gcloud:/home/appuser/.config/gcloud" \
-  -e GOOGLE_CLOUD_PROJECT=agentic-librarian-prod -e FIREBASE_WEB_API_KEY \
+  -e GOOGLE_CLOUD_PROJECT=agentic-librarian-prod -e FIREBASE_WEB_API_KEY -e FIREBASE_SERVICE_ACCOUNT_ID \
   agentic_librarian-app:latest python infra/get_firebase_token.py stranger-test@example.com)
 curl -s -o /dev/null -w '%{http_code}\n' -H "X-Serverless-Authorization: Bearer $IAM" \
   -H "Authorization: Bearer $TOKEN2" "$URL/history"   # 403
@@ -120,3 +196,10 @@ UPDATE users SET firebase_uid = NULL WHERE email = 'friend@example.com';
   helper sets email_verified on the user record; re-mint and inspect again (REC-019).
 - **`gcloud run services proxy` clobbers Authorization** — don't use it for Firebase
   testing; use the two-header curl form.
+- **`metadata.google.internal` resolution error from the token helper** — the SDK is
+  trying to sign via the GCP metadata server because it has no signing identity:
+  `FIREBASE_SERVICE_ACCOUNT_ID` isn't set/passed (`-e` on the docker run) or the §1
+  step-4 prerequisites (iamcredentials API + tokenCreator grant) are missing.
+- **`Can't locate revision identified by '7d34483879f0'`** — the orphaned
+  `alembic_version` row from the FINAL dump (see §2). Any future restore from that
+  dump re-imports it; clear before stamping.

--- a/infra/get_firebase_token.py
+++ b/infra/get_firebase_token.py
@@ -35,7 +35,12 @@ def main() -> int:
     if not api_key:
         print("error: set FIREBASE_WEB_API_KEY (Firebase console → Project settings → General)", file=sys.stderr)
         return 2
-    firebase_admin.initialize_app()
+    # Custom-token minting must SIGN. User-credential ADC has no private key, so the
+    # SDK needs a service account to sign AS via the IAM Credentials API (live-run
+    # lesson 2026-06-07): set FIREBASE_SERVICE_ACCOUNT_ID to the firebase-adminsdk SA
+    # email and grant yourself roles/iam.serviceAccountTokenCreator on it.
+    sa_id = os.environ.get("FIREBASE_SERVICE_ACCOUNT_ID")
+    firebase_admin.initialize_app(options={"serviceAccountId": sa_id} if sa_id else None)
     try:
         user = auth.get_user_by_email(email)
     except auth.UserNotFoundError:

--- a/infra/get_firebase_token.py
+++ b/infra/get_firebase_token.py
@@ -39,7 +39,7 @@ def main() -> int:
     # SDK needs a service account to sign AS via the IAM Credentials API (live-run
     # lesson 2026-06-07): set FIREBASE_SERVICE_ACCOUNT_ID to the firebase-adminsdk SA
     # email and grant yourself roles/iam.serviceAccountTokenCreator on it.
-    sa_id = os.environ.get("FIREBASE_SERVICE_ACCOUNT_ID")
+    sa_id = os.environ.get("FIREBASE_SERVICE_ACCOUNT_ID", "").strip()
     firebase_admin.initialize_app(options={"serviceAccountId": sa_id} if sa_id else None)
     try:
         user = auth.get_user_by_email(email)


### PR DESCRIPTION
## Summary

Corrections discovered while executing `docs/runbooks/lift1-multi-user-rollout.md` live on 2026-06-07 (Lift 0 → PR #40 pattern). The rollout itself **succeeded** — prod migrated, deploy green, all §5 acceptance checks passed.

- **`infra/get_firebase_token.py`**: `create_custom_token` must cryptographically sign, and user-credential ADC has no private key — the SDK fell back to the (nonexistent locally) metadata server. The helper now signs via the IAM Credentials API when `FIREBASE_SERVICE_ACCOUNT_ID` is set (no service-account key files, consistent with the project's WIF-everywhere stance).
- **Runbook §1**: the Web API key only materializes after *registering a web app* (and is not Cloud Messaging's Web Push key/sender ID); new step 4 documents the `iamcredentials.googleapis.com` enablement + `roles/iam.serviceAccountTokenCreator` grant on `firebase-adminsdk-fbsvc@…` (deliberately excluded from Owner).
- **Runbook §2/§3**: the FINAL dump *contains* an orphaned `alembic_version` row (`7d34483879f0`, pre-dump-era experiment) — both dev and prod hit `Can't locate revision` until it's cleared; documented clear command + note that future restores re-import it. Proxy liveness check (`ss -tln | grep 5433`) + `--address 0.0.0.0` variant. New §3 step 5: prod schema verification (was missing entirely).
- **Runbook (structure)**: "Where each section runs" table — the execution context (browser / dev container / plain WSL shell) changes per section and was previously implicit.
- **Runbook §5**: both token commands now carry `-e FIREBASE_SERVICE_ACCOUNT_ID`.
- **key_facts.md**: Lift 1 live date; operator account (user #1) claimed via Google sign-in.

## Test plan
- [x] Helper syntax-checked in-container; behavior unchanged when `FIREBASE_SERVICE_ACCOUNT_ID` is unset (None options = prior call)
- [x] Every runbook command in this diff was executed verbatim during the live run
- [x] CI on this PR (fast suite; docs + helper only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)