### PR TITLE
fix(build): inject Firebase web config into the prod SPA build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,12 @@ jobs:
           GCP_RUN_BASE_URL: ${{ vars.GCP_RUN_BASE_URL }}
           GCP_ENRICH_INVOKER_SA: ${{ vars.GCP_ENRICH_INVOKER_SA }}
           GCP_SEARCH_ENGINE_ID: ${{ vars.GCP_SEARCH_ENGINE_ID }}
+          # Firebase WEB config — baked into the SPA at build time (gitignored .env.local isn't
+          # in CI). Client-embeddable (not secret); required or the prod SPA can't sign in.
+          VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
         run: |
           : "${GCP_WIF_PROVIDER:?set repo Variable GCP_WIF_PROVIDER (infra/05-iam-wif.sh prints it)}"
           : "${GCP_DEPLOYER_SA:?set repo Variable GCP_DEPLOYER_SA}"
@@ -63,6 +69,10 @@ jobs:
           : "${GCP_RUN_BASE_URL:?set repo Variable GCP_RUN_BASE_URL (the Cloud Run service base URL)}"
           : "${GCP_ENRICH_INVOKER_SA:?set repo Variable GCP_ENRICH_INVOKER_SA (infra/08-cloud-tasks.sh prints it)}"
           : "${GCP_SEARCH_ENGINE_ID:?set repo Variable GCP_SEARCH_ENGINE_ID (the Programmable Search Engine id)}"
+          : "${VITE_FIREBASE_API_KEY:?set repo Variable VITE_FIREBASE_API_KEY (from frontend/.env.local)}"
+          : "${VITE_FIREBASE_AUTH_DOMAIN:?set repo Variable VITE_FIREBASE_AUTH_DOMAIN (from frontend/.env.local)}"
+          : "${VITE_FIREBASE_PROJECT_ID:?set repo Variable VITE_FIREBASE_PROJECT_ID (from frontend/.env.local)}"
+          : "${VITE_FIREBASE_APP_ID:?set repo Variable VITE_FIREBASE_APP_ID (from frontend/.env.local)}"
 
       - uses: actions/checkout@v4
 
@@ -89,7 +99,13 @@ jobs:
           pytest -m "not api_dependent and not slow and not live"
 
       - name: Build production image
-        run: docker build -f Dockerfile.api -t "$IMAGE" .
+        run: |
+          docker build -f Dockerfile.api -t "$IMAGE" \
+            --build-arg VITE_FIREBASE_API_KEY="${{ vars.VITE_FIREBASE_API_KEY }}" \
+            --build-arg VITE_FIREBASE_AUTH_DOMAIN="${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}" \
+            --build-arg VITE_FIREBASE_PROJECT_ID="${{ vars.VITE_FIREBASE_PROJECT_ID }}" \
+            --build-arg VITE_FIREBASE_APP_ID="${{ vars.VITE_FIREBASE_APP_ID }}" \
+            .
 
       - name: Smoke-test image in runner (broken images never reach the registry)
         run: |

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -9,6 +9,18 @@ WORKDIR /spa
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 COPY frontend/ ./
+# Firebase WEB config is build-time (Vite inlines import.meta.env.VITE_* into the bundle).
+# It's gitignored (.env.local) so CI passes it as build args (client-embeddable, not secret;
+# enforced by Firebase authorized-domains + security rules). Placed after npm ci so the deps
+# layer stays cached when these change.
+ARG VITE_FIREBASE_API_KEY
+ARG VITE_FIREBASE_AUTH_DOMAIN
+ARG VITE_FIREBASE_PROJECT_ID
+ARG VITE_FIREBASE_APP_ID
+ENV VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY \
+    VITE_FIREBASE_AUTH_DOMAIN=$VITE_FIREBASE_AUTH_DOMAIN \
+    VITE_FIREBASE_PROJECT_ID=$VITE_FIREBASE_PROJECT_ID \
+    VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID
 RUN npm run build   # → /spa/dist
 
 # --- Stage 2: Python runtime ---

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -43,10 +43,14 @@ on the host.
    - `GCP_ENRICH_INVOKER_SA` = the invoker SA email
    - `GCP_SEARCH_ENGINE_ID` = the Programmable Search Engine id
 4. **Firebase web config for the SPA** (so the deployed app can sign in — `firebase.ts` inlines
-   these at build time, and `.env.local` isn't in CI). Add 4 more repo **Variables** from
-   `frontend/.env.local` (client-embeddable, not secret): `VITE_FIREBASE_API_KEY`,
-   `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_APP_ID`. The deploy
-   preflight requires them; the build bakes them into the bundle.
+   these at build time). Get the values from the **Firebase Console** → Project settings →
+   General → Your apps → the Web app registered in Lift 1 (§1) → SDK setup and configuration →
+   Config (`firebase apps:sdkconfig WEB --project agentic-librarian-prod` prints the same).
+   Add 4 repo **Variables** (client-embeddable, not secret): `VITE_FIREBASE_API_KEY` = `apiKey`
+   (the `AIza…` string, = Lift 1's `FIREBASE_WEB_API_KEY`), `VITE_FIREBASE_AUTH_DOMAIN` =
+   `agentic-librarian-prod.firebaseapp.com`, `VITE_FIREBASE_PROJECT_ID` = `agentic-librarian-prod`,
+   `VITE_FIREBASE_APP_ID` = `appId` (`1:…:web:…`). The deploy preflight requires them; the build
+   bakes them into the bundle.
 5. **Authorize the Cloud Run domain in Firebase** — Console → Authentication → Settings →
    Authorized domains → add the `librarian-api-…run.app` host (from `GCP_RUN_BASE_URL`, no
    scheme). Without it, browser `signInWithPopup` fails with `auth/unauthorized-domain`.

--- a/docs/runbooks/lift2-stage4-rollout.md
+++ b/docs/runbooks/lift2-stage4-rollout.md
@@ -42,6 +42,14 @@ on the host.
      and `ENRICH_OIDC_AUDIENCE` — they MUST match or every enrichment 403s)
    - `GCP_ENRICH_INVOKER_SA` = the invoker SA email
    - `GCP_SEARCH_ENGINE_ID` = the Programmable Search Engine id
+4. **Firebase web config for the SPA** (so the deployed app can sign in — `firebase.ts` inlines
+   these at build time, and `.env.local` isn't in CI). Add 4 more repo **Variables** from
+   `frontend/.env.local` (client-embeddable, not secret): `VITE_FIREBASE_API_KEY`,
+   `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_APP_ID`. The deploy
+   preflight requires them; the build bakes them into the bundle.
+5. **Authorize the Cloud Run domain in Firebase** — Console → Authentication → Settings →
+   Authorized domains → add the `librarian-api-…run.app` host (from `GCP_RUN_BASE_URL`, no
+   scheme). Without it, browser `signInWithPopup` fails with `auth/unauthorized-domain`.
 
 ## 2. Back up prod (first prod write boundary)
 - **One-time grant (first real `gcloud sql export`):** the Cloud SQL instance's own service


### PR DESCRIPTION
## Summary
Closes a gap surfaced during live verification: the deployed SPA was built **without** the Firebase web config, so Google sign-in fails (`auth/invalid-api-key`).

`frontend/src/auth/firebase.ts` reads `VITE_FIREBASE_*` at **build time** (Vite inlines `import.meta.env`), sourced from the gitignored `frontend/.env.local`. The CI Docker build runs from a fresh checkout with no `.env.local`, so the bundle was compiled with `apiKey: undefined`.

- `Dockerfile.api`: the SPA stage takes `VITE_FIREBASE_{API_KEY,AUTH_DOMAIN,PROJECT_ID,APP_ID}` as build args → ENV before `npm run build` (placed after `npm ci` so the deps layer stays cached).
- `deploy.yml`: build step passes the four `--build-arg`s from repo Variables; the preflight requires them (a deploy can't ship a sign-in-broken SPA).

Client-embeddable, not secret (Firebase web keys are public, restricted by authorized domains + security rules) → repo **Variables**, not Secrets.

## Operator steps to make this live
1. Add 4 repo **Variables** (values from `frontend/.env.local`): `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_AUTH_DOMAIN`, `VITE_FIREBASE_PROJECT_ID`, `VITE_FIREBASE_APP_ID`.
2. Firebase console → Authentication → Settings → **Authorized domains** → add the Cloud Run host (`librarian-api-…run.app`), or `signInWithPopup` returns `auth/unauthorized-domain`.
3. Merge → CD rebuilds the SPA with the config → sign-in works.

## Test plan
- [x] Verified the build arg is inlined into `dist/assets/*.js` (targeted `--target spa-build` build with a test key → key found in the bundle).
- [x] `deploy.yml` YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)