### PR TITLE
Lift 2 Stage 4 — PR-B: rollout-enabling (IAM gate, SPA serving, async-enrich infra) [HELD]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,7 @@ scratch/
 .agent/
 .gemini/
 .claude/
+# Node: let `npm ci` build a clean, linux-correct node_modules inside the image
+# (the new multi-stage Dockerfile COPYs frontend/ — never ship the host's win32 tree).
+**/node_modules
+frontend/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
     paths:
       - "src/**"
+      - "frontend/**"
       - "pyproject.toml"
       - "Dockerfile.api"
       - ".github/workflows/deploy.yml"
@@ -81,13 +82,16 @@ jobs:
 
       - name: Smoke-test image in runner (broken images never reach the registry)
         run: |
-          docker run --rm -d -p 8080:8080 -e DATABASE_URL=postgresql://x:x@nohost:5432/x --name api-smoke "$IMAGE"
+          docker run --rm -d -p 8080:8080 -e DATABASE_URL=postgresql://x:x@nohost:5432/x -e GOOGLE_SEARCH_API_KEY=dummy-key-for-construction --name api-smoke "$IMAGE"
           ok=""
           for i in $(seq 1 30); do
             if curl -fsS http://localhost:8080/health; then ok=1; break; fi
             sleep 1
           done
           if [ -z "$ok" ]; then echo "::error::/health never came up"; docker logs api-smoke; docker rm -f api-smoke; exit 1; fi
+          if ! curl -fsS http://localhost:8080/ | grep -q 'id="root"'; then
+            echo "::error::/ did not serve the SPA shell"; docker logs api-smoke; docker rm -f api-smoke; exit 1
+          fi
           docker rm -f api-smoke
 
       - id: auth
@@ -114,12 +118,12 @@ jobs:
           region: us-central1
           image: ${{ env.IMAGE }}
           flags: >-
-            --no-allow-unauthenticated
+            --allow-unauthenticated
             --service-account=librarian-api-runtime@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             --add-cloudsql-instances=${{ vars.GCP_CLOUDSQL_CONNECTION }}
-            --set-secrets=DATABASE_URL=librarian-db-url:latest
-            --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}
-            --max-instances=1
+            --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest
+            --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},AGENT_BACKEND=adk,GEMINI_MODEL=gemini-3.1-flash-lite,CLOUD_TASKS_QUEUE=${{ vars.GCP_CLOUD_TASKS_QUEUE }},ENRICH_TARGET_BASE_URL=${{ vars.GCP_RUN_BASE_URL }},ENRICH_INVOKER_SA=${{ vars.GCP_ENRICH_INVOKER_SA }},ENRICH_OIDC_AUDIENCE=${{ vars.GCP_RUN_BASE_URL }},SEARCH_ENGINE_ID=${{ vars.GCP_SEARCH_ENGINE_ID }}
+            --max-instances=2
             --memory=512Mi
 
       - id: smoke-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,11 +47,22 @@ jobs:
           GCP_DEPLOYER_SA: ${{ vars.GCP_DEPLOYER_SA }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_CLOUDSQL_CONNECTION: ${{ vars.GCP_CLOUDSQL_CONNECTION }}
+          # Stage 4 (async enrichment) — the operator sets these during the rollout
+          # (infra/08-cloud-tasks.sh prints the queue/SA values). Required so a deploy
+          # never opens the gate with empty ENRICH_* env (which silently breaks enrichment).
+          GCP_CLOUD_TASKS_QUEUE: ${{ vars.GCP_CLOUD_TASKS_QUEUE }}
+          GCP_RUN_BASE_URL: ${{ vars.GCP_RUN_BASE_URL }}
+          GCP_ENRICH_INVOKER_SA: ${{ vars.GCP_ENRICH_INVOKER_SA }}
+          GCP_SEARCH_ENGINE_ID: ${{ vars.GCP_SEARCH_ENGINE_ID }}
         run: |
           : "${GCP_WIF_PROVIDER:?set repo Variable GCP_WIF_PROVIDER (infra/05-iam-wif.sh prints it)}"
           : "${GCP_DEPLOYER_SA:?set repo Variable GCP_DEPLOYER_SA}"
           : "${GCP_PROJECT_ID:?set repo Variable GCP_PROJECT_ID}"
           : "${GCP_CLOUDSQL_CONNECTION:?set repo Variable GCP_CLOUDSQL_CONNECTION}"
+          : "${GCP_CLOUD_TASKS_QUEUE:?set repo Variable GCP_CLOUD_TASKS_QUEUE (infra/08-cloud-tasks.sh prints it)}"
+          : "${GCP_RUN_BASE_URL:?set repo Variable GCP_RUN_BASE_URL (the Cloud Run service base URL)}"
+          : "${GCP_ENRICH_INVOKER_SA:?set repo Variable GCP_ENRICH_INVOKER_SA (infra/08-cloud-tasks.sh prints it)}"
+          : "${GCP_SEARCH_ENGINE_ID:?set repo Variable GCP_SEARCH_ENGINE_ID (the Programmable Search Engine id)}"
 
       - uses: actions/checkout@v4
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,24 +1,36 @@
-# Production API image (Lift 0). The dev image is ./Dockerfile — this one is slim:
-# no build tools, no Node/Claude CLI, no sudo, non-editable install, uvicorn entrypoint.
+# Production API image (Lift 0 → Lift 2 Stage 4: now multi-stage, also serving the SPA).
+# Stage 1 builds the Vite SPA with Node; the slim Python runtime copies the static output
+# and has no Node/build tools, no editable install, uvicorn entrypoint.
+
+# --- Stage 1: build the SPA ---
+FROM node:22-slim AS spa-build
+WORKDIR /spa
+# Install deps from the lockfile first (cached unless deps change), then build.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build   # → /spa/dist
+
+# --- Stage 2: Python runtime ---
 FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    SPA_DIST_DIR=/app/static
 
 RUN useradd --create-home appuser
 WORKDIR /app
 
 # Non-editable install of the package + prod deps only (no [dev] or [claude] extras).
-# NOTE: copying src before install means dependency layers rebuild on code changes;
-# accepted for the skeleton (CI builds, ~minutes) — revisit if it starts to hurt.
 COPY pyproject.toml ./
 COPY src ./src
 RUN pip install --no-cache-dir .
 
+# The built SPA, served same-origin by FastAPI (see api/main.py spa_catch_all).
+COPY --from=spa-build /spa/dist /app/static
+
 USER appuser
 EXPOSE 8080
 
-# Cloud Run injects PORT (default 8080). Shell form for the env expansion; exec for
-# signals (uvicorn becomes PID 1, receives SIGTERM). One process, no --workers: Cloud
-# Run scales via instances, and N workers would multiply the SQLAlchemy pool per instance.
+# Cloud Run injects PORT (default 8080). Shell form for env expansion; exec for signals.
 CMD exec uvicorn agentic_librarian.api.main:app --host 0.0.0.0 --port ${PORT:-8080} --timeout-graceful-shutdown 25

--- a/docs/project_notes/security.md
+++ b/docs/project_notes/security.md
@@ -92,3 +92,27 @@ Run this pass during each spec's review and record any findings below.
   (SEC-001/SEC-002 residual-risk arguments, absence of rate limiting) is now on a
   path to expiry: Lift 2 opens the Cloud Run IAM gate; Lift 3 performs the full
   security posture re-review.
+
+## Cloud Run IAM gate OPEN (Lift 2 Stage 4, 2026-06-10)
+
+The Cloud Run service is now deployed `--allow-unauthenticated`: the platform IAM gate no
+longer fronts the app. The boundary is therefore enforced entirely **in-app**:
+
+- **Every user-facing route is Firebase-gated** — the Lift 1 auth dependency verifies a
+  Firebase ID token (401 missing/invalid, 403 verified-but-not-invited, 503 cert-fetch
+  outage). `SIGNUP_MODE=invite` keeps the door closed to the uninvited.
+- **`/health` is intentionally open** (unauthenticated liveness); `GET /` and the SPA static
+  assets are public by design (the app shell carries no data; all data calls are Firebase-gated).
+- **The internal enrich route (`POST /internal/enrich/{work_id}`) is queue-OIDC-gated** — it
+  verifies the Cloud Tasks invoker SA's Google-signed OIDC token (email == `ENRICH_INVOKER_SA`,
+  `email_verified`, audience == `ENRICH_OIDC_AUDIENCE`) and **fails closed** if either var is
+  unset. This gate is independent of (and survives) the now-open IAM gate.
+- **FastAPI auto-docs are disabled** (`docs_url=None, redoc_url=None, openapi_url=None`) so the
+  API schema isn't served unauthenticated now that the service is public. (Those paths fall
+  through to the SPA catch-all.)
+
+**Expiring assumptions:** transport-level "single user" reasoning (the SEC-001/SEC-002
+residual-risk arguments, the absence of rate limiting) no longer holds now that the gate is
+open to invited friends. A missing/incomplete Cloud Tasks setup degrades to enrichment
+**no-ops**, not exposure. Full security re-review — rate limiting, abuse controls, non-Google
+OIDC `email_verified` semantics — is Lift 3 (open signup).

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -48,13 +48,45 @@ on the host.
 - This rollout is the first prod write (chat). From here: **back up before every migration.**
 
 ## 3. Apply the migration (gate still CLOSED)
-- **First confirm the starting point:** with cloud-sql-proxy up, `alembic current` MUST show
-  `c804d02d6fbb` (the Lift 1 head). If it shows `30f1e46533e9` already, the migration is done —
-  skip the upgrade. If it shows anything else, STOP and investigate before proceeding.
-- Start cloud-sql-proxy to the prod instance; run `alembic upgrade head` via the docker wrapper
-  (Lift 1 runbook pattern). This moves prod from the Lift 1 head `c804d02d6fbb` to the Stage 1
-  head `30f1e46533e9` (`conversations`, `messages`, `usage.conversation_id` FK).
-- Verify: `alembic current` shows `30f1e46533e9`; the `conversations`/`messages` tables exist.
+Mirrors the Lift 1 runbook §3 (proxy on the WSL host; alembic docker-wrapped). The proxy must
+be **running for the whole step** — it's a foreground binary, so start it in its own WSL shell.
+
+1. **Start the cloud-sql-proxy** (Lift 0 binary on the WSL host) in a dedicated shell — it sits
+   on a blank line while serving. `CONNECTION_NAME` = the `GCP_CLOUDSQL_CONNECTION` repo Variable,
+   or `gcloud sql instances describe librarian-sql --format='value(connectionName)'`:
+   ```bash
+   ./cloud-sql-proxy --port 5433 <CONNECTION_NAME>
+   ```
+   Confirm it's listening (a "connection refused" from the container means it isn't):
+   ```bash
+   ss -tln | grep 5433     # no output = not running. If the container still can't reach it,
+                           # restart with --address 0.0.0.0 (Ctrl-C when done; IAM still gates it).
+   ```
+2. **Build the proxy-routed DATABASE_URL** from the secret (container-routed to host.docker.internal):
+   ```bash
+   export PROD_DB_URL="$(gcloud secrets versions access latest --secret=librarian-db-url \
+     | sed -E 's#@/agentic_librarian\?host=.*#@host.docker.internal:5433/agentic_librarian#')"
+   ```
+3. **Confirm the starting point** (docker-wrapped — WSL python has no deps). It MUST print
+   `c804d02d6fbb` (the Lift 1 head). If it prints `30f1e46533e9`, the migration is already done —
+   skip to step 4. Anything else → STOP and investigate:
+   ```bash
+   docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+     -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest alembic current
+   ```
+4. **Upgrade** (moves prod `c804d02d6fbb` → `30f1e46533e9`: `conversations`, `messages`,
+   `usage.conversation_id` FK):
+   ```bash
+   docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+     -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest alembic upgrade head
+   ```
+5. **Verify** `alembic current` now prints `30f1e46533e9` and the tables exist:
+   ```bash
+   docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+     -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest \
+     python -c 'from sqlalchemy import create_engine, inspect; from agentic_librarian.db.session import resolve_database_url; i = inspect(create_engine(resolve_database_url())); print("chat tables:", [t for t in ("conversations","messages") if t in i.get_table_names()])'
+   ```
+   Ctrl-C the proxy when the step is done.
 
 ## 4. Sanity (gate still CLOSED)
 - The current (old) image is still healthy: minted-IAM-token `GET /health` returns ok.

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -28,6 +28,9 @@ then merge PR-B as the deliberate gate-opening act.
 - This rollout is the first prod write (chat). From here: **back up before every migration.**
 
 ## 3. Apply the migration (gate still CLOSED)
+- **First confirm the starting point:** with cloud-sql-proxy up, `alembic current` MUST show
+  `c804d02d6fbb` (the Lift 1 head). If it shows `30f1e46533e9` already, the migration is done —
+  skip the upgrade. If it shows anything else, STOP and investigate before proceeding.
 - Start cloud-sql-proxy to the prod instance; run `alembic upgrade head` via the docker wrapper
   (Lift 1 runbook pattern). This moves prod from the Lift 1 head `c804d02d6fbb` to the Stage 1
   head `30f1e46533e9` (`conversations`, `messages`, `usage.conversation_id` FK).

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -10,6 +10,26 @@ then merge PR-B as the deliberate gate-opening act.
 **Prereqs:** PR-A merged; PR-B reviewed/approved and **held** (not merged); `gcloud` authed to
 `agentic-librarian-prod`; cloud-sql-proxy available.
 
+**Run from (same model as the Lift 1 runbook):** a **plain WSL shell** at the WSL clone
+(`~/agentic_librarian`) — **not** from inside the dev/app container. `gcloud` and the
+cloud-sql-proxy binary live natively on the WSL host (from the Lift 0/1 runs); anything that
+needs the Python deps (alembic, the live-verify token helper) is **docker-wrapped** —
+`docker run --rm -v "$PWD":/app -w /app … agentic_librarian-app:latest <cmd>` — invoked *from*
+that WSL shell. Browser steps (Firebase sign-in, setting repo Variables, merging PR-B) happen
+on the host.
+
+> **First, get the Stage 4 code into the WSL clone:** `infra/08`/`09` and this runbook live in
+> the un-merged PR-B branch. In `~/agentic_librarian`:
+> `git fetch origin && git checkout feat/lift2-stage4-pr-b` (run the provisioning from there),
+> then merge PR-B at step 5.
+
+| Step | Where |
+|------|-------|
+| `infra/08`/`09`, `gcloud sql export`, set repo Variables | plain WSL shell (`gcloud` native) |
+| cloud-sql-proxy | native binary on the WSL host |
+| `alembic current` / `upgrade head` | docker-wrapped, invoked from the WSL shell |
+| Google sign-in + live verify, merge PR-B | browser / GitHub UI |
+
 ## 1. Provision (gate still CLOSED)
 1. `bash infra/08-cloud-tasks.sh` — creates the queue, the invoker SA, and the IAM grants.
    Note the printed `GCP_CLOUD_TASKS_QUEUE` / `GCP_ENRICH_INVOKER_SA` values.

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -1,0 +1,61 @@
+# Lift 2 Stage 4 — Rollout Runbook
+
+Takes the friends-and-family beta live: opens the Cloud Run IAM gate, provisions async
+enrichment, applies the first prod write-path migration, and verifies the live stack.
+
+**Ordering is load-bearing (spec D2):** merging PR-B's deploy opens the gate *and* ships the
+SPA/chat-reachable image at once. So **provision + migrate while the gate is still closed**,
+then merge PR-B as the deliberate gate-opening act.
+
+**Prereqs:** PR-A merged; PR-B reviewed/approved and **held** (not merged); `gcloud` authed to
+`agentic-librarian-prod`; cloud-sql-proxy available.
+
+## 1. Provision (gate still CLOSED)
+1. `bash infra/08-cloud-tasks.sh` — creates the queue, the invoker SA, and the IAM grants.
+   Note the printed `GCP_CLOUD_TASKS_QUEUE` / `GCP_ENRICH_INVOKER_SA` values.
+2. Export the three keys, then `bash infra/09-prod-secrets.sh` — creates the key secrets +
+   grants the runtime SA `secretAccessor`.
+3. Set the GitHub repo **Variables** PR-B's `deploy.yml` reads (the preflight step fails the
+   deploy if any are unset):
+   - `GCP_CLOUD_TASKS_QUEUE` = the full queue path
+   - `GCP_RUN_BASE_URL` = the Cloud Run service base URL (used for BOTH `ENRICH_TARGET_BASE_URL`
+     and `ENRICH_OIDC_AUDIENCE` — they MUST match or every enrichment 403s)
+   - `GCP_ENRICH_INVOKER_SA` = the invoker SA email
+   - `GCP_SEARCH_ENGINE_ID` = the Programmable Search Engine id
+
+## 2. Back up prod (first prod write boundary)
+- `gcloud sql export sql librarian-sql gs://agentic-librarian-prod-backups/pre-stage4-$(date +%Y%m%d).sql.gz --database=agentic_librarian`
+- This rollout is the first prod write (chat). From here: **back up before every migration.**
+
+## 3. Apply the migration (gate still CLOSED)
+- Start cloud-sql-proxy to the prod instance; run `alembic upgrade head` via the docker wrapper
+  (Lift 1 runbook pattern). This moves prod from the Lift 1 head `c804d02d6fbb` to the Stage 1
+  head `30f1e46533e9` (`conversations`, `messages`, `usage.conversation_id` FK).
+- Verify: `alembic current` shows `30f1e46533e9`; the `conversations`/`messages` tables exist.
+
+## 4. Sanity (gate still CLOSED)
+- The current (old) image is still healthy: minted-IAM-token `GET /health` returns ok.
+
+## 5. Merge PR-B → CD opens the gate
+- Merge PR-B. CD builds the multi-stage image, deploys with the new env/secrets, and flips to
+  `--allow-unauthenticated`. The CD in-runner smoke asserts `/health` + `GET /` SPA; the live
+  smoke asserts `/health` + `401`-without-Firebase.
+
+## 6. Manual live verification (gate now OPEN)
+Run through the browser as an invited user:
+- [ ] Google sign-in succeeds; the SPA shell loads at `/`.
+- [ ] A chat turn streams live activity then a reply.
+- [ ] Add-a-book logs a read (fast pass returns in seconds).
+- [ ] ~2 minutes later, deep enrichment has completed (tropes appear on the work) — confirms the
+      Cloud Task fired and the queue-OIDC internal route accepted it.
+- [ ] A metered `usage` row was written (check via a `GET /works` enriched payload or DB peek).
+- [ ] `/history` paginates ("Load more" fetches the next page).
+
+## 7. Cost watch
+- Confirm the budget alert is live; eyeball the first real `usage` rows; confirm `max-instances=2`.
+
+## Rollback (ONLY if step 5/6 fails or the deploy is broken)
+- Revert the PR-B merge commit on `main`. The next CD deploy re-applies
+  `--no-allow-unauthenticated` (re-closing the gate) and reverts the image in one move.
+- The applied migration is **additive and safe to leave** — do not run a down-migration; the
+  unused `conversations`/`messages` tables are harmless.

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -44,7 +44,19 @@ on the host.
    - `GCP_SEARCH_ENGINE_ID` = the Programmable Search Engine id
 
 ## 2. Back up prod (first prod write boundary)
-- `gcloud sql export sql librarian-sql gs://agentic-librarian-prod-backups/pre-stage4-$(date +%Y%m%d).sql.gz --database=agentic_librarian`
+- **One-time grant (first real `gcloud sql export`):** the Cloud SQL instance's own service
+  account must be able to write the dump to the bucket, or export 412s
+  ("service account does not have the required permissions for the bucket"):
+  ```bash
+  SQL_SA="$(gcloud sql instances describe librarian-sql --format='value(serviceAccountEmailAddress)')"
+  gcloud storage buckets add-iam-policy-binding gs://agentic-librarian-prod-backups \
+    --member="serviceAccount:${SQL_SA}" --role="roles/storage.objectAdmin"   # ~30s to propagate
+  ```
+- Export:
+  ```bash
+  gcloud sql export sql librarian-sql \
+    gs://agentic-librarian-prod-backups/pre-stage4-$(date +%Y%m%d).sql.gz --database=agentic_librarian
+  ```
 - This rollout is the first prod write (chat). From here: **back up before every migration.**
 
 ## 3. Apply the migration (gate still CLOSED)

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -101,7 +101,17 @@ be **running for the whole step** — it's a foreground binary, so start it in i
    Ctrl-C the proxy when the step is done.
 
 ## 4. Sanity (gate still CLOSED)
-- The current (old) image is still healthy: minted-IAM-token `GET /health` returns ok.
+A light "look before you flip the gate" check — the migration was additive (new tables the old
+image doesn't use) and nothing was redeployed, so the running service is almost certainly fine.
+Confirm it's still serving (token-free; `/health` is IAM-gated while the gate is closed and
+minting a correctly-scoped IAM token as your user account isn't worth it here):
+```bash
+gcloud run services describe librarian-api --region=us-central1 \
+  --format='table(status.conditions[].type, status.conditions[].status)'
+```
+Want `Ready = True` (+ `ConfigurationsReady`/`RoutesReady = True`). The DB side is already proven
+by step 3 (alembic at `30f1e46533e9`, tables present). The CD's own live smoke re-checks `/health`
++ 401-enforcement automatically when PR-B deploys (step 5), so a manual `/health` curl is skippable.
 
 ## 5. Merge PR-B → CD opens the gate
 - Merge PR-B. CD builds the multi-stage image, deploys with the new env/secrets, and flips to

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -73,8 +73,8 @@ export async function probeAccess(): Promise<'ready' | 'notInvited' | 'error'> {
   return 'error'
 }
 
-export function getHistory(): Promise<HistoryItem[]> {
-  return getJson<HistoryItem[]>('/history')
+export function getHistory(limit = 50, offset = 0): Promise<HistoryItem[]> {
+  return getJson<HistoryItem[]>(`/history?limit=${limit}&offset=${offset}`)
 }
 
 export function getRecommendations(): Promise<Recommendation[]> {

--- a/frontend/src/views/HistoryView.test.tsx
+++ b/frontend/src/views/HistoryView.test.tsx
@@ -1,26 +1,38 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
-vi.mock('../api/client', () => ({ getHistory: vi.fn() }))
-
-import { getHistory } from '../api/client'
 import HistoryView from './HistoryView'
+import * as client from '../api/client'
 
-describe('HistoryView', () => {
-  afterEach(() => vi.clearAllMocks())
+// The auto-mock of '../api/client' imports the real module to derive its shape,
+// which transitively loads firebase (getAuth throws without env keys under test).
+vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null) }))
+vi.mock('../api/client')
 
-  it('renders the reading log', async () => {
-    vi.mocked(getHistory).mockResolvedValue([
-      { id: 'h1', title: 'Dune', authors: ['Herbert'], date_completed: '2026-05-01', rating: 5, format: 'audiobook' },
-    ])
+function item(id: string, title: string): client.HistoryItem {
+  return { id, title, authors: ['A. Uthor'], date_completed: '2024-01-01', rating: 4, format: 'ebook' }
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe('HistoryView pagination', () => {
+  it('loads the first page and appends the next on "Load more"', async () => {
+    const full = Array.from({ length: 50 }, (_, i) => item(`a${i}`, `Book ${i}`))
+    vi.mocked(client.getHistory).mockResolvedValueOnce(full).mockResolvedValueOnce([item('b0', 'Page 2 Book')])
+
     render(<HistoryView />)
-    expect(await screen.findByText('Dune')).toBeInTheDocument()
-    expect(screen.getByText(/Herbert/)).toBeInTheDocument()
+    expect(await screen.findByText('Book 0')).toBeInTheDocument()
+    expect(client.getHistory).toHaveBeenCalledWith(50, 0)
+
+    await userEvent.click(screen.getByRole('button', { name: /load more/i }))
+    expect(await screen.findByText('Page 2 Book')).toBeInTheDocument()
+    expect(client.getHistory).toHaveBeenCalledWith(50, 50)
   })
 
-  it('shows an empty state when nothing has been read', async () => {
-    vi.mocked(getHistory).mockResolvedValue([])
+  it('hides "Load more" when the first page is short (no more rows)', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Only Book')])
     render(<HistoryView />)
-    expect(await screen.findByText(/nothing here yet/i)).toBeInTheDocument()
+    expect(await screen.findByText('Only Book')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/views/HistoryView.tsx
+++ b/frontend/src/views/HistoryView.tsx
@@ -2,12 +2,31 @@ import { useEffect, useState } from 'react'
 import { getHistory, type HistoryItem } from '../api/client'
 import './HistoryView.css'
 
+const PAGE_SIZE = 50
+
 export default function HistoryView() {
   const [items, setItems] = useState<HistoryItem[] | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
 
   useEffect(() => {
-    void getHistory().then(setItems)
+    void getHistory(PAGE_SIZE, 0).then((page) => {
+      setItems(page)
+      setHasMore(page.length === PAGE_SIZE)
+    })
   }, [])
+
+  async function loadMore() {
+    if (items === null) return
+    setLoadingMore(true)
+    try {
+      const page = await getHistory(PAGE_SIZE, items.length)
+      setItems([...items, ...page])
+      setHasMore(page.length === PAGE_SIZE)
+    } finally {
+      setLoadingMore(false)
+    }
+  }
 
   if (items === null) return <p>Loading…</p>
   if (items.length === 0) return <p>Nothing here yet — finish a book and it'll show up.</p>
@@ -30,6 +49,11 @@ export default function HistoryView() {
           </li>
         ))}
       </ul>
+      {hasMore && (
+        <button className="history-load-more" onClick={() => void loadMore()} disabled={loadingMore}>
+          {loadingMore ? 'Loading…' : 'Load more'}
+        </button>
+      )}
     </div>
   )
 }

--- a/infra/00-config.sh
+++ b/infra/00-config.sh
@@ -22,6 +22,15 @@ export SERVICE="librarian-api"
 export GITHUB_REPO="jaydee829/agentic_librarian"
 export DUMP_FILE="agentic_librarian_FINAL_20260605_014912.sql.gz"
 
+# --- Lift 2 Stage 4: async enrichment (Cloud Tasks) + deep-scout key secrets ---
+export TASKS_QUEUE_NAME="librarian-enrich"
+export TASKS_QUEUE_PATH="projects/${PROJECT_ID}/locations/${REGION}/queues/${TASKS_QUEUE_NAME}"
+export ENRICH_INVOKER_SA_NAME="librarian-enrich-invoker"
+export ENRICH_INVOKER_SA="${ENRICH_INVOKER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+export SECRET_GOOGLE_SEARCH="librarian-google-search-key"
+export SECRET_GOOGLE_BOOKS="librarian-google-books-key"
+export SECRET_HARDCOVER="librarian-hardcover-key"
+
 # Re-assert the target project in every script — prevents a fresh shell from silently
 # operating on whatever project the global gcloud config last pointed at.
 # (config set does not validate existence, so this is safe before 01 creates it.)

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Lift 2 Stage 4: provision the Cloud Tasks queue + the OIDC invoker SA, and grant the
+# runtime SA the rights to enqueue tasks that call the internal enrich route as the invoker.
+# One-shot (fails loud on ALREADY_EXISTS). Source-relative so it runs from anywhere.
+set -euo pipefail
+source "$(dirname "$0")/00-config.sh"
+
+# 1) The queue the fast /books pass enqueues onto.
+gcloud tasks queues create "${TASKS_QUEUE_NAME}" --location="${REGION}"
+
+# 2) The service account whose OIDC token authorizes calls to the internal enrich route.
+gcloud iam service-accounts create "${ENRICH_INVOKER_SA_NAME}" \
+  --display-name="Cloud Tasks → internal enrich invoker"
+
+# 3) That invoker SA may invoke the Cloud Run service (the now-open IAM gate still gates
+#    the internal route via this OIDC identity, verified in-app).
+gcloud run services add-iam-policy-binding "${SERVICE}" \
+  --region="${REGION}" \
+  --member="serviceAccount:${ENRICH_INVOKER_SA}" \
+  --role="roles/run.invoker"
+
+# 4) The runtime SA (which runs /books) may enqueue tasks…
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role="roles/cloudtasks.enqueuer"
+
+# 5) …and may mint OIDC tokens AS the invoker SA when creating those tasks.
+gcloud iam service-accounts add-iam-policy-binding "${ENRICH_INVOKER_SA}" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role="roles/iam.serviceAccountUser"
+
+echo "Cloud Tasks provisioned."
+echo "  Set these GitHub repo Variables for deploy.yml:"
+echo "    GCP_CLOUD_TASKS_QUEUE = ${TASKS_QUEUE_PATH}"
+echo "    GCP_ENRICH_INVOKER_SA = ${ENRICH_INVOKER_SA}"
+echo "    GCP_RUN_BASE_URL      = (the Cloud Run service URL; used for ENRICH_TARGET_BASE_URL + ENRICH_OIDC_AUDIENCE)"
+echo "    GCP_SEARCH_ENGINE_ID  = (the Programmable Search Engine id)"

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -12,6 +12,14 @@ gcloud tasks queues create "${TASKS_QUEUE_NAME}" --location="${REGION}"
 gcloud iam service-accounts create "${ENRICH_INVOKER_SA_NAME}" \
   --display-name="Cloud Tasks → internal enrich invoker"
 
+# New SAs propagate asynchronously; binding too fast intermittently 400s with
+# "does not exist". Poll until describable before binding (mirrors 05-iam-wif.sh).
+for i in $(seq 1 12); do
+  if gcloud iam service-accounts describe "${ENRICH_INVOKER_SA}" >/dev/null 2>&1; then break; fi
+  echo "Waiting for ${ENRICH_INVOKER_SA} to propagate (${i}/12)..."
+  sleep 5
+done
+
 # 3) That invoker SA may invoke the Cloud Run service (the now-open IAM gate still gates
 #    the internal route via this OIDC identity, verified in-app).
 gcloud run services add-iam-policy-binding "${SERVICE}" \

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -5,6 +5,11 @@
 set -euo pipefail
 source "$(dirname "$0")/00-config.sh"
 
+# 0) Enable the Cloud Tasks API — Stage 4 is the first lift to use it, so Lift 0's
+#    01-project.sh enable-list predates it. (Enabling can take ~30s to propagate; if the
+#    queue create below 403s immediately, wait and re-run — nothing before it has run yet.)
+gcloud services enable cloudtasks.googleapis.com
+
 # 1) The queue the fast /books pass enqueues onto.
 gcloud tasks queues create "${TASKS_QUEUE_NAME}" --location="${REGION}"
 

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -50,9 +50,13 @@ _retry gcloud iam service-accounts add-iam-policy-binding "${ENRICH_INVOKER_SA}"
   --member="serviceAccount:${RUNTIME_SA}" \
   --role="roles/iam.serviceAccountUser"
 
+# Look up the live service URL (the service already exists from Lift 0/1); SEARCH_ENGINE_ID
+# is YOUR Programmable Search Engine id (config, e.g. from .env) — not derivable from GCP.
+RUN_BASE_URL="$(gcloud run services describe "${SERVICE}" --region="${REGION}" --format='value(status.url)' 2>/dev/null || true)"
+
 echo "Cloud Tasks provisioned."
 echo "  Set these GitHub repo Variables for deploy.yml:"
 echo "    GCP_CLOUD_TASKS_QUEUE = ${TASKS_QUEUE_PATH}"
 echo "    GCP_ENRICH_INVOKER_SA = ${ENRICH_INVOKER_SA}"
-echo "    GCP_RUN_BASE_URL      = (the Cloud Run service URL; used for ENRICH_TARGET_BASE_URL + ENRICH_OIDC_AUDIENCE)"
-echo "    GCP_SEARCH_ENGINE_ID  = (the Programmable Search Engine id)"
+echo "    GCP_RUN_BASE_URL      = ${RUN_BASE_URL:-<gcloud run services describe ${SERVICE} --region=${REGION} --format='value(status.url)'>}"
+echo "    GCP_SEARCH_ENGINE_ID  = ${SEARCH_ENGINE_ID:-<your Programmable Search Engine id, e.g. .env SEARCH_ENGINE_ID>}"

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -1,33 +1,41 @@
 #!/usr/bin/env bash
 # Lift 2 Stage 4: provision the Cloud Tasks queue + the OIDC invoker SA, and grant the
 # runtime SA the rights to enqueue tasks that call the internal enrich route as the invoker.
-# One-shot (fails loud on ALREADY_EXISTS). Source-relative so it runs from anywhere.
+# IDEMPOTENT + retry-safe (unlike the Lift 0 one-shot scripts): a brand-new SA propagates
+# asynchronously, so resource-level bindings can transiently 400 "does not exist" — re-running
+# must be safe. Source-relative so it runs from anywhere.
 set -euo pipefail
 source "$(dirname "$0")/00-config.sh"
 
+# Retry a command to ride out IAM / new-SA propagation (a describe-poll isn't enough — the
+# resource-level run.invoker binding lags longer than the SA becoming describable).
+_retry() {
+  local n=0
+  until "$@"; do
+    n=$((n + 1))
+    if [ "$n" -ge 12 ]; then echo "giving up after $n attempts: $*" >&2; return 1; fi
+    echo "retry $n/12 (waiting on propagation): $*"
+    sleep 5
+  done
+}
+
 # 0) Enable the Cloud Tasks API — Stage 4 is the first lift to use it, so Lift 0's
-#    01-project.sh enable-list predates it. (Enabling can take ~30s to propagate; if the
-#    queue create below 403s immediately, wait and re-run — nothing before it has run yet.)
+#    01-project.sh enable-list predates it. (Idempotent; ~30s to propagate.)
 gcloud services enable cloudtasks.googleapis.com
 
-# 1) The queue the fast /books pass enqueues onto.
-gcloud tasks queues create "${TASKS_QUEUE_NAME}" --location="${REGION}"
+# 1) The queue the fast /books pass enqueues onto (create only if absent).
+gcloud tasks queues describe "${TASKS_QUEUE_NAME}" --location="${REGION}" >/dev/null 2>&1 \
+  || gcloud tasks queues create "${TASKS_QUEUE_NAME}" --location="${REGION}"
 
 # 2) The service account whose OIDC token authorizes calls to the internal enrich route.
-gcloud iam service-accounts create "${ENRICH_INVOKER_SA_NAME}" \
-  --display-name="Cloud Tasks → internal enrich invoker"
+gcloud iam service-accounts describe "${ENRICH_INVOKER_SA}" >/dev/null 2>&1 \
+  || gcloud iam service-accounts create "${ENRICH_INVOKER_SA_NAME}" \
+       --display-name="Cloud Tasks → internal enrich invoker"
 
-# New SAs propagate asynchronously; binding too fast intermittently 400s with
-# "does not exist". Poll until describable before binding (mirrors 05-iam-wif.sh).
-for i in $(seq 1 12); do
-  if gcloud iam service-accounts describe "${ENRICH_INVOKER_SA}" >/dev/null 2>&1; then break; fi
-  echo "Waiting for ${ENRICH_INVOKER_SA} to propagate (${i}/12)..."
-  sleep 5
-done
-
-# 3) That invoker SA may invoke the Cloud Run service (the now-open IAM gate still gates
-#    the internal route via this OIDC identity, verified in-app).
-gcloud run services add-iam-policy-binding "${SERVICE}" \
+# 3) That invoker SA may invoke the Cloud Run service (the now-open IAM gate still gates the
+#    internal route via this OIDC identity, verified in-app). Retried: the binding can 400
+#    "does not exist" while a freshly-created SA propagates. add-iam-policy-binding is idempotent.
+_retry gcloud run services add-iam-policy-binding "${SERVICE}" \
   --region="${REGION}" \
   --member="serviceAccount:${ENRICH_INVOKER_SA}" \
   --role="roles/run.invoker"
@@ -37,8 +45,8 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
   --member="serviceAccount:${RUNTIME_SA}" \
   --role="roles/cloudtasks.enqueuer"
 
-# 5) …and may mint OIDC tokens AS the invoker SA when creating those tasks.
-gcloud iam service-accounts add-iam-policy-binding "${ENRICH_INVOKER_SA}" \
+# 5) …and may mint OIDC tokens AS the invoker SA when creating those tasks (also retried).
+_retry gcloud iam service-accounts add-iam-policy-binding "${ENRICH_INVOKER_SA}" \
   --member="serviceAccount:${RUNTIME_SA}" \
   --role="roles/iam.serviceAccountUser"
 

--- a/infra/09-prod-secrets.sh
+++ b/infra/09-prod-secrets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Lift 2 Stage 4: create the three deep-scout key secrets from the operator's environment
+# (never hardcoded), add the first version, and grant the runtime SA read access.
+# Export the three source vars before running, e.g.:
+#   export GOOGLE_SEARCH_API_KEY=... GOOGLE_BOOKS_API_KEY=... HARDCOVER_API_KEY=...
+# One-shot (fails loud on ALREADY_EXISTS).
+set -euo pipefail
+source "$(dirname "$0")/00-config.sh"
+
+: "${GOOGLE_SEARCH_API_KEY:?export GOOGLE_SEARCH_API_KEY before running}"
+: "${GOOGLE_BOOKS_API_KEY:?export GOOGLE_BOOKS_API_KEY before running}"
+: "${HARDCOVER_API_KEY:?export HARDCOVER_API_KEY before running}"
+
+create_secret () {
+  local name="$1" value="$2"
+  gcloud secrets create "${name}" --replication-policy="automatic"
+  printf '%s' "${value}" | gcloud secrets versions add "${name}" --data-file=-
+  gcloud secrets add-iam-policy-binding "${name}" \
+    --member="serviceAccount:${RUNTIME_SA}" \
+    --role="roles/secretmanager.secretAccessor"
+}
+
+create_secret "${SECRET_GOOGLE_SEARCH}" "${GOOGLE_SEARCH_API_KEY}"
+create_secret "${SECRET_GOOGLE_BOOKS}"  "${GOOGLE_BOOKS_API_KEY}"
+create_secret "${SECRET_HARDCOVER}"     "${HARDCOVER_API_KEY}"
+
+echo "Prod key secrets created and granted to ${RUNTIME_SA}."

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -91,6 +91,9 @@ def get_history(
             .join(Edition)
             .join(Work)
             .filter(ReadingHistory.user_id == user.id)  # my history, not the commons (ADR-048)
+            # joinedload on the to-many Work.contributors is safe under LIMIT *here* (unlike
+            # /works): the paginated root is ReadingHistory and the collection sits two to-one
+            # hops below it, so SQLAlchemy subquery-wraps the LIMIT against ReadingHistory rows.
             .options(
                 joinedload(ReadingHistory.edition)
                 .joinedload(Edition.work)

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -1,7 +1,8 @@
 import contextlib
+import os
 
 from fastapi import Body, Depends, FastAPI, Query
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -228,3 +229,34 @@ def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Bod
         ),
         media_type="text/event-stream",
     )
+
+
+# ---------------------------------------------------------------------------
+# SPA static serving (Lift 2 Stage 4) — served same-origin from this container.
+# Registered LAST so every API route above takes precedence over the catch-all.
+# ---------------------------------------------------------------------------
+
+
+def _spa_dir() -> str:
+    return os.environ.get("SPA_DIST_DIR", "/app/static")
+
+
+def _spa_index() -> FileResponse:
+    return FileResponse(os.path.join(_spa_dir(), "index.html"))
+
+
+@app.get("/")
+def spa_root():
+    return _spa_index()
+
+
+@app.get("/{full_path:path}")
+def spa_catch_all(full_path: str):
+    """Serve a real built file when one exists; otherwise return the SPA shell so
+    client-side routes (e.g. /add, /history) resolve. The realpath check is a
+    path-traversal guard — a candidate that escapes the dist dir falls back to the shell."""
+    root = os.path.realpath(_spa_dir())
+    candidate = os.path.realpath(os.path.join(root, full_path))
+    if (candidate == root or candidate.startswith(root + os.sep)) and os.path.isfile(candidate):
+        return FileResponse(candidate)
+    return _spa_index()

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -54,7 +54,11 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="Agentic Librarian API", lifespan=lifespan)
+# Stage 4 opens the Cloud Run IAM gate, making this service publicly reachable (Firebase
+# gates the data routes; /health and the SPA are intentionally public). Disable FastAPI's
+# auto-docs so the full API schema isn't exposed unauthenticated. (GET /docs etc. now fall
+# through to the SPA catch-all, which is harmless.)
+app = FastAPI(title="Agentic Librarian API", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
 app.include_router(recommendations_router)
 app.include_router(analysis_router)
 app.include_router(books_router)
@@ -253,8 +257,10 @@ def spa_root():
 @app.get("/{full_path:path}")
 def spa_catch_all(full_path: str):
     """Serve a real built file when one exists; otherwise return the SPA shell so
-    client-side routes (e.g. /add, /history) resolve. The realpath check is a
-    path-traversal guard — a candidate that escapes the dist dir falls back to the shell."""
+    client-side routes (e.g. /add, /history) resolve. A genuinely-missing asset (e.g. a
+    bad /assets/* path) therefore also returns the shell (200), not a 404 — standard SPA
+    catch-all behavior. The realpath check is a path-traversal guard: a candidate that
+    escapes the dist dir falls back to the shell."""
     root = os.path.realpath(_spa_dir())
     candidate = os.path.realpath(os.path.join(root, full_path))
     if (candidate == root or candidate.startswith(root + os.sep)) and os.path.isfile(candidate):

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -78,7 +78,12 @@ def db_health_check(user: AuthenticatedUser = Depends(get_current_user)):  # noq
 
 
 @app.get("/history")
-def get_history(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+def get_history(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: AuthenticatedUser = Depends(get_current_user),  # noqa: B008
+):
+    """Paginated reading log, newest first (INF-029 — mirrors /works)."""
     with db_manager.get_session() as session:
         # Query reading history with eager loading for efficiency
         history_entries = (
@@ -92,7 +97,9 @@ def get_history(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B
                 .joinedload(Work.contributors)
                 .joinedload(WorkContributor.author)
             )
-            .order_by(ReadingHistory.date_completed.desc())
+            .order_by(ReadingHistory.date_completed.desc(), ReadingHistory.id)
+            .offset(offset)
+            .limit(limit)
             .all()
         )
 

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -46,3 +46,24 @@ def test_history_is_scoped_to_the_caller(two_user_client):
     assert [h["date_completed"] for h in mine] == ["2021-01-01"]
     theirs = two_user_client(FRIEND_ID, "friend@example.com").get("/history").json()
     assert [h["date_completed"] for h in theirs] == ["2022-02-02"]
+
+
+def test_history_paginates_newest_first(two_user_client, db_url):
+    from datetime import date as _date
+
+    from agentic_librarian.db.models import Edition as _Edition
+    from agentic_librarian.db.models import ReadingHistory as _RH
+
+    # Add three more reads for DEFAULT_USER on the shared edition, distinct dates.
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        edition_id = session.query(_Edition).first().id
+        for d in (_date(2023, 3, 3), _date(2024, 4, 4), _date(2025, 5, 5)):
+            session.add(_RH(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=d))
+        session.flush()
+
+    c = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    page1 = c.get("/history?limit=2&offset=0").json()
+    page2 = c.get("/history?limit=2&offset=2").json()
+    assert [h["date_completed"] for h in page1] == ["2025-05-05", "2024-04-04"]  # newest first
+    assert [h["date_completed"] for h in page2] == ["2023-03-03", "2021-01-01"]  # next page, no overlap

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -49,17 +49,12 @@ def test_history_is_scoped_to_the_caller(two_user_client):
 
 
 def test_history_paginates_newest_first(two_user_client, db_url):
-    from datetime import date as _date
-
-    from agentic_librarian.db.models import Edition as _Edition
-    from agentic_librarian.db.models import ReadingHistory as _RH
-
     # Add three more reads for DEFAULT_USER on the shared edition, distinct dates.
     manager = DatabaseManager(db_url)
     with manager.get_session() as session:
-        edition_id = session.query(_Edition).first().id
-        for d in (_date(2023, 3, 3), _date(2024, 4, 4), _date(2025, 5, 5)):
-            session.add(_RH(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=d))
+        edition_id = session.query(Edition).first().id
+        for d in (date(2023, 3, 3), date(2024, 4, 4), date(2025, 5, 5)):
+            session.add(ReadingHistory(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=d))
         session.flush()
 
     c = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -48,6 +48,36 @@ def test_history_is_scoped_to_the_caller(two_user_client):
     assert [h["date_completed"] for h in theirs] == ["2022-02-02"]
 
 
+def test_history_pagination_correct_with_multi_contributor_work(two_user_client, db_url):
+    # A work with 2 author-contributors multiplies the join rows; LIMIT must still count
+    # ReadingHistory rows, not multiplied rows (the joinedload-vs-selectinload question).
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = AuthorModel(name="First Author")
+        a2 = AuthorModel(name="Second Author")
+        work = Work(
+            title="Co-Authored Book",
+            contributors=[WorkContributor(author=a1, role="Author"), WorkContributor(author=a2, role="Author")],
+        )
+        edition = Edition(work=work, format="ebook")
+        session.add_all([a1, a2, work, edition])
+        session.flush()
+        for d in (date(2023, 3, 3), date(2024, 4, 4), date(2025, 5, 5)):
+            session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=d))
+        session.flush()
+
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    page = client.get("/history?limit=3&offset=0").json()
+    # 3 newest reads (all on the co-authored work) must come back as 3 DISTINCT history rows,
+    # each listing both authors — not collapsed by row multiplication.
+    assert [h["date_completed"] for h in page] == ["2025-05-05", "2024-04-04", "2023-03-03"]
+    assert all(set(h["authors"]) == {"First Author", "Second Author"} for h in page)
+    # The boundary Gemini's review worried about: limit < read-count must return exactly `limit`
+    # distinct ReadingHistory rows (not fewer because the join multiplied by 2 contributors).
+    page2 = client.get("/history?limit=2&offset=0").json()
+    assert [h["date_completed"] for h in page2] == ["2025-05-05", "2024-04-04"]
+
+
 def test_history_paginates_newest_first(two_user_client, db_url):
     # Add three more reads for DEFAULT_USER on the shared edition, distinct dates.
     manager = DatabaseManager(db_url)

--- a/test/unit/test_api_history.py
+++ b/test/unit/test_api_history.py
@@ -31,6 +31,8 @@ def test_get_history_empty():
         mock_query.filter.return_value = mock_query
         mock_query.options.return_value = mock_query
         mock_query.order_by.return_value = mock_query
+        mock_query.offset.return_value = mock_query
+        mock_query.limit.return_value = mock_query
         mock_query.all.return_value = []
 
         response = client.get("/history")
@@ -61,6 +63,8 @@ def test_get_history_with_data():
         mock_query.filter.return_value = mock_query
         mock_query.options.return_value = mock_query
         mock_query.order_by.return_value = mock_query
+        mock_query.offset.return_value = mock_query
+        mock_query.limit.return_value = mock_query
         mock_query.all.return_value = [mock_history]
 
         response = client.get("/history")
@@ -96,9 +100,42 @@ def test_get_history_no_date():
         mock_query.filter.return_value = mock_query
         mock_query.options.return_value = mock_query
         mock_query.order_by.return_value = mock_query
+        mock_query.offset.return_value = mock_query
+        mock_query.limit.return_value = mock_query
         mock_query.all.return_value = [mock_history]
 
         response = client.get("/history")
         assert response.status_code == 200
         data = response.json()
         assert data[0]["date_completed"] is None
+
+
+def _history_chain(mock_session, results):
+    """Wire query().join().join().filter().options().order_by().offset().limit().all()."""
+    mock_query = mock_session.query.return_value
+    mock_query.join.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.options.return_value = mock_query
+    mock_query.order_by.return_value = mock_query
+    mock_query.offset.return_value = mock_query
+    mock_query.limit.return_value = mock_query
+    mock_query.all.return_value = results
+    return mock_query
+
+
+def test_get_history_pagination_params_forwarded():
+    with patch("agentic_librarian.api.main.db_manager") as mock_db:
+        mock_session = MagicMock()
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+        mock_query = _history_chain(mock_session, [])
+
+        response = client.get("/history?limit=10&offset=20")
+        assert response.status_code == 200
+        mock_query.offset.assert_called_once_with(20)
+        mock_query.limit.assert_called_once_with(10)
+
+
+def test_get_history_limit_cap_enforced():
+    assert client.get("/history?limit=500").status_code == 422
+    assert client.get("/history?limit=0").status_code == 422
+    assert client.get("/history?offset=-1").status_code == 422

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -1,0 +1,62 @@
+"""Lift 2 Stage 4: FastAPI serves the built SPA same-origin, with an index.html fallback
+for client-side routes, real built files served as-is, API routes taking precedence, and a
+path-traversal guard on the catch-all."""
+
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api.main import app
+
+
+def _build_dist(root):
+    (root / "assets").mkdir()
+    (root / "index.html").write_text('<!doctype html><div id="root"></div>')
+    (root / "assets" / "app.js").write_text('console.log("spa")')
+    return root
+
+
+def test_root_serves_index(tmp_path, monkeypatch):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/")
+    assert r.status_code == 200
+    assert 'id="root"' in r.text
+
+
+def test_unknown_path_falls_back_to_index(tmp_path, monkeypatch):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/add")  # a client route, not a file
+    assert r.status_code == 200
+    assert 'id="root"' in r.text
+
+
+def test_real_asset_is_served(tmp_path, monkeypatch):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/assets/app.js")
+    assert r.status_code == 200
+    assert 'console.log("spa")' in r.text
+
+
+def test_api_route_wins_over_spa_catch_all(tmp_path, monkeypatch):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/health")  # unauthenticated API route
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_path_traversal_is_blocked(tmp_path, monkeypatch):
+    # Secret lives OUTSIDE the dist dir. Call the handler directly — the HTTP client would
+    # normalize the `..` away before routing, so a direct call is what exercises the guard.
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _build_dist(dist)
+    (tmp_path / "secret.txt").write_text("TOP-SECRET")
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+
+    from agentic_librarian.api.main import spa_catch_all
+
+    resp = spa_catch_all("../secret.txt")
+    # The escaped path is refused → falls back to the SPA shell (index.html), not the secret.
+    assert resp.path.endswith("index.html")

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -60,3 +60,32 @@ def test_path_traversal_is_blocked(tmp_path, monkeypatch):
     resp = spa_catch_all("../secret.txt")
     # The escaped path is refused → falls back to the SPA shell (index.html), not the secret.
     assert resp.path.endswith("index.html")
+
+
+def test_sibling_prefix_collision_is_blocked(tmp_path, monkeypatch):
+    # A sibling dir whose path shares the dist prefix (dist vs dist-secret) must NOT be
+    # reachable — this is why the guard compares against root + os.sep, not a bare prefix.
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _build_dist(dist)
+    sibling = tmp_path / "dist-secret"
+    sibling.mkdir()
+    (sibling / "leak.txt").write_text("SIBLING-SECRET")
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+
+    from agentic_librarian.api.main import spa_catch_all
+
+    resp = spa_catch_all("../dist-secret/leak.txt")
+    assert resp.path.endswith("index.html")  # refused → SPA shell, not the sibling file
+
+
+def test_absolute_path_input_is_blocked(tmp_path, monkeypatch):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _build_dist(dist)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+
+    from agentic_librarian.api.main import spa_catch_all
+
+    resp = spa_catch_all("/etc/hostname")
+    assert resp.path.endswith("index.html")


### PR DESCRIPTION
## ⚠️ HELD — do not merge until the operator rollout is done
Merging this PR's deploy **opens the Cloud Run IAM gate** (spec decision D2). Per `docs/runbooks/lift2-stage4-rollout.md`, the operator must first (gate still closed): provision Cloud Tasks queue/SA + key secrets, set the repo Variables, **back up** prod, and **apply the migration** (`c804d02d6fbb` → `30f1e46533e9`). Merging PR-B is the deliberate gate-opening act. Stacked on PR-A (#46) — merge that first.

## Summary
The **rollout-enabling** half of Lift 2 Stage 4.

- **`/history` pagination (INF-029):** backend `limit`/`offset` (mirrors `/works`) + a frontend "Load more".
- **SPA served same-origin** from FastAPI: an `index.html` fallback for client routes with a path-traversal guard; FastAPI auto-docs disabled (`docs_url/redoc_url/openapi_url=None`) so the schema isn't public once the gate opens.
- **Multi-stage `Dockerfile.api`:** a Node 22 stage compiles the Vite SPA; the Python runtime serves `/app/static`. `.dockerignore` excludes `node_modules`/`dist`.
- **`deploy.yml`:** opens the gate (`--allow-unauthenticated`), wires the prod key secrets + `ENRICH_*`/model env, `--max-instances=2`, adds a `GET /` SPA + boot-key assertion to the in-runner smoke, and a fail-fast preflight for the new Stage 4 repo Variables.
- **Provisioning scripts:** `infra/08-cloud-tasks.sh` (queue + OIDC invoker SA + grants) and `infra/09-prod-secrets.sh` (key secrets + secretAccessor); `infra/00-config.sh` vars.
- **Docs:** `security.md` open-gate boundary; the rollout runbook.

## Test plan
- [x] Backend **386 passed** (with the dummy key, the CI condition); frontend **29 passed + build + lint**.
- [x] New tests: `/history` pagination (unit + real-DB paging); SPA serving (root/fallback/asset/API-precedence/traversal/sibling-prefix/absolute-path).
- [x] Multi-stage image builds; `GET /` serves the SPA; `/health` green.
- [x] Provisioning scripts syntax-checked (`bash -n`); IAM/OIDC chain reviewed end-to-end. **Not executed** (operator-run).
- [ ] **Live verification** = the manual runbook checklist after the gate opens (operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)