### PR TITLE
feat(history): enrichment visibility + tropes in History (C1/C2)

### DIFF
--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -12,6 +12,12 @@ This file tracks work history and ticket references.
 
 ## Log
 
+### 2026-06-16 - DEBT-035: Detect stuck/failed background enrichment
+- **Status**: Open (deferred from C1/C2 enrichment-visibility by decision)
+- **Description**: Enrichment status is DERIVED from trope presence (no enriched_at/status column), so a deep pass that failed, found no tropes, or whose Cloud Task never fired is indistinguishable from one still in flight — History shows "Enriching…" indefinitely.
+- **URL**: spec `docs/superpowers/specs/2026-06-16-enrichment-visibility-design.md` (D5)
+- **Notes**: Future fix needs a creation/enqueue timestamp (Work has no created_at) + a timeout sweep or explicit status to flag long-pending works as failed/retryable; pairs with a retry action alongside D1b (history edit/delete).
+
 ### 2026-01-27 - MEM-001: Initialize Project Memory
 - **Status**: Completed
 - **Description**: Setting up `docs/project_notes/` and memory protocols.

--- a/docs/superpowers/plans/2026-06-16-enrichment-visibility.md
+++ b/docs/superpowers/plans/2026-06-16-enrichment-visibility.md
@@ -1,0 +1,294 @@
+# Enrichment Visibility + Tropes in History — Implementation Plan (C1/C2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show each History row's genre + top tropes once its deep enrichment lands (and an "Enriching…" state until then), and set the expectation on the add screen that enrichment runs in the background.
+
+**Architecture:** Derive enrichment status from trope presence (no DB migration). Backend adds `genre` + top-3 `tropes` to the `/history` payload; the frontend renders chips or an "Enriching…" indicator; `AddBookView` shows a static expectation message after a successful add.
+
+**Tech Stack:** FastAPI + SQLAlchemy (backend), React 19 + TypeScript + Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-enrichment-visibility-design.md`
+
+---
+
+## Test commands
+
+Run via the **PowerShell tool**.
+- **Backend integration** (needs the compose DB):
+  `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest <path> -q`
+- **Frontend** (Windows host, from `C:\dev\agentic_librarian\frontend`): `cd C:\dev\agentic_librarian\frontend; npx vitest run <path>` ; `npm run build` ; `npm run lint`
+
+vitest-4: use `mockResolvedValueOnce` for per-test returns. `App.test.tsx` already mocks both views (no new route added).
+
+## File Structure
+
+- `src/agentic_librarian/api/main.py` — `/history` eager-load + payload (`genre`, `tropes`).
+- `docs/project_notes/issues.md` — append DEBT-035.
+- `frontend/src/api/client.ts` — `HistoryItem` gains `genre?`, `tropes?`.
+- `frontend/src/views/HistoryView.tsx` (+ `.css`) — genre/trope chips + "Enriching…".
+- `frontend/src/views/AddBookView.tsx` — success expectation message.
+- Tests: `test/integration/test_api_history_db.py` (extend), `frontend/src/views/HistoryView.test.tsx`, `frontend/src/views/AddBookView.test.tsx`.
+
+---
+
+### Task 1: `/history` payload — genre + top-3 tropes (+ DEBT-035)
+
+**Files:** Modify `src/agentic_librarian/api/main.py`, `docs/project_notes/issues.md`; Test `test/integration/test_api_history_db.py`.
+
+`main.py` already imports `selectinload`, `joinedload`, `WorkTrope`, `Work`, `Edition`, `ReadingHistory`, `WorkContributor` — no new imports needed (`wt.trope.name` is reached via the relationship).
+
+- [ ] **Step 1: Write the failing integration tests** — APPEND to `test/integration/test_api_history_db.py` (it already has `pytestmark = pytest.mark.db_integration`, the `two_user_client` fixture, `DEFAULT_USER_ID`, `AuthorModel`, `Edition`, `ReadingHistory`, `Work`, `WorkContributor`, `DatabaseManager`, `date`):
+
+```python
+def test_history_includes_genre_and_top_three_tropes(two_user_client, db_url):
+    from agentic_librarian.db.models import Trope, WorkTrope
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = AuthorModel(name="Trope Author")
+        work = Work(
+            title="Tropey Book",
+            genres=["Fantasy", "Adventure"],
+            contributors=[WorkContributor(author=author, role="Author")],
+        )
+        edition = Edition(work=work, format="ebook")
+        session.add_all([author, work, edition])
+        session.flush()
+        # 4 tropes at varying relevance; only the top 3 by score surface, score-desc.
+        for name, score in [("Heist", 0.90), ("Found Family", 0.95), ("Antihero", 0.99), ("Low Score", 0.10)]:
+            trope = Trope(name=name)
+            session.add(trope)
+            session.flush()
+            session.add(WorkTrope(work_id=work.id, trope_id=trope.id, relevance_score=score))
+        session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2026, 1, 2)))
+        session.flush()
+
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    row = next(r for r in rows if r["title"] == "Tropey Book")
+    assert row["genre"] == "Fantasy"
+    assert row["tropes"] == ["Antihero", "Found Family", "Heist"]  # top 3, score desc; "Low Score" dropped
+
+
+def test_history_no_tropes_returns_empty_list(two_user_client):
+    # The fixture's "Shared Book" has no tropes/genres -> drives the "Enriching…" UI state.
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    shared = next(r for r in rows if r["title"] == "Shared Book")
+    assert shared["tropes"] == []
+    assert shared["genre"] is None
+```
+
+- [ ] **Step 2: Run — expect failure** (`KeyError: 'genre'`)
+
+`docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest test/integration/test_api_history_db.py -q`
+
+- [ ] **Step 3: Implement.** In `get_history` (`main.py`), extend the `.options(...)` with a second
+chain that shares the `edition→work` join strategy and diverges only at the trope collection
+(`selectinload` so the to-many doesn't cartesian-multiply rows):
+
+```python
+            .options(
+                joinedload(ReadingHistory.edition)
+                .joinedload(Edition.work)
+                .joinedload(Work.contributors)
+                .joinedload(WorkContributor.author),
+                joinedload(ReadingHistory.edition)
+                .joinedload(Edition.work)
+                .selectinload(Work.tropes)
+                .joinedload(WorkTrope.trope),
+            )
+```
+
+Then in the return list comprehension, compute the top tropes + genre per row and add the two keys:
+
+```python
+        def _genre_and_tropes(work):
+            top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
+            return (work.genres[0] if work.genres else None, [wt.trope.name for wt in top])
+
+        result = []
+        for h in history_entries:
+            genre, tropes = _genre_and_tropes(h.edition.work)
+            result.append(
+                {
+                    "id": str(h.id),
+                    "title": h.edition.work.title,
+                    "authors": [c.author.name for c in h.edition.work.contributors if c.role == "Author"],
+                    "date_completed": h.date_completed.isoformat() if h.date_completed else None,
+                    "rating": h.user_rating,
+                    "format": h.edition.format,
+                    "genre": genre,
+                    "tropes": tropes,
+                }
+            )
+        return result
+```
+(Replace the existing `return [ ... ]` comprehension with this loop form.)
+
+- [ ] **Step 4: Append DEBT-035** to `docs/project_notes/issues.md` (under the `## Log` section, newest first — place it above the most recent dated entry):
+
+```markdown
+### 2026-06-16 - DEBT-035: Detect stuck/failed background enrichment
+- **Status**: Open (deferred from C1/C2 enrichment-visibility by decision)
+- **Description**: Enrichment status is DERIVED from trope presence (no enriched_at/status column), so a deep pass that failed, found no tropes, or whose Cloud Task never fired is indistinguishable from one still in flight — History shows "Enriching…" indefinitely.
+- **URL**: spec `docs/superpowers/specs/2026-06-16-enrichment-visibility-design.md` (D5)
+- **Notes**: Future fix needs a creation/enqueue timestamp (Work has no created_at) + a timeout sweep or explicit status to flag long-pending works as failed/retryable; pairs with a retry action alongside D1b (history edit/delete).
+```
+
+- [ ] **Step 5: Run — expect pass** (both new tests + the existing history tests). Command from Step 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/api/main.py test/integration/test_api_history_db.py docs/project_notes/issues.md
+git commit -m "feat(history): genre + top-3 tropes in /history payload (derive-only status); log DEBT-035"
+```
+
+---
+
+### Task 2: HistoryView — genre/trope chips + "Enriching…"
+
+**Files:** Modify `frontend/src/api/client.ts`, `frontend/src/views/HistoryView.tsx`, `frontend/src/views/HistoryView.css`, `frontend/src/views/HistoryView.test.tsx`.
+
+- [ ] **Step 1: Add failing tests** — APPEND to `frontend/src/views/HistoryView.test.tsx` (it mocks `../api/client` and `../auth/firebase`; `client`, `render`, `screen`, `userEvent`, `vi` already imported):
+
+```tsx
+  it('renders genre + trope chips when a row has tropes', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([
+      {
+        id: 'x', title: 'Tropey', authors: ['A'], date_completed: '2024-01-01', rating: 4, format: 'ebook',
+        genre: 'Fantasy', tropes: ['Found Family', 'Antihero', 'Heist'],
+      },
+    ])
+    render(<HistoryView />)
+    expect(await screen.findByText('Tropey')).toBeInTheDocument()
+    expect(screen.getByText('Fantasy')).toBeInTheDocument()
+    expect(screen.getByText('Found Family')).toBeInTheDocument()
+    expect(screen.queryByText(/Enriching/)).not.toBeInTheDocument()
+  })
+
+  it('renders an Enriching… chip when a row has no tropes', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([
+      {
+        id: 'y', title: 'Fresh', authors: ['B'], date_completed: '2024-01-01', rating: null, format: 'ebook',
+        genre: null, tropes: [],
+      },
+    ])
+    render(<HistoryView />)
+    expect(await screen.findByText('Fresh')).toBeInTheDocument()
+    expect(screen.getByText(/Enriching/)).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run — expect the 2 new tests FAIL** (no chips/Enriching rendered; possibly TS error on `genre`/`tropes`).
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/HistoryView.test.tsx`
+
+- [ ] **Step 3a: Extend `HistoryItem`** in `frontend/src/api/client.ts`:
+
+```ts
+export interface HistoryItem {
+  id: string
+  title: string
+  authors: string[]
+  date_completed: string | null
+  rating: number | null
+  format: string | null
+  genre?: string | null
+  tropes?: string[]
+}
+```
+
+- [ ] **Step 3b: Render the trope line** in `frontend/src/views/HistoryView.tsx` — add a block inside the `<li>`, after the `history-meta` div:
+
+```tsx
+            <div className="history-tropes">
+              {h.tropes && h.tropes.length > 0 ? (
+                <>
+                  {h.genre && <span className="trope-chip genre">{h.genre}</span>}
+                  {h.tropes.map((t) => (
+                    <span key={t} className="trope-chip">{t}</span>
+                  ))}
+                </>
+              ) : (
+                <span className="trope-chip enriching">Enriching…</span>
+              )}
+            </div>
+```
+
+- [ ] **Step 3c: Chip styles** — append to `frontend/src/views/HistoryView.css`:
+
+```css
+.history-tropes { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.trope-chip { font-size: 12px; padding: 2px 8px; border-radius: 10px; background: #eef2ff; color: #3730a3; }
+.trope-chip.genre { background: #e0e7ff; font-weight: 600; }
+.trope-chip.enriching { background: transparent; color: #6b7280; font-style: italic; padding-left: 0; }
+```
+
+- [ ] **Step 4: Run — expect pass** (new + the 2 pre-existing pagination tests; the pagination `item()` helper omits `genre`/`tropes`, so those rows render "Enriching…", which doesn't affect the title assertions).
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/HistoryView.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/views/HistoryView.tsx frontend/src/views/HistoryView.css frontend/src/views/HistoryView.test.tsx
+git commit -m "feat(history): genre + trope chips, Enriching… state per row"
+```
+
+---
+
+### Task 3: AddBookView — background-enrichment expectation message
+
+**Files:** Modify `frontend/src/views/AddBookView.tsx`, `frontend/src/views/AddBookView.test.tsx`.
+
+- [ ] **Step 1: Read `AddBookView.test.tsx`** to find the existing success-path assertion (it asserts the old `Added "<title>" to your history.` copy). Update that assertion to match the new copy AND add an explicit check for the enrichment message. The success test should assert text matching `/Enriching in the background/i`.
+
+Concretely, change the existing success assertion to:
+```tsx
+    expect(await screen.findByText(/Enriching in the background/i)).toBeInTheDocument()
+```
+(Keep the rest of that test — the mocked `addBook` resolving, the form fill, the submit — as-is.)
+
+- [ ] **Step 2: Run — expect failure** (old copy gone / new copy not present yet).
+
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/AddBookView.test.tsx`
+
+- [ ] **Step 3: Update the success message** in `frontend/src/views/AddBookView.tsx` — replace:
+```tsx
+      setDone(`Added "${result.title}" to your history.`)
+```
+with:
+```tsx
+      setDone(
+        `Added "${result.title}"! Enriching in the background (~a minute) — its tropes will appear in your History.`,
+      )
+```
+
+- [ ] **Step 4: Run — expect pass.** Command from Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/views/AddBookView.tsx frontend/src/views/AddBookView.test.tsx
+git commit -m "feat(add-book): set background-enrichment expectation on success"
+```
+
+---
+
+### Task 4: Full verification + finish
+
+- [ ] **Step 1: Backend integration suite** — `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest test/integration -m "not api_dependent" -q` → pass.
+- [ ] **Step 2: Frontend** — `cd C:\dev\agentic_librarian\frontend; npx vitest run` ; `npm run build` ; `npm run lint` → all green.
+- [ ] **Step 3: Lint parity (backend)** — keep added lines ≤120 cols; if a clean `python:3.11-slim` + `pip install ruff==0.15.16` is available, run `ruff format`/`ruff check` on `src/agentic_librarian/api/main.py` and the test file (ruff isn't in the runtime image); else rely on CI ruff-format.
+- [ ] **Step 4: Finish** — use superpowers:finishing-a-development-branch (push + PR; Gemini review → squash-merge).
+
+---
+
+## Self-Review
+
+**Spec coverage:** D1 derive-from-tropes (no migration) → `/history` returns `tropes`; empty list when none (Task 1) → frontend "Enriching…" (Task 2). D2 add-flow expectation message (Task 3). D3 genre + top-3 tropes by `relevance_score`, "Enriching…" when none, genre not shown alone (Task 2 conditional). D4 no polling (nothing added). D5 DEBT-035 logged (Task 1 Step 4). Tests: backend top-3 ordering + empty-list; frontend chips vs Enriching; add-book message.
+
+**Placeholder scan:** none — full code/commands per step. The success copy is finalized in Task 3.
+
+**Type consistency:** `HistoryItem.genre?: string | null` / `tropes?: string[]` (client) match the `/history` keys `genre` (str|None) / `tropes` (list[str]) from Task 1, and the `HistoryView` render guards on `h.tropes?.length`. The eager-load shares the `edition→work` joinedload prefix in both option chains (avoids the mixed-strategy conflict), diverging to `selectinload` only for the trope to-many.

--- a/docs/superpowers/specs/2026-06-16-enrichment-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-16-enrichment-visibility-design.md
@@ -1,0 +1,143 @@
+# Enrichment Visibility + Tropes in History — Design (C1/C2)
+
+**Date:** 2026-06-16
+**Status:** Approved (brainstormed), pending plan
+**Origin:** Friends-and-family beta feedback, items C1 + C2 (see project memory `beta-feedback-triage`).
+
+---
+
+## 1. Background & Problem
+
+Adding a book runs **two-phase enrichment**: `POST /books` does the fast API-scout pass (seconds —
+persists the Work + genres/description, logs the read) and enqueues a Cloud Task for the slow LLM
+**deep pass** (`enrich_deep`), which adds tropes/styles ~1–2 minutes later. The operator reported two
+gaps:
+
+- **C1:** after adding a book, there's no signal that the background enrichment finished or succeeded —
+  `POST /books` only returns `enrichment_enqueued` ("task queued").
+- **C2:** the History tab shows title/authors/date/rating/format but **no tropes**, so there's nothing
+  that reveals whether enrichment landed.
+
+The operator's own framing ties them together: showing tropes in History *is* the "enrichment
+succeeded" signal.
+
+**Code reality (confirmed):** there is no enrichment status/timestamp on `Work` (fields: title, year,
+description, genres, moods) and no `created_at`. Tropes attach via `WorkTrope`, which carries a
+**`relevance_score`** (Float) — so "top tropes" is a clean ordered query. The fast pass writes genres
+but **no tropes**; tropes appear only after the deep pass. `/history` (`api/main.py`) currently eager-loads
+contributors only.
+
+## 2. Goals
+
+- **C1:** History clearly distinguishes a book whose deep enrichment has landed from one still working,
+  and the add screen sets the expectation that enrichment runs in the background.
+- **C2:** Each History row shows a genre + its top tropes once enriched.
+
+## 3. Non-Goals (YAGNI)
+
+- **No DB migration / new columns.** Status is derived from trope presence.
+- No add-screen polling or per-work status endpoint (the add flow uses a static expectation message).
+- No live polling/refresh of the History view (it reflects state at load).
+- No distinct "failed" state or retry action (see Decisions / debt).
+
+## 4. Decisions (from brainstorm)
+
+- **D1 — C1 status is DERIVED:** a work is "enriched" iff it has ≥1 trope. No schema change, no
+  backfill; existing books are correct automatically.
+- **D2 — Add-flow signal is a static expectation message** in `AddBookView` after a successful add.
+- **D3 — History trope line:** if the work has tropes → **genre + top 3 tropes** (by
+  `relevance_score` desc); if it has **no tropes → an "Enriching…" indicator** (we do NOT show the
+  fast-pass genre alone while tropes are pending — "Enriching…" is the cleaner done/not-done signal).
+- **D4 — No live History polling:** state reflects load time; reloading/revisiting shows current state.
+- **D5 — DEBT (logged, not built):** derive-only cannot distinguish a failed/empty or never-ran
+  enrichment from one still in flight, so a stuck work shows "Enriching…" indefinitely. Future cleanup:
+  a timeout/sweep (needs a creation timestamp) to flag long-pending works as failed/retryable. Recorded
+  as **DEBT-035** in `docs/project_notes/issues.md`.
+
+## 5. Architecture
+
+Backend payload change + frontend rendering. No mesh/enrichment-logic changes; no schema change.
+
+### 5.1 `/history` payload (`src/agentic_librarian/api/main.py`)
+
+- The current query eager-loads contributors via a chained `joinedload` (safe under LIMIT because the
+  paginated root is `ReadingHistory`). Add the trope collection via **`selectinload`** (NOT `joinedload`):
+  tropes are a second to-many under `Work`, and a second `joinedload` would cartesian-multiply rows.
+  Concretely add, alongside the existing contributor chain:
+  `.options(selectinload(ReadingHistory.edition).selectinload(Edition.work).selectinload(Work.tropes).joinedload(WorkTrope.trope))`
+  — keep the existing contributor `joinedload` chain too. (Verify both option chains coexist; if SQLAlchemy
+  objects to mixed strategies on the shared `edition→work` path, load `Work.contributors` via
+  `selectinload` as well — both are to-many and selectin is correct under the paginated root.)
+- Per row, compute and add to the dict:
+  - `tropes`: the work's tropes sorted by `relevance_score` desc, take 3, output `Trope.name`.
+  - `genre`: `work.genres[0]` if `work.genres` else `None`.
+- Existing fields (`id`, `title`, `authors`, `date_completed`, `rating`, `format`) are unchanged.
+
+### 5.2 `HistoryView` (`frontend/src/views/HistoryView.tsx`) + `client.ts`
+
+- `HistoryItem` gains `genre?: string | null` and `tropes?: string[]`.
+- Each row renders a new line under the authors:
+  - **tropes present** → a genre chip (if `genre`) followed by up to 3 trope chips.
+  - **tropes empty/absent** → a single muted **"Enriching…"** chip.
+- `HistoryView.css` gets chip styles (reuse the existing visual language; trope chips muted, the
+  "Enriching…" chip italic/subtle).
+
+### 5.3 `AddBookView` (`frontend/src/views/AddBookView.tsx`)
+
+- On a successful add, the success state shows the **expectation message**:
+  "Added '<title>'! Enriching in the background (~a minute) — its tropes will appear in your History."
+  (Wording final in the plan.) No polling.
+
+## 6. Data Flow
+
+```
+POST /books -> fast pass persists Work (+genres) + logs read, enqueues deep pass; returns enrichment_enqueued
+AddBookView success -> shows the static "enriching in the background" expectation message
+... deep pass (Cloud Task -> /internal/enrich) adds tropes to the Work ~1-2 min later ...
+GET /history -> per row: top-3 tropes (relevance_score desc) + first genre
+HistoryView -> tropes present ? [genre + 3 trope chips] : ["Enriching..." chip]
+```
+
+## 7. Error / Edge Handling
+
+- A work with genres but no tropes (fast done, deep pending OR deep found none OR deep failed) → renders
+  "Enriching…" (the known derive-only limitation; DEBT-035).
+- A re-read (multiple `ReadingHistory` rows for the same work) → each row shows the same work's tropes
+  (correct; they share the Work).
+- Trope load must not regress `/history` pagination — the paginated root stays `ReadingHistory`; tropes
+  load via `selectinload` (separate query keyed by the page's work ids).
+- Empty/duplicate genres: take the first genre as-is; trope list de-duped is unnecessary (WorkTrope is
+  unique per work+trope).
+
+## 8. Testing Strategy
+
+**Backend (integration, DB):**
+- Seed a work with 4 tropes at varying `relevance_score` + a read for the user → `/history` returns the
+  top 3 names in score-desc order and the first genre.
+- Seed a work with NO tropes + a read → `/history` returns `tropes: []` (drives the "Enriching…" state).
+- Pagination unaffected: a multi-read / multi-contributor work still paginates to exact `limit` rows
+  (existing guard tests stay green).
+
+**Frontend (vitest):**
+- `HistoryView`: a row with `tropes` renders the genre + trope chips; a row with empty `tropes` renders
+  "Enriching…".
+- `AddBookView`: a successful add shows the enrichment expectation message.
+- Mind the vitest-4 `...Once` mock rule; `App.test.tsx` already mocks both views (no new route).
+
+## 9. Files Touched
+
+- `src/agentic_librarian/api/main.py` — `/history` eager-load + payload (`tropes`, `genre`).
+- `frontend/src/api/client.ts` — `HistoryItem` fields.
+- `frontend/src/views/HistoryView.tsx` (+ `.css`) — trope/genre chips + "Enriching…" state.
+- `frontend/src/views/AddBookView.tsx` — success expectation message.
+- `docs/project_notes/issues.md` — log DEBT-035.
+- Tests: `test/integration/test_api_history_db.py` (extend), `frontend/src/views/HistoryView.test.tsx`,
+  `frontend/src/views/AddBookView.test.tsx`.
+
+## 10. Out of Scope / Future
+
+- **DEBT-035:** stuck/failed-enrichment detection (timeout sweep + a `created_at`/status), and a retry
+  action — pairs naturally with **D1b** (history edit/delete) actions.
+- Showing the fast-pass genre while tropes are still pending (decided against for a clean signal).
+- Live History polling so "Enriching…" flips to tropes without a reload.
+- The remaining beta items: D1b history edit/delete, E1 dark mode (separate specs).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,8 @@ export interface HistoryItem {
   date_completed: string | null
   rating: number | null
   format: string | null
+  genre?: string | null
+  tropes?: string[]
 }
 
 export interface Recommendation {

--- a/frontend/src/views/AddBookView.test.tsx
+++ b/frontend/src/views/AddBookView.test.tsx
@@ -43,7 +43,7 @@ describe('AddBookView', () => {
     expect(vi.mocked(addBook)).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Dune', author: 'Frank Herbert' }),
     )
-    expect(await screen.findByText(/added .*dune/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Enriching in the background/i)).toBeInTheDocument()
   })
 
   it('shows an error when the book is not found', async () => {

--- a/frontend/src/views/AddBookView.tsx
+++ b/frontend/src/views/AddBookView.tsx
@@ -43,7 +43,9 @@ export default function AddBookView() {
       })
       // Came from a recommendation's "I read this" → close the loop.
       if (prefill.suggestionId) await setRecommendationStatus(prefill.suggestionId, 'Read')
-      setDone(`Added "${result.title}" to your history.`)
+      setDone(
+        `Added "${result.title}"! Enriching in the background (~a minute) — its tropes will appear in your History.`,
+      )
     } catch {
       setError("Couldn't add that book — check the title and author and try again.")
     } finally {

--- a/frontend/src/views/HistoryView.css
+++ b/frontend/src/views/HistoryView.css
@@ -8,3 +8,7 @@
 .history-authors { color: #6b7280; font-size: 14px; }
 .history-meta { display: flex; gap: 10px; align-items: center; font-size: 13px; color: #6b7280; }
 .history-rating { color: #f59e0b; }
+.history-tropes { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.trope-chip { font-size: 12px; padding: 2px 8px; border-radius: 10px; background: #eef2ff; color: #3730a3; }
+.trope-chip.genre { background: #e0e7ff; font-weight: 600; }
+.trope-chip.enriching { background: transparent; color: #6b7280; font-style: italic; padding-left: 0; }

--- a/frontend/src/views/HistoryView.test.tsx
+++ b/frontend/src/views/HistoryView.test.tsx
@@ -35,4 +35,30 @@ describe('HistoryView pagination', () => {
     expect(await screen.findByText('Only Book')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
   })
+
+  it('renders genre + trope chips when a row has tropes', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([
+      {
+        id: 'x', title: 'Tropey', authors: ['A'], date_completed: '2024-01-01', rating: 4, format: 'ebook',
+        genre: 'Fantasy', tropes: ['Found Family', 'Antihero', 'Heist'],
+      },
+    ])
+    render(<HistoryView />)
+    expect(await screen.findByText('Tropey')).toBeInTheDocument()
+    expect(screen.getByText('Fantasy')).toBeInTheDocument()
+    expect(screen.getByText('Found Family')).toBeInTheDocument()
+    expect(screen.queryByText(/Enriching/)).not.toBeInTheDocument()
+  })
+
+  it('renders an Enriching… chip when a row has no tropes', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([
+      {
+        id: 'y', title: 'Fresh', authors: ['B'], date_completed: '2024-01-01', rating: null, format: 'ebook',
+        genre: null, tropes: [],
+      },
+    ])
+    render(<HistoryView />)
+    expect(await screen.findByText('Fresh')).toBeInTheDocument()
+    expect(screen.getByText(/Enriching/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/views/HistoryView.tsx
+++ b/frontend/src/views/HistoryView.tsx
@@ -46,6 +46,18 @@ export default function HistoryView() {
               {h.format && <span className="history-format">{h.format}</span>}
               {h.date_completed && <span className="history-date">{h.date_completed}</span>}
             </div>
+            <div className="history-tropes">
+              {h.tropes && h.tropes.length > 0 ? (
+                <>
+                  {h.genre && <span className="trope-chip genre">{h.genre}</span>}
+                  {h.tropes.map((t) => (
+                    <span key={t} className="trope-chip">{t}</span>
+                  ))}
+                </>
+              ) : (
+                <span className="trope-chip enriching">Enriching…</span>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -99,11 +99,17 @@ def get_history(
             # joinedload on the to-many Work.contributors is safe under LIMIT *here* (unlike
             # /works): the paginated root is ReadingHistory and the collection sits two to-one
             # hops below it, so SQLAlchemy subquery-wraps the LIMIT against ReadingHistory rows.
+            # Work.tropes is a to-many so we use selectinload (separate IN query) to avoid
+            # cartesian-multiplying rows with the contributors joinedload.
             .options(
                 joinedload(ReadingHistory.edition)
                 .joinedload(Edition.work)
                 .joinedload(Work.contributors)
-                .joinedload(WorkContributor.author)
+                .joinedload(WorkContributor.author),
+                joinedload(ReadingHistory.edition)
+                .joinedload(Edition.work)
+                .selectinload(Work.tropes)
+                .joinedload(WorkTrope.trope),
             )
             .order_by(ReadingHistory.date_completed.desc(), ReadingHistory.id)
             .offset(offset)
@@ -111,21 +117,26 @@ def get_history(
             .all()
         )
 
-        return [
-            {
-                "id": str(h.id),
-                "title": h.edition.work.title,
-                "authors": [
-                    c.author.name for c in h.edition.work.contributors if c.role == "Author"
-                ],  # ETL always writes role="Author"
-                "date_completed": h.date_completed.isoformat()
-                if h.date_completed
-                else None,  # schema forbids NULL; guard is defensive only
-                "rating": h.user_rating,
-                "format": h.edition.format,
-            }
-            for h in history_entries
-        ]
+        def _genre_and_tropes(work):
+            top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
+            return (work.genres[0] if work.genres else None, [wt.trope.name for wt in top])
+
+        result = []
+        for h in history_entries:
+            genre, tropes = _genre_and_tropes(h.edition.work)
+            result.append(
+                {
+                    "id": str(h.id),
+                    "title": h.edition.work.title,
+                    "authors": [c.author.name for c in h.edition.work.contributors if c.role == "Author"],
+                    "date_completed": h.date_completed.isoformat() if h.date_completed else None,
+                    "rating": h.user_rating,
+                    "format": h.edition.format,
+                    "genre": genre,
+                    "tropes": tropes,
+                }
+            )
+        return result
 
 
 @app.get("/works")

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -92,3 +92,38 @@ def test_history_paginates_newest_first(two_user_client, db_url):
     page2 = c.get("/history?limit=2&offset=2").json()
     assert [h["date_completed"] for h in page1] == ["2025-05-05", "2024-04-04"]  # newest first
     assert [h["date_completed"] for h in page2] == ["2023-03-03", "2021-01-01"]  # next page, no overlap
+
+
+def test_history_includes_genre_and_top_three_tropes(two_user_client, db_url):
+    from agentic_librarian.db.models import Trope, WorkTrope
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = AuthorModel(name="Trope Author")
+        work = Work(
+            title="Tropey Book",
+            genres=["Fantasy", "Adventure"],
+            contributors=[WorkContributor(author=author, role="Author")],
+        )
+        edition = Edition(work=work, format="ebook")
+        session.add_all([author, work, edition])
+        session.flush()
+        for name, score in [("Heist", 0.90), ("Found Family", 0.95), ("Antihero", 0.99), ("Low Score", 0.10)]:
+            trope = Trope(name=name)
+            session.add(trope)
+            session.flush()
+            session.add(WorkTrope(work_id=work.id, trope_id=trope.id, relevance_score=score))
+        session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2026, 1, 2)))
+        session.flush()
+
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    row = next(r for r in rows if r["title"] == "Tropey Book")
+    assert row["genre"] == "Fantasy"
+    assert row["tropes"] == ["Antihero", "Found Family", "Heist"]  # top 3, score desc; "Low Score" dropped
+
+
+def test_history_no_tropes_returns_empty_list(two_user_client):
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    shared = next(r for r in rows if r["title"] == "Shared Book")
+    assert shared["tropes"] == []
+    assert shared["genre"] is None


### PR DESCRIPTION
Implements beta-feedback items **C1** (tell when background enrichment landed) and **C2** (show tropes in History). Spec/plan: `docs/superpowers/{specs,plans}/2026-06-16-enrichment-visibility*`.

## Approach — derived status, no DB migration
Adding a book runs two-phase enrichment; tropes appear only after the slow deep pass (~1-2 min). We derive "enriched" from **trope presence** rather than adding a status column:
- **`/history` payload** now includes `genre` (first of `Work.genres`) and `tropes` (top 3 `Trope.name` by `WorkTrope.relevance_score`). Loaded via `selectinload` on the trope to-many (sharing the `edition→work` joinedload prefix) so pagination is unaffected.
- **`HistoryView`** renders a genre chip + trope chips once enriched, or an **"Enriching…"** chip when a row has no tropes yet.
- **`AddBookView`** success message now sets the expectation: "Enriching in the background (~a minute) — its tropes will appear in your History." (no polling / no status endpoint).

## Known limitation (logged: DEBT-035)
Derive-only can't distinguish a failed / empty / never-ran enrichment from one still in flight — a stuck work shows "Enriching…" indefinitely. Logged in `docs/project_notes/issues.md` for a future timeout/sweep (needs a creation timestamp; pairs with D1b retry actions).

## Tests
TDD: backend integration (`/history` returns top-3 tropes in score-desc order + first genre; a tropeless work returns `tropes: []`; pagination guards stay green) and frontend vitest (genre/trope chips vs the "Enriching…" state; add-book expectation message). Backend integration 109 passed; frontend 44 passed + build + lint clean. No schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)