### PR TITLE
Lift 2 Stage 1: backend chat + transcript store (SSE /chat over the mesh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Brainstorming visual companion (mockups, session state)
+.superpowers/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/alembic/versions/30f1e46533e9_chat_transcript_store.py
+++ b/alembic/versions/30f1e46533e9_chat_transcript_store.py
@@ -5,17 +5,19 @@ Revises: c804d02d6fbb
 Create Date: 2026-06-09 19:14:35.030845
 
 """
-from typing import Sequence, Union
+
+from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
-revision: str = '30f1e46533e9'
-down_revision: Union[str, None] = 'c804d02d6fbb'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision: str = "30f1e46533e9"
+down_revision: str | None = "c804d02d6fbb"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -24,8 +26,8 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
         sa.Column("title", sa.String(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
-        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
     )
     op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
     op.create_table(
@@ -34,9 +36,18 @@ def upgrade() -> None:
         sa.Column("conversation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("conversations.id"), nullable=False),
         sa.Column("role", sa.String(), nullable=False),
         sa.Column("content", sa.Text(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
     )
     op.create_index("ix_messages_conversation_id", "messages", ["conversation_id"])
+    # usage.conversation_id existed since Lift 1 with no FK; pre-Stage-1 rows may hold
+    # ADK session uuids that match no conversations row. NULL those orphans so the FK can
+    # be added on databases that already have usage data (conversations is empty at this
+    # migration, so every non-null value is an orphan).
+    op.execute(
+        "UPDATE usage SET conversation_id = NULL "
+        "WHERE conversation_id IS NOT NULL "
+        "AND conversation_id NOT IN (SELECT id FROM conversations)"
+    )
     op.create_foreign_key("fk_usage_conversation_id", "usage", "conversations", ["conversation_id"], ["id"])
 
 

--- a/alembic/versions/30f1e46533e9_chat_transcript_store.py
+++ b/alembic/versions/30f1e46533e9_chat_transcript_store.py
@@ -1,0 +1,48 @@
+"""chat transcript store
+
+Revision ID: 30f1e46533e9
+Revises: c804d02d6fbb
+Create Date: 2026-06-09 19:14:35.030845
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '30f1e46533e9'
+down_revision: Union[str, None] = 'c804d02d6fbb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+    )
+    op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
+    op.create_table(
+        "messages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("conversations.id"), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+    )
+    op.create_index("ix_messages_conversation_id", "messages", ["conversation_id"])
+    op.create_foreign_key("fk_usage_conversation_id", "usage", "conversations", ["conversation_id"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_usage_conversation_id", "usage", type_="foreignkey")
+    op.drop_index("ix_messages_conversation_id", table_name="messages")
+    op.drop_table("messages")
+    op.drop_index("ix_conversations_user_id", table_name="conversations")
+    op.drop_table("conversations")

--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -208,3 +208,9 @@ This file tracks work history and ticket references.
 - **URL**: N/A (PR pending)
 - **Notes**:
     - **Tracked follow-up (schema, ask-first)**: add `series_name`/`series_position` to `works`, populated from Hardcover `featured_series` + a backfill pass over the existing catalog — makes the series rule deterministic instead of model-knowledge-based.
+
+### 2026-06-09 - INF-030: Move per-turn chat DB writes off the event loop (Lift 2 Stage 4)
+- **Status**: Open (deferred from Lift 2 Stage 1, PR #43)
+- **Description**: The SSE chat turn (`chat/stream.py` `sse_turn`) issues synchronous INSERTs on the asyncio event loop — both `transcript.append_message` calls (`on_persist`) AND the `usage.record_llm_call` write in `runtime._record_event_usage`. Under concurrent `/chat` load this blocks the loop. Gemini flagged the transcript write HIGH on PR #43; the fix must cover BOTH writes coherently via `asyncio.to_thread(...)`.
+- **URL**: PR #43 (review reply discussion_r3383988870); see also the `core/usage.py` latency note.
+- **Notes**: Do alongside the Stage 4 DatabaseManager pool consolidation. `asyncio.to_thread` copies the current context, so verify `as_user`/`current_user_id` still resolves inside the worker thread. No live impact until the service deploys against Cloud SQL (Stage 4 opens the IAM gate).

--- a/docs/superpowers/plans/2026-06-09-lift2-stage1-backend-chat.md
+++ b/docs/superpowers/plans/2026-06-09-lift2-stage1-backend-chat.md
@@ -1,0 +1,873 @@
+# Lift 2 Stage 1 — Backend Chat + Transcript Store Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the FastAPI service a Firebase-gated, SSE chat endpoint over the Librarian mesh whose conversation memory lives in Postgres, so chats survive Cloud Run recycling and become resumable.
+
+**Architecture:** A new `chat` package owns the transcript (a `conversations`/`messages` schema) and the SSE turn loop. Each `/chat` turn loads the active conversation's prior messages, **rehydrates** them into a fresh ADK session (via `append_event`), runs the mesh while streaming agent-activity events, then persists the user message and the assistant reply. The conversation row's id IS the ADK session id, so the Lift 1 `usage.conversation_id` rows line up and gain a real FK.
+
+**Tech Stack:** FastAPI (`StreamingResponse`, `text/event-stream`), SQLAlchemy + Alembic, `google-adk` sessions/events, pytest (`db_integration` + FastAPI `TestClient`).
+
+**Scope note:** This is Stage 1 of 4 (spec `docs/superpowers/specs/2026-06-09-lift2-front-end-design.md`). The SPA (Stage 2), async enrichment (Stage 3), and IAM-gate/cleanups/rollout (Stage 4) are separate plans. **Beta streaming decision:** the mesh runs in ADK's default (non-streaming) mode — one final response per turn. So this stage streams **agent-activity live** and the **reply as a single final chunk**; token-by-token streaming (ADK `StreamingMode.SSE`) is deferred future work.
+
+**Conventions (from Lift 1):** run all commands **inside the dev container**; in-container pre-commit (pinned ruff) is authoritative — bare `ruff check` gives false I001s. DB tests carry the `db_integration` marker and run against `agentic_librarian_test`. Every scoping test must FAIL when its filter is deleted (mutation mindset).
+
+---
+
+## File Structure
+
+- `alembic/versions/<rev>_chat_transcript_store.py` — **Create.** Migration: `conversations`, `messages`, and the `usage.conversation_id` → `conversations.id` FK. Down-revision = current head `c804d02d6fbb`.
+- `src/agentic_librarian/db/models.py` — **Modify.** Add `Conversation` and `Message` models; add the `ForeignKey("conversations.id")` to `Usage.conversation_id`.
+- `src/agentic_librarian/chat/__init__.py` — **Create.** Empty package marker.
+- `src/agentic_librarian/chat/transcript.py` — **Create.** User-scoped transcript store: resolve/create the active conversation, start a new one, load history, append a message.
+- `src/agentic_librarian/agents/runtime.py` — **Modify.** Extend `astart_conversation` to accept an explicit `session_id` and a `history` list, seeding prior turns into the session via `append_event`.
+- `src/agentic_librarian/chat/stream.py` — **Create.** The SSE turn loop: bridge the backend conversation's `on_event` + final reply into an async stream of SSE lines, and persist the transcript.
+- `src/agentic_librarian/api/main.py` — **Modify.** Add `GET /conversations/current`, `POST /conversations`, and `POST /chat` (SSE), all behind `get_current_user`.
+- `test/integration/test_transcript_store.py` — **Create.** Transcript store + scoping (db_integration).
+- `test/unit/test_chat_rehydrate.py` — **Create.** Rehydration seeds session events.
+- `test/unit/test_chat_stream.py` — **Create.** SSE turn loop with a fake backend.
+- `test/integration/test_chat_api.py` — **Create.** The three endpoints end-to-end (db_integration).
+
+---
+
+## Task 1: Schema — conversations, messages, usage FK
+
+**Files:**
+- Create: `alembic/versions/<rev>_chat_transcript_store.py`
+- Modify: `src/agentic_librarian/db/models.py`
+- Test: `test/integration/test_transcript_store.py` (schema assertion only in this task)
+
+- [ ] **Step 1: Generate an empty migration**
+
+Run (in the dev container): `alembic revision -m "chat transcript store"`
+This creates `alembic/versions/<rev>_chat_transcript_store.py` with `down_revision = "c804d02d6fbb"` auto-filled (the current head). Confirm that down_revision value; if it differs, the head moved — stop and reconcile.
+
+- [ ] **Step 2: Write the migration body**
+
+Replace the generated `upgrade()`/`downgrade()` with:
+
+```python
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+def upgrade() -> None:
+    op.create_table(
+        "conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+    )
+    op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
+    op.create_table(
+        "messages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("conversations.id"), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("timezone('utc', now())")),
+    )
+    op.create_index("ix_messages_conversation_id", "messages", ["conversation_id"])
+    # The column exists from Lift 1 (migration c804d02d6fbb); add the FK now that its target exists.
+    op.create_foreign_key("fk_usage_conversation_id", "usage", "conversations", ["conversation_id"], ["id"])
+
+def downgrade() -> None:
+    op.drop_constraint("fk_usage_conversation_id", "usage", type_="foreignkey")
+    op.drop_index("ix_messages_conversation_id", table_name="messages")
+    op.drop_table("messages")
+    op.drop_index("ix_conversations_user_id", table_name="conversations")
+    op.drop_table("conversations")
+```
+
+- [ ] **Step 3: Add the ORM models**
+
+In `src/agentic_librarian/db/models.py`, add after the `Suggestions` class (the imports `UTC, datetime, UUID, uuid4, ForeignKey, String, Text, DateTime, PG_UUID, Mapped, mapped_column, relationship` are all already present):
+
+```python
+class Conversation(Base):
+    """One chat thread (Lift 2). The active thread is the user's most-recent row;
+    New chat inserts a new one. title is nullable now so the future switchable-list
+    needs no migration. id doubles as the ADK session id so usage rows line up."""
+
+    __tablename__ = "conversations"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False
+    )
+
+    messages: Mapped[list["Message"]] = relationship(back_populates="conversation", cascade="all, delete-orphan")
+
+
+class Message(Base):
+    """One turn in a conversation (Lift 2). role is 'user' or 'assistant'."""
+
+    __tablename__ = "messages"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    conversation_id: Mapped[UUID] = mapped_column(ForeignKey("conversations.id"), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+
+    conversation: Mapped["Conversation"] = relationship(back_populates="messages")
+```
+
+Then change the `Usage.conversation_id` column to carry the FK:
+
+```python
+    conversation_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True
+    )
+```
+
+- [ ] **Step 4: Write the failing schema test**
+
+Create `test/integration/test_transcript_store.py`:
+
+```python
+import pytest
+from sqlalchemy import inspect
+
+from agentic_librarian.db.session import DatabaseManager
+
+
+@pytest.mark.db_integration
+def test_chat_tables_and_usage_fk_exist():
+    engine = DatabaseManager().engine
+    inspector = inspect(engine)
+    names = set(inspector.get_table_names())
+    assert {"conversations", "messages"} <= names
+    fks = inspector.get_foreign_keys("usage")
+    assert any(fk["referred_table"] == "conversations" for fk in fks)
+```
+
+If `DatabaseManager` exposes the engine under a different attribute, read `src/agentic_librarian/db/session.py` and use the correct accessor (e.g. `_engine`); adjust the test to match.
+
+- [ ] **Step 5: Run it to verify it fails**
+
+Run: `pytest test/integration/test_transcript_store.py -m db_integration -v`
+Expected: FAIL — the test DB schema predates the new migration.
+
+- [ ] **Step 6: Rebuild the test schema and verify it passes**
+
+The schema is built once per session by conftest via `alembic upgrade head`. Drop and recreate so the new migration applies:
+Run: `psql "$TEST_DATABASE_URL" -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'` (or `docker exec` into the db container, db `agentic_librarian_test`), then
+Run: `pytest test/integration/test_transcript_store.py -m db_integration -v`
+Expected: PASS.
+
+- [ ] **Step 7: Verify migration fidelity (Lift 1 gate)**
+
+Run: `alembic upgrade head && alembic downgrade -1 && alembic upgrade head`
+Expected: no errors; the autogenerate check (env.py `compare_metadata`) shows the models and schema agree.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add alembic/versions/ src/agentic_librarian/db/models.py test/integration/test_transcript_store.py
+git commit -m "feat(lift2): chat transcript schema — conversations, messages, usage FK"
+```
+
+---
+
+## Task 2: Transcript store (`chat/transcript.py`)
+
+**Files:**
+- Create: `src/agentic_librarian/chat/__init__.py` (empty)
+- Create: `src/agentic_librarian/chat/transcript.py`
+- Test: `test/integration/test_transcript_store.py` (append to it)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/integration/test_transcript_store.py`:
+
+```python
+from uuid import UUID
+
+from agentic_librarian.chat import transcript
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user
+
+OTHER_USER = UUID("00000000-0000-4000-8000-0000000000ff")
+
+
+@pytest.mark.db_integration
+def test_active_conversation_is_created_then_reused():
+    first = transcript.get_or_create_active_conversation()
+    second = transcript.get_or_create_active_conversation()
+    assert first.conversation_id == second.conversation_id  # most-recent row reused
+    assert first.history == []
+
+
+@pytest.mark.db_integration
+def test_append_then_history_round_trips_in_order():
+    ctx = transcript.get_or_create_active_conversation()
+    transcript.append_message(ctx.conversation_id, "user", "hello")
+    transcript.append_message(ctx.conversation_id, "assistant", "hi there")
+    reloaded = transcript.get_or_create_active_conversation()
+    assert reloaded.conversation_id == ctx.conversation_id
+    assert reloaded.history == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+
+
+@pytest.mark.db_integration
+def test_new_conversation_becomes_the_active_one():
+    first = transcript.get_or_create_active_conversation()
+    transcript.append_message(first.conversation_id, "user", "old thread")
+    fresh = transcript.start_new_conversation()
+    assert fresh.conversation_id != first.conversation_id
+    assert fresh.history == []
+    assert transcript.get_or_create_active_conversation().conversation_id == fresh.conversation_id
+
+
+@pytest.mark.db_integration
+def test_active_conversation_is_user_scoped():
+    mine = transcript.get_or_create_active_conversation()  # default user (conftest context)
+    with as_user(OTHER_USER):
+        # Seed the other user so the FK holds, then check isolation.
+        from agentic_librarian.db.models import User
+        from agentic_librarian.db.session import DatabaseManager
+
+        with DatabaseManager().get_session() as s:
+            s.merge(User(id=OTHER_USER, email="other@example.com"))
+        theirs = transcript.get_or_create_active_conversation()
+        assert theirs.conversation_id != mine.conversation_id  # FAILS if the query forgets user scoping
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest test/integration/test_transcript_store.py -m db_integration -v`
+Expected: FAIL — `agentic_librarian.chat.transcript` does not exist.
+
+- [ ] **Step 3: Implement the store**
+
+Create `src/agentic_librarian/chat/__init__.py` (empty). Create `src/agentic_librarian/chat/transcript.py`:
+
+```python
+"""User-scoped chat transcript store (Lift 2). The active thread is the current
+user's most-recent conversation; New chat inserts a new row. Identity comes from
+the context (get_required_user_id) — never a parameter (ADR-048)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.models import Conversation, Message
+from agentic_librarian.db.session import DatabaseManager
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager) -> None:
+    """Override the module db_manager (for tests) — the mcp/server.py pattern."""
+    global db_manager
+    db_manager = new_manager
+
+
+@dataclass(frozen=True)
+class TurnContext:
+    """Everything a chat turn needs: which conversation, and its prior turns
+    (oldest first) as plain {'role','content'} dicts."""
+
+    conversation_id: UUID
+    history: list[dict]
+
+
+def _history(session, conversation_id: UUID) -> list[dict]:
+    rows = (
+        session.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at, Message.id)  # id tiebreaks same-timestamp inserts
+        .all()
+    )
+    return [{"role": m.role, "content": m.content} for m in rows]
+
+
+def get_or_create_active_conversation() -> TurnContext:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        conv = (
+            session.query(Conversation)
+            .filter(Conversation.user_id == user_id)  # scoping: my threads only
+            .order_by(Conversation.created_at.desc(), Conversation.id.desc())
+            .first()
+        )
+        if conv is None:
+            conv = Conversation(user_id=user_id)
+            session.add(conv)
+            session.flush()
+        return TurnContext(conversation_id=conv.id, history=_history(session, conv.id))
+
+
+def start_new_conversation() -> TurnContext:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        conv = Conversation(user_id=user_id)
+        session.add(conv)
+        session.flush()
+        return TurnContext(conversation_id=conv.id, history=[])
+
+
+def append_message(conversation_id: UUID, role: str, content: str) -> None:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        # Scoping: only write into a conversation the caller owns.
+        conv = (
+            session.query(Conversation)
+            .filter(Conversation.id == conversation_id, Conversation.user_id == user_id)
+            .first()
+        )
+        if conv is None:
+            raise PermissionError(f"conversation {conversation_id} not found for this user")
+        session.add(Message(conversation_id=conversation_id, role=role, content=content))
+        session.flush()
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest test/integration/test_transcript_store.py -m db_integration -v`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Mutation check (scoping is real)**
+
+Temporarily delete `.filter(Conversation.user_id == user_id)` from `get_or_create_active_conversation`. Run the suite; `test_active_conversation_is_user_scoped` MUST fail. Restore the filter.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/chat/ test/integration/test_transcript_store.py
+git commit -m "feat(lift2): user-scoped chat transcript store"
+```
+
+---
+
+## Task 3: Rehydration — seed an ADK session from stored history
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/runtime.py:118-128` (`astart_conversation`/`start_conversation`)
+- Test: `test/unit/test_chat_rehydrate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test_chat_rehydrate.py`:
+
+```python
+import asyncio
+
+from agentic_librarian.agents import runtime
+
+
+class _FakeSessionService:
+    def __init__(self):
+        self.created = []
+        self.appended = []
+
+    async def create_session(self, app_name, user_id, session_id):
+        self.created.append(session_id)
+        return object()
+
+    async def get_session(self, app_name, user_id, session_id):
+        return object()
+
+    async def append_event(self, session, event):
+        self.appended.append(event)
+        return event
+
+
+class _FakeRunner:
+    def __init__(self):
+        self.session_service = _FakeSessionService()
+
+
+def test_history_is_seeded_as_events_in_order():
+    runner = _FakeRunner()
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    conv = asyncio.run(
+        runtime.astart_conversation(user_id="u", runner=runner, session_id="abc123", history=history)
+    )
+    assert conv.session_id == "abc123"
+    assert runner.session_service.created == ["abc123"]
+    # Two prior turns -> two seeded events, oldest first, with the right content roles.
+    assert len(runner.session_service.appended) == 2
+    roles = [e.content.role for e in runner.session_service.appended]
+    assert roles == ["user", "model"]
+    texts = [e.content.parts[0].text for e in runner.session_service.appended]
+    assert texts == ["hello", "hi there"]
+
+
+def test_no_history_seeds_no_events():
+    runner = _FakeRunner()
+    asyncio.run(runtime.astart_conversation(user_id="u", runner=runner, session_id="abc", history=None))
+    assert runner.session_service.appended == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest test/unit/test_chat_rehydrate.py -v`
+Expected: FAIL — `astart_conversation` takes no `session_id`/`history`.
+
+- [ ] **Step 3: Implement rehydration**
+
+In `src/agentic_librarian/agents/runtime.py`, add the import near the top (with the other `google.adk`/`google.genai` imports):
+
+```python
+from google.adk.events import Event
+```
+
+Replace `astart_conversation` and `start_conversation` (currently lines ~118-128) with:
+
+```python
+async def astart_conversation(
+    user_id: str = "local",
+    runner: Runner | None = None,
+    on_event=None,
+    session_id: str | None = None,
+    history: list[dict] | None = None,
+) -> LibrarianConversation:
+    """Open a conversation. `session_id` lets the caller pin the ADK session id to a
+    stored conversation id (so usage rows line up). `history` (oldest first, each
+    {'role': 'user'|'assistant', 'content': str}) is seeded into the session as events
+    so the mesh has prior context WITHOUT re-running earlier turns (Lift 2)."""
+    runner = runner or build_runner()
+    session_id = session_id or uuid.uuid4().hex
+    session = await runner.session_service.create_session(
+        app_name=APP_NAME, user_id=user_id, session_id=session_id
+    )
+    for turn in history or []:
+        role = "user" if turn["role"] == "user" else "model"
+        author = "user" if turn["role"] == "user" else "librarian"
+        content = types.Content(role=role, parts=[types.Part(text=turn["content"])])
+        await runner.session_service.append_event(session, Event(author=author, content=content))
+    return LibrarianConversation(runner, user_id, session_id, on_event=on_event)
+
+
+def start_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None,
+    session_id: str | None = None, history: list[dict] | None = None,
+) -> LibrarianConversation:
+    return asyncio.run(
+        astart_conversation(
+            user_id=user_id, runner=runner, on_event=on_event, session_id=session_id, history=history
+        )
+    )
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest test/unit/test_chat_rehydrate.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the existing conversation tests still pass**
+
+Run: `pytest test/unit -k "conversation or runtime" -v`
+Expected: PASS — the new params are optional and default to today's behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/agents/runtime.py test/unit/test_chat_rehydrate.py
+git commit -m "feat(lift2): rehydrate ADK sessions from stored history via append_event"
+```
+
+---
+
+## Task 4: SSE turn loop (`chat/stream.py`)
+
+**Files:**
+- Create: `src/agentic_librarian/chat/stream.py`
+- Test: `test/unit/test_chat_stream.py`
+
+The turn loop bridges the backend's synchronous `on_event(kind, detail)` callback and its single final reply into an ordered async stream of SSE lines, persisting the transcript at the end. It is backend-agnostic: tests drive it with a fake conversation, no ADK.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test_chat_stream.py`:
+
+```python
+import asyncio
+import json
+from uuid import UUID
+
+from agentic_librarian.chat import stream
+
+_USER = UUID("00000000-0000-4000-8000-000000000001")
+
+
+class _FakeConversation:
+    """Mimics a BackendConversation: fires on_event during asend, returns a final reply."""
+
+    def __init__(self, on_event):
+        self._on_event = on_event
+
+    async def asend(self, message: str) -> str:
+        self._on_event("agent", "Explorer")
+        self._on_event("tool", "search_internal_database")
+        return f"reply to: {message}"
+
+    def close(self):
+        pass
+
+
+def _collect(message, recorded):
+    async def run():
+        out = []
+        async for line in stream.sse_turn(
+            message=message,
+            conversation=_FakeConversation,  # factory: takes on_event
+            on_persist=lambda role, content: recorded.append((role, content)),
+            user_id=_USER,
+        ):
+            out.append(line)
+        return out
+
+    return asyncio.run(run())
+
+
+def test_stream_emits_activity_then_text_then_done():
+    recorded = []
+    lines = _collect("hi", recorded)
+    body = "".join(lines)
+    # Activity events arrive before the reply; stream terminates with done.
+    assert body.index("Explorer") < body.index("reply to: hi")
+    assert "event: activity" in body
+    assert "event: text" in body
+    assert body.rstrip().endswith("event: done\ndata: {}")
+
+
+def test_stream_persists_user_then_assistant():
+    recorded = []
+    _collect("hi", recorded)
+    assert recorded == [("user", "hi"), ("assistant", "reply to: hi")]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest test/unit/test_chat_stream.py -v`
+Expected: FAIL — `agentic_librarian.chat.stream` does not exist.
+
+- [ ] **Step 3: Implement the turn loop**
+
+Create `src/agentic_librarian/chat/stream.py`:
+
+```python
+"""SSE turn loop (Lift 2). Bridges a backend conversation's on_event callback and its
+single final reply into an ordered text/event-stream, persisting the transcript.
+
+Beta scope: agent-activity streams live; the reply is one final chunk (the mesh runs
+in ADK's default non-streaming mode). Token-level streaming is future work."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+from uuid import UUID
+
+from agentic_librarian.core.user_context import as_user
+
+_DONE = object()  # sentinel marking the queue's end
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def sse_turn(
+    message: str,
+    conversation: Callable,
+    on_persist: Callable[[str, str], None],
+    user_id: UUID,
+) -> AsyncIterator[str]:
+    """Run one turn. `conversation` is a factory taking an on_event callback and
+    returning an object with `async asend(message) -> str` and `close()`. `on_persist`
+    stores one (role, content) message. `user_id` re-establishes identity inside the
+    turn: the SSE generator runs on the event loop after the endpoint returns, where the
+    auth dependency's ContextVar is no longer active — so the mesh tools, usage metering,
+    and the transcript writes would otherwise see no user (the Lift 1 _with_user lesson)."""
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def on_event(kind: str, detail: str) -> None:
+        queue.put_nowait(_sse("activity", {"kind": kind, "detail": detail}))
+
+    conv = conversation(on_event)
+
+    async def drive() -> None:
+        try:
+            with as_user(user_id):  # identity live for the mesh tools, usage, and persist
+                reply = await conv.asend(message)
+                on_persist("user", message)
+                on_persist("assistant", reply)
+            queue.put_nowait(_sse("text", {"text": reply}))
+        finally:
+            conv.close()
+            queue.put_nowait(_DONE)
+
+    task = asyncio.create_task(drive())
+    try:
+        while True:
+            item = await queue.get()
+            if item is _DONE:
+                break
+            yield item
+        yield _sse("done", {})
+    finally:
+        await task  # surface any exception from the driver
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest test/unit/test_chat_stream.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/chat/stream.py test/unit/test_chat_stream.py
+git commit -m "feat(lift2): SSE chat turn loop with activity streaming + transcript persist"
+```
+
+---
+
+## Task 5: API endpoints — /conversations + /chat
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py`
+- Test: `test/integration/test_chat_api.py`
+
+Wire the store (Task 2), rehydration (Task 3), and turn loop (Task 4) together. `/chat` opens the ADK conversation with `session_id = conversation_id.hex` and the stored history, then streams.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/integration/test_chat_api.py`:
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import auth, main
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, DEFAULT_USER_EMAIL
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Bypass Firebase: the auth dependency resolves the default user directly.
+    async def _fake_dep():
+        from agentic_librarian.core.user_context import current_user_id
+        user = auth.AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
+        current_user_id.set(user.id)
+        return user
+
+    main.app.dependency_overrides[auth.get_current_user] = _fake_dep
+    # Make /chat deterministic: a fake backend that needs no LLM. _open_conversation is
+    # async, so the replacement must be an async function (it is awaited in _SyncOpener).
+    class _FakeConv:
+        async def asend(self, message): return f"echo:{message}"
+        def close(self): ...
+    async def _fake_open(**kwargs): return _FakeConv()
+    monkeypatch.setattr(main, "_open_conversation", _fake_open)
+    yield TestClient(main.app)
+    main.app.dependency_overrides.clear()
+
+
+@pytest.mark.db_integration
+def test_current_conversation_then_chat_then_resume(client):
+    current = client.get("/conversations/current").json()
+    assert current["messages"] == []
+    cid = current["id"]
+
+    with client.stream("POST", "/chat", json={"message": "hi"}) as r:
+        body = "".join(chunk for chunk in r.iter_text())
+    assert "echo:hi" in body
+    assert body.rstrip().endswith("event: done\ndata: {}")
+
+    resumed = client.get("/conversations/current").json()
+    assert resumed["id"] == cid
+    assert resumed["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "echo:hi"},
+    ]
+
+
+@pytest.mark.db_integration
+def test_new_conversation_starts_empty(client):
+    client.get("/conversations/current")
+    fresh = client.post("/conversations").json()
+    assert fresh["messages"] == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest test/integration/test_chat_api.py -m db_integration -v`
+Expected: FAIL — the routes and `_open_conversation` don't exist.
+
+- [ ] **Step 3: Implement the endpoints**
+
+In `src/agentic_librarian/api/main.py`, add imports:
+
+```python
+from agentic_librarian.agents.runtime import astart_conversation
+from agentic_librarian.chat import stream, transcript
+from fastapi import Body
+from fastapi.responses import StreamingResponse
+```
+
+Add a seam for the backend conversation (so tests can replace it) and the routes:
+
+```python
+async def _open_conversation(*, user_id, session_id, history, on_event):
+    """Open the mesh conversation for one turn (seam: tests replace this)."""
+    return await astart_conversation(
+        user_id=user_id, session_id=session_id, history=history, on_event=on_event
+    )
+
+
+@app.get("/conversations/current")
+def get_current_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    ctx = transcript.get_or_create_active_conversation()
+    return {"id": str(ctx.conversation_id), "messages": ctx.history}
+
+
+@app.post("/conversations")
+def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    ctx = transcript.start_new_conversation()
+    return {"id": str(ctx.conversation_id), "messages": ctx.history}
+
+
+@app.post("/chat")
+def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    ctx = transcript.get_or_create_active_conversation()
+    adk_user_id = str(user.id)  # ADK wants a string user id; as_user wants the UUID
+    return StreamingResponse(
+        stream.sse_turn(
+            message=message,
+            conversation=lambda on_event: _SyncOpener(adk_user_id, ctx, on_event),
+            on_persist=lambda role, content: transcript.append_message(ctx.conversation_id, role, content),
+            user_id=user.id,
+        ),
+        media_type="text/event-stream",
+    )
+```
+
+`_SyncOpener` bridges the async `astart_conversation` into `sse_turn`'s synchronous factory by opening the
+conversation lazily on the first `asend`, inside the request's running event loop. Add it near the routes:
+
+```python
+class _SyncOpener:
+    """Lazily opens the async mesh conversation on first asend, inside the running loop.
+    session_id = the conversation id so usage rows (keyed off the ADK session uuid) FK to it."""
+
+    def __init__(self, user_id, ctx, on_event):
+        self._user_id, self._ctx, self._on_event, self._conv = user_id, ctx, on_event, None
+
+    async def asend(self, message: str) -> str:
+        if self._conv is None:
+            self._conv = await _open_conversation(
+                user_id=self._user_id, session_id=self._ctx.conversation_id.hex,
+                history=self._ctx.history, on_event=self._on_event,
+            )
+        return await self._conv.asend(message)
+
+    def close(self):
+        if self._conv is not None:
+            self._conv.close()
+```
+
+The test replaces `main._open_conversation`, so `_SyncOpener` calls the fake conversation instead of the mesh.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest test/integration/test_chat_api.py -m db_integration -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + lint**
+
+Run: `pytest -m "not live and not api_dependent" -q` then `pre-commit run --all-files`
+Expected: green (in-container pre-commit is authoritative).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/api/main.py test/integration/test_chat_api.py
+git commit -m "feat(lift2): /chat SSE endpoint + /conversations resume & new"
+```
+
+---
+
+## Task 6: Usage rows line up with conversations (FK proof)
+
+**Files:**
+- Test: `test/integration/test_chat_api.py` (append)
+
+This task adds no production code — it proves the design choice (conversation id == ADK session id) makes Lift 1 usage rows FK-valid, so a future regression that breaks the alignment is caught.
+
+- [ ] **Step 1: Write the guard test**
+
+Append to `test/integration/test_chat_api.py`:
+
+```python
+@pytest.mark.db_integration
+def test_usage_rows_reference_the_conversation(client, monkeypatch):
+    # Drive a turn whose fake backend records a usage row against the session id,
+    # mirroring runtime._record_event_usage, and assert the FK resolves.
+    from uuid import UUID
+    from agentic_librarian.core import usage
+
+    current = client.get("/conversations/current").json()
+    cid = UUID(current["id"])
+
+    class _UsingConv:
+        async def asend(self, message):
+            usage.record_llm_call(vendor="gemini", model="test", input_tokens=1,
+                                  output_tokens=1, conversation_id=cid)
+            return "ok"
+        def close(self): ...
+    async def _using_open(**kwargs): return _UsingConv()
+    monkeypatch.setattr(main, "_open_conversation", _using_open)
+
+    with client.stream("POST", "/chat", json={"message": "go"}) as r:
+        "".join(r.iter_text())
+
+    from agentic_librarian.db.models import Usage
+    from agentic_librarian.db.session import DatabaseManager
+    with DatabaseManager().get_session() as s:
+        row = s.query(Usage).filter(Usage.conversation_id == cid).first()
+        assert row is not None  # FK held: the conversation existed when usage was written
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest test/integration/test_chat_api.py::test_usage_rows_reference_the_conversation -m db_integration -v`
+Expected: PASS (the conversation row is created by `/conversations/current` before the usage insert; the FK from Task 1 resolves).
+
+- [ ] **Step 3: Mutation check**
+
+Temporarily drop `fk_usage_conversation_id` (or point the insert at a random UUID): writing usage with a non-existent `conversation_id` must raise an IntegrityError. Confirm, then restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/test_chat_api.py
+git commit -m "test(lift2): usage rows FK-resolve to their conversation"
+```
+
+---
+
+## Final review
+
+After all tasks: dispatch a final code reviewer over the whole Stage 1 diff, then use superpowers:finishing-a-development-branch. Stage 1 ships as its own PR (Gemini review → CI green → squash-merge "(#N)"), and the live `/chat` smoke is deferred to Stage 4's rollout (it needs the prod Gemini key + open IAM gate). Stage 2 (the SPA) is planned against this merged contract.
+
+## Self-review notes (author)
+
+- The `_SyncOpener` indirection exists because `astart_conversation` is async but `sse_turn`'s `conversation` factory is called synchronously then `asend`-ed inside the loop — opening lazily on first `asend` keeps everything on the request's event loop. If the implementer finds a cleaner bridge (e.g. making `sse_turn` accept an async factory), that is welcome — keep the tests green.
+- True token streaming is intentionally out of scope (see header). If the mesh is later switched to `StreamingMode.SSE`, `_record_event_usage`'s "one usage event per call" assumption (runtime.py) must be revisited.

--- a/docs/superpowers/specs/2026-06-09-lift2-front-end-design.md
+++ b/docs/superpowers/specs/2026-06-09-lift2-front-end-design.md
@@ -1,0 +1,226 @@
+# Lift 2 — Front End (Friends & Family Beta)
+
+**Date:** 2026-06-09
+**Status:** Approved (brainstormed with user)
+**Branch:** `feat/lift2-front-end`
+**Roadmap:** ADR-046 (`docs/superpowers/specs/2026-06-05-product-roadmap-design.md`), lift 2 of 4. Builds on
+Lift 0 (ADR-047, GCP walking skeleton) and Lift 1 (ADR-048, multi-user foundation). A new ADR-049
+will record this lift's decisions at implementation time.
+
+This is the design for the **friends & family beta**: a chat-centric web app over the conversational
+Librarian, served from the existing FastAPI/Cloud Run service, gated solely by Firebase Auth.
+
+---
+
+## Decisions locked (brainstorm)
+
+| # | Decision | Choice | Why |
+|---|----------|--------|-----|
+| D1 | Information architecture | **Chat-centric** | The Librarian conversation is the product's personality; ship depth in one place, not four thin screens. |
+| D2 | Frontend framework | **Vite + React (TypeScript)** | Auth-gated app → no SSR/SEO need; a static SPA over the existing FastAPI is the least machinery. TS catches shape errors early. |
+| D3 | SPA hosting | **Served from the FastAPI container** (same origin) | One origin (no CORS), one deploy, reuses the existing CD. Migrating to Firebase Hosting later is config-only (a `firebase.json` rewrite), so it's not a one-way door. |
+| D4 | Chat transport | **SSE** (Server-Sent Events) | A mesh turn takes seconds across multiple agents; stream reply text **and** live agent/tool activity off the runtime's existing `on_event` hook. WebSocket is more than turn-based chat needs. |
+| D5 | Conversation memory | **Owned transcript in Postgres** | Survives Cloud Run scale-to-zero / multi-instance recycling, is backend-agnostic, and *becomes* the resume / future chat-history feature. The Lift 1 `usage.conversation_id` column finally gets a table to reference. |
+| D6 | Chat screen | **Single active thread** + Resume + New chat | Smallest UI surface; "resume my conversation" is a natural mental model. Transcript stored either way; the switchable list (option B) is a no-migration add later. |
+| D7 | Navigation | **Chat · History · Recommendations · Analysis · Add** | Side icon rail on desktop; bottom nav bar on mobile. |
+| D8 | Analysis views (beta) | **Reading snapshot · Genre & mood mix · Top tropes · Authors & narrators** | Buildable from existing data; *Top tropes* (the vectorized-trope fingerprint) is the signature view. Ratings-over-time and taste-profile deferred. |
+| D9 | Recommendations view | **Actionable** | Reads the Lift 1 `Suggestions` table; **✓ I read this** → add-book prefilled → status `Read`; **Not for me** → status `Dismissed`. Closes the suggest→read→rate loop. |
+| D10 | Add-a-book form | Title + Author (required) · Format/Rating/Notes (optional) · **Date finished pre-filled today, editable** | IMP-028. Look-up-on-submit (no autocomplete in beta). Re-reads = a new read-event row (existing model). |
+| D11 | Enrichment timing | **Two-phase** | Fast pass (API scouts, ~seconds) creates the Work + logs the read immediately; deep pass (LLM scouts, ~2m30s) runs in the background. The user never waits on the LLM. |
+| D12 | Deep-enrichment mechanism | **Cloud Tasks → internal endpoint** | Cloud Run throttles CPU after a response, so an in-process background thread is unreliable. A queued task re-enters the service as a fresh request with full CPU + long timeout. The async-work pattern needed at open signup, learned on a small surface. |
+| D13 | Sign-in | **Google only** (Firebase JS SDK) | Every friend has a Google account; simplest path; already enabled in Lift 1. Email/password deferred to open signup. |
+| D14 | Responsiveness | **Mobile + desktop browser** (one codebase) | A React SPA runs in any modern browser; responsive layout (mobile-first chat, rail→bottom-nav) makes it usable on a phone. Native apps and PWA are out of scope (PWA logged as future). |
+
+---
+
+## §1 Architecture overview
+
+A Vite + React SPA is compiled during the Docker image build and served as static files by the existing
+FastAPI app on Cloud Run — **one origin, one deploy**. The browser signs in with Firebase (Google), receives
+an ID token, and attaches it as `Authorization: Bearer <token>` on every API/SSE call — the exact token the
+Lift 1 auth dependency already verifies. The **Cloud Run IAM gate opens** (browsers cannot attach a Google IAM
+identity token), making **Firebase the sole gate**; `SIGNUP_MODE=invite` keeps the door closed to the uninvited.
+
+New FastAPI surface (all Firebase-gated unless noted):
+
+| Route | Purpose |
+|-------|---------|
+| `POST /chat` | SSE stream — drives the mesh, streams activity + reply, persists transcript + usage |
+| `GET /conversations/current` (+ messages) | Resume the active thread |
+| `POST /conversations` | Start a new chat |
+| `POST /books` | Add-a-book fast pass: identity match → log read-event → enqueue deep enrichment |
+| `POST /internal/enrich/{work_id}` | **Cloud Tasks target** (queue-OIDC-gated, not Firebase) — deep LLM pass |
+| `GET /recommendations` · `POST /recommendations/{id}/status` | Suggestions list + Read/Dismissed actions |
+| `GET /analysis/...` | The four beta analysis views |
+| `GET /history` | Now **paginated** (`limit`/`offset`) — closes INF-029 |
+| `GET /health` | Stays open (unauthenticated) |
+
+**Mesh is already in the image:** `google-adk`, `google-genai`, `mcp`, `fastmcp`, and the scout libraries
+are base `dependencies`, so `pip install .` in `Dockerfile.api` already bakes them in. "Deploying the mesh"
+is *wiring* (endpoints + prod API keys + env), not packaging.
+
+**Cost reality:** this is when prod begins **spending LLM tokens** (chat + enrichment). Lift 1's usage metering
+starts producing real rows; the $25/mo budget guardrail becomes live-relevant. The prod model stays on Gemini
+Flash-Lite (cheapest), per the roadmap lock.
+
+---
+
+## §2 Frontend
+
+**Build & language.** Vite builds the React app (TypeScript) into static files copied into the image. TypeScript
+is chosen to catch typos/shape errors before runtime.
+
+**App shell.** One persistent frame: a top bar (app name · avatar + sign-out) and navigation that renders as a
+**left icon rail on desktop** and a **bottom nav bar on mobile** (same components, layout keyed off width).
+Client-side routing (React Router) swaps views without full reloads.
+
+**The five views, each a focused component:**
+- **Chat** (home) — message thread, live activity chip, input box, New chat / resume controls.
+- **History** — paginated reading log, newest first.
+- **Recommendations** — the Suggestions list with ✓ I read this / Not for me.
+- **Analysis** — the four views (snapshot, genre/mood, top tropes, authors & narrators).
+- **Add a book** — the form panel, opens over the current view.
+
+**Firebase sign-in flow:**
+1. Initialize the Firebase JS SDK with the web config; show **Sign in with Google** when logged out.
+2. On sign-in the SDK provides a user + ID token; attach the token on every API/SSE call (SDK auto-refreshes).
+3. **403 (verified but not invited)** → a friendly "ask the operator for an invite" screen. Signed-out → the
+   sign-in screen. A sign-out button clears state.
+
+**SSE chat client.** The browser's built-in `EventSource` cannot POST or set an `Authorization` header, so the
+client consumes the stream with **`fetch()` + a streaming reader**: POST the message, read the `text/event-stream`
+response incrementally. It parses three event kinds — **activity** (`Explorer is searching…` → chip), **text**
+(reply chunks appended live), **done** (turn complete) — mapping onto the runtime's `on_event` hook + final response.
+
+**Responsiveness** is a beta requirement: mobile-first chat layout, rail→bottom-nav, usable on a phone browser.
+
+---
+
+## §3 Backend
+
+### A chat turn (`POST /chat`, SSE)
+
+1. The Lift 1 auth dependency resolves the user and sets `current_user_id` — every MCP tool the mesh calls is
+   already scoped to that friend (no change to the security seam).
+2. The request carries the message and which conversation it belongs to (active, or fresh from New chat).
+3. The backend loads that conversation's prior **messages** and **rehydrates** context — replaying them into a
+   fresh in-memory mesh session — then sends the new message. Memory is reconstructed from the DB each turn,
+   so it survives Cloud Run recycling.
+4. SSE events stream off `on_event` (activity) plus reply text, then `done`.
+5. On completion, the user message and assistant reply are written to **messages**. Usage rows (Lift 1, per LLM
+   call) now carry a real `conversation_id`.
+
+Because the transcript is owned as plain text, the turn is **backend-agnostic** (ADK/Gemini in prod, Claude in
+dev). *Deferred:* replaying the full thread each turn grows token cost on long conversations; windowing/
+summarization is future work (beta conversations are short).
+
+### Two-phase enrichment
+
+- `POST /books` runs a **fast pass** — `ScoutManager` restricted to the API scouts (Hardcover, Google Books;
+  priorities 1–2). On a match it persists the Work + Edition with basic metadata, logs the read-event (the
+  existing `add_book_to_history` logic minus the slow scouts), **enqueues a Cloud Task** for the deep pass, and
+  returns the logged book. No match → an honest "couldn't find it."
+- `POST /internal/enrich/{work_id}` is the **Cloud Tasks target** — it runs the slow LLM scouts (priorities 3–6),
+  then `persist_enriched_work` *updates* the same Work with tropes/styles and embeds them. It is **idempotent**
+  (Cloud Tasks retries are safe) and **queue-OIDC-gated**: it verifies the OIDC token the queue attaches (only
+  the queue's service account may call it), since it sits behind the now-open IAM gate rather than the Firebase gate.
+
+A fast-only enrichment path is added to `ScoutManager` (e.g. an API-scouts-only subset) so the fast pass does not
+invoke the LLM scouts.
+
+### Coupled cleanups (roadmap-mandated)
+
+- **Open the Cloud Run IAM gate** (`--allow-unauthenticated`); every user-facing route stays Firebase-gated,
+  `/health` stays open, the internal enrich route is queue-OIDC-gated. `security.md` gains the updated boundary.
+- **Consolidate the two `DatabaseManager` pools** — `api/main.py` and `api/auth.py` share one injected manager
+  (the Lift 1 T5 note).
+- **`/history` pagination** — `limit`/`offset` mirroring `/works` (INF-029).
+- **Prod secrets/env** — add the Gemini, Google Books, and Hardcover API keys to Secret Manager and wire them
+  (plus `GEMINI_MODEL` and the Gemini backend) into the Cloud Run service; provision the Cloud Tasks queue + SA.
+- **Prod usage flow** goes live naturally — real chat/enrichment calls produce metered rows.
+
+---
+
+## §4 Data model & migration
+
+One Alembic migration (down-revision = the Lift 1 head `c804d02d6fbb`):
+
+- **`conversations`** — `id` (uuid PK), `user_id` (FK → users, indexed), `created_at`, `updated_at`, `title`
+  (nullable — present now so the future switchable-list is a no-migration add). The **active** thread is the
+  user's most-recent row; New chat inserts a new one.
+- **`messages`** — `id` (uuid PK), `conversation_id` (FK → conversations, indexed), `role` (`user`/`assistant`),
+  `content` (text), `created_at`.
+- **`usage.conversation_id`** — add the FK constraint to `conversations.id` (the column exists from Lift 1).
+
+Conftest builds the test schema via `alembic upgrade head` (Lift 1 pattern). User-scoping is enforced exactly as
+in Lift 1: conversations/messages are read only for `current_user_id`.
+
+---
+
+## §5 Testing
+
+**Frontend (new to the repo):** Vitest + React Testing Library for component tests — the sign-in gate, rendering
+streamed chat events, the add-book form, acting on a recommendation — backend/SSE mocked. Playwright (already in
+the stack) for a couple of end-to-end happy-paths against a running stack.
+
+**Backend (pytest):**
+- Chat endpoint — SSE events stream, transcript persists, usage records, **rehydration** replays prior messages.
+- Transcript store + migration — schema via `alembic upgrade head`; resume vs new-chat.
+- **User-scoping** — extend the Lift 1 isolation tests so one friend cannot read another's conversation.
+- Two-phase enrichment — fast pass runs *only* API scouts and enqueues (Cloud Tasks client mocked); internal
+  endpoint runs deep scouts, updates the Work, is **idempotent** on retry, and **rejects non-queue callers**.
+- `/history` pagination; the single pooled `DatabaseManager`.
+
+**Discipline (Lift 1 lessons):** the mutation-testing mindset (every scoping/security test must fail when its
+filter is deleted); live/api_dependent tests (real Firebase, real Gemini) stay operator-run, never CI. The CD
+smoke gains "`GET /` serves the SPA" alongside the existing 401-enforcement assertion.
+
+---
+
+## §6 Rollout (runbook, like Lift 1's)
+
+- **Build change:** the image becomes a **multi-stage Docker build** — a Node stage compiles the Vite SPA; the
+  Python runtime stage copies in the static output. The runtime still has no Node; only the build does.
+- **Provision first:** the Cloud Tasks queue + its service account (OIDC invoker on the internal route); the
+  Gemini / Google Books / Hardcover key secrets, granted to the Cloud Run runtime service account.
+- **Migration with a backup:** prod's "no backup needed" reasoning (Lift 1 §6) **expires at the first prod
+  write**, and chat is that write. From here on: **`gcloud sql export` before every migration**, then apply
+  `conversations`/`messages`/the usage FK via the proxy + docker wrapper.
+- **Deploy & flip:** merge → CD builds and deploys with the new env/secrets → **open the IAM gate**. Because
+  `SIGNUP_MODE=invite` and Firebase still gate everything, opening the IAM gate exposes nothing to the uninvited.
+- **Verify live:** gate open, Google sign-in, a real chat turn (streamed activity + reply), add-a-book, and that
+  deep enrichment completes a couple minutes later (tropes appear). Confirm a metered usage row was written.
+- **Cost watch:** confirm budget alerts; cap Cloud Run max-instances/concurrency to bound spend; eyeball the
+  first real usage rows.
+
+---
+
+## §7 Future improvements (logged, not built now)
+
+- Recommendation card: **jump-into-chat "tell me more"**, and a **bookseller / Amazon link**.
+- **Switchable chat list** (brainstorm option B) — the `conversations` table already supports many-per-user.
+- **PWA / add-to-home-screen** — make the web app installable and app-like.
+- **Firebase Hosting** migration — CDN, instant first paint, easy custom domain (config-only).
+- **Conversation windowing / summarization** for long threads (token-cost control).
+- Analysis: **ratings-over-time** and **taste-profile** views.
+- Add-book **title autocomplete**; **DNF/abandoned** status, page count, series.
+
+## §8 Out of scope (this lift)
+
+- Native mobile apps; the A2A external mesh (ADR-035 deferral stands).
+- Per-user quota enforcement, Stripe billing, the BYOK feature, Claude prod enablement — all **Lift 3**.
+- Bulk user-facing import (DEBT-001 stays operator-run local Dagster).
+- Email/password sign-in (Lift 3, open signup).
+
+---
+
+## Plan staging note
+
+This lift is large (frontend + chat backend + async enrichment + cleanups). It stays **one spec**, but the
+implementation **plan** will be staged so each stage is independently testable:
+
+1. **Backend chat + transcript store** (migration, `/chat` SSE, conversations/messages, rehydration, usage FK).
+2. **Frontend SPA** built against that real contract (app shell, five views, Firebase sign-in, SSE client).
+3. **Async enrichment** (two-phase `/books`, internal endpoint, Cloud Tasks).
+4. **Cleanups + rollout** (IAM gate, pool consolidation, `/history` pagination, prod secrets, multi-stage build,
+   runbook).

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -129,9 +129,7 @@ async def astart_conversation(
     so the mesh has prior context WITHOUT re-running earlier turns (Lift 2)."""
     runner = runner or build_runner()
     session_id = session_id or uuid.uuid4().hex
-    session = await runner.session_service.create_session(
-        app_name=APP_NAME, user_id=user_id, session_id=session_id
-    )
+    session = await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
     for turn in history or []:
         role = "user" if turn["role"] == "user" else "model"
         author = "user" if turn["role"] == "user" else "librarian"
@@ -141,13 +139,14 @@ async def astart_conversation(
 
 
 def start_conversation(
-    user_id: str = "local", runner: Runner | None = None, on_event=None,
-    session_id: str | None = None, history: list[dict] | None = None,
+    user_id: str = "local",
+    runner: Runner | None = None,
+    on_event=None,
+    session_id: str | None = None,
+    history: list[dict] | None = None,
 ) -> LibrarianConversation:
     return asyncio.run(
-        astart_conversation(
-            user_id=user_id, runner=runner, on_event=on_event, session_id=session_id, history=history
-        )
+        astart_conversation(user_id=user_id, runner=runner, on_event=on_event, session_id=session_id, history=history)
     )
 
 

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -9,6 +9,7 @@ import uuid
 from agentic_librarian.agents.backends import get_backend
 from agentic_librarian.agents.services import create_agent_mesh
 from agentic_librarian.core.usage import record_llm_call
+from google.adk.events import Event
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -116,16 +117,38 @@ class LibrarianConversation:
 
 
 async def astart_conversation(
-    user_id: str = "local", runner: Runner | None = None, on_event=None
+    user_id: str = "local",
+    runner: Runner | None = None,
+    on_event=None,
+    session_id: str | None = None,
+    history: list[dict] | None = None,
 ) -> LibrarianConversation:
+    """Open a conversation. `session_id` lets the caller pin the ADK session id to a
+    stored conversation id (so usage rows line up). `history` (oldest first, each
+    {'role': 'user'|'assistant', 'content': str}) is seeded into the session as events
+    so the mesh has prior context WITHOUT re-running earlier turns (Lift 2)."""
     runner = runner or build_runner()
-    session_id = uuid.uuid4().hex
-    await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
+    session_id = session_id or uuid.uuid4().hex
+    session = await runner.session_service.create_session(
+        app_name=APP_NAME, user_id=user_id, session_id=session_id
+    )
+    for turn in history or []:
+        role = "user" if turn["role"] == "user" else "model"
+        author = "user" if turn["role"] == "user" else "librarian"
+        content = types.Content(role=role, parts=[types.Part(text=turn["content"])])
+        await runner.session_service.append_event(session, Event(author=author, content=content))
     return LibrarianConversation(runner, user_id, session_id, on_event=on_event)
 
 
-def start_conversation(user_id: str = "local", runner: Runner | None = None, on_event=None) -> LibrarianConversation:
-    return asyncio.run(astart_conversation(user_id=user_id, runner=runner, on_event=on_event))
+def start_conversation(
+    user_id: str = "local", runner: Runner | None = None, on_event=None,
+    session_id: str | None = None, history: list[dict] | None = None,
+) -> LibrarianConversation:
+    return asyncio.run(
+        astart_conversation(
+            user_id=user_id, runner=runner, on_event=on_event, session_id=session_id, history=history
+        )
+    )
 
 
 def run_recommendation(prompt: str, user_id: str = "local") -> str:

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -18,9 +18,9 @@ from sqlalchemy.orm import joinedload, selectinload
 
 app = FastAPI(title="Agentic Librarian API")
 db_manager = DatabaseManager()
-# NOTE: api/auth.py owns a second lazy DatabaseManager (two pools). Acceptable at
-# Lift 1 scale; consolidate into one shared manager when Lift 2 wires the chat
-# endpoint (T5 review).
+# NOTE: several modules each own a lazy DatabaseManager (this module, api/auth.py,
+# chat/transcript.py, core/usage.py) — ~4 pools. Acceptable at friends-scale; consolidating
+# into one shared manager is deferred to Lift 2 Stage 4 (cleanups), per the Stage 1 final review.
 
 
 @app.get("/health")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -1,4 +1,7 @@
+from agentic_librarian.agents.runtime import astart_conversation
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.chat import stream, transcript
+from agentic_librarian.core.user_context import as_user
 from agentic_librarian.db.models import (
     Edition,
     ReadingHistory,
@@ -8,8 +11,8 @@ from agentic_librarian.db.models import (
     WorkTrope,
 )
 from agentic_librarian.db.session import DatabaseManager
-from fastapi import Depends, FastAPI, Query
-from fastapi.responses import JSONResponse
+from fastapi import Body, Depends, FastAPI, Query
+from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -111,3 +114,65 @@ def get_works(
             }
             for w in works
         ]
+
+
+# ---------------------------------------------------------------------------
+# Chat endpoints (Lift 2)
+# ---------------------------------------------------------------------------
+
+
+async def _open_conversation(*, user_id, session_id, history, on_event):
+    """Open the mesh conversation for one turn (seam: tests replace this)."""
+    return await astart_conversation(
+        user_id=user_id, session_id=session_id, history=history, on_event=on_event
+    )
+
+
+class _SyncOpener:
+    """Lazily opens the async mesh conversation on first asend, inside the running loop.
+    session_id = the conversation id so usage rows (keyed off the ADK session uuid) FK to it."""
+
+    def __init__(self, user_id, ctx, on_event):
+        self._user_id, self._ctx, self._on_event, self._conv = user_id, ctx, on_event, None
+
+    async def asend(self, message: str) -> str:
+        if self._conv is None:
+            self._conv = await _open_conversation(
+                user_id=self._user_id, session_id=self._ctx.conversation_id.hex,
+                history=self._ctx.history, on_event=self._on_event,
+            )
+        return await self._conv.asend(message)
+
+    def close(self):
+        if self._conv is not None:
+            self._conv.close()
+
+
+@app.get("/conversations/current")
+def get_current_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with as_user(user.id):
+        ctx = transcript.get_or_create_active_conversation()
+    return {"id": str(ctx.conversation_id), "messages": ctx.history}
+
+
+@app.post("/conversations")
+def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with as_user(user.id):
+        ctx = transcript.start_new_conversation()
+    return {"id": str(ctx.conversation_id), "messages": ctx.history}
+
+
+@app.post("/chat")
+def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    with as_user(user.id):
+        ctx = transcript.get_or_create_active_conversation()
+    adk_user_id = str(user.id)
+    return StreamingResponse(
+        stream.sse_turn(
+            message=message,
+            conversation=lambda on_event: _SyncOpener(adk_user_id, ctx, on_event),
+            on_persist=lambda role, content: transcript.append_message(ctx.conversation_id, role, content),
+            user_id=user.id,
+        ),
+        media_type="text/event-stream",
+    )

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -1,4 +1,4 @@
-from agentic_librarian.agents.runtime import astart_conversation
+from agentic_librarian.agents.runtime import LibrarianConversation, astart_conversation
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
 from agentic_librarian.chat import stream, transcript
 from agentic_librarian.core.user_context import as_user
@@ -121,7 +121,7 @@ def get_works(
 # ---------------------------------------------------------------------------
 
 
-async def _open_conversation(*, user_id, session_id, history, on_event):
+async def _open_conversation(*, user_id: str, session_id: str, history: list[dict], on_event) -> LibrarianConversation:
     """Open the mesh conversation for one turn (seam: tests replace this)."""
     return await astart_conversation(
         user_id=user_id, session_id=session_id, history=history, on_event=on_event
@@ -129,11 +129,16 @@ async def _open_conversation(*, user_id, session_id, history, on_event):
 
 
 class _SyncOpener:
-    """Lazily opens the async mesh conversation on first asend, inside the running loop.
-    session_id = the conversation id so usage rows (keyed off the ADK session uuid) FK to it."""
+    """The conversation object returned by the factory passed to sse_turn. Lazily opens
+    the async mesh conversation on first asend — deferred so the open runs inside the
+    event loop, not the sync endpoint frame. session_id = conversation_id.hex so usage
+    rows (keyed off the ADK session uuid) FK to the transcript row."""
 
     def __init__(self, user_id, ctx, on_event):
-        self._user_id, self._ctx, self._on_event, self._conv = user_id, ctx, on_event, None
+        self._user_id = user_id
+        self._ctx = ctx
+        self._on_event = on_event
+        self._conv = None  # opened lazily on first asend
 
     async def asend(self, message: str) -> str:
         if self._conv is None:

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -123,9 +123,7 @@ def get_works(
 
 async def _open_conversation(*, user_id: str, session_id: str, history: list[dict], on_event) -> LibrarianConversation:
     """Open the mesh conversation for one turn (seam: tests replace this)."""
-    return await astart_conversation(
-        user_id=user_id, session_id=session_id, history=history, on_event=on_event
-    )
+    return await astart_conversation(user_id=user_id, session_id=session_id, history=history, on_event=on_event)
 
 
 class _SyncOpener:
@@ -143,8 +141,10 @@ class _SyncOpener:
     async def asend(self, message: str) -> str:
         if self._conv is None:
             self._conv = await _open_conversation(
-                user_id=self._user_id, session_id=self._ctx.conversation_id.hex,
-                history=self._ctx.history, on_event=self._on_event,
+                user_id=self._user_id,
+                session_id=self._ctx.conversation_id.hex,
+                history=self._ctx.history,
+                on_event=self._on_event,
             )
         return await self._conv.asend(message)
 

--- a/src/agentic_librarian/chat/stream.py
+++ b/src/agentic_librarian/chat/stream.py
@@ -1,0 +1,62 @@
+"""SSE turn loop (Lift 2). Bridges a backend conversation's on_event callback and its
+single final reply into an ordered text/event-stream, persisting the transcript.
+
+Beta scope: agent-activity streams live; the reply is one final chunk (the mesh runs
+in ADK's default non-streaming mode). Token-level streaming is future work."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+from uuid import UUID
+
+from agentic_librarian.core.user_context import as_user
+
+_DONE = object()  # sentinel marking the queue's end
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def sse_turn(
+    message: str,
+    conversation: Callable,
+    on_persist: Callable[[str, str], None],
+    user_id: UUID,
+) -> AsyncIterator[str]:
+    """Run one turn. `conversation` is a factory taking an on_event callback and
+    returning an object with `async asend(message) -> str` and `close()`. `on_persist`
+    stores one (role, content) message. `user_id` re-establishes identity inside the
+    turn: the SSE generator runs on the event loop after the endpoint returns, where the
+    auth dependency's ContextVar is no longer active — so the mesh tools, usage metering,
+    and the transcript writes would otherwise see no user (the Lift 1 _with_user lesson)."""
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def on_event(kind: str, detail: str) -> None:
+        queue.put_nowait(_sse("activity", {"kind": kind, "detail": detail}))
+
+    conv = conversation(on_event)
+
+    async def drive() -> None:
+        try:
+            with as_user(user_id):  # identity live for the mesh tools, usage, and persist
+                reply = await conv.asend(message)
+                on_persist("user", message)
+                on_persist("assistant", reply)
+            queue.put_nowait(_sse("text", {"text": reply}))
+        finally:
+            conv.close()
+            queue.put_nowait(_DONE)
+
+    task = asyncio.create_task(drive())
+    try:
+        while True:
+            item = await queue.get()
+            if item is _DONE:
+                break
+            yield item
+        yield _sse("done", {})
+    finally:
+        await task  # surface any exception from the driver

--- a/src/agentic_librarian/chat/stream.py
+++ b/src/agentic_librarian/chat/stream.py
@@ -8,6 +8,7 @@ Token-level streaming is future work (the mesh runs in ADK's default non-streami
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from collections.abc import AsyncGenerator, Callable
@@ -61,20 +62,27 @@ async def sse_turn(
             queue.put_nowait(_DONE)
 
     task = asyncio.create_task(drive())
-
-    # Stream live activity until the driver signals it has finished.
-    while True:
-        item = await queue.get()
-        if item is _DONE:
-            break
-        yield item
-
-    # The turn is finished: surface the reply, or a single error event — never a false done.
     try:
-        reply = await task
-    except Exception as exc:  # noqa: BLE001 - one bad turn must end the stream cleanly, not crash it
-        logger.warning("chat turn failed", exc_info=True)
-        yield _sse("error", {"detail": str(exc)})
-        return
-    yield _sse("text", {"text": reply})
-    yield _sse("done", {})
+        # Stream live activity until the driver signals it has finished.
+        while True:
+            item = await queue.get()
+            if item is _DONE:
+                break
+            yield item
+        # The turn is finished: surface the reply, or a single error event — never a false done.
+        try:
+            reply = await task
+        except Exception:  # noqa: BLE001 - one bad turn ends the stream cleanly, not crash it
+            logger.warning("chat turn failed", exc_info=True)
+            yield _sse("error", {"detail": "The Librarian hit a problem. Please try again."})
+            return
+        yield _sse("text", {"text": reply})
+        yield _sse("done", {})
+    finally:
+        # If the consumer went away (client disconnect -> GeneratorExit) while the turn
+        # was still in flight, cancel the mesh instead of leaking a running task that
+        # keeps burning tokens. No-op on the normal/error paths (task already done).
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/src/agentic_librarian/chat/stream.py
+++ b/src/agentic_librarian/chat/stream.py
@@ -1,19 +1,23 @@
 """SSE turn loop (Lift 2). Bridges a backend conversation's on_event callback and its
 single final reply into an ordered text/event-stream, persisting the transcript.
 
-Beta scope: agent-activity streams live; the reply is one final chunk (the mesh runs
-in ADK's default non-streaming mode). Token-level streaming is future work."""
+Beta scope: agent-activity streams live; on success the reply is one `text` event then
+`done`; on failure a single `error` event ends the stream (never a false `done`).
+Token-level streaming is future work (the mesh runs in ADK's default non-streaming mode)."""
 
 from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Callable
+import logging
+from collections.abc import AsyncGenerator, Callable
 from uuid import UUID
 
 from agentic_librarian.core.user_context import as_user
 
-_DONE = object()  # sentinel marking the queue's end
+logger = logging.getLogger(__name__)
+
+_DONE = object()  # sentinel marking the end of the live activity stream
 
 
 def _sse(event: str, data: dict) -> str:
@@ -25,38 +29,52 @@ async def sse_turn(
     conversation: Callable,
     on_persist: Callable[[str, str], None],
     user_id: UUID,
-) -> AsyncIterator[str]:
-    """Run one turn. `conversation` is a factory taking an on_event callback and
-    returning an object with `async asend(message) -> str` and `close()`. `on_persist`
-    stores one (role, content) message. `user_id` re-establishes identity inside the
-    turn: the SSE generator runs on the event loop after the endpoint returns, where the
-    auth dependency's ContextVar is no longer active — so the mesh tools, usage metering,
-    and the transcript writes would otherwise see no user (the Lift 1 _with_user lesson)."""
-    queue: asyncio.Queue = asyncio.Queue()
+) -> AsyncGenerator[str, None]:
+    """Run one turn as an SSE stream. `conversation` is a factory taking an on_event
+    callback and returning an object with `async asend(message) -> str` and `close()`.
+    `on_persist` stores one (role, content) message.
+
+    Activity events stream live as the mesh works; then on success a `text` event + `done`,
+    or on failure a single `error` event (never a false `done`). `user_id` re-establishes
+    identity inside the turn: the generator runs on the event loop after the endpoint
+    returns, where the auth dependency's ContextVar is no longer active — so the mesh tools,
+    usage metering, and transcript writes would otherwise see no user (the Lift 1 _with_user
+    lesson)."""
+    queue: asyncio.Queue = asyncio.Queue()  # carries live activity events only
 
     def on_event(kind: str, detail: str) -> None:
         queue.put_nowait(_sse("activity", {"kind": kind, "detail": detail}))
 
     conv = conversation(on_event)
 
-    async def drive() -> None:
+    async def drive() -> str:
+        """Run the turn; return the reply (or raise). Persists inside as_user so the
+        mesh tools and transcript writes see the right user."""
         try:
-            with as_user(user_id):  # identity live for the mesh tools, usage, and persist
+            with as_user(user_id):
                 reply = await conv.asend(message)
                 on_persist("user", message)
                 on_persist("assistant", reply)
-            queue.put_nowait(_sse("text", {"text": reply}))
+            return reply
         finally:
             conv.close()
             queue.put_nowait(_DONE)
 
     task = asyncio.create_task(drive())
+
+    # Stream live activity until the driver signals it has finished.
+    while True:
+        item = await queue.get()
+        if item is _DONE:
+            break
+        yield item
+
+    # The turn is finished: surface the reply, or a single error event — never a false done.
     try:
-        while True:
-            item = await queue.get()
-            if item is _DONE:
-                break
-            yield item
-        yield _sse("done", {})
-    finally:
-        await task  # surface any exception from the driver
+        reply = await task
+    except Exception as exc:  # noqa: BLE001 - one bad turn must end the stream cleanly, not crash it
+        logger.warning("chat turn failed", exc_info=True)
+        yield _sse("error", {"detail": str(exc)})
+        return
+    yield _sse("text", {"text": reply})
+    yield _sse("done", {})

--- a/src/agentic_librarian/chat/transcript.py
+++ b/src/agentic_librarian/chat/transcript.py
@@ -1,0 +1,79 @@
+"""User-scoped chat transcript store (Lift 2). The active thread is the current
+user's most-recent conversation; New chat inserts a new row. Identity comes from
+the context (get_required_user_id) — never a parameter (ADR-048)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.models import Conversation, Message
+from agentic_librarian.db.session import DatabaseManager
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager) -> None:
+    """Override the module db_manager (for tests) — the mcp/server.py pattern."""
+    global db_manager
+    db_manager = new_manager
+
+
+@dataclass(frozen=True)
+class TurnContext:
+    """Everything a chat turn needs: which conversation, and its prior turns
+    (oldest first) as plain {'role','content'} dicts."""
+
+    conversation_id: UUID
+    history: list[dict]
+
+
+def _history(session, conversation_id: UUID) -> list[dict]:
+    rows = (
+        session.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at, Message.id)  # id tiebreaks same-timestamp inserts
+        .all()
+    )
+    return [{"role": m.role, "content": m.content} for m in rows]
+
+
+def get_or_create_active_conversation() -> TurnContext:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        conv = (
+            session.query(Conversation)
+            .filter(Conversation.user_id == user_id)  # scoping: my threads only
+            .order_by(Conversation.created_at.desc(), Conversation.id.desc())
+            .first()
+        )
+        if conv is None:
+            conv = Conversation(user_id=user_id)
+            session.add(conv)
+            session.flush()
+        return TurnContext(conversation_id=conv.id, history=_history(session, conv.id))
+
+
+def start_new_conversation() -> TurnContext:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        conv = Conversation(user_id=user_id)
+        session.add(conv)
+        session.flush()
+        return TurnContext(conversation_id=conv.id, history=[])
+
+
+def append_message(conversation_id: UUID, role: str, content: str) -> None:
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        # Scoping: only write into a conversation the caller owns.
+        conv = (
+            session.query(Conversation)
+            .filter(Conversation.id == conversation_id, Conversation.user_id == user_id)
+            .first()
+        )
+        if conv is None:
+            raise PermissionError(f"conversation {conversation_id} not found for this user")
+        session.add(Message(conversation_id=conversation_id, role=role, content=content))
+        session.flush()

--- a/src/agentic_librarian/chat/transcript.py
+++ b/src/agentic_librarian/chat/transcript.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.models import Conversation, Message
 from agentic_librarian.db.session import DatabaseManager
+from sqlalchemy.orm import Session
 
 db_manager = DatabaseManager()
 
@@ -29,11 +30,13 @@ class TurnContext:
     history: list[dict]
 
 
-def _history(session, conversation_id: UUID) -> list[dict]:
+def _history(session: Session, conversation_id: UUID) -> list[dict]:
     rows = (
         session.query(Message)
+        # created_at orders the turns; id is a STABLE (not chronological — UUID v4)
+        # tiebreak, only relevant for the negligible same-microsecond-insert case.
         .filter(Message.conversation_id == conversation_id)
-        .order_by(Message.created_at, Message.id)  # id tiebreaks same-timestamp inserts
+        .order_by(Message.created_at, Message.id)
         .all()
     )
     return [{"role": m.role, "content": m.content} for m in rows]
@@ -45,6 +48,8 @@ def get_or_create_active_conversation() -> TurnContext:
         conv = (
             session.query(Conversation)
             .filter(Conversation.user_id == user_id)  # scoping: my threads only
+            # most-recent first; id.desc() is a stable (UUID v4, non-chronological)
+            # tiebreak — exact created_at ties are negligible at this scale.
             .order_by(Conversation.created_at.desc(), Conversation.id.desc())
             .first()
         )

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -185,6 +185,38 @@ class Suggestions(Base):
     work: Mapped["Work"] = relationship(back_populates="suggestions")
 
 
+class Conversation(Base):
+    """One chat thread (Lift 2). The active thread is the user's most-recent row;
+    New chat inserts a new one. title is nullable now so the future switchable-list
+    needs no migration. id doubles as the ADK session id so usage rows line up."""
+
+    __tablename__ = "conversations"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    title: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False
+    )
+
+    messages: Mapped[list["Message"]] = relationship(back_populates="conversation", cascade="all, delete-orphan")
+
+
+class Message(Base):
+    """One turn in a conversation (Lift 2). role is 'user' or 'assistant'."""
+
+    __tablename__ = "messages"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    conversation_id: Mapped[UUID] = mapped_column(ForeignKey("conversations.id"), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+
+    conversation: Mapped["Conversation"] = relationship(back_populates="messages")
+
+
 class User(Base):
     """An account holder (Lift 1, ADR-048). The catalog is communal; reading_history,
     suggestions, and usage are per-user. firebase_uid is NULL for invited users who
@@ -212,7 +244,9 @@ class Usage(Base):
     model: Mapped[str] = mapped_column(String, nullable=False)
     input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    conversation_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+    conversation_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
 
 

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -16,8 +16,10 @@ def client(db_url, monkeypatch):
     monkeypatch.setattr(api_main, "db_manager", manager)
     monkeypatch.setattr(transcript, "db_manager", manager)  # chat endpoints use the store's manager
     # Endpoints wrap store calls in as_user(user.id), so a plain user object suffices.
-    api_main.app.dependency_overrides[auth.get_current_user] = lambda: auth.AuthenticatedUser(
-        id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL
+    monkeypatch.setitem(
+        api_main.app.dependency_overrides,
+        auth.get_current_user,
+        lambda: auth.AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL),
     )
 
     class _FakeConv:
@@ -32,7 +34,6 @@ def client(db_url, monkeypatch):
 
     monkeypatch.setattr(api_main, "_open_conversation", _fake_open)
     yield TestClient(api_main.app)
-    api_main.app.dependency_overrides.clear()
 
 
 def test_current_conversation_then_chat_then_resume(client):
@@ -54,6 +55,7 @@ def test_current_conversation_then_chat_then_resume(client):
 
 
 def test_new_conversation_starts_empty(client):
-    client.get("/conversations/current")
+    current = client.get("/conversations/current").json()
     fresh = client.post("/conversations").json()
     assert fresh["messages"] == []
+    assert fresh["id"] != current["id"]  # New chat is a distinct conversation

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -1,0 +1,59 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import auth
+from agentic_librarian.api import main as api_main
+from agentic_librarian.chat import transcript
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(api_main, "db_manager", manager)
+    monkeypatch.setattr(transcript, "db_manager", manager)  # chat endpoints use the store's manager
+    # Endpoints wrap store calls in as_user(user.id), so a plain user object suffices.
+    api_main.app.dependency_overrides[auth.get_current_user] = lambda: auth.AuthenticatedUser(
+        id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL
+    )
+
+    class _FakeConv:
+        async def asend(self, message):
+            return f"echo:{message}"
+
+        def close(self):
+            ...
+
+    async def _fake_open(**kwargs):
+        return _FakeConv()
+
+    monkeypatch.setattr(api_main, "_open_conversation", _fake_open)
+    yield TestClient(api_main.app)
+    api_main.app.dependency_overrides.clear()
+
+
+def test_current_conversation_then_chat_then_resume(client):
+    current = client.get("/conversations/current").json()
+    assert current["messages"] == []
+    cid = current["id"]
+
+    with client.stream("POST", "/chat", json={"message": "hi"}) as r:
+        body = "".join(r.iter_text())
+    assert "echo:hi" in body
+    assert body.rstrip().endswith("event: done\ndata: {}")
+
+    resumed = client.get("/conversations/current").json()
+    assert resumed["id"] == cid
+    assert resumed["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "echo:hi"},
+    ]
+
+
+def test_new_conversation_starts_empty(client):
+    client.get("/conversations/current")
+    fresh = client.post("/conversations").json()
+    assert fresh["messages"] == []

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -1,12 +1,11 @@
 import pytest
-from fastapi.testclient import TestClient
-
 from agentic_librarian.api import auth
 from agentic_librarian.api import main as api_main
 from agentic_librarian.chat import transcript
 from agentic_librarian.core import usage as usage_mod
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
 from agentic_librarian.db.session import DatabaseManager
+from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.db_integration
 
@@ -28,8 +27,7 @@ def client(db_url, monkeypatch):
         async def asend(self, message):
             return f"echo:{message}"
 
-        def close(self):
-            ...
+        def close(self): ...
 
     async def _fake_open(**kwargs):
         return _FakeConv()
@@ -76,13 +74,10 @@ def test_usage_rows_reference_the_conversation(client, db_url, monkeypatch):
     class _UsingConv:
         async def asend(self, message):
             # mirrors runtime._record_event_usage: meter against the conversation id
-            usage.record_llm_call(
-                vendor="gemini", model="test", input_tokens=1, output_tokens=1, conversation_id=cid
-            )
+            usage.record_llm_call(vendor="gemini", model="test", input_tokens=1, output_tokens=1, conversation_id=cid)
             return "ok"
 
-        def close(self):
-            ...
+        def close(self): ...
 
     async def _using_open(**kwargs):
         return _UsingConv()

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from agentic_librarian.api import auth
 from agentic_librarian.api import main as api_main
 from agentic_librarian.chat import transcript
+from agentic_librarian.core import usage as usage_mod
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
 from agentic_librarian.db.session import DatabaseManager
 
@@ -15,6 +16,7 @@ def client(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(api_main, "db_manager", manager)
     monkeypatch.setattr(transcript, "db_manager", manager)  # chat endpoints use the store's manager
+    monkeypatch.setattr(usage_mod, "db_manager", manager)  # usage recorder writes to the test DB
     # Endpoints wrap store calls in as_user(user.id), so a plain user object suffices.
     monkeypatch.setitem(
         api_main.app.dependency_overrides,
@@ -59,3 +61,37 @@ def test_new_conversation_starts_empty(client):
     fresh = client.post("/conversations").json()
     assert fresh["messages"] == []
     assert fresh["id"] != current["id"]  # New chat is a distinct conversation
+
+
+def test_usage_rows_reference_the_conversation(client, db_url, monkeypatch):
+    from uuid import UUID
+
+    from agentic_librarian.core import usage
+    from agentic_librarian.db.models import Usage
+    from agentic_librarian.db.session import DatabaseManager
+
+    current = client.get("/conversations/current").json()
+    cid = UUID(current["id"])
+
+    class _UsingConv:
+        async def asend(self, message):
+            # mirrors runtime._record_event_usage: meter against the conversation id
+            usage.record_llm_call(
+                vendor="gemini", model="test", input_tokens=1, output_tokens=1, conversation_id=cid
+            )
+            return "ok"
+
+        def close(self):
+            ...
+
+    async def _using_open(**kwargs):
+        return _UsingConv()
+
+    monkeypatch.setattr(api_main, "_open_conversation", _using_open)
+
+    with client.stream("POST", "/chat", json={"message": "go"}) as r:
+        "".join(r.iter_text())
+
+    with DatabaseManager(db_url).get_session() as s:
+        row = s.query(Usage).filter(Usage.conversation_id == cid).first()
+        assert row is not None  # FK held: the conversation existed when usage was written

--- a/test/integration/test_transcript_store.py
+++ b/test/integration/test_transcript_store.py
@@ -1,12 +1,11 @@
 from uuid import UUID
 
 import pytest
-from sqlalchemy import inspect
-
 from agentic_librarian.chat import transcript
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.db.models import User
 from agentic_librarian.db.session import DatabaseManager
+from sqlalchemy import inspect
 
 pytestmark = pytest.mark.db_integration
 

--- a/test/integration/test_transcript_store.py
+++ b/test/integration/test_transcript_store.py
@@ -1,0 +1,14 @@
+import pytest
+from sqlalchemy import inspect
+
+from agentic_librarian.db.session import DatabaseManager
+
+
+@pytest.mark.db_integration
+def test_chat_tables_and_usage_fk_exist(db_url):
+    engine = DatabaseManager(db_url).engine
+    inspector = inspect(engine)
+    names = set(inspector.get_table_names())
+    assert {"conversations", "messages"} <= names
+    fks = inspector.get_foreign_keys("usage")
+    assert any(fk["referred_table"] == "conversations" for fk in fks)

--- a/test/integration/test_transcript_store.py
+++ b/test/integration/test_transcript_store.py
@@ -1,9 +1,26 @@
+from uuid import UUID
+
 import pytest
 from sqlalchemy import inspect
 
+from agentic_librarian.chat import transcript
+from agentic_librarian.core.user_context import as_user
+from agentic_librarian.db.models import User
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
+
+OTHER_USER = UUID("00000000-0000-4000-8000-0000000000ff")
+
+
+@pytest.fixture
+def store_db(db_url):
+    """Point the transcript module at the isolated test DB (test_usage_db.py pattern)."""
+    manager = DatabaseManager(db_url)
+    original = transcript.db_manager
+    transcript.set_db_manager(manager)
+    yield manager
+    transcript.set_db_manager(original)
 
 
 def test_chat_tables_and_usage_fk_exist(db_url):
@@ -13,3 +30,40 @@ def test_chat_tables_and_usage_fk_exist(db_url):
     assert {"conversations", "messages"} <= names
     fks = inspector.get_foreign_keys("usage")
     assert any(fk["referred_table"] == "conversations" for fk in fks)
+
+
+def test_active_conversation_is_created_then_reused(store_db):
+    first = transcript.get_or_create_active_conversation()
+    second = transcript.get_or_create_active_conversation()
+    assert first.conversation_id == second.conversation_id  # most-recent row reused
+    assert first.history == []
+
+
+def test_append_then_history_round_trips_in_order(store_db):
+    ctx = transcript.get_or_create_active_conversation()
+    transcript.append_message(ctx.conversation_id, "user", "hello")
+    transcript.append_message(ctx.conversation_id, "assistant", "hi there")
+    reloaded = transcript.get_or_create_active_conversation()
+    assert reloaded.conversation_id == ctx.conversation_id
+    assert reloaded.history == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+
+
+def test_new_conversation_becomes_the_active_one(store_db):
+    first = transcript.get_or_create_active_conversation()
+    transcript.append_message(first.conversation_id, "user", "old thread")
+    fresh = transcript.start_new_conversation()
+    assert fresh.conversation_id != first.conversation_id
+    assert fresh.history == []
+    assert transcript.get_or_create_active_conversation().conversation_id == fresh.conversation_id
+
+
+def test_active_conversation_is_user_scoped(store_db):
+    mine = transcript.get_or_create_active_conversation()  # default user (conftest context)
+    with as_user(OTHER_USER):
+        with store_db.get_session() as s:
+            s.merge(User(id=OTHER_USER, email="other@example.com"))
+        theirs = transcript.get_or_create_active_conversation()
+        assert theirs.conversation_id != mine.conversation_id  # FAILS if scoping is dropped

--- a/test/integration/test_transcript_store.py
+++ b/test/integration/test_transcript_store.py
@@ -3,8 +3,9 @@ from sqlalchemy import inspect
 
 from agentic_librarian.db.session import DatabaseManager
 
+pytestmark = pytest.mark.db_integration
 
-@pytest.mark.db_integration
+
 def test_chat_tables_and_usage_fk_exist(db_url):
     engine = DatabaseManager(db_url).engine
     inspector = inspect(engine)

--- a/test/unit/test_chat_rehydrate.py
+++ b/test/unit/test_chat_rehydrate.py
@@ -12,9 +12,6 @@ class _FakeSessionService:
         self.created.append(session_id)
         return object()
 
-    async def get_session(self, app_name, user_id, session_id):
-        return object()
-
     async def append_event(self, session, event):
         self.appended.append(event)
         return event

--- a/test/unit/test_chat_rehydrate.py
+++ b/test/unit/test_chat_rehydrate.py
@@ -41,6 +41,8 @@ def test_history_is_seeded_as_events_in_order():
     assert roles == ["user", "model"]
     texts = [e.content.parts[0].text for e in runner.session_service.appended]
     assert texts == ["hello", "hi there"]
+    authors = [e.author for e in runner.session_service.appended]
+    assert authors == ["user", "librarian"]
 
 
 def test_no_history_seeds_no_events():

--- a/test/unit/test_chat_rehydrate.py
+++ b/test/unit/test_chat_rehydrate.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from agentic_librarian.agents import runtime
+
+
+class _FakeSessionService:
+    def __init__(self):
+        self.created = []
+        self.appended = []
+
+    async def create_session(self, app_name, user_id, session_id):
+        self.created.append(session_id)
+        return object()
+
+    async def get_session(self, app_name, user_id, session_id):
+        return object()
+
+    async def append_event(self, session, event):
+        self.appended.append(event)
+        return event
+
+
+class _FakeRunner:
+    def __init__(self):
+        self.session_service = _FakeSessionService()
+
+
+def test_history_is_seeded_as_events_in_order():
+    runner = _FakeRunner()
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    conv = asyncio.run(
+        runtime.astart_conversation(user_id="u", runner=runner, session_id="abc123", history=history)
+    )
+    assert conv.session_id == "abc123"
+    assert runner.session_service.created == ["abc123"]
+    assert len(runner.session_service.appended) == 2
+    roles = [e.content.role for e in runner.session_service.appended]
+    assert roles == ["user", "model"]
+    texts = [e.content.parts[0].text for e in runner.session_service.appended]
+    assert texts == ["hello", "hi there"]
+
+
+def test_no_history_seeds_no_events():
+    runner = _FakeRunner()
+    asyncio.run(runtime.astart_conversation(user_id="u", runner=runner, session_id="abc", history=None))
+    assert runner.session_service.appended == []

--- a/test/unit/test_chat_rehydrate.py
+++ b/test/unit/test_chat_rehydrate.py
@@ -28,9 +28,7 @@ def test_history_is_seeded_as_events_in_order():
         {"role": "user", "content": "hello"},
         {"role": "assistant", "content": "hi there"},
     ]
-    conv = asyncio.run(
-        runtime.astart_conversation(user_id="u", runner=runner, session_id="abc123", history=history)
-    )
+    conv = asyncio.run(runtime.astart_conversation(user_id="u", runner=runner, session_id="abc123", history=history))
     assert conv.session_id == "abc123"
     assert runner.session_service.created == ["abc123"]
     assert len(runner.session_service.appended) == 2

--- a/test/unit/test_chat_stream.py
+++ b/test/unit/test_chat_stream.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 from uuid import UUID
 
 from agentic_librarian.chat import stream
@@ -22,12 +21,26 @@ class _FakeConversation:
         pass
 
 
-def _collect(message, recorded):
+class _FailingConversation:
+    """Fires one activity event, then the backend fails mid-turn."""
+
+    def __init__(self, on_event):
+        self._on_event = on_event
+
+    async def asend(self, message: str) -> str:
+        self._on_event("agent", "Explorer")
+        raise RuntimeError("backend down")
+
+    def close(self):
+        pass
+
+
+def _collect(message, recorded, conversation=_FakeConversation):
     async def run():
         out = []
         async for line in stream.sse_turn(
             message=message,
-            conversation=_FakeConversation,  # factory: takes on_event
+            conversation=conversation,
             on_persist=lambda role, content: recorded.append((role, content)),
             user_id=_USER,
         ):
@@ -51,3 +64,14 @@ def test_stream_persists_user_then_assistant():
     recorded = []
     _collect("hi", recorded)
     assert recorded == [("user", "hi"), ("assistant", "reply to: hi")]
+
+
+def test_stream_emits_error_and_no_done_on_failure():
+    recorded = []
+    body = "".join(_collect("hi", recorded, conversation=_FailingConversation))
+    assert "event: activity" in body  # the activity that fired before the failure still streamed
+    assert "event: error" in body
+    assert "backend down" in body
+    assert "event: done" not in body  # NO false success signal
+    assert "event: text" not in body
+    assert recorded == []  # asend raised before any persistence

--- a/test/unit/test_chat_stream.py
+++ b/test/unit/test_chat_stream.py
@@ -1,0 +1,53 @@
+import asyncio
+import json
+from uuid import UUID
+
+from agentic_librarian.chat import stream
+
+_USER = UUID("00000000-0000-4000-8000-000000000001")
+
+
+class _FakeConversation:
+    """Mimics a BackendConversation: fires on_event during asend, returns a final reply."""
+
+    def __init__(self, on_event):
+        self._on_event = on_event
+
+    async def asend(self, message: str) -> str:
+        self._on_event("agent", "Explorer")
+        self._on_event("tool", "search_internal_database")
+        return f"reply to: {message}"
+
+    def close(self):
+        pass
+
+
+def _collect(message, recorded):
+    async def run():
+        out = []
+        async for line in stream.sse_turn(
+            message=message,
+            conversation=_FakeConversation,  # factory: takes on_event
+            on_persist=lambda role, content: recorded.append((role, content)),
+            user_id=_USER,
+        ):
+            out.append(line)
+        return out
+
+    return asyncio.run(run())
+
+
+def test_stream_emits_activity_then_text_then_done():
+    recorded = []
+    lines = _collect("hi", recorded)
+    body = "".join(lines)
+    assert body.index("Explorer") < body.index("reply to: hi")
+    assert "event: activity" in body
+    assert "event: text" in body
+    assert body.rstrip().endswith("event: done\ndata: {}")
+
+
+def test_stream_persists_user_then_assistant():
+    recorded = []
+    _collect("hi", recorded)
+    assert recorded == [("user", "hi"), ("assistant", "reply to: hi")]

--- a/test/unit/test_chat_stream.py
+++ b/test/unit/test_chat_stream.py
@@ -71,7 +71,7 @@ def test_stream_emits_error_and_no_done_on_failure():
     body = "".join(_collect("hi", recorded, conversation=_FailingConversation))
     assert "event: activity" in body  # the activity that fired before the failure still streamed
     assert "event: error" in body
-    assert "backend down" in body
+    assert "backend down" not in body  # internal detail is logged server-side, not streamed
     assert "event: done" not in body  # NO false success signal
     assert "event: text" not in body
     assert recorded == []  # asend raised before any persistence


### PR DESCRIPTION
## Summary
Stage 1 of Lift 2 (friends & family front end) — the backend the SPA will build against. Spec/plan in `docs/superpowers/{specs,plans}/2026-06-09-*`. A Firebase-gated SSE chat endpoint over the Librarian mesh whose conversation memory lives in Postgres, so chats survive Cloud Run scale-to-zero/recycling and become resumable.

- **Schema** (Alembic `30f1e46533e9`): `conversations` + `messages` tables; FK `usage.conversation_id` → `conversations.id`, with an orphan-NULL data step so the FK is safe to add on already-populated DBs.
- **Transcript store** (`chat/transcript.py`): user-scoped active / new / append; identity from the request context (ADR-048), never a tool/function parameter; mutation-tested isolation.
- **Rehydration** (`agents/runtime.py`): `astart_conversation(session_id=, history=)` seeds prior turns into a fresh ADK session via `append_event` — context restored each turn without re-running earlier turns.
- **SSE turn loop** (`chat/stream.py`): streams live agent activity, then `text`+`done` on success or a single generic `error` event on failure (never a false `done`); wraps the turn in `as_user` so identity survives the post-return streaming generator; cancels the mesh on client disconnect.
- **Endpoints** (`api/main.py`): `GET /conversations/current` (resume), `POST /conversations` (new chat), `POST /chat` (SSE). `/chat` pins `session_id = conversation_id.hex` so Lift 1 usage rows FK to the transcript.

Beta scope: activity streams live, the reply is one final chunk (token-level streaming deferred). Built subagent-driven with TDD; two-stage review (spec then quality) per task plus a final holistic review.

## Test Plan
- [x] Full non-live suite green — **339 passed** (db_integration run against the compose pgvector DB via throwaway container)
- [x] Per-task red→green + mutation checks (user-scoping filters fail when removed; the usage-FK guard fails against a non-existent `conversation_id` — verified `ForeignKeyViolation`)
- [x] Migration fidelity: `test_upgrade_head_matches_models_exactly` green; orphan-NULL keeps the FK safe on populated DBs
- [ ] CI: `lint.yml` (authoritative pinned-ruff pre-commit) + test workflow
- No live/`api_dependent` tests needed for Stage 1 (fakes throughout — no prod Gemini key required)

## Deferred to later stages (from the final review)
- **Stage 2:** history windowing/summarization (each turn replays the full transcript → token growth); cached/shared mesh runner (`build_runner()` per turn serializes concurrent chats); `GET /conversations` list + thread-switch endpoints (the `title` column is already nullable-ready); Stage-2 thread list should tolerate/hide empty conversations.
- **Stage 4 (cleanups):** consolidate the ~4 DatabaseManager pools; move per-turn sync INSERTs off the event loop for Cloud SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)