### PR TITLE
feat(chat): legible activity trail in chat (B1)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-chat-activity-trail.md
+++ b/docs/superpowers/plans/2026-06-16-chat-activity-trail.md
@@ -1,0 +1,504 @@
+# Chat Activity Trail — Implementation Plan (B1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single overwritten activity chip with a live, friendly, collapsing step trail so a chat turn shows which stage the mesh is in and never looks blank.
+
+**Architecture:** Frontend-only. The backend already streams `activity {kind, detail}`; we add a label map (rotating themed phrase pools), accumulate ordered steps per turn in `ChatView`, and render an `ActivityTrail` (live checklist + collapsed "How I found these" toggle). Live-only — finished steps ride on the in-session message, never persisted.
+
+**Tech Stack:** React 19 + TypeScript + Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-chat-activity-trail-design.md`
+
+---
+
+## Test commands (frontend, Windows host — NOT Docker)
+
+Run from `C:\dev\agentic_librarian\frontend` via the PowerShell tool:
+- Targeted test: `cd C:\dev\agentic_librarian\frontend; npx vitest run src/<path>`
+- Full suite: `cd C:\dev\agentic_librarian\frontend; npx vitest run`
+- Build (type-check): `cd C:\dev\agentic_librarian\frontend; npm run build`
+- Lint: `cd C:\dev\agentic_librarian\frontend; npm run lint`
+
+vitest-4 gotcha: use single-use `mockResolvedValueOnce`/`mockImplementationOnce` for per-test overrides. `App.test.tsx` mocks every view module — this plan adds no new view route, so no change there.
+
+## File Structure
+
+- `frontend/src/api/activityLabels.ts` (new) — themed phrase pools + `labelForActivity` + the `ActivityStep` type.
+- `frontend/src/views/ActivityTrail.tsx` (new) + `ActivityTrail.css` (new) — presentational live + completed trail.
+- `frontend/src/api/client.ts` — add optional `steps?: ActivityStep[]` to `ChatMessage`.
+- `frontend/src/views/ChatView.tsx` — step accumulator, completion handoff, render the trail (replaces the chip).
+- `frontend/src/views/ChatView.css` — drop the `.activity-chip` rule.
+- Tests: `activityLabels.test.ts`, `ActivityTrail.test.tsx`, updated `ChatView.test.tsx`.
+
+---
+
+### Task 1: `activityLabels.ts` — themed phrase pools + mapper
+
+**Files:** Create `frontend/src/api/activityLabels.ts`, `frontend/src/api/activityLabels.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `frontend/src/api/activityLabels.test.ts`
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { _STEP_LABELS, labelForActivity } from './activityLabels'
+
+describe('labelForActivity', () => {
+  it('maps an ADK tool-named specialist and a Claude agent-named one to the same pool', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0) // first phrase
+    expect(labelForActivity('tool', 'Explorer')).toEqual({ text: 'Checking the stacks', stepKind: 'stage' })
+    expect(labelForActivity('agent', 'explorer')).toEqual({ text: 'Checking the stacks', stepKind: 'stage' })
+    vi.restoreAllMocks()
+  })
+
+  it('marks slow tools as milestones, stages as stages', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    expect(labelForActivity('tool', 'enrich_and_persist_work')?.stepKind).toBe('milestone')
+    expect(labelForActivity('tool', 'Analyst')?.stepKind).toBe('stage')
+    vi.restoreAllMocks()
+  })
+
+  it('hides unmapped tool/DB calls and blanks', () => {
+    expect(labelForActivity('tool', 'search_internal_database')).toBeNull()
+    expect(labelForActivity('tool', '')).toBeNull()
+  })
+
+  it('every pool is non-empty', () => {
+    for (const v of Object.values(_STEP_LABELS)) expect(v.phrases.length).toBeGreaterThan(0)
+  })
+
+  it('picks from the pool by random index', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99) // last phrase
+    const pool = _STEP_LABELS['analyst'].phrases
+    expect(labelForActivity('tool', 'Analyst')?.text).toBe(pool[pool.length - 1])
+    vi.restoreAllMocks()
+  })
+})
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/api/activityLabels.test.ts`
+Expected: FAIL — cannot resolve `./activityLabels`.
+
+- [ ] **Step 3: Implement** `frontend/src/api/activityLabels.ts`
+
+```ts
+export type StepKind = 'stage' | 'milestone'
+
+export interface ActivityStep {
+  id: number
+  text: string
+  stepKind: StepKind
+  status: 'running' | 'done'
+}
+
+export interface ActivityLabel {
+  text: string
+  stepKind: StepKind
+}
+
+interface StepPool {
+  phrases: string[]
+  stepKind: StepKind
+}
+
+// Keyed by lower-cased activity `detail` so it covers ADK's ("tool","Explorer") and Claude's
+// ("agent","explorer") uniformly. Unmapped details are hidden. All copy is original
+// library/fantasy-themed homage (not quotations from any book).
+const STEP_LABELS: Record<string, StepPool> = {
+  analyst: {
+    stepKind: 'stage',
+    phrases: [
+      'Analyzing your tastes',
+      'Comparing tropes',
+      'Consulting the card catalog',
+      'Cross-referencing your shelves',
+      'Reading the runes of your history',
+    ],
+  },
+  explorer: {
+    stepKind: 'stage',
+    phrases: [
+      'Checking the stacks',
+      'Searching L-space',
+      'Wandering the infinite shelves',
+      'Following a trail between worlds',
+      'Off to the far reading-rooms',
+    ],
+  },
+  critic: {
+    stepKind: 'stage',
+    phrases: ['Ranking matches', 'Weighing the contenders', 'Sorting wheat from chaff', 'Judging covers and contents'],
+  },
+  librarian: {
+    stepKind: 'stage',
+    phrases: ['Ook!', 'Tending the collection', 'Consulting the Head Librarian', 'Shhh… working'],
+  },
+  get_recommendation_candidates: {
+    stepKind: 'milestone',
+    phrases: [
+      'Checking your recommendations',
+      'I think I have just the thing',
+      'Pulling a few from the back room',
+      'Dusting off some candidates',
+    ],
+  },
+  enrich_and_persist_work: {
+    stepKind: 'milestone',
+    phrases: ['Cataloging a discovery', 'Filing it under the right tropes', 'Enriching a new find'],
+  },
+}
+
+/** Map a raw (kind, detail) activity event to a display label, or null to hide it.
+ *  `kind` is accepted for symmetry with the SSE callback; classification is by `detail`. */
+export function labelForActivity(_kind: string, detail: string): ActivityLabel | null {
+  const pool = STEP_LABELS[(detail || '').toLowerCase()]
+  if (!pool) return null
+  const text = pool.phrases[Math.floor(Math.random() * pool.phrases.length)]
+  return { text, stepKind: pool.stepKind }
+}
+
+export const _STEP_LABELS = STEP_LABELS // exported for the non-empty-pool guard test
+```
+
+- [ ] **Step 4: Run it — expect pass**
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/api/activityLabels.test.ts` → PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/activityLabels.ts frontend/src/api/activityLabels.test.ts
+git commit -m "feat(chat): activityLabels - themed rotating phrase pools + mapper"
+```
+
+---
+
+### Task 2: `ActivityTrail` component (live checklist + collapsed toggle)
+
+**Files:** Create `frontend/src/views/ActivityTrail.tsx`, `frontend/src/views/ActivityTrail.css`, `frontend/src/views/ActivityTrail.test.tsx`.
+
+- [ ] **Step 1: Write the failing test** `frontend/src/views/ActivityTrail.test.tsx`
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { CompletedActivityTrail, LiveActivityTrail } from './ActivityTrail'
+import type { ActivityStep } from '../api/activityLabels'
+
+const steps: ActivityStep[] = [
+  { id: 1, text: 'Analyzing your tastes', stepKind: 'stage', status: 'done' },
+  { id: 2, text: 'Checking the stacks', stepKind: 'stage', status: 'running' },
+]
+
+describe('ActivityTrail', () => {
+  it('live trail shows every step', () => {
+    render(<LiveActivityTrail steps={steps} />)
+    expect(screen.getByText('Analyzing your tastes')).toBeInTheDocument()
+    expect(screen.getByText('Checking the stacks')).toBeInTheDocument()
+  })
+
+  it('live trail renders nothing when empty', () => {
+    const { container } = render(<LiveActivityTrail steps={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('completed trail starts collapsed, expands on click', async () => {
+    render(<CompletedActivityTrail steps={steps} />)
+    expect(screen.queryByText('Analyzing your tastes')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /how i found these \(2 steps\)/i }))
+    expect(screen.getByText('Analyzing your tastes')).toBeInTheDocument()
+  })
+
+  it('completed trail renders nothing when empty', () => {
+    const { container } = render(<CompletedActivityTrail steps={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/ActivityTrail.test.tsx` → FAIL (cannot resolve `./ActivityTrail`).
+
+- [ ] **Step 3: Implement** `frontend/src/views/ActivityTrail.tsx`
+
+```tsx
+import { useState } from 'react'
+import type { ActivityStep } from '../api/activityLabels'
+import './ActivityTrail.css'
+
+function StepRow({ step }: { step: ActivityStep }) {
+  return (
+    <div className={`trail-step ${step.stepKind}`}>
+      <span className={`trail-mark ${step.status}`} aria-hidden>
+        {step.status === 'done' ? '✓' : '⟳'}
+      </span>
+      <span className="trail-text">{step.text}</span>
+    </div>
+  )
+}
+
+/** In-flight trail: a live checklist that also serves as the pending indicator. */
+export function LiveActivityTrail({ steps }: { steps: ActivityStep[] }) {
+  if (steps.length === 0) return null
+  return (
+    <div className="activity-trail live" role="status" aria-live="polite">
+      {steps.map((s) => (
+        <StepRow key={s.id} step={s} />
+      ))}
+    </div>
+  )
+}
+
+/** Completed trail on a finished assistant message: a collapsed disclosure above the reply. */
+export function CompletedActivityTrail({ steps }: { steps: ActivityStep[] }) {
+  const [open, setOpen] = useState(false)
+  if (steps.length === 0) return null
+  return (
+    <div className="activity-trail done">
+      <button className="trail-toggle" onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+        {open ? '▾' : '▸'} How I found these ({steps.length} step{steps.length === 1 ? '' : 's'})
+      </button>
+      {open && steps.map((s) => <StepRow key={s.id} step={s} />)}
+    </div>
+  )
+}
+```
+
+`frontend/src/views/ActivityTrail.css`:
+
+```css
+.activity-trail { align-self: flex-start; display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #6b7280; }
+.activity-trail.done { margin: 2px 0; }
+.trail-step { display: flex; align-items: center; gap: 6px; }
+.trail-step.milestone .trail-text { font-style: italic; }
+.trail-mark { display: inline-block; width: 1em; text-align: center; }
+.trail-mark.running { animation: trail-spin 1s linear infinite; }
+.trail-mark.done { color: #1f6f43; }
+.trail-toggle { background: none; border: none; padding: 0; color: #6b7280; cursor: pointer; font-size: 13px; text-align: left; }
+@keyframes trail-spin { to { transform: rotate(360deg); } }
+```
+
+- [ ] **Step 4: Run it — expect pass**
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/ActivityTrail.test.tsx` → PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/views/ActivityTrail.tsx frontend/src/views/ActivityTrail.css frontend/src/views/ActivityTrail.test.tsx
+git commit -m "feat(chat): ActivityTrail - live checklist + collapsed disclosure"
+```
+
+---
+
+### Task 3: Wire the trail into `ChatView`
+
+**Files:** Modify `frontend/src/api/client.ts`, `frontend/src/views/ChatView.tsx`, `frontend/src/views/ChatView.css`, `frontend/src/views/ChatView.test.tsx`.
+
+- [ ] **Step 1: Add failing tests** — APPEND to `frontend/src/views/ChatView.test.tsx` (keep existing tests):
+
+```tsx
+  it('shows a live trail step for a mapped agent, then a collapsed trail after the reply', async () => {
+    vi.mocked(streamChat).mockImplementation(async (_msg: string, h: ChatHandlers) => {
+      h.onActivity('tool', 'Explorer') // maps to an Explorer phrase (stage)
+      h.onText('Try Dune.')
+    })
+    render(<ChatView />)
+    await screen.findByPlaceholderText(/ask the librarian/i)
+    await userEvent.type(screen.getByPlaceholderText(/ask the librarian/i), 'recommend a book')
+    await userEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => expect(screen.getByText('Try Dune.')).toBeInTheDocument())
+    // After the turn, the collapsed trail toggle is present (1 step recorded).
+    expect(screen.getByRole('button', { name: /how i found these/i })).toBeInTheDocument()
+  })
+
+  it('hides unmapped tool calls (no trail recorded)', async () => {
+    vi.mocked(streamChat).mockImplementation(async (_msg: string, h: ChatHandlers) => {
+      h.onActivity('tool', 'search_internal_database') // unmapped -> hidden
+      h.onText('Done.')
+    })
+    render(<ChatView />)
+    await screen.findByPlaceholderText(/ask the librarian/i)
+    await userEvent.type(screen.getByPlaceholderText(/ask the librarian/i), 'hi')
+    await userEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => expect(screen.getByText('Done.')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /how i found these/i })).not.toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run — expect the 2 new tests FAIL** (no toggle rendered yet)
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/ChatView.test.tsx`
+
+- [ ] **Step 3a: Extend `ChatMessage`** in `frontend/src/api/client.ts` — add the import and the optional field:
+
+At the top (with the other imports/types) ensure this import exists:
+```ts
+import type { ActivityStep } from './activityLabels'
+```
+Then in the `ChatMessage` interface add the field:
+```ts
+export interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  steps?: ActivityStep[]
+}
+```
+
+- [ ] **Step 3b: Rewrite `frontend/src/views/ChatView.tsx`** to accumulate steps and render the trail:
+
+```tsx
+import { useEffect, useRef, useState } from 'react'
+import { getCurrentConversation, newConversation, streamChat, type ChatMessage } from '../api/client'
+import { labelForActivity, type ActivityStep } from '../api/activityLabels'
+import { CompletedActivityTrail, LiveActivityTrail } from './ActivityTrail'
+import './ChatView.css'
+
+export default function ChatView() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [liveSteps, setLiveSteps] = useState<ActivityStep[]>([])
+  const [sending, setSending] = useState(false)
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const stepId = useRef(0)
+
+  useEffect(() => {
+    void getCurrentConversation().then((c) => setMessages(c.messages))
+  }, [])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView?.({ behavior: 'smooth' })
+  }, [messages, liveSteps])
+
+  async function send() {
+    const text = input.trim()
+    if (!text || sending) return
+    setInput('')
+    setSending(true)
+    setLiveSteps([])
+    stepId.current = 0
+    let steps: ActivityStep[] = []
+    // Append the user turn plus an in-flight assistant placeholder (empty content; not rendered
+    // as a bubble until text arrives — the live trail is the pending indicator).
+    setMessages((m) => [...m, { role: 'user', content: text }, { role: 'assistant', content: '' }])
+    let reply = ''
+    await streamChat(text, {
+      onActivity: (kind, detail) => {
+        const label = labelForActivity(kind, detail)
+        if (!label) return
+        const prev = steps[steps.length - 1]
+        if (prev && prev.status === 'running') {
+          if (prev.text === label.text) return // dedupe consecutive identical labels
+          steps = [
+            ...steps.slice(0, -1),
+            { ...prev, status: 'done' },
+            { id: ++stepId.current, text: label.text, stepKind: label.stepKind, status: 'running' },
+          ]
+        } else {
+          steps = [...steps, { id: ++stepId.current, text: label.text, stepKind: label.stepKind, status: 'running' }]
+        }
+        setLiveSteps(steps)
+      },
+      onText: (chunk) => {
+        reply += chunk
+        setMessages((m) => [...m.slice(0, -1), { role: 'assistant', content: reply }])
+      },
+      onError: (detail) => {
+        reply = reply || detail
+        setMessages((m) => [...m.slice(0, -1), { role: 'assistant', content: reply }])
+      },
+    })
+    // Finalize: mark the last running step done and attach the trail to the assistant message.
+    steps = steps.map((s) => (s.status === 'running' ? { ...s, status: 'done' } : s))
+    setMessages((m) => {
+      const copy = [...m]
+      const last = copy[copy.length - 1]
+      if (last && last.role === 'assistant') copy[copy.length - 1] = { ...last, steps }
+      return copy
+    })
+    setLiveSteps([])
+    setSending(false)
+  }
+
+  async function startNew() {
+    const c = await newConversation()
+    setMessages(c.messages)
+    setLiveSteps([])
+  }
+
+  return (
+    <div className="chat">
+      <div className="chat-toolbar">
+        <button onClick={() => void startNew()} disabled={sending}>New chat</button>
+      </div>
+      <div className="chat-thread">
+        {messages.map((m, i) => (
+          <div key={i} className="msg-row">
+            {m.role === 'assistant' && m.steps && m.steps.length > 0 && <CompletedActivityTrail steps={m.steps} />}
+            {(m.content || m.role === 'user') && <div className={`bubble ${m.role}`}>{m.content}</div>}
+          </div>
+        ))}
+        {sending && <LiveActivityTrail steps={liveSteps} />}
+        <div ref={bottomRef} />
+      </div>
+      <form
+        className="chat-input"
+        onSubmit={(e) => {
+          e.preventDefault()
+          void send()
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask the Librarian…"
+          aria-label="Message"
+        />
+        <button type="submit" disabled={sending}>Send</button>
+      </form>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3c: Drop the dead `.activity-chip` rule** in `frontend/src/views/ChatView.css` (remove the line `.activity-chip { ... }`). Add a tiny wrapper rule so the msg-row groups the trail with its bubble:
+```css
+.msg-row { display: flex; flex-direction: column; gap: 4px; }
+```
+
+- [ ] **Step 4: Run the full ChatView suite + the trail/label suites — expect all pass**
+
+`cd C:\dev\agentic_librarian; cd frontend; npx vitest run src/views/ChatView.test.tsx src/views/ActivityTrail.test.tsx src/api/activityLabels.test.ts`
+Expected: PASS, including the 3 PRE-EXISTING ChatView tests (resume, send-and-stream, new-chat). If "sends a message and streams activity then reply" breaks: it calls `onActivity('search','Explorer is searching')` (unmapped → hidden), then `onText('Try Dune.')` — it only asserts the reply + user message, so it must still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/views/ChatView.tsx frontend/src/views/ChatView.css frontend/src/views/ChatView.test.tsx
+git commit -m "feat(chat): render the activity trail in ChatView (replaces the chip)"
+```
+
+---
+
+### Task 4: Full frontend verification
+
+- [ ] **Step 1: Full test suite** — `cd C:\dev\agentic_librarian\frontend; npx vitest run` → all files pass.
+- [ ] **Step 2: Build (type-check)** — `cd C:\dev\agentic_librarian\frontend; npm run build` → succeeds (no TS errors; confirms `ActivityStep` import wiring across api/views).
+- [ ] **Step 3: Lint** — `cd C:\dev\agentic_librarian\frontend; npm run lint` → clean. (The `★`-free file set; ensure no unused-var lint from the renamed state.)
+- [ ] **Step 4: Finish** — use superpowers:finishing-a-development-branch (push + PR per the project's Gemini-review → squash-merge workflow).
+
+---
+
+## Self-Review
+
+**Spec coverage:** D1 granularity (stages + milestones; unmapped hidden) → `labelForActivity` map + `null` (Task 1). D2 collapsing trail + pending → `LiveActivityTrail` (doubles as pending; empty in-flight bubble suppressed) + `CompletedActivityTrail` toggle (Tasks 2–3). D3 live-only → steps attached to the in-session message; transcript-loaded messages have no `steps`, so no trail (Task 3). D4 rotating themed pools, original homage copy, random pick → Task 1. Error path → `onError` falls through to finalize which marks steps done and attaches them; no orphan spinner (Task 3). Tests cover labels, component, and ChatView integration including the hidden-unmapped and post-reply-toggle cases.
+
+**Placeholder scan:** none — every step has complete code/commands.
+
+**Type consistency:** `ActivityStep` is defined once in `activityLabels.ts` and imported by `ActivityTrail.tsx`, `client.ts` (`ChatMessage.steps`), and `ChatView.tsx`. `labelForActivity` returns `{text, stepKind} | null`, consumed in `ChatView` as `label.text`/`label.stepKind`. `LiveActivityTrail`/`CompletedActivityTrail` both take `{ steps: ActivityStep[] }`.

--- a/docs/superpowers/specs/2026-06-16-chat-activity-trail-design.md
+++ b/docs/superpowers/specs/2026-06-16-chat-activity-trail-design.md
@@ -1,0 +1,166 @@
+# Chat Activity Trail — Design (B1)
+
+**Date:** 2026-06-16
+**Status:** Approved (brainstormed), pending plan
+**Origin:** Friends-and-family beta feedback, item B1 (see project memory `beta-feedback-triage`).
+
+---
+
+## 1. Background & Problem
+
+During a chat turn the mesh can run for many seconds (Analyst → Critic → Explorer → enrichment),
+but the operator couldn't tell what was happening: the assistant bubble sat **blank**, and the only
+progress signal was a single status chip that **flickered with raw labels** ("Critic", a tool name)
+and was cleared at the end. The operator saw "Critic" but couldn't tell the Explorer ran, and a lot
+of the turn read as empty.
+
+**Root cause (confirmed in code):** the activity data already flows end-to-end — each backend calls
+`on_event(kind, detail)` (`agents/runtime.py:99-108` for ADK; `agents/backends/claude.py:_emit_block_event`
+for Claude), `chat/stream.py` relays it as an SSE `activity {kind, detail}` event, and the client
+forwards both to `onActivity(kind, detail)` (`frontend/src/api/client.ts:210`). The **frontend throws it
+away**: `ChatView` ignores `kind`, stores `detail` in a single overwritten `activity` string, and renders
+it as a transient chip while an empty assistant bubble shows for the whole run
+(`frontend/src/views/ChatView.tsx`).
+
+So B1 is a **presentation gap**, fixable almost entirely in the frontend.
+
+## 2. Goals
+
+- Show **which stage** the mesh is in, live, with friendly library-themed copy — not raw identifiers.
+- The in-flight assistant bubble must **never look blank** (a pending state).
+- Keep a **reviewable record** of the steps for a completed turn, without cluttering the thread.
+
+## 3. Non-Goals (YAGNI)
+
+- No backend / mesh changes — the events already carry everything needed.
+- No persistence of activity steps. They are ephemeral (live-streamed). Reloaded past turns show the
+  reply with no trail (unchanged from today). Persisting would need a schema change — out of scope.
+- No token-level streaming of the reply (separate future work).
+- No exhaustive trace of every tool/DB call (see granularity decision below).
+
+## 4. Decisions (from brainstorm)
+
+- **D1 — Granularity:** show **agent stages + slow tool milestones** (the ~minute enrichment, the
+  library-candidate check). Other raw tool/DB calls are hidden.
+- **D2 — Presentation:** a **collapsing step trail**. Steps accumulate as a live checklist (✓ done /
+  ⟳ running) where the empty bubble is today; once the reply arrives the trail collapses into a small
+  `▸ How I found these (N steps)` toggle above the answer. The live checklist doubles as the pending
+  indicator.
+- **D3 — Persistence:** **live-only**. The finished step list is kept on the in-session message object
+  (so its toggle works), but is not persisted; reloaded older turns have no trail.
+- **D4 — Labels:** each step maps to an **array of phrases**; the UI picks one at random each time the
+  step fires (fresh per turn). Copy is **original, library/fantasy-themed homage** (light nods such as
+  "Ook!", "L-space", "the stacks") — not quotations from any book.
+
+## 5. Architecture (frontend-only)
+
+### 5.1 `frontend/src/api/activityLabels.ts` (new)
+
+A pure module that turns a raw `(kind, detail)` event into a display step, or `null` to hide it.
+
+```
+type StepKind = "stage" | "milestone"
+interface StepLabel { phrases: string[]; stepKind: StepKind }
+
+const STEP_LABELS: Record<string, StepLabel>   // keyed by detail.toLowerCase()
+function labelForActivity(kind: string, detail: string): { text: string; stepKind: StepKind } | null
+```
+
+- Lookup is by `detail.toLowerCase()` so it covers ADK's `("tool","Explorer")` *and* Claude's
+  `("agent","explorer")` uniformly (the incoming `kind` is not needed to classify; the map carries the
+  `stepKind`).
+- `labelForActivity` returns `null` for any key not in the map (raw DB/tool calls stay hidden), and
+  otherwise returns a **randomly chosen** phrase from the pool plus its `stepKind`.
+- Starter pools (approved; freely extensible — all original homage lines):
+  - `analyst`: "Analyzing your tastes" · "Comparing tropes" · "Consulting the card catalog" ·
+    "Cross-referencing your shelves" · "Reading the runes of your history" — stage
+  - `explorer`: "Checking the stacks" · "Searching L-space" · "Wandering the infinite shelves" ·
+    "Following a trail between worlds" · "Off to the far reading-rooms" — stage
+  - `critic`: "Ranking matches" · "Weighing the contenders" · "Sorting wheat from chaff" ·
+    "Judging covers and contents" — stage
+  - `librarian`: "Ook!" · "Tending the collection" · "Consulting the Head Librarian" · "Shhh… working" — stage
+  - `get_recommendation_candidates`: "Checking your recommendations" · "I think I have just the thing" ·
+    "Pulling a few from the back room" · "Dusting off some candidates" — milestone
+  - `enrich_and_persist_work`: "Cataloging a discovery" · "Filing it under the right tropes" ·
+    "Enriching a new find" — milestone
+
+### 5.2 `ChatView` state changes
+
+Replace the single `activity` string with a per-turn step accumulator:
+
+```
+interface ActivityStep { id: number; text: string; stepKind: "stage" | "milestone"; status: "running" | "done" }
+const [liveSteps, setLiveSteps] = useState<ActivityStep[]>([])
+```
+
+- `onActivity(kind, detail)`: `const label = labelForActivity(kind, detail)`. If `null`, ignore.
+  Otherwise mark any current `running` step `done` and append the new step as `running`. **Dedupe**:
+  if the new label text equals the current running step's text, do nothing (avoid repeats from
+  multiple events of the same stage).
+- `onText` / `onError`: mark the last step `done`.
+- Turn completion: attach the finished `liveSteps` to the assistant message (see 5.3), then reset
+  `liveSteps` to `[]`.
+
+### 5.3 Local `ChatMessage` gains `steps`
+
+The frontend `ChatMessage` type gets an optional `steps?: ActivityStep[]`. When a live turn completes,
+its accumulated steps are written onto that assistant message so its collapsed toggle can render. Messages
+loaded from the transcript have no `steps` (live-only, D3).
+
+### 5.4 `ActivityTrail` component (new)
+
+- **In-flight** (passed `liveSteps`, rendered where the empty assistant bubble is): a vertical checklist
+  — each step shows ✓ when `done`, an animated ⟳ spinner when `running`. This is also the pending
+  indicator, so the bubble never looks blank.
+- **Completed** (passed a message's `steps`): a collapsed `▸ How I found these (N steps)` disclosure
+  above the reply; expanding shows the same checklist (all ✓). Milestone steps may get a subtle marker
+  but render in the same list.
+
+## 6. Data Flow
+
+```
+backend on_event(kind, detail) -> SSE activity{kind,detail} -> client onActivity(kind, detail)
+  -> ChatView: label = labelForActivity(kind, detail)
+       null            -> ignore
+       {text,stepKind} -> prior running step => done; append {text, running}; (dedupe consecutive)
+  -> onText/onError    -> last step => done
+  -> turn complete     -> assistantMessage.steps = liveSteps; liveSteps = []
+ActivityTrail renders liveSteps (live checklist + pending) and, per finished message, the collapsed toggle.
+```
+
+## 7. Error Handling
+
+- On the `error` SSE event the running step is marked `done` and the existing error message fills the
+  assistant bubble; the trail collapses normally (no false "done", no orphan spinner).
+- Client disconnect / abort mid-turn (existing behavior): the generator is cancelled; `liveSteps` is
+  reset on unmount — no spinner is left running.
+- An empty pool or unknown key never throws: unknown → `null` (hidden); pools are non-empty by
+  construction (a unit test guards this).
+
+## 8. Testing (vitest)
+
+- `activityLabels`: known keys (both `("tool","Explorer")` and `("agent","explorer")`) return a phrase
+  from the right pool with the right `stepKind`; unknown keys return `null`; every pool is non-empty;
+  random pick is stable to test by stubbing `Math.random`.
+- `ChatView`: driving an `onActivity` sequence accumulates ordered steps with running→done transitions;
+  consecutive duplicate labels dedupe; unmapped tool calls are hidden; the live checklist shows while
+  running (bubble not blank); after `onText` the trail collapses to the toggle and expands to the list;
+  the `error` path closes the trail with the error message.
+- Mind the vitest-4 `...Once` mock-leak rule and the `App.test.tsx` "mock every view" rule.
+
+## 9. Files Touched
+
+- `frontend/src/api/activityLabels.ts` (new) + test
+- `frontend/src/views/ChatView.tsx` — step accumulator, completion handoff, pending state
+- `frontend/src/views/ActivityTrail.tsx` (new) + `.css` (spinner, checklist, disclosure)
+- `frontend/src/views/ChatView.css` — minor, if needed
+- `frontend/src/api/client.ts` — add `steps?` to the local `ChatMessage` type (if the type lives there)
+- `frontend/src/views/ChatView.test.tsx`, `frontend/src/api/activityLabels.test.ts`
+
+## 10. Out of Scope / Future
+
+- Persisting activity steps so reloaded turns keep their trail (needs a schema change).
+- Token-level streaming of the reply text.
+- More themed phrases / per-agent iconography — the pools are intentionally easy to extend.
+- The other beta items: C1/C2 enrichment visibility + tropes-in-history, D1b history edit/delete,
+  E1 dark mode (separate specs).

--- a/frontend/src/api/activityLabels.test.ts
+++ b/frontend/src/api/activityLabels.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { _STEP_LABELS, labelForActivity } from './activityLabels'
+
+describe('labelForActivity', () => {
+  it('maps an ADK tool-named specialist and a Claude agent-named one to the same pool', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0) // first phrase
+    expect(labelForActivity('tool', 'Explorer')).toEqual({ text: 'Checking the stacks', stepKind: 'stage' })
+    expect(labelForActivity('agent', 'explorer')).toEqual({ text: 'Checking the stacks', stepKind: 'stage' })
+    vi.restoreAllMocks()
+  })
+
+  it('marks slow tools as milestones, stages as stages', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    expect(labelForActivity('tool', 'enrich_and_persist_work')?.stepKind).toBe('milestone')
+    expect(labelForActivity('tool', 'Analyst')?.stepKind).toBe('stage')
+    vi.restoreAllMocks()
+  })
+
+  it('hides unmapped tool/DB calls and blanks', () => {
+    expect(labelForActivity('tool', 'search_internal_database')).toBeNull()
+    expect(labelForActivity('tool', '')).toBeNull()
+  })
+
+  it('every pool is non-empty', () => {
+    for (const v of Object.values(_STEP_LABELS)) expect(v.phrases.length).toBeGreaterThan(0)
+  })
+
+  it('picks from the pool by random index', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.99) // last phrase
+    const pool = _STEP_LABELS['analyst'].phrases
+    expect(labelForActivity('tool', 'Analyst')?.text).toBe(pool[pool.length - 1])
+    vi.restoreAllMocks()
+  })
+})

--- a/frontend/src/api/activityLabels.ts
+++ b/frontend/src/api/activityLabels.ts
@@ -1,0 +1,76 @@
+export type StepKind = 'stage' | 'milestone'
+
+export interface ActivityStep {
+  id: number
+  text: string
+  stepKind: StepKind
+  status: 'running' | 'done'
+}
+
+export interface ActivityLabel {
+  text: string
+  stepKind: StepKind
+}
+
+interface StepPool {
+  phrases: string[]
+  stepKind: StepKind
+}
+
+// Keyed by lower-cased activity `detail` so it covers ADK's ("tool","Explorer") and Claude's
+// ("agent","explorer") uniformly. Unmapped details are hidden. All copy is original
+// library/fantasy-themed homage (not quotations from any book).
+const STEP_LABELS: Record<string, StepPool> = {
+  analyst: {
+    stepKind: 'stage',
+    phrases: [
+      'Analyzing your tastes',
+      'Comparing tropes',
+      'Consulting the card catalog',
+      'Cross-referencing your shelves',
+      'Reading the runes of your history',
+    ],
+  },
+  explorer: {
+    stepKind: 'stage',
+    phrases: [
+      'Checking the stacks',
+      'Searching L-space',
+      'Wandering the infinite shelves',
+      'Following a trail between worlds',
+      'Off to the far reading-rooms',
+    ],
+  },
+  critic: {
+    stepKind: 'stage',
+    phrases: ['Ranking matches', 'Weighing the contenders', 'Sorting wheat from chaff', 'Judging covers and contents'],
+  },
+  librarian: {
+    stepKind: 'stage',
+    phrases: ['Ook!', 'Tending the collection', 'Consulting the Head Librarian', 'Shhh… working'],
+  },
+  get_recommendation_candidates: {
+    stepKind: 'milestone',
+    phrases: [
+      'Checking your recommendations',
+      'I think I have just the thing',
+      'Pulling a few from the back room',
+      'Dusting off some candidates',
+    ],
+  },
+  enrich_and_persist_work: {
+    stepKind: 'milestone',
+    phrases: ['Cataloging a discovery', 'Filing it under the right tropes', 'Enriching a new find'],
+  },
+}
+
+/** Map a raw (kind, detail) activity event to a display label, or null to hide it.
+ *  `kind` is accepted for symmetry with the SSE callback; classification is by `detail`. */
+export function labelForActivity(_kind: string, detail: string): ActivityLabel | null {
+  const pool = STEP_LABELS[(detail || '').toLowerCase()]
+  if (!pool) return null
+  const text = pool.phrases[Math.floor(Math.random() * pool.phrases.length)]
+  return { text, stepKind: pool.stepKind }
+}
+
+export const _STEP_LABELS = STEP_LABELS // exported for the non-empty-pool guard test

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { getIdToken } from '../auth/firebase'
+import type { ActivityStep } from './activityLabels'
 
 export interface HistoryItem {
   id: string
@@ -46,6 +47,7 @@ export interface Analysis {
 export interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
+  steps?: ActivityStep[]
 }
 
 export interface Conversation {

--- a/frontend/src/views/ActivityTrail.css
+++ b/frontend/src/views/ActivityTrail.css
@@ -1,0 +1,9 @@
+.activity-trail { align-self: flex-start; display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #6b7280; }
+.activity-trail.done { margin: 2px 0; }
+.trail-step { display: flex; align-items: center; gap: 6px; }
+.trail-step.milestone .trail-text { font-style: italic; }
+.trail-mark { display: inline-block; width: 1em; text-align: center; }
+.trail-mark.running { animation: trail-spin 1s linear infinite; }
+.trail-mark.done { color: #1f6f43; }
+.trail-toggle { background: none; border: none; padding: 0; color: #6b7280; cursor: pointer; font-size: 13px; text-align: left; }
+@keyframes trail-spin { to { transform: rotate(360deg); } }

--- a/frontend/src/views/ActivityTrail.test.tsx
+++ b/frontend/src/views/ActivityTrail.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { CompletedActivityTrail, LiveActivityTrail } from './ActivityTrail'
+import type { ActivityStep } from '../api/activityLabels'
+
+const steps: ActivityStep[] = [
+  { id: 1, text: 'Analyzing your tastes', stepKind: 'stage', status: 'done' },
+  { id: 2, text: 'Checking the stacks', stepKind: 'stage', status: 'running' },
+]
+
+describe('ActivityTrail', () => {
+  it('live trail shows every step', () => {
+    render(<LiveActivityTrail steps={steps} />)
+    expect(screen.getByText('Analyzing your tastes')).toBeInTheDocument()
+    expect(screen.getByText('Checking the stacks')).toBeInTheDocument()
+  })
+
+  it('live trail renders nothing when empty', () => {
+    const { container } = render(<LiveActivityTrail steps={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('completed trail starts collapsed, expands on click', async () => {
+    render(<CompletedActivityTrail steps={steps} />)
+    expect(screen.queryByText('Analyzing your tastes')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /how i found these \(2 steps\)/i }))
+    expect(screen.getByText('Analyzing your tastes')).toBeInTheDocument()
+  })
+
+  it('completed trail renders nothing when empty', () => {
+    const { container } = render(<CompletedActivityTrail steps={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/views/ActivityTrail.tsx
+++ b/frontend/src/views/ActivityTrail.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import type { ActivityStep } from '../api/activityLabels'
+import './ActivityTrail.css'
+
+function StepRow({ step }: { step: ActivityStep }) {
+  return (
+    <div className={`trail-step ${step.stepKind}`}>
+      <span className={`trail-mark ${step.status}`} aria-hidden>
+        {step.status === 'done' ? '✓' : '⟳'}
+      </span>
+      <span className="trail-text">{step.text}</span>
+    </div>
+  )
+}
+
+/** In-flight trail: a live checklist that also serves as the pending indicator. */
+export function LiveActivityTrail({ steps }: { steps: ActivityStep[] }) {
+  if (steps.length === 0) return null
+  return (
+    <div className="activity-trail live" role="status" aria-live="polite">
+      {steps.map((s) => (
+        <StepRow key={s.id} step={s} />
+      ))}
+    </div>
+  )
+}
+
+/** Completed trail on a finished assistant message: a collapsed disclosure above the reply. */
+export function CompletedActivityTrail({ steps }: { steps: ActivityStep[] }) {
+  const [open, setOpen] = useState(false)
+  if (steps.length === 0) return null
+  return (
+    <div className="activity-trail done">
+      <button className="trail-toggle" onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+        {open ? '▾' : '▸'} How I found these ({steps.length} step{steps.length === 1 ? '' : 's'})
+      </button>
+      {open && steps.map((s) => <StepRow key={s.id} step={s} />)}
+    </div>
+  )
+}

--- a/frontend/src/views/ChatView.css
+++ b/frontend/src/views/ChatView.css
@@ -5,7 +5,7 @@
 .bubble { padding: 10px 14px; border-radius: 14px; max-width: 80%; white-space: pre-wrap; }
 .bubble.user { align-self: flex-end; background: #6366f1; color: #fff; }
 .bubble.assistant { align-self: flex-start; background: #f3f4f6; color: #111827; }
-.activity-chip { align-self: flex-start; font-size: 13px; color: #6b7280; font-style: italic; }
+.msg-row { display: flex; flex-direction: column; gap: 4px; }
 .chat-input { display: flex; gap: 8px; position: sticky; bottom: 0; background: #fff; padding-top: 8px; }
 .chat-input input { flex: 1; padding: 10px 12px; border: 1px solid #d1d5db; border-radius: 8px; }
 .chat-input button { padding: 10px 16px; border: none; border-radius: 8px; background: #111827; color: #fff; }

--- a/frontend/src/views/ChatView.test.tsx
+++ b/frontend/src/views/ChatView.test.tsx
@@ -86,4 +86,21 @@ describe('ChatView', () => {
     await waitFor(() => expect(screen.getByText('Done.')).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: /how i found these/i })).not.toBeInTheDocument()
   })
+
+  it('dedupes consecutive same-stage events into one step (random phrase per call)', async () => {
+    vi.mocked(streamChat).mockImplementation(async (_msg: string, h: ChatHandlers) => {
+      // Two Explorer events: phrases are random per call, so dedupe must key on the detail,
+      // not the phrase text — otherwise these collapse to two steps.
+      h.onActivity('tool', 'Explorer')
+      h.onActivity('tool', 'Explorer')
+      h.onText('Try Dune.')
+    })
+    render(<ChatView />)
+    await screen.findByPlaceholderText(/ask the librarian/i)
+    await userEvent.type(screen.getByPlaceholderText(/ask the librarian/i), 'recommend a book')
+    await userEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => expect(screen.getByText('Try Dune.')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /how i found these \(1 step\)/i })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/views/ChatView.test.tsx
+++ b/frontend/src/views/ChatView.test.tsx
@@ -58,4 +58,32 @@ describe('ChatView', () => {
     await waitFor(() => expect(screen.queryByText('old thread')).not.toBeInTheDocument())
     expect(vi.mocked(newConversation)).toHaveBeenCalled()
   })
+
+  it('shows a live trail step for a mapped agent, then a collapsed trail after the reply', async () => {
+    vi.mocked(streamChat).mockImplementation(async (_msg: string, h: ChatHandlers) => {
+      h.onActivity('tool', 'Explorer') // maps to an Explorer phrase (stage)
+      h.onText('Try Dune.')
+    })
+    render(<ChatView />)
+    await screen.findByPlaceholderText(/ask the librarian/i)
+    await userEvent.type(screen.getByPlaceholderText(/ask the librarian/i), 'recommend a book')
+    await userEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => expect(screen.getByText('Try Dune.')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /how i found these/i })).toBeInTheDocument()
+  })
+
+  it('hides unmapped tool calls (no trail recorded)', async () => {
+    vi.mocked(streamChat).mockImplementation(async (_msg: string, h: ChatHandlers) => {
+      h.onActivity('tool', 'search_internal_database') // unmapped -> hidden
+      h.onText('Done.')
+    })
+    render(<ChatView />)
+    await screen.findByPlaceholderText(/ask the librarian/i)
+    await userEvent.type(screen.getByPlaceholderText(/ask the librarian/i), 'hi')
+    await userEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    await waitFor(() => expect(screen.getByText('Done.')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /how i found these/i })).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
 import { getCurrentConversation, newConversation, streamChat, type ChatMessage } from '../api/client'
+import { labelForActivity, type ActivityStep } from '../api/activityLabels'
+import { CompletedActivityTrail, LiveActivityTrail } from './ActivityTrail'
 import './ChatView.css'
 
 export default function ChatView() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
-  const [activity, setActivity] = useState<string | null>(null)
+  const [liveSteps, setLiveSteps] = useState<ActivityStep[]>([])
   const [sending, setSending] = useState(false)
   const bottomRef = useRef<HTMLDivElement>(null)
+  const stepId = useRef(0)
 
   useEffect(() => {
     void getCurrentConversation().then((c) => setMessages(c.messages))
@@ -15,19 +18,37 @@ export default function ChatView() {
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView?.({ behavior: 'smooth' })
-  }, [messages, activity])
+  }, [messages, liveSteps])
 
   async function send() {
     const text = input.trim()
     if (!text || sending) return
     setInput('')
     setSending(true)
-    setActivity(null)
-    // Append the user turn plus an empty assistant bubble we fill in as text streams in.
+    setLiveSteps([])
+    stepId.current = 0
+    let steps: ActivityStep[] = []
+    // Append the user turn plus an in-flight assistant placeholder (empty content; not rendered
+    // as a bubble until text arrives — the live trail is the pending indicator).
     setMessages((m) => [...m, { role: 'user', content: text }, { role: 'assistant', content: '' }])
     let reply = ''
     await streamChat(text, {
-      onActivity: (_kind, detail) => setActivity(detail),
+      onActivity: (kind, detail) => {
+        const label = labelForActivity(kind, detail)
+        if (!label) return
+        const prev = steps[steps.length - 1]
+        if (prev && prev.status === 'running') {
+          if (prev.text === label.text) return // dedupe consecutive identical labels
+          steps = [
+            ...steps.slice(0, -1),
+            { ...prev, status: 'done' },
+            { id: ++stepId.current, text: label.text, stepKind: label.stepKind, status: 'running' },
+          ]
+        } else {
+          steps = [...steps, { id: ++stepId.current, text: label.text, stepKind: label.stepKind, status: 'running' }]
+        }
+        setLiveSteps(steps)
+      },
       onText: (chunk) => {
         reply += chunk
         setMessages((m) => [...m.slice(0, -1), { role: 'assistant', content: reply }])
@@ -37,14 +58,22 @@ export default function ChatView() {
         setMessages((m) => [...m.slice(0, -1), { role: 'assistant', content: reply }])
       },
     })
-    setActivity(null)
+    // Finalize: mark the last running step done and attach the trail to the assistant message.
+    steps = steps.map((s) => (s.status === 'running' ? { ...s, status: 'done' } : s))
+    setMessages((m) => {
+      const copy = [...m]
+      const last = copy[copy.length - 1]
+      if (last && last.role === 'assistant') copy[copy.length - 1] = { ...last, steps }
+      return copy
+    })
+    setLiveSteps([])
     setSending(false)
   }
 
   async function startNew() {
     const c = await newConversation()
     setMessages(c.messages)
-    setActivity(null)
+    setLiveSteps([])
   }
 
   return (
@@ -54,9 +83,12 @@ export default function ChatView() {
       </div>
       <div className="chat-thread">
         {messages.map((m, i) => (
-          <div key={i} className={`bubble ${m.role}`}>{m.content}</div>
+          <div key={i} className="msg-row">
+            {m.role === 'assistant' && m.steps && m.steps.length > 0 && <CompletedActivityTrail steps={m.steps} />}
+            {(m.content || m.role === 'user') && <div className={`bubble ${m.role}`}>{m.content}</div>}
+          </div>
         ))}
-        {activity && <div className="activity-chip">{activity}…</div>}
+        {sending && <LiveActivityTrail steps={liveSteps} />}
         <div ref={bottomRef} />
       </div>
       <form

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -28,6 +28,7 @@ export default function ChatView() {
     setLiveSteps([])
     stepId.current = 0
     let steps: ActivityStep[] = []
+    let lastDetail = ''
     // Append the user turn plus an in-flight assistant placeholder (empty content; not rendered
     // as a bubble until text arrives — the live trail is the pending indicator).
     setMessages((m) => [...m, { role: 'user', content: text }, { role: 'assistant', content: '' }])
@@ -36,9 +37,13 @@ export default function ChatView() {
       onActivity: (kind, detail) => {
         const label = labelForActivity(kind, detail)
         if (!label) return
+        // Dedupe on the stable detail key, NOT the phrase: labelForActivity picks a random
+        // phrase each call, so consecutive same-stage events would otherwise read as distinct.
+        const normalizedDetail = (detail || '').toLowerCase()
+        if (normalizedDetail === lastDetail) return
+        lastDetail = normalizedDetail
         const prev = steps[steps.length - 1]
         if (prev && prev.status === 'running') {
-          if (prev.text === label.text) return // dedupe consecutive identical labels
           steps = [
             ...steps.slice(0, -1),
             { ...prev, status: 'done' },


### PR DESCRIPTION
Implements beta-feedback item **B1** — the chat turn no longer sits blank with a flickering raw-label chip. Spec/plan: `docs/superpowers/{specs,plans}/2026-06-16-chat-activity-trail*`.

## Root cause
The backend already streams `activity {kind, detail}` (SSE → `onActivity`), but `ChatView` ignored `kind`, stored `detail` in a single overwritten string, and showed an empty assistant bubble for the whole multi-second mesh run. Purely a presentation gap.

## Change (frontend-only)
- **`activityLabels.ts`** — maps an activity event to a friendly, rotating themed phrase (keyed by lower-cased `detail`, so it covers ADK's `("tool","Explorer")` and Claude's `("agent","explorer")`); unmapped tool/DB calls return `null` and are hidden. Shows agent stages + the slow milestones (enrichment, library check). Copy is original library-themed homage.
- **`ActivityTrail.tsx`** — `LiveActivityTrail` (a checklist that doubles as the pending indicator, so the bubble never looks blank) and `CompletedActivityTrail` (a collapsed `▸ How I found these (N steps)` toggle above the reply).
- **`ChatView`** accumulates ordered steps per turn (running→done, consecutive-dupe dedupe), attaches them to the in-session assistant message on completion, and replaces the old chip.

## Scope
**Live-only** by design: steps are ephemeral (never persisted), so reloaded older conversations show the reply with no trail — avoids a schema change. No backend/mesh changes; no new view route.

## Tests
TDD throughout: label mapping (both backends' event shapes, milestone vs stage, hidden unmapped, non-empty pools, random pick), the trail component (live render, collapse/expand, empty cases), and ChatView integration (live step → collapsed toggle after reply; unmapped calls record no trail; the 3 pre-existing tests still pass). Full frontend suite 41 passed + build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)