### PR TITLE
feat(history): edit/delete reading-history entries (D1b)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-history-edit-delete.md
+++ b/docs/superpowers/plans/2026-06-16-history-edit-delete.md
@@ -1,0 +1,604 @@
+# History Edit / Delete — Implementation Plan (D1b)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user delete a reading-history entry (with confirmation) and edit its rating/date/notes, from the UI, scoped to themselves.
+
+**Architecture:** Two user-scoped endpoints (`DELETE` + `PATCH /history/{id}`); a per-row ⋮ menu in `HistoryView` (Delete → confirm dialog; Edit → a dedicated `/history/:id/edit` view prefilled via router state). No DB migration, no new MCP tools.
+
+**Tech Stack:** FastAPI + SQLAlchemy (backend), React 19 + react-router + Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-history-edit-delete-design.md`
+
+---
+
+## Test commands
+
+Run via the **PowerShell tool**.
+- **Backend integration** (DB up): `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest <path> -q`
+- **Frontend** (Windows host, from `C:\dev\agentic_librarian\frontend`): `cd C:\dev\agentic_librarian\frontend; npx vitest run <path>` ; `npm run build` ; `npm run lint`
+
+vitest-4: `mockResolvedValueOnce` for per-test returns. Adding a new view route → **`App.test.tsx` must mock the new view** (Task 3).
+
+## File Structure
+
+- `src/agentic_librarian/api/main.py` — `_history_item` serializer (refactor + add `notes`), `DELETE /history/{id}`, `PATCH /history/{id}` (+ `HistoryUpdate`).
+- `frontend/src/api/client.ts` — `deleteHistory`, `updateHistory`, `HistoryItem.notes`.
+- `frontend/src/views/HistoryView.tsx` (+ `.css`) — per-row ⋮ menu + confirm dialog.
+- `frontend/src/views/HistoryEditView.tsx` — new edit view (reuses `AddBookView.css`).
+- `frontend/src/App.tsx` (route) + `frontend/src/App.test.tsx` (mock).
+- Tests: `test/integration/test_api_history_db.py`, `frontend/src/views/HistoryView.test.tsx`, `frontend/src/views/HistoryEditView.test.tsx` (new).
+
+---
+
+### Task 1: Backend — DELETE + PATCH /history/{id}
+
+**Files:** Modify `src/agentic_librarian/api/main.py`; Test `test/integration/test_api_history_db.py`.
+
+- [ ] **Step 1: Write failing integration tests** — APPEND to `test/integration/test_api_history_db.py` (it has `two_user_client`, `FRIEND_ID`, `DEFAULT_USER_ID`, `ReadingHistory`, `DatabaseManager`, `UUID`, `date`, `pytest.mark.db_integration`):
+
+```python
+def test_delete_history_removes_only_callers_row(two_user_client):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    assert client.delete(f"/history/{entry_id}").status_code == 200
+    assert entry_id not in [h["id"] for h in client.get("/history").json()]
+
+
+def test_delete_history_other_users_row_is_404(two_user_client, db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
+    assert two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").delete(f"/history/{friend_id}").status_code == 404
+    with manager.get_session() as session:
+        assert session.get(ReadingHistory, UUID(friend_id)) is not None  # untouched
+
+
+def test_patch_history_updates_rating_date_notes(two_user_client):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    resp = client.patch(f"/history/{entry_id}", json={"rating": 5, "date_completed": "2020-12-31", "notes": "loved it"})
+    assert resp.status_code == 200
+    assert resp.json()["rating"] == 5 and resp.json()["date_completed"] == "2020-12-31"
+    row = next(h for h in client.get("/history").json() if h["id"] == entry_id)
+    assert row["rating"] == 5 and row["date_completed"] == "2020-12-31" and row["notes"] == "loved it"
+
+
+def test_patch_history_rejects_bad_input_and_other_users(two_user_client, db_url):
+    from datetime import timedelta
+
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    assert client.patch(f"/history/{entry_id}", json={"rating": True}).status_code == 422
+    assert client.patch(f"/history/{entry_id}", json={"rating": 9}).status_code == 422
+    future = (date.today() + timedelta(days=3)).isoformat()
+    assert client.patch(f"/history/{entry_id}", json={"date_completed": future}).status_code == 422
+    assert client.patch(f"/history/{entry_id}", json={"date_completed": None}).status_code == 422  # NOT NULL
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
+    assert client.patch(f"/history/{friend_id}", json={"rating": 3}).status_code == 404
+```
+
+- [ ] **Step 2: Run — expect failure** (405/404 for the new verbs)
+
+`docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest test/integration/test_api_history_db.py -q`
+
+- [ ] **Step 3: Implement in `main.py`.**
+
+(a) Ensure these imports exist at the top (add any missing): `from uuid import UUID`, `from datetime import date`, `from pydantic import BaseModel, field_validator`, and add `HTTPException` to the existing `from fastapi import ...` line.
+
+(b) Refactor the `get_history` row dict into a module-level serializer (add `notes`); replace the inline `_genre_and_tropes` + loop with a call to it:
+
+```python
+def _history_item(h) -> dict:
+    """Serialize one ReadingHistory row to the /history payload shape (shared by GET + PATCH)."""
+    work = h.edition.work
+    top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
+    return {
+        "id": str(h.id),
+        "title": work.title,
+        "authors": [c.author.name for c in work.contributors if c.role == "Author"],
+        "date_completed": h.date_completed.isoformat() if h.date_completed else None,
+        "rating": h.user_rating,
+        "format": h.edition.format,
+        "notes": h.user_notes,
+        "genre": work.genres[0] if work.genres else None,
+        "tropes": [wt.trope.name for wt in top],
+    }
+```
+In `get_history`, replace the return with: `return [_history_item(h) for h in history_entries]` (drop the now-unused inline helper/loop).
+
+(c) Add the update model + two endpoints (place after `get_history`):
+
+```python
+class HistoryUpdate(BaseModel):
+    date_completed: date | None = None
+    rating: int | None = None
+    notes: str | None = None
+
+    @field_validator("rating", mode="before")
+    @classmethod
+    def _no_bool_rating(cls, v: object) -> object:
+        if isinstance(v, bool):
+            raise ValueError("rating must be an integer, not a boolean")
+        return v
+
+    @field_validator("rating")
+    @classmethod
+    def _rating_range(cls, v: int | None) -> int | None:
+        if v is not None and not 1 <= v <= 5:
+            raise ValueError("rating must be from 1 to 5")
+        return v
+
+    @field_validator("date_completed")
+    @classmethod
+    def _not_future(cls, v: date | None) -> date | None:
+        if v is not None and v > date.today():
+            raise ValueError("date_completed cannot be in the future")
+        return v
+
+
+@app.delete("/history/{entry_id}")
+def delete_history(entry_id: UUID, user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with db_manager.get_session() as session:
+        row = (
+            session.query(ReadingHistory)
+            .filter(ReadingHistory.id == entry_id, ReadingHistory.user_id == user.id)  # only mine (ADR-048)
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="history entry not found")
+        session.delete(row)
+        session.flush()
+    return {"id": str(entry_id), "deleted": True}
+
+
+@app.patch("/history/{entry_id}")
+def update_history(
+    entry_id: UUID,
+    req: HistoryUpdate,
+    user: AuthenticatedUser = Depends(get_current_user),  # noqa: B008
+):
+    fields = req.model_dump(exclude_unset=True)  # only what the client actually sent
+    if "date_completed" in fields and fields["date_completed"] is None:
+        raise HTTPException(status_code=422, detail="date_completed cannot be null")
+    with db_manager.get_session() as session:
+        row = (
+            session.query(ReadingHistory)
+            .filter(ReadingHistory.id == entry_id, ReadingHistory.user_id == user.id)
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="history entry not found")
+        if "date_completed" in fields:
+            row.date_completed = fields["date_completed"]
+        if "rating" in fields:
+            row.user_rating = fields["rating"]
+        if "notes" in fields:
+            row.user_notes = fields["notes"]
+        session.flush()
+        return _history_item(row)
+```
+
+- [ ] **Step 4: Run — expect pass** (the 4 new tests + existing history tests). Command from Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/api/main.py test/integration/test_api_history_db.py
+git commit -m "feat(history): user-scoped DELETE + PATCH /history/{id}; shared serializer (+ notes)"
+```
+
+---
+
+### Task 2: HistoryView — ⋮ menu + delete confirm (+ client.deleteHistory)
+
+**Files:** Modify `frontend/src/api/client.ts`, `frontend/src/views/HistoryView.tsx`, `frontend/src/views/HistoryView.css`, `frontend/src/views/HistoryView.test.tsx`.
+
+**Note:** `HistoryView` will use `useNavigate`, so its tests must render inside a router. Update ALL existing `render(<HistoryView />)` calls to a `MemoryRouter` wrapper.
+
+- [ ] **Step 1: Update existing tests to a router wrapper + add new tests.** In `frontend/src/views/HistoryView.test.tsx`:
+  - Add `import { MemoryRouter } from 'react-router'` and a helper `const renderView = () => render(<HistoryView />, { wrapper: MemoryRouter })`; replace the existing `render(<HistoryView />)` calls (in the 4 current tests) with `renderView()`.
+  - Append:
+```tsx
+  it('opens the ⋮ menu with Edit and Delete', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+  })
+
+  it('confirms then deletes the row', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    vi.mocked(client.deleteHistory).mockResolvedValueOnce()
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    // confirm dialog
+    await userEvent.click(screen.getByRole('button', { name: /delete entry/i }))
+    expect(client.deleteHistory).toHaveBeenCalledWith('a0')
+    await waitFor(() => expect(screen.queryByText('Jhereg')).not.toBeInTheDocument())
+  })
+
+  it('cancel in the confirm dialog keeps the row', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(client.deleteHistory).not.toHaveBeenCalled()
+    expect(screen.getByText('Jhereg')).toBeInTheDocument()
+  })
+```
+  (`waitFor` is already imported in this file; `deleteHistory` is auto-mocked by `vi.mock('../api/client')`.)
+
+- [ ] **Step 2: Run — expect new tests FAIL.** `cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/HistoryView.test.tsx`
+
+- [ ] **Step 3a: `client.ts`** — add `deleteHistory` and `HistoryItem.notes`:
+```ts
+export interface HistoryItem {
+  id: string
+  title: string
+  authors: string[]
+  date_completed: string | null
+  rating: number | null
+  format: string | null
+  notes?: string | null
+  genre?: string | null
+  tropes?: string[]
+}
+```
+```ts
+export async function deleteHistory(id: string): Promise<void> {
+  const res = await authedFetchRaw(`/history/${id}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`delete history → ${res.status}`)
+}
+```
+
+- [ ] **Step 3b: Rewrite `frontend/src/views/HistoryView.tsx`** to add the ⋮ menu + confirm dialog:
+```tsx
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { deleteHistory, getHistory, type HistoryItem } from '../api/client'
+import './HistoryView.css'
+
+const PAGE_SIZE = 50
+
+export default function HistoryView() {
+  const navigate = useNavigate()
+  const [items, setItems] = useState<HistoryItem[] | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [menuFor, setMenuFor] = useState<string | null>(null)
+  const [confirm, setConfirm] = useState<HistoryItem | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    void getHistory(PAGE_SIZE, 0).then((page) => {
+      setItems(page)
+      setHasMore(page.length === PAGE_SIZE)
+    })
+  }, [])
+
+  async function loadMore() {
+    if (items === null) return
+    setLoadingMore(true)
+    try {
+      const page = await getHistory(PAGE_SIZE, items.length)
+      setItems([...items, ...page])
+      setHasMore(page.length === PAGE_SIZE)
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  async function doDelete() {
+    if (!confirm) return
+    setDeleting(true)
+    try {
+      await deleteHistory(confirm.id)
+      setItems((cur) => (cur ? cur.filter((h) => h.id !== confirm.id) : cur))
+      setConfirm(null)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  if (items === null) return <p>Loading…</p>
+  if (items.length === 0) return <p>Nothing here yet — finish a book and it'll show up.</p>
+
+  return (
+    <div>
+      <h2>Reading history</h2>
+      <ul className="history-list">
+        {items.map((h) => (
+          <li key={h.id} className="history-row">
+            <div className="history-main">
+              <span className="history-title">{h.title}</span>
+              <span className="history-authors">{h.authors.join(', ')}</span>
+            </div>
+            <div className="history-meta">
+              {h.rating != null && <span className="history-rating">{'★'.repeat(h.rating)}</span>}
+              {h.format && <span className="history-format">{h.format}</span>}
+              {h.date_completed && <span className="history-date">{h.date_completed}</span>}
+            </div>
+            <div className="history-tropes">
+              {h.tropes && h.tropes.length > 0 ? (
+                <>
+                  {h.genre && <span className="trope-chip genre">{h.genre}</span>}
+                  {h.tropes.map((t) => (
+                    <span key={t} className="trope-chip">{t}</span>
+                  ))}
+                </>
+              ) : (
+                <span className="trope-chip enriching">Enriching…</span>
+              )}
+            </div>
+            <div className="history-actions">
+              <button
+                className="kebab"
+                aria-label={`Actions for ${h.title}`}
+                aria-haspopup="menu"
+                onClick={() => setMenuFor(menuFor === h.id ? null : h.id)}
+              >
+                ⋮
+              </button>
+              {menuFor === h.id && (
+                <div className="row-menu" role="menu">
+                  <button
+                    onClick={() => {
+                      setMenuFor(null)
+                      navigate(`/history/${h.id}/edit`, { state: h })
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMenuFor(null)
+                      setConfirm(h)
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {hasMore && (
+        <button className="history-load-more" onClick={() => void loadMore()} disabled={loadingMore}>
+          {loadingMore ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+      {confirm && (
+        <div className="confirm-backdrop" role="dialog" aria-modal="true" aria-label="Confirm delete">
+          <div className="confirm-box">
+            <p>
+              Delete your read of “{confirm.title}”
+              {confirm.date_completed ? ` finished ${confirm.date_completed}` : ''}? This can't be undone.
+            </p>
+            <div className="confirm-actions">
+              <button onClick={() => setConfirm(null)} disabled={deleting}>Cancel</button>
+              <button className="danger" onClick={() => void doDelete()} disabled={deleting}>
+                {deleting ? 'Deleting…' : 'Delete entry'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3c: Append CSS** to `frontend/src/views/HistoryView.css`:
+```css
+.history-row { position: relative; }
+.history-actions { position: absolute; top: 6px; right: 6px; }
+.kebab { background: none; border: none; font-size: 18px; line-height: 1; padding: 2px 6px; cursor: pointer; color: #6b7280; }
+.row-menu { position: absolute; right: 0; top: 100%; z-index: 5; background: #fff; border: 1px solid #d1d5db; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); display: flex; flex-direction: column; min-width: 96px; }
+.row-menu button { background: none; border: none; text-align: left; padding: 8px 12px; cursor: pointer; }
+.row-menu button:hover { background: #f3f4f6; }
+.confirm-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: grid; place-items: center; z-index: 50; }
+.confirm-box { background: #fff; border-radius: 12px; padding: 20px; max-width: 22rem; }
+.confirm-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.confirm-actions .danger { background: #c62828; color: #fff; border: none; border-radius: 6px; padding: 6px 12px; }
+```
+
+- [ ] **Step 4: Run — expect all HistoryView tests pass** (4 pre-existing now wrapped + 3 new). Command from Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/views/HistoryView.tsx frontend/src/views/HistoryView.css frontend/src/views/HistoryView.test.tsx
+git commit -m "feat(history): per-row ⋮ menu + delete confirm dialog"
+```
+
+---
+
+### Task 3: HistoryEditView + route + client.updateHistory
+
+**Files:** Create `frontend/src/views/HistoryEditView.tsx`, `frontend/src/views/HistoryEditView.test.tsx`; Modify `frontend/src/api/client.ts`, `frontend/src/App.tsx`, `frontend/src/App.test.tsx`.
+
+- [ ] **Step 1: Write the failing test** `frontend/src/views/HistoryEditView.test.tsx`:
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import type { HistoryItem } from '../api/client'
+
+vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null) }))
+vi.mock('../api/client')
+import * as client from '../api/client'
+import HistoryEditView from './HistoryEditView'
+
+const row: HistoryItem = {
+  id: 'h1', title: 'Jhereg', authors: ['Steven Brust'], date_completed: '2019-03-14',
+  rating: 4, format: 'ebook', notes: 'fun', genre: 'Fantasy', tropes: ['Antihero'],
+}
+
+function renderAt(state: HistoryItem | null) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/history/h1/edit', state }]}>
+      <Routes>
+        <Route path="/history/:id/edit" element={<HistoryEditView />} />
+        <Route path="/history" element={<div>history-list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HistoryEditView', () => {
+  it('prefills from router state and saves edits', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row, rating: 5 })
+    renderAt(row)
+    expect(screen.getByDisplayValue('2019-03-14')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() => expect(client.updateHistory).toHaveBeenCalledWith('h1', expect.objectContaining({ date_completed: '2019-03-14' })))
+    expect(await screen.findByText('history-list')).toBeInTheDocument()  // navigated back
+  })
+
+  it('redirects to history when opened with no router state', () => {
+    renderAt(null)
+    expect(screen.getByText('history-list')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect failure** (cannot resolve `./HistoryEditView`). `cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/HistoryEditView.test.tsx`
+
+- [ ] **Step 3a: `client.ts`** — add `updateHistory`:
+```ts
+export interface HistoryUpdate {
+  date_completed?: string | null
+  rating?: number | null
+  notes?: string | null
+}
+
+export async function updateHistory(id: string, body: HistoryUpdate): Promise<HistoryItem> {
+  const res = await authedFetchRaw(`/history/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`update history → ${res.status}`)
+  return res.json()
+}
+```
+
+- [ ] **Step 3b: Create `frontend/src/views/HistoryEditView.tsx`** (reuse `AddBookView.css`):
+```tsx
+import { useState, type FormEvent } from 'react'
+import { Navigate, useLocation, useNavigate, useParams } from 'react-router'
+import { updateHistory, type HistoryItem } from '../api/client'
+import './AddBookView.css'
+
+export default function HistoryEditView() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const row = (useLocation().state as HistoryItem | null) ?? null
+  const [rating, setRating] = useState(row?.rating != null ? String(row.rating) : '')
+  const [dateFinished, setDateFinished] = useState(row?.date_completed ?? '')
+  const [notes, setNotes] = useState(row?.notes ?? '')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!row || !id) return <Navigate to="/history" replace />
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      await updateHistory(id as string, {
+        rating: rating ? Number(rating) : null,
+        date_completed: dateFinished || null,
+        notes: notes.trim() || null,
+      })
+      navigate('/history')
+    } catch {
+      setError("Couldn't save those changes — try again.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="addbook">
+      <h2>Edit read</h2>
+      <p className="edit-context">
+        <strong>{row.title}</strong>
+        <br />
+        {row.authors.join(', ')}
+        {row.format ? ` · ${row.format}` : ''}
+      </p>
+      <form onSubmit={onSubmit} className="addbook-form">
+        <label>
+          Rating
+          <select value={rating} onChange={(e) => setRating(e.target.value)}>
+            <option value="">—</option>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>{'★'.repeat(n)}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Date finished
+          <input type="date" value={dateFinished} onChange={(e) => setDateFinished(e.target.value)} required />
+        </label>
+        <label>
+          Notes
+          <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} />
+        </label>
+        <div className="edit-actions">
+          <button type="submit" disabled={busy}>Save changes</button>
+          <button type="button" onClick={() => navigate('/history')} disabled={busy}>Cancel</button>
+        </div>
+      </form>
+      {error && <p className="addbook-error">{error}</p>}
+    </div>
+  )
+}
+```
+(Add minimal CSS for `.edit-context`/`.edit-actions` to `AddBookView.css` — e.g. `.edit-actions { display: flex; gap: 8px; }` — or skip if visually acceptable; keep it tiny.)
+
+- [ ] **Step 3c: Register the route** in `frontend/src/App.tsx`: add the import `import HistoryEditView from './views/HistoryEditView'` and, inside the `<Route element={<AppShell />}>` block, `<Route path="history/:id/edit" element={<HistoryEditView />} />`.
+
+- [ ] **Step 3d: Mock the new view** in `frontend/src/App.test.tsx`: add `vi.mock('./views/HistoryEditView', () => ({ default: () => <div>history-edit-view</div> }))` alongside the other view mocks.
+
+- [ ] **Step 4: Run — expect pass.** Run the edit-view test AND App.test:
+`cd C:\dev\agentic_librarian\frontend; npx vitest run src/views/HistoryEditView.test.tsx src/App.test.tsx`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/views/HistoryEditView.tsx frontend/src/views/HistoryEditView.test.tsx frontend/src/views/AddBookView.css frontend/src/App.tsx frontend/src/App.test.tsx
+git commit -m "feat(history): dedicated edit view (rating/date/notes) + route"
+```
+
+---
+
+### Task 4: Full verification + finish
+
+- [ ] **Step 1: Backend integration** — `docker run --rm -v "C:\dev\agentic_librarian:/app" -w /app --network agentic_librarian_default -e POSTGRES_HOST=db agentic_librarian-app:latest python -m pytest test/integration -m "not api_dependent" -q` → pass.
+- [ ] **Step 2: Frontend** — `cd C:\dev\agentic_librarian\frontend; npx vitest run` ; `npm run build` ; `npm run lint` → all green.
+- [ ] **Step 3: Backend lint parity** — keep added lines ≤120 cols; if a clean `python:3.11-slim` + `pip install ruff==0.15.16` is handy, run `ruff format`/`ruff check` on `main.py` + the test file; else rely on CI ruff-format.
+- [ ] **Step 4: Finish** — use superpowers:finishing-a-development-branch (push + PR; Gemini review → squash-merge).
+
+---
+
+## Self-Review
+
+**Spec coverage:** D1 delete+edit (Tasks 1–3); D2 dedicated edit view route (Task 3); D3 per-row ⋮ menu (Task 2); D4 router-state prefill + redirect-when-absent (Task 3 `<Navigate>`); D5 confirm dialog before delete (Task 2); D6 API+UI only, no MCP tools (Task 1 endpoints only). Backend tests cover scoping (cross-user 404), validation (bool/range/future/null date), and delete-isolation; frontend tests cover the menu, confirm+delete, cancel, edit prefill+save, and the no-state redirect.
+
+**Placeholder scan:** none — full code/commands per step.
+
+**Type consistency:** `HistoryItem` gains `notes?` (Task 2) matching the backend serializer's new `notes` key (Task 1); `updateHistory(id, HistoryUpdate)` body keys (`date_completed`/`rating`/`notes`) match the backend `HistoryUpdate` model and are applied via `exclude_unset`; the edit view passes the row through router state typed as `HistoryItem`; the PATCH response is `HistoryItem` (full serializer). `useNavigate` in `HistoryView` is why its tests move to a `MemoryRouter` wrapper (Task 2 Step 1).

--- a/docs/superpowers/specs/2026-06-16-history-edit-delete-design.md
+++ b/docs/superpowers/specs/2026-06-16-history-edit-delete-design.md
@@ -1,0 +1,143 @@
+# History Edit / Delete — Design (D1b)
+
+**Date:** 2026-06-16
+**Status:** Approved (brainstormed), pending plan
+**Origin:** Friends-and-family beta feedback, item D1b (see project memory `beta-feedback-triage`).
+
+---
+
+## 1. Background & Problem
+
+The operator wants to **edit and delete reading-history entries from the UI, without talking to the
+Librarian** — concretely, to remove a read-event the Librarian added in error (the duplicate
+*Book of Jhereg*). Today there is **no mutation path for reading history**: `grep` confirms no
+DELETE / PATCH / PUT endpoint anywhere in `src/agentic_librarian/api`, and history is only ever created
+(`add_book_to_history` / `add_read_event` / `update_reading_status`), never removed or edited.
+
+**Code reality:** `ReadingHistory` is one row per read-event — `id`, `edition_id`, `user_id`,
+`date_started` (nullable, unused in UI), `date_completed` (NOT NULL), `user_rating` (nullable),
+`user_notes` (nullable). `/history` already returns each row's `id` plus title/authors/date/rating/format
+(and now genre/tropes from C1/C2). `format` lives on `Edition` (shared across reads), not on the
+read-event.
+
+## 2. Goals
+
+- Delete a single reading-history entry (read-event) from the UI, with a confirmation step.
+- Edit a single entry's **rating / date finished / notes** from the UI.
+- Both strictly scoped to the authenticated user (ADR-048).
+
+## 3. Non-Goals (YAGNI)
+
+- **No new MCP/Librarian tools** — API + UI only (the agent keeps its add/update tools). Parity can come later.
+- **No editing of `format`** (Edition-level, shared across reads) or title/author (Work-level).
+- No bulk select/delete; no undo (a confirm dialog covers the destructive case).
+- No DB migration (uses existing columns).
+- No GET-by-id endpoint (the edit view receives the row via router state; see D4).
+
+## 4. Decisions (from brainstorm)
+
+- **D1 — Scope:** delete **and** edit (rating / date_completed / notes).
+- **D2 — Edit UX:** a **dedicated edit view** at route `/history/:id/edit` (not inline, not a modal).
+- **D3 — Affordance:** a **per-row ⋮ (kebab) menu** with **Edit** and **Delete** — one small icon per row,
+  no selection mode.
+- **D4 — Edit data source:** the row is passed to the edit view via **router state** (the `AddBookView`
+  prefill pattern); a direct load with no state **redirects to `/history`** (no GET-by-id endpoint).
+- **D5 — Delete requires a confirmation dialog** before the call.
+- **D6 — API + UI only:** no Librarian delete/edit tools this pass.
+
+## 5. Architecture
+
+Two user-scoped endpoints + frontend (kebab menu, confirm dialog, new edit view). No schema change.
+
+### 5.1 Backend (`src/agentic_librarian/api/main.py`)
+
+Mirror the existing user-scoping pattern (`/recommendations/{id}/status`, `/history`): resolve the row by
+id **and** `user_id == user.id`; 404 if not found/not theirs.
+
+- **`DELETE /history/{entry_id}`** → finds the caller's `ReadingHistory` row, deletes it, returns
+  `{"id": str(entry_id), "deleted": true}`. 404 (not 403) when the id isn't the caller's — don't leak
+  existence (matches the recommendations endpoint).
+- **`PATCH /history/{entry_id}`** with a Pydantic body `HistoryUpdate { date_completed: date | None,
+  rating: int | None, notes: str | None }` → updates only the provided fields on the caller's row.
+  Validation reuses the `AddBookRequest` rules: `rating` 1–5 and **reject bool** (`field_validator(mode="before")`),
+  `date_completed` not in the future. `date_completed` is NOT NULL — a PATCH may change it but a request
+  that explicitly sets it null is rejected. Returns the updated row in the same shape `/history` uses
+  (id/title/authors/date_completed/rating/format/genre/tropes) so the client can refresh in place.
+- Both run inside `with as_user(user.id)` only if a tool needs context; here they query directly with
+  `user.id` from the auth dependency (no MCP tools involved).
+
+### 5.2 Frontend
+
+- **`client.ts`:**
+  - `deleteHistory(id: string): Promise<void>` → `DELETE /history/${id}` (throws on non-ok).
+  - `updateHistory(id, body: { date_completed?: string | null; rating?: number | null; notes?: string | null }): Promise<HistoryItem>`
+    → `PATCH /history/${id}`, returns the updated `HistoryItem`.
+- **`HistoryView.tsx`:** each row gets a **⋮ button** opening a small menu (Edit / Delete).
+  - **Delete** → a confirm dialog (e.g. "Delete your read of '<title>' finished <date>? This can't be
+    undone." → Delete / Cancel). On confirm → `deleteHistory(id)` → remove the row from local state.
+  - **Edit** → `navigate(`/history/${id}/edit`, { state: row })`.
+  - The open/closed kebab state is per-row local UI state; clicking elsewhere / a second action closes it.
+- **`HistoryEditView.tsx`** (new) at route `/history/:id/edit`:
+  - Reads the row from `useLocation().state`; if absent → `<Navigate to="/history" replace />`.
+  - Form fields: **Rating** (—/1–5, like AddBookView), **Date finished** (date input), **Notes** (textarea),
+    prefilled from the row. Title/author/format shown read-only for context.
+  - **Save** → `updateHistory(id, { date_completed, rating, notes })` → on success `navigate('/history')`.
+  - A `useParams()` `id` is the source of truth for the call (router state only prefills the form).
+- **`App.tsx`:** register `<Route path="/history/:id/edit" element={<HistoryEditView />} />`.
+  **`App.test.tsx` must add `vi.mock('./views/HistoryEditView', …)`** (the established "mock every view"
+  rule — otherwise the real `client.ts`→`firebase.ts` import throws under test).
+- **CSS:** kebab button + menu + confirm-dialog styles (reuse the app's existing visual language;
+  a lightweight dialog, not a new dependency).
+
+## 6. Data Flow
+
+```
+HistoryView row ⋮ -> Delete -> confirm dialog -> DELETE /history/:id -> drop row from list state
+HistoryView row ⋮ -> Edit   -> navigate(/history/:id/edit, {state: row})
+HistoryEditView (prefill from state; id from useParams) -> Save
+   -> PATCH /history/:id {date_completed?, rating?, notes?} -> navigate(/history)
+direct load /history/:id/edit with no router state -> <Navigate to="/history" replace />
+```
+
+## 7. Error / Edge Handling
+
+- Cross-user or unknown `entry_id` → **404** on both endpoints; the UI shows a generic error and the row
+  stays/refreshes.
+- PATCH validation failures → 422 (bool rating, out-of-range rating, future date); the form surfaces the
+  error and keeps the user's input.
+- Deleting one read of a multi-read work removes only that event; the Work/Edition stay in the catalog
+  (and other reads of it remain in History).
+- Edit view opened directly (no router state) → redirect to `/history` (no crash, no GET-by-id needed).
+- A PATCH `date_completed` that happens to match another read of the same work is allowed (no
+  work+date uniqueness constraint exists; this edits an existing event, it doesn't run the add-path dedupe).
+
+## 8. Testing Strategy
+
+**Backend (integration, DB):**
+- DELETE removes the caller's row and 404s for another user's row (and leaves that row intact).
+- PATCH updates rating/date/notes on the caller's row; 404 for another user's row; 422 on bool rating /
+  out-of-range rating / future date.
+
+**Frontend (vitest):**
+- `HistoryView`: the ⋮ menu reveals Edit + Delete; Delete opens the confirm dialog, and confirming calls
+  `deleteHistory` and removes the row; canceling calls nothing.
+- `HistoryEditView`: prefills from router state; Save calls `updateHistory` with the edited fields; a
+  render with no router state redirects to `/history`.
+- Remember the vitest-4 `...Once` mock rule and add the `App.test.tsx` mock for the new view.
+
+## 9. Files Touched
+
+- `src/agentic_librarian/api/main.py` — `DELETE /history/{id}` + `PATCH /history/{id}` (+ `HistoryUpdate` model).
+- `frontend/src/api/client.ts` — `deleteHistory`, `updateHistory`.
+- `frontend/src/views/HistoryView.tsx` (+ `.css`) — per-row ⋮ menu + confirm dialog.
+- `frontend/src/views/HistoryEditView.tsx` (+ `.css`) — new edit view.
+- `frontend/src/App.tsx` — new route; `frontend/src/App.test.tsx` — mock the new view.
+- Tests: `test/integration/test_api_history_db.py` (extend), `frontend/src/views/HistoryView.test.tsx`,
+  `frontend/src/views/HistoryEditView.test.tsx` (new).
+
+## 10. Out of Scope / Future
+
+- Librarian/MCP delete & edit tools (parity).
+- Editing `format` / converting a read to a different edition.
+- A DEBT-035 "retry enrichment" action (deferred; this view is its natural future home).
+- The remaining beta item: E1 dark mode (separate spec).

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -21,6 +21,7 @@ vi.mock('./views/HistoryView', () => ({ default: () => <div>history-view</div> }
 vi.mock('./views/RecommendationsView', () => ({ default: () => <div>recs-view</div> }))
 vi.mock('./views/AnalysisView', () => ({ default: () => <div>analysis-view</div> }))
 vi.mock('./views/AddBookView', () => ({ default: () => <div>add-view</div> }))
+vi.mock('./views/HistoryEditView', () => ({ default: () => <div>history-edit-view</div> }))
 
 import App from './App'
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SignIn from './components/SignIn'
 import AddBookView from './views/AddBookView'
 import AnalysisView from './views/AnalysisView'
 import ChatView from './views/ChatView'
+import HistoryEditView from './views/HistoryEditView'
 import HistoryView from './views/HistoryView'
 import RecommendationsView from './views/RecommendationsView'
 
@@ -20,6 +21,7 @@ function Gate() {
         <Route element={<AppShell />}>
           <Route index element={<ChatView />} />
           <Route path="history" element={<HistoryView />} />
+          <Route path="history/:id/edit" element={<HistoryEditView />} />
           <Route path="recommendations" element={<RecommendationsView />} />
           <Route path="analysis" element={<AnalysisView />} />
           <Route path="add" element={<AddBookView />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,7 @@ export interface HistoryItem {
   date_completed: string | null
   rating: number | null
   format: string | null
+  notes?: string | null
   genre?: string | null
   tropes?: string[]
 }
@@ -82,6 +83,11 @@ export async function probeAccess(): Promise<'ready' | 'notInvited' | 'error'> {
 
 export function getHistory(limit = 50, offset = 0): Promise<HistoryItem[]> {
   return getJson<HistoryItem[]>(`/history?limit=${limit}&offset=${offset}`)
+}
+
+export async function deleteHistory(id: string): Promise<void> {
+  const res = await authedFetchRaw(`/history/${id}`, { method: 'DELETE' })
+  if (!res.ok) throw new Error(`delete history → ${res.status}`)
 }
 
 export function getRecommendations(): Promise<Recommendation[]> {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -90,6 +90,22 @@ export async function deleteHistory(id: string): Promise<void> {
   if (!res.ok) throw new Error(`delete history → ${res.status}`)
 }
 
+export interface HistoryUpdate {
+  date_completed?: string | null
+  rating?: number | null
+  notes?: string | null
+}
+
+export async function updateHistory(id: string, body: HistoryUpdate): Promise<HistoryItem> {
+  const res = await authedFetchRaw(`/history/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`update history → ${res.status}`)
+  return res.json()
+}
+
 export function getRecommendations(): Promise<Recommendation[]> {
   return getJson<Recommendation[]>('/recommendations')
 }

--- a/frontend/src/views/AddBookView.css
+++ b/frontend/src/views/AddBookView.css
@@ -14,3 +14,5 @@
 .addbook-error {
   color: var(--danger, #c62828);
 }
+.edit-context { font-size: 0.9rem; color: #374151; }
+.edit-actions { display: flex; gap: 0.5rem; }

--- a/frontend/src/views/HistoryEditView.test.tsx
+++ b/frontend/src/views/HistoryEditView.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import type { HistoryItem } from '../api/client'
+
+vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null) }))
+vi.mock('../api/client')
+import * as client from '../api/client'
+import HistoryEditView from './HistoryEditView'
+
+const row: HistoryItem = {
+  id: 'h1', title: 'Jhereg', authors: ['Steven Brust'], date_completed: '2019-03-14',
+  rating: 4, format: 'ebook', notes: 'fun', genre: 'Fantasy', tropes: ['Antihero'],
+}
+
+function renderAt(state: HistoryItem | null) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/history/h1/edit', state }]}>
+      <Routes>
+        <Route path="/history/:id/edit" element={<HistoryEditView />} />
+        <Route path="/history" element={<div>history-list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HistoryEditView', () => {
+  it('prefills from router state and saves edits', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row, rating: 5 })
+    renderAt(row)
+    expect(screen.getByDisplayValue('2019-03-14')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() =>
+      expect(client.updateHistory).toHaveBeenCalledWith('h1', expect.objectContaining({ date_completed: '2019-03-14' })),
+    )
+    expect(await screen.findByText('history-list')).toBeInTheDocument()
+  })
+
+  it('redirects to history when opened with no router state', () => {
+    renderAt(null)
+    expect(screen.getByText('history-list')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/HistoryEditView.tsx
+++ b/frontend/src/views/HistoryEditView.tsx
@@ -54,7 +54,13 @@ export default function HistoryEditView() {
         </label>
         <label>
           Date finished
-          <input type="date" value={dateFinished} onChange={(e) => setDateFinished(e.target.value)} required />
+          <input
+            type="date"
+            value={dateFinished}
+            onChange={(e) => setDateFinished(e.target.value)}
+            max={new Date().toLocaleDateString('en-CA')}
+            required
+          />
         </label>
         <label>
           Notes

--- a/frontend/src/views/HistoryEditView.tsx
+++ b/frontend/src/views/HistoryEditView.tsx
@@ -1,0 +1,71 @@
+import { useState, type FormEvent } from 'react'
+import { Navigate, useLocation, useNavigate, useParams } from 'react-router'
+import { updateHistory, type HistoryItem } from '../api/client'
+import './AddBookView.css'
+
+export default function HistoryEditView() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const row = (useLocation().state as HistoryItem | null) ?? null
+  const [rating, setRating] = useState(row?.rating != null ? String(row.rating) : '')
+  const [dateFinished, setDateFinished] = useState(row?.date_completed ?? '')
+  const [notes, setNotes] = useState(row?.notes ?? '')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!row || !id) return <Navigate to="/history" replace />
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      await updateHistory(id as string, {
+        rating: rating ? Number(rating) : null,
+        date_completed: dateFinished || null,
+        notes: notes.trim() || null,
+      })
+      navigate('/history')
+    } catch {
+      setError("Couldn't save those changes — try again.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="addbook">
+      <h2>Edit read</h2>
+      <p className="edit-context">
+        <strong>{row.title}</strong>
+        <br />
+        {row.authors.join(', ')}
+        {row.format ? ` · ${row.format}` : ''}
+      </p>
+      <form onSubmit={onSubmit} className="addbook-form">
+        <label>
+          Rating
+          <select value={rating} onChange={(e) => setRating(e.target.value)}>
+            <option value="">—</option>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>{'★'.repeat(n)}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Date finished
+          <input type="date" value={dateFinished} onChange={(e) => setDateFinished(e.target.value)} required />
+        </label>
+        <label>
+          Notes
+          <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} />
+        </label>
+        <div className="edit-actions">
+          <button type="submit" disabled={busy}>Save changes</button>
+          <button type="button" onClick={() => navigate('/history')} disabled={busy}>Cancel</button>
+        </div>
+      </form>
+      {error && <p className="addbook-error">{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/views/HistoryView.css
+++ b/frontend/src/views/HistoryView.css
@@ -21,4 +21,5 @@
 .confirm-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: grid; place-items: center; z-index: 50; }
 .confirm-box { background: #fff; border-radius: 12px; padding: 20px; max-width: 22rem; }
 .confirm-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.confirm-error { color: #c62828; font-size: 0.9rem; margin-top: 8px; }
 .confirm-actions .danger { background: #c62828; color: #fff; border: none; border-radius: 6px; padding: 6px 12px; }

--- a/frontend/src/views/HistoryView.css
+++ b/frontend/src/views/HistoryView.css
@@ -12,3 +12,13 @@
 .trope-chip { font-size: 12px; padding: 2px 8px; border-radius: 10px; background: #eef2ff; color: #3730a3; }
 .trope-chip.genre { background: #e0e7ff; font-weight: 600; }
 .trope-chip.enriching { background: transparent; color: #6b7280; font-style: italic; padding-left: 0; }
+.history-row { position: relative; }
+.history-actions { position: absolute; top: 6px; right: 6px; }
+.kebab { background: none; border: none; font-size: 18px; line-height: 1; padding: 2px 6px; cursor: pointer; color: #6b7280; }
+.row-menu { position: absolute; right: 0; top: 100%; z-index: 5; background: #fff; border: 1px solid #d1d5db; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); display: flex; flex-direction: column; min-width: 96px; }
+.row-menu button { background: none; border: none; text-align: left; padding: 8px 12px; cursor: pointer; }
+.row-menu button:hover { background: #f3f4f6; }
+.confirm-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: grid; place-items: center; z-index: 50; }
+.confirm-box { background: #fff; border-radius: 12px; padding: 20px; max-width: 22rem; }
+.confirm-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+.confirm-actions .danger { background: #c62828; color: #fff; border: none; border-radius: 6px; padding: 6px 12px; }

--- a/frontend/src/views/HistoryView.test.tsx
+++ b/frontend/src/views/HistoryView.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router'
 import HistoryView from './HistoryView'
 import * as client from '../api/client'
 
@@ -13,6 +14,8 @@ function item(id: string, title: string): client.HistoryItem {
   return { id, title, authors: ['A. Uthor'], date_completed: '2024-01-01', rating: 4, format: 'ebook' }
 }
 
+const renderView = () => render(<HistoryView />, { wrapper: MemoryRouter })
+
 afterEach(() => vi.clearAllMocks())
 
 describe('HistoryView pagination', () => {
@@ -20,7 +23,7 @@ describe('HistoryView pagination', () => {
     const full = Array.from({ length: 50 }, (_, i) => item(`a${i}`, `Book ${i}`))
     vi.mocked(client.getHistory).mockResolvedValueOnce(full).mockResolvedValueOnce([item('b0', 'Page 2 Book')])
 
-    render(<HistoryView />)
+    renderView()
     expect(await screen.findByText('Book 0')).toBeInTheDocument()
     expect(client.getHistory).toHaveBeenCalledWith(50, 0)
 
@@ -31,7 +34,7 @@ describe('HistoryView pagination', () => {
 
   it('hides "Load more" when the first page is short (no more rows)', async () => {
     vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Only Book')])
-    render(<HistoryView />)
+    renderView()
     expect(await screen.findByText('Only Book')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument()
   })
@@ -43,7 +46,7 @@ describe('HistoryView pagination', () => {
         genre: 'Fantasy', tropes: ['Found Family', 'Antihero', 'Heist'],
       },
     ])
-    render(<HistoryView />)
+    renderView()
     expect(await screen.findByText('Tropey')).toBeInTheDocument()
     expect(screen.getByText('Fantasy')).toBeInTheDocument()
     expect(screen.getByText('Found Family')).toBeInTheDocument()
@@ -57,8 +60,40 @@ describe('HistoryView pagination', () => {
         genre: null, tropes: [],
       },
     ])
-    render(<HistoryView />)
+    renderView()
     expect(await screen.findByText('Fresh')).toBeInTheDocument()
     expect(screen.getByText(/Enriching/)).toBeInTheDocument()
+  })
+
+  it('opens the ⋮ menu with Edit and Delete', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+  })
+
+  it('confirms then deletes the row', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    vi.mocked(client.deleteHistory).mockResolvedValueOnce()
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /delete entry/i }))
+    expect(client.deleteHistory).toHaveBeenCalledWith('a0')
+    await waitFor(() => expect(screen.queryByText('Jhereg')).not.toBeInTheDocument())
+  })
+
+  it('cancel in the confirm dialog keeps the row', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(client.deleteHistory).not.toHaveBeenCalled()
+    expect(screen.getByText('Jhereg')).toBeInTheDocument()
   })
 })

--- a/frontend/src/views/HistoryView.test.tsx
+++ b/frontend/src/views/HistoryView.test.tsx
@@ -86,6 +86,18 @@ describe('HistoryView pagination', () => {
     await waitFor(() => expect(screen.queryByText('Jhereg')).not.toBeInTheDocument())
   })
 
+  it('shows an error and keeps the row when delete fails', async () => {
+    vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
+    vi.mocked(client.deleteHistory).mockRejectedValueOnce(new Error('boom'))
+    renderView()
+    await screen.findByText('Jhereg')
+    await userEvent.click(screen.getByRole('button', { name: /actions for Jhereg/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /delete entry/i }))
+    expect(await screen.findByText(/couldn't delete that entry/i)).toBeInTheDocument()
+    expect(screen.getByText('Jhereg')).toBeInTheDocument()  // row stays
+  })
+
   it('cancel in the confirm dialog keeps the row', async () => {
     vi.mocked(client.getHistory).mockResolvedValueOnce([item('a0', 'Jhereg')])
     renderView()

--- a/frontend/src/views/HistoryView.tsx
+++ b/frontend/src/views/HistoryView.tsx
@@ -13,6 +13,7 @@ export default function HistoryView() {
   const [menuFor, setMenuFor] = useState<string | null>(null)
   const [confirm, setConfirm] = useState<HistoryItem | null>(null)
   const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     void getHistory(PAGE_SIZE, 0).then((page) => {
@@ -36,10 +37,13 @@ export default function HistoryView() {
   async function doDelete() {
     if (!confirm) return
     setDeleting(true)
+    setError(null)
     try {
       await deleteHistory(confirm.id)
       setItems((cur) => (cur ? cur.filter((h) => h.id !== confirm.id) : cur))
       setConfirm(null)
+    } catch {
+      setError("Couldn't delete that entry — try again.")
     } finally {
       setDeleting(false)
     }
@@ -120,8 +124,17 @@ export default function HistoryView() {
               Delete your read of "{confirm.title}"
               {confirm.date_completed ? ` finished ${confirm.date_completed}` : ''}? This can't be undone.
             </p>
+            {error && <p className="confirm-error">{error}</p>}
             <div className="confirm-actions">
-              <button onClick={() => setConfirm(null)} disabled={deleting}>Cancel</button>
+              <button
+                onClick={() => {
+                  setConfirm(null)
+                  setError(null)
+                }}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
               <button className="danger" onClick={() => void doDelete()} disabled={deleting}>
                 {deleting ? 'Deleting…' : 'Delete entry'}
               </button>

--- a/frontend/src/views/HistoryView.tsx
+++ b/frontend/src/views/HistoryView.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useState } from 'react'
-import { getHistory, type HistoryItem } from '../api/client'
+import { useNavigate } from 'react-router'
+import { deleteHistory, getHistory, type HistoryItem } from '../api/client'
 import './HistoryView.css'
 
 const PAGE_SIZE = 50
 
 export default function HistoryView() {
+  const navigate = useNavigate()
   const [items, setItems] = useState<HistoryItem[] | null>(null)
   const [hasMore, setHasMore] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [menuFor, setMenuFor] = useState<string | null>(null)
+  const [confirm, setConfirm] = useState<HistoryItem | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   useEffect(() => {
     void getHistory(PAGE_SIZE, 0).then((page) => {
@@ -25,6 +30,18 @@ export default function HistoryView() {
       setHasMore(page.length === PAGE_SIZE)
     } finally {
       setLoadingMore(false)
+    }
+  }
+
+  async function doDelete() {
+    if (!confirm) return
+    setDeleting(true)
+    try {
+      await deleteHistory(confirm.id)
+      setItems((cur) => (cur ? cur.filter((h) => h.id !== confirm.id) : cur))
+      setConfirm(null)
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -58,6 +75,36 @@ export default function HistoryView() {
                 <span className="trope-chip enriching">Enriching…</span>
               )}
             </div>
+            <div className="history-actions">
+              <button
+                className="kebab"
+                aria-label={`Actions for ${h.title}`}
+                aria-haspopup="menu"
+                onClick={() => setMenuFor(menuFor === h.id ? null : h.id)}
+              >
+                ⋮
+              </button>
+              {menuFor === h.id && (
+                <div className="row-menu" role="menu">
+                  <button
+                    onClick={() => {
+                      setMenuFor(null)
+                      navigate(`/history/${h.id}/edit`, { state: h })
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMenuFor(null)
+                      setConfirm(h)
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
           </li>
         ))}
       </ul>
@@ -65,6 +112,22 @@ export default function HistoryView() {
         <button className="history-load-more" onClick={() => void loadMore()} disabled={loadingMore}>
           {loadingMore ? 'Loading…' : 'Load more'}
         </button>
+      )}
+      {confirm && (
+        <div className="confirm-backdrop" role="dialog" aria-modal="true" aria-label="Confirm delete">
+          <div className="confirm-box">
+            <p>
+              Delete your read of "{confirm.title}"
+              {confirm.date_completed ? ` finished ${confirm.date_completed}` : ''}? This can't be undone.
+            </p>
+            <div className="confirm-actions">
+              <button onClick={() => setConfirm(null)} disabled={deleting}>Cancel</button>
+              <button className="danger" onClick={() => void doDelete()} disabled={deleting}>
+                {deleting ? 'Deleting…' : 'Delete entry'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -1,7 +1,10 @@
 import contextlib
 import os
+from datetime import date
+from uuid import UUID
 
-from fastapi import Body, Depends, FastAPI, Query
+from fastapi import Body, Depends, FastAPI, HTTPException, Query
+from pydantic import BaseModel, field_validator
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload, selectinload
@@ -82,6 +85,37 @@ def db_health_check(user: AuthenticatedUser = Depends(get_current_user)):  # noq
         return JSONResponse(status_code=503, content={"status": "error", "detail": str(e)})
 
 
+def _history_item(h) -> dict:
+    """Serialize one ReadingHistory row to the /history payload shape (shared by GET + PATCH)."""
+    work = h.edition.work
+    top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
+    return {
+        "id": str(h.id),
+        "title": work.title,
+        "authors": [c.author.name for c in work.contributors if c.role == "Author"],
+        "date_completed": h.date_completed.isoformat() if h.date_completed else None,
+        "rating": h.user_rating,
+        "format": h.edition.format,
+        "notes": h.user_notes,
+        "genre": work.genres[0] if work.genres else None,
+        "tropes": [wt.trope.name for wt in top],
+    }
+
+
+def _history_options():
+    """Shared eager-load options for ReadingHistory queries (GET + PATCH)."""
+    return [
+        joinedload(ReadingHistory.edition)
+        .joinedload(Edition.work)
+        .joinedload(Work.contributors)
+        .joinedload(WorkContributor.author),
+        joinedload(ReadingHistory.edition)
+        .joinedload(Edition.work)
+        .selectinload(Work.tropes)
+        .joinedload(WorkTrope.trope),
+    ]
+
+
 @app.get("/history")
 def get_history(
     limit: int = Query(50, ge=1, le=200),
@@ -101,42 +135,83 @@ def get_history(
             # hops below it, so SQLAlchemy subquery-wraps the LIMIT against ReadingHistory rows.
             # Work.tropes is a to-many so we use selectinload (separate IN query) to avoid
             # cartesian-multiplying rows with the contributors joinedload.
-            .options(
-                joinedload(ReadingHistory.edition)
-                .joinedload(Edition.work)
-                .joinedload(Work.contributors)
-                .joinedload(WorkContributor.author),
-                joinedload(ReadingHistory.edition)
-                .joinedload(Edition.work)
-                .selectinload(Work.tropes)
-                .joinedload(WorkTrope.trope),
-            )
+            .options(*_history_options())
             .order_by(ReadingHistory.date_completed.desc(), ReadingHistory.id)
             .offset(offset)
             .limit(limit)
             .all()
         )
+        return [_history_item(h) for h in history_entries]
 
-        def _genre_and_tropes(work):
-            top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
-            return (work.genres[0] if work.genres else None, [wt.trope.name for wt in top])
 
-        result = []
-        for h in history_entries:
-            genre, tropes = _genre_and_tropes(h.edition.work)
-            result.append(
-                {
-                    "id": str(h.id),
-                    "title": h.edition.work.title,
-                    "authors": [c.author.name for c in h.edition.work.contributors if c.role == "Author"],
-                    "date_completed": h.date_completed.isoformat() if h.date_completed else None,
-                    "rating": h.user_rating,
-                    "format": h.edition.format,
-                    "genre": genre,
-                    "tropes": tropes,
-                }
-            )
-        return result
+class HistoryUpdate(BaseModel):
+    date_completed: date | None = None
+    rating: int | None = None
+    notes: str | None = None
+
+    @field_validator("rating", mode="before")
+    @classmethod
+    def _no_bool_rating(cls, v: object) -> object:
+        if isinstance(v, bool):
+            raise ValueError("rating must be an integer, not a boolean")
+        return v
+
+    @field_validator("rating")
+    @classmethod
+    def _rating_range(cls, v: int | None) -> int | None:
+        if v is not None and not 1 <= v <= 5:
+            raise ValueError("rating must be from 1 to 5")
+        return v
+
+    @field_validator("date_completed")
+    @classmethod
+    def _not_future(cls, v: date | None) -> date | None:
+        if v is not None and v > date.today():
+            raise ValueError("date_completed cannot be in the future")
+        return v
+
+
+@app.delete("/history/{entry_id}")
+def delete_history(entry_id: UUID, user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with db_manager.get_session() as session:
+        row = (
+            session.query(ReadingHistory)
+            .filter(ReadingHistory.id == entry_id, ReadingHistory.user_id == user.id)  # only mine (ADR-048)
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="history entry not found")
+        session.delete(row)
+        session.flush()
+    return {"id": str(entry_id), "deleted": True}
+
+
+@app.patch("/history/{entry_id}")
+def update_history(
+    entry_id: UUID,
+    req: HistoryUpdate,
+    user: AuthenticatedUser = Depends(get_current_user),  # noqa: B008
+):
+    fields = req.model_dump(exclude_unset=True)  # only what the client actually sent
+    if "date_completed" in fields and fields["date_completed"] is None:
+        raise HTTPException(status_code=422, detail="date_completed cannot be null")
+    with db_manager.get_session() as session:
+        row = (
+            session.query(ReadingHistory)
+            .filter(ReadingHistory.id == entry_id, ReadingHistory.user_id == user.id)
+            .options(*_history_options())
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="history entry not found")
+        if "date_completed" in fields:
+            row.date_completed = fields["date_completed"]
+        if "rating" in fields:
+            row.user_rating = fields["rating"]
+        if "notes" in fields:
+            row.user_notes = fields["notes"]
+        session.flush()
+        return _history_item(row)
 
 
 @app.get("/works")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -4,8 +4,8 @@ from datetime import date
 from uuid import UUID
 
 from fastapi import Body, Depends, FastAPI, HTTPException, Query
-from pydantic import BaseModel, field_validator
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from pydantic import BaseModel, field_validator
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload, selectinload
 

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -127,3 +127,45 @@ def test_history_no_tropes_returns_empty_list(two_user_client):
     shared = next(r for r in rows if r["title"] == "Shared Book")
     assert shared["tropes"] == []
     assert shared["genre"] is None
+
+
+def test_delete_history_removes_only_callers_row(two_user_client):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    assert client.delete(f"/history/{entry_id}").status_code == 200
+    assert entry_id not in [h["id"] for h in client.get("/history").json()]
+
+
+def test_delete_history_other_users_row_is_404(two_user_client, db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
+    assert two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").delete(f"/history/{friend_id}").status_code == 404
+    with manager.get_session() as session:
+        assert session.get(ReadingHistory, UUID(friend_id)) is not None
+
+
+def test_patch_history_updates_rating_date_notes(two_user_client):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    resp = client.patch(f"/history/{entry_id}", json={"rating": 5, "date_completed": "2020-12-31", "notes": "loved it"})
+    assert resp.status_code == 200
+    assert resp.json()["rating"] == 5 and resp.json()["date_completed"] == "2020-12-31"
+    row = next(h for h in client.get("/history").json() if h["id"] == entry_id)
+    assert row["rating"] == 5 and row["date_completed"] == "2020-12-31" and row["notes"] == "loved it"
+
+
+def test_patch_history_rejects_bad_input_and_other_users(two_user_client, db_url):
+    from datetime import timedelta
+
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry_id = client.get("/history").json()[0]["id"]
+    assert client.patch(f"/history/{entry_id}", json={"rating": True}).status_code == 422
+    assert client.patch(f"/history/{entry_id}", json={"rating": 9}).status_code == 422
+    future = (date.today() + timedelta(days=3)).isoformat()
+    assert client.patch(f"/history/{entry_id}", json={"date_completed": future}).status_code == 422
+    assert client.patch(f"/history/{entry_id}", json={"date_completed": None}).status_code == 422
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
+    assert client.patch(f"/history/{friend_id}", json={"rating": 3}).status_code == 404


### PR DESCRIPTION
Implements beta-feedback item **D1b** — edit and delete reading-history entries from the UI, without the Librarian. Spec/plan: `docs/superpowers/{specs,plans}/2026-06-16-history-edit-delete*`.

## Backend — two user-scoped endpoints (no migration, no new MCP tools)
- **`DELETE /history/{id}`** — removes one read-event; 404 if the id isn't the caller's (ADR-048).
- **`PATCH /history/{id}`** — partial update of `rating` / `date_completed` / `notes` via `exclude_unset` (reuses the add-book validation: rating 1–5, reject bool, no future date; `date_completed` NOT NULL → explicit null rejected). 404 cross-user.
- Refactored the `/history` row into a shared `_history_item` serializer (now also returns `notes`) + a `_history_options()` eager-load helper reused by GET and PATCH.

## Frontend
- **`HistoryView`** — a per-row **⋮ menu** (Edit / Delete); Delete opens a **confirm dialog**; Edit navigates to the edit view with the row in router state. (View now uses `useNavigate`, so its tests render within a `MemoryRouter`.)
- **`HistoryEditView`** (new `/history/:id/edit`) — focused rating/date/notes form, prefilled from router state; **redirects to `/history`** if opened with no state (no GET-by-id endpoint needed).
- `client.ts` `deleteHistory` / `updateHistory` + `HistoryItem.notes`; App route + the required `App.test.tsx` view mock.

## Scope
Editing covers rating/date/notes only (format is edition-level; title/author are work-level). API + UI only — the Librarian keeps its add/update tools.

## Tests
TDD: backend integration (delete isolation + cross-user 404; PATCH updates + validation rejects bool/range/future/null-date + cross-user 404) and frontend vitest (⋮ menu, confirm+delete, cancel-keeps-row, edit prefill+save, no-state redirect). Backend integration 113 passed; frontend 49 passed + build + lint clean. No schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)