### PR TITLE
feat(tags): genre/mood QC cleaning + backfill

### DIFF
--- a/docs/superpowers/plans/2026-06-22-genre-mood-tag-cleaning.md
+++ b/docs/superpowers/plans/2026-06-22-genre-mood-tag-cleaning.md
@@ -1,0 +1,739 @@
+# Genre / Mood Tag Cleaning — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clean `Work.genres` / `Work.moods` — strip UUID/junk, collapse case/spelling variants to a BISAC-formatted canonical, split true combos, drop non-genres — at every write path, plus a one-off backfill of the live DB.
+
+**Architecture:** Two pure modules — `etl/tag_maps.py` (curated `ALIAS_MAP`/`COMBO_MAP`/`DENYLIST`/`CONDITIONAL_DROP` + mood maps, seeded from examples) and `etl/tag_cleaning.py` (`clean_genres`/`clean_moods`) — hooked into `etl/persist.py` so all writes are cleaned. An operator script `scripts/clean_tags.py` (`--inventory`/`--dry-run`/`--apply`) re-cleans existing rows against **live prod**, guarded against backups/stale DBs. No schema change, no embeddings.
+
+**Tech Stack:** Python 3 / SQLAlchemy / pytest (`db_integration` marker for DB tests). Run tests with `uv run pytest …`; format before pushing with `uvx ruff@0.15.16 format .` (CI runs the `ruff-format` pre-commit hook — `ruff check` alone misses it).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/agentic_librarian/etl/tag_maps.py` — curated lookup data (dicts/sets), keys pre-normalized (lowercase, spaces).
+- **Create** `src/agentic_librarian/etl/tag_cleaning.py` — pure `clean_genres`/`clean_moods` + helpers.
+- **Modify** `src/agentic_librarian/etl/persist.py` (~L140-141) — wrap genres/moods coercion in the cleaners.
+- **Create** `src/agentic_librarian/etl/tag_backfill.py` — testable backfill logic (`plan_changes`/`apply_changes`/`inventory`/`is_prod_url`).
+- **Create** `scripts/clean_tags.py` — thin standalone CLI (inventory/dry-run/apply), run directly.
+- **Test** `test/unit/test_tag_cleaning.py`, `test/unit/test_tag_backfill.py`, `test/integration/test_persist_tag_cleaning.py`, `test/integration/test_tag_backfill_db.py`.
+
+**Normalization contract (used everywhere):** a tag is "normalized" by stripping a trailing UUID, replacing `-`/`_` with spaces, lowercasing, and collapsing whitespace. All map **keys** are normalized form; map **values** (RHS) are the canonical display spelling (BISAC where one exists).
+
+---
+
+## Task 1: `tag_maps.py` — curated seed maps
+
+**Files:**
+- Create: `src/agentic_librarian/etl/tag_maps.py`
+- Test: `test/unit/test_tag_cleaning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/test_tag_cleaning.py`:
+
+```python
+from agentic_librarian.etl import tag_maps
+
+
+def test_seed_maps_have_expected_entries():
+    assert tag_maps.ALIAS_MAP["sci fi"] == "Science Fiction"
+    assert tag_maps.ALIAS_MAP["action adventure"] == "Action & Adventure"
+    assert tag_maps.ALIAS_MAP["business economics"] == "Business & Economics"
+    assert tag_maps.COMBO_MAP["science fiction fantasy"] == ["Science Fiction", "Fantasy"]
+    assert "audiobook" in tag_maps.DENYLIST
+    assert "general" in tag_maps.DENYLIST
+    assert "Fiction" in tag_maps.CONDITIONAL_DROP
+    # mood maps exist
+    assert isinstance(tag_maps.MOOD_ALIAS_MAP, dict)
+    assert isinstance(tag_maps.MOOD_DENYLIST, set)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py::test_seed_maps_have_expected_entries -v`
+Expected: FAIL with `ModuleNotFoundError: …etl.tag_maps`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/agentic_librarian/etl/tag_maps.py`:
+
+```python
+"""Curated lookup tables for genre/mood cleaning (Spec 2026-06-22). Keys are NORMALIZED
+(lowercase, hyphens/underscores -> spaces, whitespace-collapsed); values are the canonical
+display spelling, following BISAC where one exists. Seeded from the operator's known examples;
+expand from the `scripts/clean_tags.py --inventory` output during rollout."""
+
+from __future__ import annotations
+
+# normalized variant -> canonical (BISAC-formatted) spelling
+ALIAS_MAP: dict[str, str] = {
+    "fiction": "Fiction",
+    "nonfiction": "Nonfiction",
+    "non fiction": "Nonfiction",
+    "sci fi": "Science Fiction",
+    "scifi": "Science Fiction",
+    "sf": "Science Fiction",
+    "science fiction": "Science Fiction",
+    "action adventure": "Action & Adventure",
+    "business economics": "Business & Economics",
+    "business & economics": "Business & Economics",
+    "epic": "Epic",
+    "fantasy": "Fantasy",
+}
+
+# normalized true-combo slug -> list of canonical genres (split)
+COMBO_MAP: dict[str, list[str]] = {
+    "science fiction fantasy": ["Science Fiction", "Fantasy"],
+}
+
+# normalized tags dropped always (non-genres: formats, fillers)
+DENYLIST: set[str] = {
+    "audiobook", "audio", "audio cd", "audible audio",
+    "ebook", "e book", "kindle edition", "paperback", "hardcover", "mass market paperback",
+    "general", "books", "miscellaneous", "uncategorized", "other",
+}
+
+# canonical genres dropped iff other genres remain in the list
+CONDITIONAL_DROP: set[str] = {"Fiction"}
+
+# moods: permissive QC — collapse only, drop only clear junk
+MOOD_ALIAS_MAP: dict[str, str] = {
+    "lighthearted": "Lighthearted",
+    "light hearted": "Lighthearted",
+}
+MOOD_DENYLIST: set[str] = {"audiobook", "ebook", "general", "n a", "na"}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py::test_seed_maps_have_expected_entries -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/tag_maps.py test/unit/test_tag_cleaning.py
+git commit -m "feat(tags): seed genre/mood cleaning maps"
+```
+
+---
+
+## Task 2: `tag_cleaning.py` — normalization helpers
+
+**Files:**
+- Create: `src/agentic_librarian/etl/tag_cleaning.py`
+- Test: `test/unit/test_tag_cleaning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/test_tag_cleaning.py`:
+
+```python
+from agentic_librarian.etl import tag_cleaning as tc
+
+
+def test_strip_uuid_and_normalize():
+    assert tc._strip_uuid("science-fiction-fantasy-4c14c349-8d52-4893-aaf0-34f7e33bf275") == "science-fiction-fantasy"
+    assert tc._strip_uuid("epic") == "epic"
+    assert tc._normalize("Science-Fiction") == "science fiction"
+    assert tc._normalize("  Business & Economics ") == "business & economics"
+
+
+def test_bisac_reduce_takes_deepest_non_filler():
+    assert tc._bisac_reduce("Fiction / Science Fiction / General") == "Science Fiction"
+    assert tc._bisac_reduce("Fantasy") == "Fantasy"
+
+
+def test_titlecase():
+    assert tc._titlecase("science fiction") == "Science Fiction"
+    assert tc._titlecase("business & economics") == "Business & Economics"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -k "strip_uuid or bisac or titlecase" -v`
+Expected: FAIL with `ModuleNotFoundError: …etl.tag_cleaning`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/agentic_librarian/etl/tag_cleaning.py`:
+
+```python
+"""Pure QC/cleaning for Work.genres / Work.moods (Spec 2026-06-22). No I/O; deterministic;
+parametrised by the curated maps in tag_maps.py."""
+
+from __future__ import annotations
+
+import re
+
+from agentic_librarian.etl import tag_maps
+
+_UUID_RE = re.compile(r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+_HAS_DIGIT_RE = re.compile(r"\d")
+_BISAC_FILLER = {"general", "fiction", "nonfiction", "non fiction", "books", "miscellaneous"}
+
+
+def _strip_uuid(tag: str) -> str:
+    return _UUID_RE.sub("", tag or "")
+
+
+def _normalize(tag: str) -> str:
+    s = (tag or "").replace("-", " ").replace("_", " ")
+    return " ".join(s.lower().split())
+
+
+def _bisac_reduce(tag: str) -> str:
+    """BISAC path 'A / B / C' -> the deepest non-filler segment; otherwise the tag unchanged."""
+    if "/" not in tag:
+        return tag
+    segments = [seg.strip() for seg in tag.split("/") if seg.strip()]
+    for seg in reversed(segments):
+        if _normalize(seg) not in _BISAC_FILLER:
+            return seg
+    return segments[-1] if segments else ""
+
+
+def _titlecase(norm: str) -> str:
+    return " ".join(w.capitalize() for w in norm.split())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -k "strip_uuid or bisac or titlecase" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/tag_cleaning.py test/unit/test_tag_cleaning.py
+git commit -m "feat(tags): normalization helpers (uuid strip, normalize, bisac, titlecase)"
+```
+
+---
+
+## Task 3: `clean_genres` — the full pipeline
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/tag_cleaning.py`
+- Test: `test/unit/test_tag_cleaning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/test_tag_cleaning.py` (these are the spec's real-string acceptance cases):
+
+```python
+import pytest
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ([f"science-fiction-fantasy-{UUID}"], ["Science Fiction", "Fantasy"]),
+    ([f"audiobook-{UUID}"], []),
+    ([f"epic-{UUID}"], ["Epic"]),
+    ([f"action-adventure-{UUID}"], ["Action & Adventure"]),
+    (["fiction", "Fiction", "Fantasy"], ["Fantasy"]),
+    (["fiction"], ["Fiction"]),
+    (["business-economics", "Business & Economics"], ["Business & Economics"]),
+    (["sci-fi", "scifi", "Science-Fiction"], ["Science Fiction"]),
+    ([f"general-{UUID}", "Fiction / Science Fiction / General"], ["Science Fiction"]),
+    ([], []),
+    (None, []),
+])
+def test_clean_genres(raw, expected):
+    assert tc.clean_genres(raw) == expected
+
+
+def test_clean_genres_is_idempotent():
+    msgs = [f"science-fiction-fantasy-{UUID}", "fiction", "Fantasy", f"audiobook-{UUID}"]
+    once = tc.clean_genres(msgs)
+    assert tc.clean_genres(once) == once
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -k clean_genres -v`
+Expected: FAIL with `AttributeError: …has no attribute 'clean_genres'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/agentic_librarian/etl/tag_cleaning.py`:
+
+```python
+def _clean_one(tag: str, *, alias: dict, combo: dict, denylist: set) -> list[str]:
+    n = _normalize(_bisac_reduce(_strip_uuid(tag)))
+    if not n:
+        return []
+    if n in combo:
+        return list(combo[n])          # already canonical
+    if n in alias:
+        return [alias[n]]
+    if n in denylist or _HAS_DIGIT_RE.search(n) or len(n) <= 1:
+        return []
+    return [_titlecase(n)]              # unknown-but-valid: keep, cleaned
+
+
+def _dedup(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for it in items:
+        k = it.lower()
+        if k not in seen:
+            seen.add(k)
+            out.append(it)
+    return out
+
+
+def clean_genres(raw: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for tag in raw or []:
+        out.extend(_clean_one(tag, alias=tag_maps.ALIAS_MAP, combo=tag_maps.COMBO_MAP, denylist=tag_maps.DENYLIST))
+    result = _dedup(out)
+    if len(result) > 1:  # drop over-broad umbrellas only when more specific genres remain
+        pruned = [g for g in result if g not in tag_maps.CONDITIONAL_DROP]
+        result = pruned or result
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -k clean_genres -v`
+Expected: PASS (all parametrized cases + idempotency).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/tag_cleaning.py test/unit/test_tag_cleaning.py
+git commit -m "feat(tags): clean_genres pipeline (alias/combo/deny/conditional-drop)"
+```
+
+---
+
+## Task 4: `clean_moods`
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/tag_cleaning.py`
+- Test: `test/unit/test_tag_cleaning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/test_tag_cleaning.py`:
+
+```python
+@pytest.mark.parametrize("raw,expected", [
+    ([f"dark-{UUID}", "Dark"], ["Dark"]),                 # uuid strip + case dedup
+    ([f"audiobook-{UUID}"], []),                          # junk dropped
+    (["lighthearted", "Light-Hearted"], ["Lighthearted"]),  # alias collapse
+    (["Mysterious", "reflective"], ["Mysterious", "Reflective"]),  # unknown kept, title-cased
+    (["general"], []),
+    (None, []),
+])
+def test_clean_moods(raw, expected):
+    assert tc.clean_moods(raw) == expected
+
+
+def test_clean_moods_no_combo_split():
+    # moods never split on the genre COMBO_MAP
+    assert tc.clean_moods(["science fiction fantasy"]) == ["Science Fiction Fantasy"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -k clean_moods -v`
+Expected: FAIL (`clean_moods` not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/agentic_librarian/etl/tag_cleaning.py`:
+
+```python
+def clean_moods(raw: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for tag in raw or []:
+        out.extend(_clean_one(tag, alias=tag_maps.MOOD_ALIAS_MAP, combo={}, denylist=tag_maps.MOOD_DENYLIST))
+    return _dedup(out)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest test/unit/test_tag_cleaning.py -v`
+Expected: PASS (whole file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/tag_cleaning.py test/unit/test_tag_cleaning.py
+git commit -m "feat(tags): clean_moods (permissive QC, no combo-split)"
+```
+
+---
+
+## Task 5: Hook the cleaners into `persist.py`
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/persist.py`
+- Test: `test/integration/test_persist_tag_cleaning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/integration/test_persist_tag_cleaning.py`:
+
+```python
+"""persist_enriched_work stores cleaned genres/moods (Spec 2026-06-22)."""
+
+import pytest
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl.persist import persist_enriched_work
+
+pytestmark = pytest.mark.db_integration
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+class _NullManager:
+    """Stand-in for Trope/Style managers — never actually called for a skip_enrichment row,
+    but persist takes them as args."""
+
+    def standardize_trope(self, *a, **k):
+        return None
+
+    def standardize_style(self, *a, **k):
+        return None
+
+
+def test_persist_cleans_genres_and_moods(db_url):
+    manager = DatabaseManager(db_url)
+    row = {
+        "Title": "Tag Cleaning Test",
+        "Author_1": "T. Author",
+        "genres": [f"science-fiction-fantasy-{UUID}", f"audiobook-{UUID}", "Fiction"],
+        "moods": [f"dark-{UUID}", "Dark"],
+        "skip_enrichment": True,  # new work: genres set at creation, no trope/embedding work
+    }
+    with manager.get_session() as session:
+        persist_enriched_work(session, row, _NullManager(), _NullManager())
+        session.flush()
+        work = session.query(Work).filter_by(title="Tag Cleaning Test").one()
+        assert work.genres == ["Science Fiction", "Fantasy"]  # combo split, audiobook dropped, Fiction dropped (others present)
+        assert work.moods == ["Dark"]
+```
+
+- [ ] **Step 2: Run test to verify it fails (or skips)**
+
+Run: `uv run pytest test/integration/test_persist_tag_cleaning.py -v`
+Expected: FAIL (genres stored raw) if a DB is present; SKIP if no Postgres. Either confirms wiring.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/agentic_librarian/etl/persist.py`, add the import near the other `agentic_librarian.etl`/scout imports at the top:
+
+```python
+from agentic_librarian.etl.tag_cleaning import clean_genres, clean_moods
+```
+
+Then change the two coercion lines (currently `genres = _nan_to_list(row.get("genres"))` / `moods = _nan_to_list(row.get("moods"))`) to:
+
+```python
+    genres = clean_genres(_nan_to_list(row.get("genres")))
+    moods = clean_moods(_nan_to_list(row.get("moods")))
+```
+
+Do not change anything else (the rest of the function consumes `genres`/`moods` unchanged, including the fallback-trope set at `all_fallback_tags = set(genres) | set(moods)` — which now benefits from clean tags).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest test/integration/test_persist_tag_cleaning.py -v`
+Expected: PASS (or SKIP without a DB). Also run the existing persist tests to confirm no regression:
+Run: `uv run pytest test/integration/test_persist.py test/integration/test_persist_enriched.py -v`
+Expected: PASS or SKIP.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/persist.py test/integration/test_persist_tag_cleaning.py
+git commit -m "feat(tags): clean genres/moods at persist (covers all write paths)"
+```
+
+---
+
+## Task 6: Backfill logic `etl/tag_backfill.py` + thin CLI `scripts/clean_tags.py`
+
+**Files:**
+- Create: `src/agentic_librarian/etl/tag_backfill.py` (testable logic)
+- Create: `scripts/clean_tags.py` (thin standalone CLI, run directly)
+- Test: `test/unit/test_tag_backfill.py`, `test/integration/test_tag_backfill_db.py`
+
+> **Why the logic lives in `src/`:** pytest only puts `src` on the path (`pythonpath = ["src"]` in
+> `pyproject.toml`), so `from scripts import …` does NOT resolve in tests. The testable logic lives in
+> `agentic_librarian.etl.tag_backfill`; `scripts/clean_tags.py` is a thin wrapper run directly
+> (`python scripts/clean_tags.py …`), never imported — so no `scripts/__init__.py` is needed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/test_tag_backfill.py` (pure guard logic — no DB):
+
+```python
+import pytest
+
+from agentic_librarian.etl import tag_backfill
+
+
+@pytest.mark.parametrize("url,ok", [
+    ("postgresql://u:p@10.1.2.3:5432/agentic_librarian", True),
+    ("postgresql://u:p@host.docker.internal:5433/agentic_librarian", True),
+    ("postgresql://u:p@localhost:5432/agentic_librarian", False),
+    ("postgresql://u:p@127.0.0.1:5432/agentic_librarian", False),
+    ("sqlite:///data/backups/snapshot.db", False),
+    ("postgresql://u:p@/agentic_librarian?host=/cloudsql/proj:reg:inst", True),
+])
+def test_is_prod_url(url, ok):
+    assert tag_backfill.is_prod_url(url) is ok
+```
+
+Create `test/integration/test_tag_backfill_db.py`:
+
+```python
+"""plan_changes / apply_changes over real rows (Spec 2026-06-22)."""
+
+import pytest
+
+from agentic_librarian.db.models import Author, Edition, Work, WorkContributor
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import tag_backfill
+
+pytestmark = pytest.mark.db_integration
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+def _seed(manager, genres, moods):
+    with manager.get_session() as s:
+        a = Author(name="B. Author")
+        w = Work(title="Backfill Test", contributors=[WorkContributor(author=a, role="Author")],
+                 genres=genres, moods=moods)
+        s.add_all([a, w, Edition(work=w, format="ebook")])
+        s.flush()
+        return w.id
+
+
+def test_plan_and_apply(db_url):
+    manager = DatabaseManager(db_url)
+    wid = _seed(manager, [f"science-fiction-fantasy-{UUID}", f"audiobook-{UUID}"], [f"dark-{UUID}", "Dark"])
+
+    with manager.get_session() as session:
+        mine = [c for c in tag_backfill.plan_changes(session) if c.work_id == wid]
+        assert len(mine) == 1
+        assert mine[0].genres_after == ["Science Fiction", "Fantasy"]
+        assert mine[0].moods_after == ["Dark"]
+
+    with manager.get_session() as session:
+        tag_backfill.apply_changes(session)
+
+    with manager.get_session() as session:
+        w = session.get(Work, wid)
+        assert w.genres == ["Science Fiction", "Fantasy"]
+        assert w.moods == ["Dark"]
+        # idempotent: a second plan over already-clean data finds no change for this work
+        assert all(c.work_id != wid for c in tag_backfill.plan_changes(session))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest test/unit/test_tag_backfill.py test/integration/test_tag_backfill_db.py -v`
+Expected: FAIL with `ModuleNotFoundError: …etl.tag_backfill` (guard test fails; DB test fails or skips without a DB).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/agentic_librarian/etl/tag_backfill.py`:
+
+```python
+"""Backfill logic for genre/mood cleaning (Spec 2026-06-22): session in, lists out, no CLI/I-O of
+its own. The thin operator CLI is scripts/clean_tags.py."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from uuid import UUID
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.etl.tag_cleaning import clean_genres, clean_moods
+
+
+@dataclass
+class Change:
+    work_id: UUID
+    title: str
+    genres_before: list[str]
+    genres_after: list[str]
+    moods_before: list[str]
+    moods_after: list[str]
+
+
+def plan_changes(session) -> list[Change]:
+    """Works whose cleaned genres/moods differ from what's stored."""
+    out: list[Change] = []
+    for w in session.query(Work).all():
+        gb, mb = list(w.genres or []), list(w.moods or [])
+        ga, ma = clean_genres(gb), clean_moods(mb)
+        if ga != gb or ma != mb:
+            out.append(Change(w.id, w.title, gb, ga, mb, ma))
+    return out
+
+
+def apply_changes(session) -> int:
+    n = 0
+    for c in plan_changes(session):
+        w = session.get(Work, c.work_id)
+        w.genres, w.moods = c.genres_after, c.moods_after
+        n += 1
+    return n
+
+
+def inventory(session) -> tuple[Counter, Counter]:
+    genres: Counter = Counter()
+    moods: Counter = Counter()
+    for w in session.query(Work).all():
+        genres.update(w.genres or [])
+        moods.update(w.moods or [])
+    return genres, moods
+
+
+def is_prod_url(url: str) -> bool:
+    """True only for a real remote/proxy Postgres — NOT sqlite, backups, or a local dev DB."""
+    u = (url or "").lower()
+    if u.startswith("sqlite") or "/backups/" in u or "data/backups" in u:
+        return False
+    if "@localhost" in u or "@127.0.0.1" in u:
+        return False
+    return u.startswith("postgresql")
+```
+
+Create `scripts/clean_tags.py` (thin CLI — run directly, never imported by tests):
+
+```python
+"""Operator backfill CLI for genre/mood cleaning (Spec 2026-06-22).
+
+  python scripts/clean_tags.py --inventory      # read-only; distinct values + frequency
+  python scripts/clean_tags.py --dry-run        # read-only; show changes, NO writes
+  python scripts/clean_tags.py --apply --yes    # write cleaned values (idempotent)
+
+Run against LIVE prod via the app container + Cloud SQL proxy (docs/runbooks/bulk-import-rollout.md §3).
+Refuses --apply against a sqlite/backup/localhost DB."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.db.session import DatabaseManager, resolve_database_url
+from agentic_librarian.etl import tag_backfill
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Clean Work.genres / Work.moods.")
+    ap.add_argument("--inventory", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
+    args = ap.parse_args(argv)
+
+    url = resolve_database_url()
+    safe = url.split("@")[-1] if "@" in url else url  # never print credentials
+    manager = DatabaseManager(url)
+
+    with manager.get_session() as session:
+        print(f"DB target: …@{safe}")
+        print(f"recency probe: works={session.query(Work).count()}  (confirm CURRENT prod, not a backup)")
+
+        if args.inventory:
+            genres, moods = tag_backfill.inventory(session)
+            print("\n=== distinct GENRES (count | value) ===")
+            for val, c in genres.most_common():
+                print(f"{c:5d}  {val!r}")
+            print("\n=== distinct MOODS (count | value) ===")
+            for val, c in moods.most_common():
+                print(f"{c:5d}  {val!r}")
+            return 0
+
+        changes = tag_backfill.plan_changes(session)
+        print(f"\n{len(changes)} works would change.")
+        for c in changes[:50]:
+            if c.genres_before != c.genres_after:
+                print(f"  [{c.title[:40]:40}] genres {c.genres_before} -> {c.genres_after}")
+            if c.moods_before != c.moods_after:
+                print(f"  [{c.title[:40]:40}] moods  {c.moods_before} -> {c.moods_after}")
+
+        if args.dry_run or not args.apply:
+            print("\n(dry-run: no writes)")
+            return 0
+        if not args.yes:
+            print("\nREFUSING --apply without --yes.")
+            return 2
+        if not tag_backfill.is_prod_url(url):
+            print(f"\nREFUSING --apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+            return 2
+
+        print(f"\napplied: {tag_backfill.apply_changes(session)} works updated.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest test/unit/test_tag_backfill.py -v`
+Expected: PASS (6 cases).
+Run: `uv run pytest test/integration/test_tag_backfill_db.py -v`
+Expected: PASS (or SKIP without a DB).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/etl/tag_backfill.py scripts/clean_tags.py test/unit/test_tag_backfill.py test/integration/test_tag_backfill_db.py
+git commit -m "feat(tags): backfill logic + CLI with live-DB guard"
+```
+
+---
+
+## Task 7: Verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint (CI parity)**
+
+Run: `uvx ruff@0.15.16 format src/agentic_librarian/etl/tag_cleaning.py src/agentic_librarian/etl/tag_maps.py src/agentic_librarian/etl/tag_backfill.py src/agentic_librarian/etl/persist.py scripts/clean_tags.py test/unit/test_tag_cleaning.py test/unit/test_tag_backfill.py test/integration/test_persist_tag_cleaning.py test/integration/test_tag_backfill_db.py`
+Then: `uv run ruff check src/agentic_librarian/etl scripts/clean_tags.py test/unit/test_tag_cleaning.py test/unit/test_tag_backfill.py`
+Expected: format makes only intended changes; check is clean. (CI runs the `ruff-format` pre-commit hook — never push without running format first.)
+
+- [ ] **Step 2: Full backend suite**
+
+Run: `uv run pytest test/unit test/integration -q`
+Expected: the new tag tests PASS; `db_integration` tests SKIP if no Postgres; the only failures are the 5 pre-existing environmental ones (live API/DB). Any other failure is a regression.
+
+- [ ] **Step 3: Commit any format fixes**
+
+```bash
+git add -A
+git commit -m "chore(tags): ruff format"
+```
+
+---
+
+## Rollout (operator, post-merge)
+
+1. Deploy ships the persist hook → all **new** enrichment writes are cleaned automatically (no env/migration).
+2. Inventory the live DB (app container + Cloud SQL proxy, per `docs/runbooks/bulk-import-rollout.md` §3):
+   `… agentic_librarian-app:latest python scripts/clean_tags.py --inventory`
+3. Expand `tag_maps.py` from the inventory output (review the new aliases/combos/denials), reconcile canonical genre names against design-work's `GenreIcon` set (coordination board), re-run unit tests.
+4. `python scripts/clean_tags.py --dry-run` → eyeball the diff + the recency probe (confirm it's CURRENT prod, not a `data/backups` snapshot).
+5. `python scripts/clean_tags.py --apply --yes` → backfill. Idempotent; re-runnable.

--- a/docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md
+++ b/docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md
@@ -44,7 +44,7 @@ a free side benefit, no extra work.
   - `science-fiction-fantasy-<uuid>` → `["Science Fiction", "Fantasy"]`
   - `audiobook-<uuid>` → dropped (not a genre)
   - `epic-<uuid>` → `["Epic"]`
-  - `action-adventure-<uuid>` → `["Action", "Adventure"]`
+  - `action-adventure-<uuid>` → `["Action & Adventure"]` (BISAC keeps it as one genre, not split)
   - `fiction` / `Fiction` → collapse to `Fiction`, and **drop if other genres are present**
   - `business-economics` + `Business & Economics` → `["Business & Economics"]`
   - sci-fi variants → `["Science Fiction"]`; `general` → dropped
@@ -66,8 +66,9 @@ a free side benefit, no extra work.
 - **D1 — Mechanism:** a deterministic **cleaning pipeline** over the existing `ARRAY(String)` columns,
   parametrised by small curated lookup maps. Genres and moods share the pipeline with different configs.
 - **D2 — Scope:** genres + moods only.
-- **D3 — Combos:** explicit `COMBO_MAP` (`science-fiction-fantasy` → `[Science Fiction, Fantasy]`;
-  `action-adventure` → `[Action, Adventure]`).
+- **D3 — Combos:** explicit `COMBO_MAP` for true multi-genre slugs (`science-fiction-fantasy` →
+  `[Science Fiction, Fantasy]`). Where BISAC keeps terms together as one genre, alias to the single
+  BISAC form instead of splitting (`action-adventure` → `Action & Adventure`, via `ALIAS_MAP`).
 - **D4 — Over-broad terms:** `General` → always drop; `Fiction` → drop **only if** other genres remain
   (sole-genre `Fiction` is kept); `Nonfiction` → kept as-is.
 - **D5 — Maps seeded from data:** the alias/combo/deny maps are curated from a one-time **inventory** of
@@ -75,8 +76,14 @@ a free side benefit, no extra work.
 - **D6 — Graceful degradation:** the cleaner works before maps are complete (unknown tags get
   UUID-strip + Title-Case + junk-reject); maps grow from the inventory.
 - **D7 — Backfill targets LIVE prod**, never a backup/snapshot; guarded by an explicit connection check.
-- **D8 — Coordinate canonical genre names with the design-work "13-genre icons"** so each canonical
-  genre maps to an icon (cross-session; see Rollout notes).
+- **D8 — Genre names ↔ design-work icons (relaxed):** `GenreIcon` resolves via fuzzy
+  `canonicalizeGenre()` (token-contains, case-insensitive) — NOT exact strings — so canonical names need
+  only *contain* the recognizable genre token (`Action & Adventure` → Adventure icon). The 13 icon
+  genres are listed in Rollout notes; anything else degrades to a fallback star. (Confirmed with
+  design-work, 2026-06-22.)
+- **D9 — BISAC is the formatting authority:** canonical genre names follow BISAC spelling/format where a
+  BISAC equivalent exists (`Business & Economics`, `Action & Adventure`); when unsure how to represent a
+  genre, use BISAC for the canonical form.
 
 ## 5. Architecture & Placement
 
@@ -107,11 +114,12 @@ No schema change. `Work.genres`/`Work.moods` stay `ARRAY(String)`.
 2. **Normalize form** — hyphens/underscores → spaces; collapse whitespace; for BISAC paths
    (`A / B / C`) take the most specific meaningful segment (`Fiction / Science Fiction / General` →
    `Science Fiction`); lowercase for lookup.
-3. **Alias lookup** (`ALIAS_MAP`) — snap known variants to one canonical spelling: `fiction`→`Fiction`,
-   `sci-fi`/`scifi`/`science-fiction`→`Science Fiction`, `business-economics`→`Business & Economics`,
-   `epic`→`Epic`.
-4. **Combo split** (`COMBO_MAP`) — `science-fiction-fantasy` → `[Science Fiction, Fantasy]`;
-   `action-adventure` → `[Action, Adventure]`. (Each split member is itself canonical.)
+3. **Alias lookup** (`ALIAS_MAP`) — snap known variants to one canonical (BISAC-formatted) spelling:
+   `fiction`→`Fiction`, `sci-fi`/`scifi`/`science-fiction`→`Science Fiction`,
+   `business-economics`→`Business & Economics`, `action-adventure`→`Action & Adventure`, `epic`→`Epic`.
+4. **Combo split** (`COMBO_MAP`) — only true multi-genre slugs: `science-fiction-fantasy` →
+   `[Science Fiction, Fantasy]`. (Each split member is itself canonical. `action-adventure` is NOT split
+   — BISAC treats it as one genre, so it's an `ALIAS_MAP` entry above.)
 5. **Reject junk** — drop the tag if: on `DENYLIST` (`audiobook`, `ebook`, `paperback`,
    `kindle edition`, format words, `general`, `books`…); contains digits/leftover hex after step 1;
    empty or a single stray char.
@@ -131,6 +139,7 @@ The maps in `tag_maps.py` are built from reality, in three steps:
    from the live DB.
 2. **Curate** — from that inventory we (operator + author) fill `ALIAS_MAP` / `COMBO_MAP` / `DENYLIST` /
    `CONDITIONAL_DROP`. Seeded with the known examples; expanded to cover the actual distinct values.
+   Canonical (RHS) spellings follow **BISAC** where one exists (D9) — it is the formatting authority.
 3. **Review** — operator eyeballs the maps and the dry-run diff before applying.
 
 Map shapes:
@@ -174,7 +183,7 @@ real strings:
 | `["science-fiction-fantasy-<uuid>"]` | `["Science Fiction", "Fantasy"]` |
 | `["audiobook-<uuid>"]` | `[]` |
 | `["epic-<uuid>"]` | `["Epic"]` |
-| `["action-adventure-<uuid>"]` | `["Action", "Adventure"]` |
+| `["action-adventure-<uuid>"]` | `["Action & Adventure"]` |
 | `["fiction", "Fiction", "Fantasy"]` | `["Fantasy"]` |
 | `["fiction"]` | `["Fiction"]` |
 | `["business-economics", "Business & Economics"]` | `["Business & Economics"]` |
@@ -191,8 +200,12 @@ and writes nothing; `--apply` writes cleaned values; second `--apply` is a no-op
 - **Sequence:** ship the cleaner + persist hook + seed maps (go-forward correctness) → operator runs
   `--inventory` on prod → expand the maps from the inventory (review) → `--dry-run` (eyeball) →
   `--apply` against **live** prod.
-- **Cross-session (D8):** the canonical genre names (RHS of the maps) must line up with the
-  **design-work** session's "13-genre line-art icons" so each genre maps to an icon. Coordinate the
-  canonical genre list on the agent coordination board before finalising the maps.
+- **Cross-session (D8, resolved):** design-work's `GenreIcon` resolves genres via fuzzy
+  `canonicalizeGenre()` (regex token-contains, case-insensitive) in `frontend/src/components/genreUtils.ts`
+  — so the cleaning maps do **not** need exact-string parity with the icons; a cleaned canonical name just
+  needs to *contain* the recognizable token. The **13 icon genres**: Fantasy, Science Fiction, Adventure,
+  Mystery, Romance, Horror, Thriller, Literary, Historical, Young Adult, LGBTQ, War, Dystopian — anything
+  else → a graceful fallback star. BISAC formatting (D9) is compatible (e.g. `Action & Adventure` →
+  Adventure icon). Coordinated on the board, 2026-06-22.
 - No migration, no env changes, no deploy gating — the persist-hook change rides a normal deploy; the
   backfill is a one-off operator script.

--- a/docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md
+++ b/docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md
@@ -1,0 +1,198 @@
+# Genre / Mood Tag Cleaning — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (brainstormed), pending plan
+**Origin:** Bug — `Work.genres`/`Work.moods` contain raw, un-canonicalized external tags (Hardcover
+slug+UUID strings, Google Books BISAC paths, combos like "science fiction fantasy", non-genres like
+"audiobook"). Tropes/styles are clean; genres/moods are not. Fix go-forward + correct the existing DB.
+
+---
+
+## 1. Background & Problem
+
+`Work.genres` and `Work.moods` are `ARRAY(String)` columns populated verbatim from external scouts:
+
+- **Hardcover** genre/mood tagSlugs — and in practice these arrive with a UUID appended, e.g.
+  `science-fiction-fantasy-4c14c349-8d52-4893-aaf0-34f7e33bf275`,
+  `audiobook-28d9b978-31e9-43d5-a61a-499c03237945`, `epic-cb4665c5-…`, `action-adventure-885c1c28-…`.
+- **Google Books** `categories` — hierarchical BISAC paths, e.g. `Fiction / Science Fiction / General`,
+  and ampersand forms like `Business & Economics`.
+
+`ScoutManager` merges these into a set (exact-dedup only) and `persist_enriched_work` writes them
+verbatim (`persist.py:140-141, 176-177`). There is **no normalization, no canonicalization, no junk
+rejection**. Result: combos (`science fiction fantasy`), garbage (UUID-tailed slugs, digits),
+non-genres (`audiobook`), case/spelling variants (`fiction` vs `Fiction`; `business-economics` vs
+`Business & Economics`; a host of sci-fi variants), and over-broad umbrellas (`Fiction`, `General`) all
+coexist. These surface raw in the UI/analysis (`analysis.py:74-75` counts `work.genres` directly).
+
+**Why tropes/styles are NOT affected (verified):** there is no title-casing step anywhere in the code.
+Tropes/styles are clean because they are **LLM-sourced** (consistent casing) **and** run through
+`standardize_trope` / `standardize_style` (exact + semantic dedup). Genres/moods get none of that. So
+the fix is scoped to **genres + moods**; tropes/styles are untouched.
+
+**Note on coupling:** when a work has no enriched tropes, genres+moods are reused as *fallback tropes*
+(`persist.py:286`). Cleaning genres/moods at persist therefore also improves those fallback tropes —
+a free side benefit, no extra work.
+
+## 2. Goals
+
+- **QC / cleanup, not taxonomy.** Keep the existing emergent vocabulary; just clean it. No controlled
+  allow-list, no new tables, no embeddings.
+- **Go-forward:** every new enrichment write stores cleaned genres/moods.
+- **Backfill:** correct the existing values already in the **live production** database.
+- Concretely, per the operator's examples:
+  - `science-fiction-fantasy-<uuid>` → `["Science Fiction", "Fantasy"]`
+  - `audiobook-<uuid>` → dropped (not a genre)
+  - `epic-<uuid>` → `["Epic"]`
+  - `action-adventure-<uuid>` → `["Action", "Adventure"]`
+  - `fiction` / `Fiction` → collapse to `Fiction`, and **drop if other genres are present**
+  - `business-economics` + `Business & Economics` → `["Business & Economics"]`
+  - sci-fi variants → `["Science Fiction"]`; `general` → dropped
+
+## 3. Non-Goals (YAGNI)
+
+- **No controlled-vocabulary allow-list** — unknown-but-valid tags pass through (cleaned), not rejected.
+- **No genre hierarchy/taxonomy** — the only hierarchy concession is dropping over-broad `Fiction` when
+  more specific genres exist.
+- **No new tables / embeddings / semantic dedup** for genres/moods (that's the trope/style mechanism;
+  we deliberately don't mirror it here — it wouldn't split combos and is overkill for QC).
+- **No re-enrichment** — the raw values are already in the columns; backfill re-cleans in place.
+- **No general greedy combo-splitter** — combos are handled by an explicit, curated `COMBO_MAP`
+  (predictable, no surprises).
+- **No changes to tropes/styles.**
+
+## 4. Decisions (from brainstorm)
+
+- **D1 — Mechanism:** a deterministic **cleaning pipeline** over the existing `ARRAY(String)` columns,
+  parametrised by small curated lookup maps. Genres and moods share the pipeline with different configs.
+- **D2 — Scope:** genres + moods only.
+- **D3 — Combos:** explicit `COMBO_MAP` (`science-fiction-fantasy` → `[Science Fiction, Fantasy]`;
+  `action-adventure` → `[Action, Adventure]`).
+- **D4 — Over-broad terms:** `General` → always drop; `Fiction` → drop **only if** other genres remain
+  (sole-genre `Fiction` is kept); `Nonfiction` → kept as-is.
+- **D5 — Maps seeded from data:** the alias/combo/deny maps are curated from a one-time **inventory** of
+  the live DB's distinct values, not invented — "use what we already have as the baseline."
+- **D6 — Graceful degradation:** the cleaner works before maps are complete (unknown tags get
+  UUID-strip + Title-Case + junk-reject); maps grow from the inventory.
+- **D7 — Backfill targets LIVE prod**, never a backup/snapshot; guarded by an explicit connection check.
+- **D8 — Coordinate canonical genre names with the design-work "13-genre icons"** so each canonical
+  genre maps to an icon (cross-session; see Rollout notes).
+
+## 5. Architecture & Placement
+
+Two new pure modules + one persist hook + one operator script.
+
+- **`src/agentic_librarian/etl/tag_cleaning.py`** — pure functions, no I/O:
+  `clean_genres(raw: list[str]) -> list[str]` and `clean_moods(raw: list[str]) -> list[str]`.
+- **`src/agentic_librarian/etl/tag_maps.py`** — the curated lookup tables (plain Python dicts/sets, so
+  they version-control and diff cleanly): `ALIAS_MAP`, `COMBO_MAP`, `DENYLIST`, `CONDITIONAL_DROP`,
+  plus the parallel mood maps. The right-hand sides of the maps constitute the **canonical set**.
+- **`etl/persist.py`** — the single chokepoint. Replace lines 140-141:
+  ```python
+  genres = clean_genres(_nan_to_list(row.get("genres")))
+  moods  = clean_moods(_nan_to_list(row.get("moods")))
+  ```
+  Every write path (fast `/books`, deep Cloud-Task enrich, ETL, and the backfill) funnels through
+  `persist_enriched_work`, so this one change covers all go-forward writes.
+- **`scripts/clean_tags.py`** — the operator backfill (inventory / dry-run / apply).
+
+No schema change. `Work.genres`/`Work.moods` stay `ARRAY(String)`.
+
+## 6. The Cleaning Pipeline
+
+`clean_genres(raw_list)` — per tag, then a list-level pass:
+
+1. **Strip trailing UUID/hex** — regex off a trailing `-<uuid>` (8-4-4-4-12 hex) and stray hex tails.
+   `science-fiction-fantasy-4c14c3…` → `science-fiction-fantasy`.
+2. **Normalize form** — hyphens/underscores → spaces; collapse whitespace; for BISAC paths
+   (`A / B / C`) take the most specific meaningful segment (`Fiction / Science Fiction / General` →
+   `Science Fiction`); lowercase for lookup.
+3. **Alias lookup** (`ALIAS_MAP`) — snap known variants to one canonical spelling: `fiction`→`Fiction`,
+   `sci-fi`/`scifi`/`science-fiction`→`Science Fiction`, `business-economics`→`Business & Economics`,
+   `epic`→`Epic`.
+4. **Combo split** (`COMBO_MAP`) — `science-fiction-fantasy` → `[Science Fiction, Fantasy]`;
+   `action-adventure` → `[Action, Adventure]`. (Each split member is itself canonical.)
+5. **Reject junk** — drop the tag if: on `DENYLIST` (`audiobook`, `ebook`, `paperback`,
+   `kindle edition`, format words, `general`, `books`…); contains digits/leftover hex after step 1;
+   empty or a single stray char.
+6. **Title-Case fallback** — unknown-but-valid tags (not in any map, passed QC) are kept, Title-Cased.
+7. **List-level pass** — dedup (case-insensitive, order-preserving); then apply `CONDITIONAL_DROP`:
+   remove `Fiction` iff the list has ≥1 other genre.
+
+`clean_moods(raw_list)` — same pipeline, mood config: **more permissive** (there is no allow-list — keep
+the tag unless it's clear junk), the same UUID/junk stripping and alias collapsing, **no combo-splitting
+and no `CONDITIONAL_DROP`** (moods don't have the umbrella problem). QC, not collapsing.
+
+## 7. Curated Maps (seeded from a DB inventory)
+
+The maps in `tag_maps.py` are built from reality, in three steps:
+
+1. **Inventory** (`clean_tags.py --inventory`) dumps every distinct `genres`/`moods` value + frequency
+   from the live DB.
+2. **Curate** — from that inventory we (operator + author) fill `ALIAS_MAP` / `COMBO_MAP` / `DENYLIST` /
+   `CONDITIONAL_DROP`. Seeded with the known examples; expanded to cover the actual distinct values.
+3. **Review** — operator eyeballs the maps and the dry-run diff before applying.
+
+Map shapes:
+```python
+ALIAS_MAP: dict[str, str]          # normalized variant  -> canonical spelling
+COMBO_MAP: dict[str, list[str]]    # normalized combo slug -> [canonical, canonical]
+DENYLIST: set[str]                 # normalized tags to drop always
+CONDITIONAL_DROP: set[str]         # canonical tags dropped iff other genres remain  ({"Fiction"})
+# parallel: MOOD_ALIAS_MAP, MOOD_DENYLIST
+```
+Because lookups are by normalized form, the cleaner stays graceful: a tag absent from every map still
+gets UUID-strip + Title-Case + junk-reject.
+
+## 8. Backfill — Correcting the Live Database
+
+One script, `scripts/clean_tags.py`, run via the app container against **live prod** (same wrapper as
+the Alembic migrations — Cloud SQL Auth Proxy + the `librarian-db-url` secret; see
+`docs/runbooks/bulk-import-rollout.md` §3). Modes:
+
+- **`--inventory`** — read-only; prints distinct genres/moods + frequencies. (Step 0 for map curation.)
+- **`--dry-run`** — read-only; for every `Work`, computes cleaned arrays and prints (a) a per-distinct
+  value `raw → result` table, (b) a sample of per-work before→after, (c) a summary (counts of
+  split/collapsed/dropped/unchanged). **No writes.**
+- **`--apply`** — writes cleaned `genres`/`moods` back per `Work`. Idempotent (cleaned values clean to
+  themselves), so re-running is safe.
+
+**Live-DB safeguard (D7):** before `--apply` (and reported in `--dry-run`), the script prints the
+connection target and a recency sanity check, and **refuses to run** unless it confirms it is the live
+prod DB — concretely: print the host from the resolved `DATABASE_URL`, assert it is **not** a SQLite
+file / `data/backups/*` path / `localhost` dev DB, and echo a recency probe (e.g. `COUNT(works)` and
+the max `reading_history.date_completed`) for the operator to confirm against known-current values
+before typing the confirmation. This prevents cleaning a stale snapshot.
+
+## 9. Testing
+
+The pure functions carry the weight (`test/unit/test_tag_cleaning.py`), tested against the operator's
+real strings:
+
+| input | expected |
+|---|---|
+| `["science-fiction-fantasy-<uuid>"]` | `["Science Fiction", "Fantasy"]` |
+| `["audiobook-<uuid>"]` | `[]` |
+| `["epic-<uuid>"]` | `["Epic"]` |
+| `["action-adventure-<uuid>"]` | `["Action", "Adventure"]` |
+| `["fiction", "Fiction", "Fantasy"]` | `["Fantasy"]` |
+| `["fiction"]` | `["Fiction"]` |
+| `["business-economics", "Business & Economics"]` | `["Business & Economics"]` |
+| `["sci-fi", "scifi", "Science-Fiction"]` | `["Science Fiction"]` |
+| `["general-<uuid>", "Fiction / Science Fiction / General"]` | `["Science Fiction"]` |
+
+Plus: **idempotency** (`clean(clean(x)) == clean(x)`); parallel **mood** tests (permissive QC — junk
+stripping + alias collapse, no combo-split, no conditional drop); a `db_integration` test that persisting a messy work
+stores clean arrays (proves the `persist.py` hook); and a backfill test (dry-run produces the right diff
+and writes nothing; `--apply` writes cleaned values; second `--apply` is a no-op).
+
+## 10. Rollout / Ops Notes
+
+- **Sequence:** ship the cleaner + persist hook + seed maps (go-forward correctness) → operator runs
+  `--inventory` on prod → expand the maps from the inventory (review) → `--dry-run` (eyeball) →
+  `--apply` against **live** prod.
+- **Cross-session (D8):** the canonical genre names (RHS of the maps) must line up with the
+  **design-work** session's "13-genre line-art icons" so each genre maps to an icon. Coordinate the
+  canonical genre list on the agent coordination board before finalising the maps.
+- No migration, no env changes, no deploy gating — the persist-hook change rides a normal deploy; the
+  backfill is a one-off operator script.

--- a/scripts/clean_tags.py
+++ b/scripts/clean_tags.py
@@ -1,0 +1,69 @@
+"""Operator backfill CLI for genre/mood cleaning (Spec 2026-06-22).
+
+  python scripts/clean_tags.py --inventory      # read-only; distinct values + frequency
+  python scripts/clean_tags.py --dry-run        # read-only; show changes, NO writes
+  python scripts/clean_tags.py --apply --yes    # write cleaned values (idempotent)
+
+Run against LIVE prod via the app container + Cloud SQL proxy (docs/runbooks/bulk-import-rollout.md §3).
+Refuses --apply against a sqlite/backup/localhost DB."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.db.session import DatabaseManager, resolve_database_url
+from agentic_librarian.etl import tag_backfill
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Clean Work.genres / Work.moods.")
+    ap.add_argument("--inventory", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
+    args = ap.parse_args(argv)
+
+    url = resolve_database_url()
+    safe = url.split("@")[-1] if "@" in url else url  # never print credentials
+    manager = DatabaseManager(url)
+
+    with manager.get_session() as session:
+        print(f"DB target: …@{safe}")
+        print(f"recency probe: works={session.query(Work).count()}  (confirm CURRENT prod, not a backup)")
+
+        if args.inventory:
+            genres, moods = tag_backfill.inventory(session)
+            print("\n=== distinct GENRES (count | value) ===")
+            for val, c in genres.most_common():
+                print(f"{c:5d}  {val!r}")
+            print("\n=== distinct MOODS (count | value) ===")
+            for val, c in moods.most_common():
+                print(f"{c:5d}  {val!r}")
+            return 0
+
+        changes = tag_backfill.plan_changes(session)
+        print(f"\n{len(changes)} works would change.")
+        for c in changes[:50]:
+            if c.genres_before != c.genres_after:
+                print(f"  [{c.title[:40]:40}] genres {c.genres_before} -> {c.genres_after}")
+            if c.moods_before != c.moods_after:
+                print(f"  [{c.title[:40]:40}] moods  {c.moods_before} -> {c.moods_after}")
+
+        if args.dry_run or not args.apply:
+            print("\n(dry-run: no writes)")
+            return 0
+        if not args.yes:
+            print("\nREFUSING --apply without --yes.")
+            return 2
+        if not tag_backfill.is_prod_url(url):
+            print(f"\nREFUSING --apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+            return 2
+
+        print(f"\napplied: {tag_backfill.apply_changes(session)} works updated.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/clean_tags.py
+++ b/scripts/clean_tags.py
@@ -61,7 +61,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\nREFUSING --apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
             return 2
 
-        print(f"\napplied: {tag_backfill.apply_changes(session)} works updated.")
+        print(f"\napplied: {tag_backfill.apply_changes(session, changes)} works updated.")
         return 0
 
 

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -22,6 +22,7 @@ from agentic_librarian.db.models import (
     WorkStyle,
     WorkTrope,
 )
+from agentic_librarian.etl.tag_cleaning import clean_genres, clean_moods
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
 
@@ -137,8 +138,8 @@ def persist_enriched_work(
     # DatatypeMismatch (NaN into an Integer/Date column) across the whole persist path.
     original_publication_year = _nan_to_none(row.get("original_publication_year"))
     description = _nan_to_none(row.get("description"))
-    genres = _nan_to_list(row.get("genres"))
-    moods = _nan_to_list(row.get("moods"))
+    genres = clean_genres(_nan_to_list(row.get("genres")))
+    moods = clean_moods(_nan_to_list(row.get("moods")))
     enriched_tropes = _nan_to_list(row.get("enriched_tropes"))
     user_rating = _nan_to_none(row.get("user_rating"))
     user_notes = _nan_to_none(row.get("user_notes"))

--- a/src/agentic_librarian/etl/tag_backfill.py
+++ b/src/agentic_librarian/etl/tag_backfill.py
@@ -40,6 +40,8 @@ def apply_changes(session, changes: list[Change] | None = None) -> int:
     n = 0
     for c in changes:
         w = session.get(Work, c.work_id)  # identity-map hit — plan_changes already loaded it
+        if w is None:  # deleted between plan and apply — skip
+            continue
         w.genres, w.moods = c.genres_after, c.moods_after
         n += 1
     return n

--- a/src/agentic_librarian/etl/tag_backfill.py
+++ b/src/agentic_librarian/etl/tag_backfill.py
@@ -1,0 +1,60 @@
+"""Backfill logic for genre/mood cleaning (Spec 2026-06-22): session in, lists out, no CLI/I-O of
+its own. The thin operator CLI is scripts/clean_tags.py."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from uuid import UUID
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.etl.tag_cleaning import clean_genres, clean_moods
+
+
+@dataclass
+class Change:
+    work_id: UUID
+    title: str
+    genres_before: list[str]
+    genres_after: list[str]
+    moods_before: list[str]
+    moods_after: list[str]
+
+
+def plan_changes(session) -> list[Change]:
+    """Works whose cleaned genres/moods differ from what's stored."""
+    out: list[Change] = []
+    for w in session.query(Work).all():
+        gb, mb = list(w.genres or []), list(w.moods or [])
+        ga, ma = clean_genres(gb), clean_moods(mb)
+        if ga != gb or ma != mb:
+            out.append(Change(w.id, w.title, gb, ga, mb, ma))
+    return out
+
+
+def apply_changes(session) -> int:
+    n = 0
+    for c in plan_changes(session):
+        w = session.get(Work, c.work_id)
+        w.genres, w.moods = c.genres_after, c.moods_after
+        n += 1
+    return n
+
+
+def inventory(session) -> tuple[Counter, Counter]:
+    genres: Counter = Counter()
+    moods: Counter = Counter()
+    for w in session.query(Work).all():
+        genres.update(w.genres or [])
+        moods.update(w.moods or [])
+    return genres, moods
+
+
+def is_prod_url(url: str) -> bool:
+    """True only for a real remote/proxy Postgres — NOT sqlite, backups, or a local dev DB."""
+    u = (url or "").lower()
+    if u.startswith("sqlite") or "/backups/" in u or "data/backups" in u:
+        return False
+    if "@localhost" in u or "@127.0.0.1" in u:
+        return False
+    return u.startswith("postgresql")

--- a/src/agentic_librarian/etl/tag_backfill.py
+++ b/src/agentic_librarian/etl/tag_backfill.py
@@ -32,10 +32,14 @@ def plan_changes(session) -> list[Change]:
     return out
 
 
-def apply_changes(session) -> int:
+def apply_changes(session, changes: list[Change] | None = None) -> int:
+    """Apply the given changes (or compute them if not supplied). Passing the list the caller
+    already previewed guarantees applied == previewed."""
+    if changes is None:
+        changes = plan_changes(session)
     n = 0
-    for c in plan_changes(session):
-        w = session.get(Work, c.work_id)
+    for c in changes:
+        w = session.get(Work, c.work_id)  # identity-map hit — plan_changes already loaded it
         w.genres, w.moods = c.genres_after, c.moods_after
         n += 1
     return n

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -34,3 +34,38 @@ def _bisac_reduce(tag: str) -> str:
 
 def _titlecase(norm: str) -> str:
     return " ".join(w.capitalize() for w in norm.split())
+
+
+def _clean_one(tag: str, *, alias: dict, combo: dict, denylist: set) -> list[str]:
+    n = _normalize(_bisac_reduce(_strip_uuid(tag)))
+    if not n:
+        return []
+    if n in combo:
+        return list(combo[n])  # already canonical
+    if n in alias:
+        return [alias[n]]
+    if n in denylist or _HAS_DIGIT_RE.search(n) or len(n) <= 1:
+        return []
+    return [_titlecase(n)]  # unknown-but-valid: keep, cleaned
+
+
+def _dedup(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for it in items:
+        k = it.lower()
+        if k not in seen:
+            seen.add(k)
+            out.append(it)
+    return out
+
+
+def clean_genres(raw: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for tag in raw or []:
+        out.extend(_clean_one(tag, alias=tag_maps.ALIAS_MAP, combo=tag_maps.COMBO_MAP, denylist=tag_maps.DENYLIST))
+    result = _dedup(out)
+    if len(result) > 1:  # drop over-broad umbrellas only when more specific genres remain
+        pruned = [g for g in result if g not in tag_maps.CONDITIONAL_DROP]
+        result = pruned or result
+    return result

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -12,8 +12,10 @@ _HAS_DIGIT_RE = re.compile(r"\d")
 _BISAC_FILLER = {"general", "fiction", "nonfiction", "non fiction", "books", "miscellaneous"}
 
 
-def _strip_uuid(tag: str) -> str:
-    return _UUID_RE.sub("", tag or "")
+def _strip_uuid(tag: object) -> str:
+    if not isinstance(tag, str):
+        return ""  # non-string tags (scraper noise) are dropped downstream
+    return _UUID_RE.sub("", tag)
 
 
 def _normalize(tag: str) -> str:

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -69,3 +69,10 @@ def clean_genres(raw: list[str] | None) -> list[str]:
         pruned = [g for g in result if g not in tag_maps.CONDITIONAL_DROP]
         result = pruned or result  # never empty the list, even if every genre were an umbrella term
     return result
+
+
+def clean_moods(raw: list[str] | None) -> list[str]:
+    out: list[str] = []
+    for tag in raw or []:
+        out.extend(_clean_one(tag, alias=tag_maps.MOOD_ALIAS_MAP, combo={}, denylist=tag_maps.MOOD_DENYLIST))
+    return _dedup(out)

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -1,0 +1,36 @@
+"""Pure QC/cleaning for Work.genres / Work.moods (Spec 2026-06-22). No I/O; deterministic;
+parametrised by the curated maps in tag_maps.py."""
+
+from __future__ import annotations
+
+import re
+
+from agentic_librarian.etl import tag_maps
+
+_UUID_RE = re.compile(r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+_HAS_DIGIT_RE = re.compile(r"\d")
+_BISAC_FILLER = {"general", "fiction", "nonfiction", "non fiction", "books", "miscellaneous"}
+
+
+def _strip_uuid(tag: str) -> str:
+    return _UUID_RE.sub("", tag or "")
+
+
+def _normalize(tag: str) -> str:
+    s = (tag or "").replace("-", " ").replace("_", " ")
+    return " ".join(s.lower().split())
+
+
+def _bisac_reduce(tag: str) -> str:
+    """BISAC path 'A / B / C' -> the deepest non-filler segment; otherwise the tag unchanged."""
+    if "/" not in tag:
+        return tag
+    segments = [seg.strip() for seg in tag.split("/") if seg.strip()]
+    for seg in reversed(segments):
+        if _normalize(seg) not in _BISAC_FILLER:
+            return seg
+    return segments[-1] if segments else ""
+
+
+def _titlecase(norm: str) -> str:
+    return " ".join(w.capitalize() for w in norm.split())

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -36,7 +36,7 @@ def _titlecase(norm: str) -> str:
     return " ".join(w.capitalize() for w in norm.split())
 
 
-def _clean_one(tag: str, *, alias: dict, combo: dict, denylist: set) -> list[str]:
+def _clean_one(tag: str, *, alias: dict[str, str], combo: dict[str, list[str]], denylist: set[str]) -> list[str]:
     n = _normalize(_bisac_reduce(_strip_uuid(tag)))
     if not n:
         return []
@@ -67,5 +67,5 @@ def clean_genres(raw: list[str] | None) -> list[str]:
     result = _dedup(out)
     if len(result) > 1:  # drop over-broad umbrellas only when more specific genres remain
         pruned = [g for g in result if g not in tag_maps.CONDITIONAL_DROP]
-        result = pruned or result
+        result = pruned or result  # never empty the list, even if every genre were an umbrella term
     return result

--- a/src/agentic_librarian/etl/tag_maps.py
+++ b/src/agentic_librarian/etl/tag_maps.py
@@ -1,0 +1,56 @@
+"""Curated lookup tables for genre/mood cleaning (Spec 2026-06-22). Keys are NORMALIZED
+(lowercase, hyphens/underscores -> spaces, whitespace-collapsed); values are the canonical
+display spelling, following BISAC where one exists. Seeded from the operator's known examples;
+expand from the `scripts/clean_tags.py --inventory` output during rollout."""
+
+from __future__ import annotations
+
+# normalized variant -> canonical (BISAC-formatted) spelling
+ALIAS_MAP: dict[str, str] = {
+    "fiction": "Fiction",
+    "nonfiction": "Nonfiction",
+    "non fiction": "Nonfiction",
+    "sci fi": "Science Fiction",
+    "scifi": "Science Fiction",
+    "sf": "Science Fiction",
+    "science fiction": "Science Fiction",
+    "action adventure": "Action & Adventure",
+    "business economics": "Business & Economics",
+    "business & economics": "Business & Economics",
+    "epic": "Epic",
+    "fantasy": "Fantasy",
+}
+
+# normalized true-combo slug -> list of canonical genres (split)
+COMBO_MAP: dict[str, list[str]] = {
+    "science fiction fantasy": ["Science Fiction", "Fantasy"],
+}
+
+# normalized tags dropped always (non-genres: formats, fillers)
+DENYLIST: set[str] = {
+    "audiobook",
+    "audio",
+    "audio cd",
+    "audible audio",
+    "ebook",
+    "e book",
+    "kindle edition",
+    "paperback",
+    "hardcover",
+    "mass market paperback",
+    "general",
+    "books",
+    "miscellaneous",
+    "uncategorized",
+    "other",
+}
+
+# canonical genres dropped iff other genres remain in the list
+CONDITIONAL_DROP: set[str] = {"Fiction"}
+
+# moods: permissive QC — collapse only, drop only clear junk
+MOOD_ALIAS_MAP: dict[str, str] = {
+    "lighthearted": "Lighthearted",
+    "light hearted": "Lighthearted",
+}
+MOOD_DENYLIST: set[str] = {"audiobook", "ebook", "general", "n a", "na"}

--- a/test/integration/test_persist_tag_cleaning.py
+++ b/test/integration/test_persist_tag_cleaning.py
@@ -27,6 +27,7 @@ def test_persist_cleans_genres_and_moods(db_url):
     row = {
         "Title": "Tag Cleaning Test",
         "Author_1": "T. Author",
+        "format": "ebook",
         "genres": [f"science-fiction-fantasy-{UUID}", f"audiobook-{UUID}", "Fiction"],
         "moods": [f"dark-{UUID}", "Dark"],
         "skip_enrichment": True,

--- a/test/integration/test_persist_tag_cleaning.py
+++ b/test/integration/test_persist_tag_cleaning.py
@@ -1,0 +1,39 @@
+"""persist_enriched_work stores cleaned genres/moods (Spec 2026-06-22)."""
+
+import pytest
+
+from agentic_librarian.db.models import Work
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl.persist import persist_enriched_work
+
+pytestmark = pytest.mark.db_integration
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+class _NullManager:
+    """Stand-in for Trope/Style managers — never actually called for a skip_enrichment row,
+    but persist takes them as args."""
+
+    def standardize_trope(self, *a, **k):
+        return None
+
+    def standardize_style(self, *a, **k):
+        return None
+
+
+def test_persist_cleans_genres_and_moods(db_url):
+    manager = DatabaseManager(db_url)
+    row = {
+        "Title": "Tag Cleaning Test",
+        "Author_1": "T. Author",
+        "genres": [f"science-fiction-fantasy-{UUID}", f"audiobook-{UUID}", "Fiction"],
+        "moods": [f"dark-{UUID}", "Dark"],
+        "skip_enrichment": True,
+    }
+    with manager.get_session() as session:
+        persist_enriched_work(session, row, _NullManager(), _NullManager())
+        session.flush()
+        work = session.query(Work).filter_by(title="Tag Cleaning Test").one()
+        assert work.genres == ["Science Fiction", "Fantasy"]
+        assert work.moods == ["Dark"]

--- a/test/integration/test_tag_backfill_db.py
+++ b/test/integration/test_tag_backfill_db.py
@@ -1,0 +1,42 @@
+"""plan_changes / apply_changes over real rows (Spec 2026-06-22)."""
+
+import pytest
+
+from agentic_librarian.db.models import Author, Edition, Work, WorkContributor
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import tag_backfill
+
+pytestmark = pytest.mark.db_integration
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+def _seed(manager, genres, moods):
+    with manager.get_session() as s:
+        a = Author(name="B. Author")
+        w = Work(
+            title="Backfill Test", contributors=[WorkContributor(author=a, role="Author")], genres=genres, moods=moods
+        )
+        s.add_all([a, w, Edition(work=w, format="ebook")])
+        s.flush()
+        return w.id
+
+
+def test_plan_and_apply(db_url):
+    manager = DatabaseManager(db_url)
+    wid = _seed(manager, [f"science-fiction-fantasy-{UUID}", f"audiobook-{UUID}"], [f"dark-{UUID}", "Dark"])
+
+    with manager.get_session() as session:
+        mine = [c for c in tag_backfill.plan_changes(session) if c.work_id == wid]
+        assert len(mine) == 1
+        assert mine[0].genres_after == ["Science Fiction", "Fantasy"]
+        assert mine[0].moods_after == ["Dark"]
+
+    with manager.get_session() as session:
+        tag_backfill.apply_changes(session)
+
+    with manager.get_session() as session:
+        w = session.get(Work, wid)
+        assert w.genres == ["Science Fiction", "Fantasy"]
+        assert w.moods == ["Dark"]
+        assert all(c.work_id != wid for c in tag_backfill.plan_changes(session))  # idempotent

--- a/test/unit/test_tag_backfill.py
+++ b/test/unit/test_tag_backfill.py
@@ -1,0 +1,18 @@
+import pytest
+
+from agentic_librarian.etl import tag_backfill
+
+
+@pytest.mark.parametrize(
+    "url,ok",
+    [
+        ("postgresql://u:p@10.1.2.3:5432/agentic_librarian", True),
+        ("postgresql://u:p@host.docker.internal:5433/agentic_librarian", True),
+        ("postgresql://u:p@localhost:5432/agentic_librarian", False),
+        ("postgresql://u:p@127.0.0.1:5432/agentic_librarian", False),
+        ("sqlite:///data/backups/snapshot.db", False),
+        ("postgresql://u:p@/agentic_librarian?host=/cloudsql/proj:reg:inst", True),
+    ],
+)
+def test_is_prod_url(url, ok):
+    assert tag_backfill.is_prod_url(url) is ok

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -11,3 +11,23 @@ def test_seed_maps_have_expected_entries():
     assert "Fiction" in tag_maps.CONDITIONAL_DROP
     assert isinstance(tag_maps.MOOD_ALIAS_MAP, dict)
     assert isinstance(tag_maps.MOOD_DENYLIST, set)
+
+
+from agentic_librarian.etl import tag_cleaning as tc
+
+
+def test_strip_uuid_and_normalize():
+    assert tc._strip_uuid("science-fiction-fantasy-4c14c349-8d52-4893-aaf0-34f7e33bf275") == "science-fiction-fantasy"
+    assert tc._strip_uuid("epic") == "epic"
+    assert tc._normalize("Science-Fiction") == "science fiction"
+    assert tc._normalize("  Business & Economics ") == "business & economics"
+
+
+def test_bisac_reduce_takes_deepest_non_filler():
+    assert tc._bisac_reduce("Fiction / Science Fiction / General") == "Science Fiction"
+    assert tc._bisac_reduce("Fantasy") == "Fantasy"
+
+
+def test_titlecase():
+    assert tc._titlecase("science fiction") == "Science Fiction"
+    assert tc._titlecase("business & economics") == "Business & Economics"

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -60,3 +60,23 @@ def test_clean_genres_is_idempotent():
     msgs = [f"science-fiction-fantasy-{UUID}", "fiction", "Fantasy", f"audiobook-{UUID}"]
     once = tc.clean_genres(msgs)
     assert tc.clean_genres(once) == once
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ([f"dark-{UUID}", "Dark"], ["Dark"]),  # uuid strip + case dedup
+        ([f"audiobook-{UUID}"], []),  # junk dropped
+        (["lighthearted", "Light-Hearted"], ["Lighthearted"]),  # alias collapse
+        (["Mysterious", "reflective"], ["Mysterious", "Reflective"]),  # unknown kept, title-cased
+        (["general"], []),
+        (None, []),
+    ],
+)
+def test_clean_moods(raw, expected):
+    assert tc.clean_moods(raw) == expected
+
+
+def test_clean_moods_no_combo_split():
+    # moods never split on the genre COMBO_MAP
+    assert tc.clean_moods(["science fiction fantasy"]) == ["Science Fiction Fantasy"]

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -1,0 +1,13 @@
+from agentic_librarian.etl import tag_maps
+
+
+def test_seed_maps_have_expected_entries():
+    assert tag_maps.ALIAS_MAP["sci fi"] == "Science Fiction"
+    assert tag_maps.ALIAS_MAP["action adventure"] == "Action & Adventure"
+    assert tag_maps.ALIAS_MAP["business economics"] == "Business & Economics"
+    assert tag_maps.COMBO_MAP["science fiction fantasy"] == ["Science Fiction", "Fantasy"]
+    assert "audiobook" in tag_maps.DENYLIST
+    assert "general" in tag_maps.DENYLIST
+    assert "Fiction" in tag_maps.CONDITIONAL_DROP
+    assert isinstance(tag_maps.MOOD_ALIAS_MAP, dict)
+    assert isinstance(tag_maps.MOOD_DENYLIST, set)

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -1,3 +1,6 @@
+import pytest
+
+from agentic_librarian.etl import tag_cleaning as tc
 from agentic_librarian.etl import tag_maps
 
 
@@ -11,9 +14,6 @@ def test_seed_maps_have_expected_entries():
     assert "Fiction" in tag_maps.CONDITIONAL_DROP
     assert isinstance(tag_maps.MOOD_ALIAS_MAP, dict)
     assert isinstance(tag_maps.MOOD_DENYLIST, set)
-
-
-from agentic_librarian.etl import tag_cleaning as tc
 
 
 def test_strip_uuid_and_normalize():
@@ -31,3 +31,32 @@ def test_bisac_reduce_takes_deepest_non_filler():
 def test_titlecase():
     assert tc._titlecase("science fiction") == "Science Fiction"
     assert tc._titlecase("business & economics") == "Business & Economics"
+
+
+UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ([f"science-fiction-fantasy-{UUID}"], ["Science Fiction", "Fantasy"]),
+        ([f"audiobook-{UUID}"], []),
+        ([f"epic-{UUID}"], ["Epic"]),
+        ([f"action-adventure-{UUID}"], ["Action & Adventure"]),
+        (["fiction", "Fiction", "Fantasy"], ["Fantasy"]),
+        (["fiction"], ["Fiction"]),
+        (["business-economics", "Business & Economics"], ["Business & Economics"]),
+        (["sci-fi", "scifi", "Science-Fiction"], ["Science Fiction"]),
+        ([f"general-{UUID}", "Fiction / Science Fiction / General"], ["Science Fiction"]),
+        ([], []),
+        (None, []),
+    ],
+)
+def test_clean_genres(raw, expected):
+    assert tc.clean_genres(raw) == expected
+
+
+def test_clean_genres_is_idempotent():
+    msgs = [f"science-fiction-fantasy-{UUID}", "fiction", "Fantasy", f"audiobook-{UUID}"]
+    once = tc.clean_genres(msgs)
+    assert tc.clean_genres(once) == once

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -48,6 +48,7 @@ UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
         (["business-economics", "Business & Economics"], ["Business & Economics"]),
         (["sci-fi", "scifi", "Science-Fiction"], ["Science Fiction"]),
         ([f"general-{UUID}", "Fiction / Science Fiction / General"], ["Science Fiction"]),
+        ([123, None, "Fantasy"], ["Fantasy"]),  # non-string elements dropped
         ([], []),
         (None, []),
     ],


### PR DESCRIPTION
## What

Cleans `Work.genres` / `Work.moods` — raw external tags become canonical (BISAC-formatted) values. Fixes the messy data you flagged: Hardcover slug+UUID strings (`science-fiction-fantasy-<uuid>`), Google Books BISAC paths (`Fiction / Science Fiction / General`), combos, case/spelling variants, and non-genres like `audiobook`.

- **Spec:** `docs/superpowers/specs/2026-06-22-genre-mood-tag-cleaning-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-22-genre-mood-tag-cleaning.md` (7 TDD tasks, each spec+quality reviewed + a final whole-branch review)

## How

A deterministic **cleaning pipeline** (no schema change, no embeddings, no controlled allow-list — QC, not taxonomy):
- `etl/tag_maps.py` — curated `ALIAS_MAP` / `COMBO_MAP` / `DENYLIST` / `CONDITIONAL_DROP` (+ mood maps), seeded from your examples, expanded from a DB inventory at rollout.
- `etl/tag_cleaning.py` — `clean_genres` / `clean_moods`: strip UUID → BISAC-reduce → alias-collapse → combo-split → junk-reject → Title-Case fallback → dedup → drop `Fiction` only when other genres remain.
- Hooked at `etl/persist.py` (~L141) so **every** write path (fast `/books`, deep enrich, ETL, backfill) stores clean tags. Unknown-but-valid tags pass through cleaned (open vocabulary preserved).
- `etl/tag_backfill.py` + `scripts/clean_tags.py` — operator backfill (`--inventory` / `--dry-run` / `--apply --yes`) for existing rows, guarded against sqlite/backup/localhost so it only ever writes **live prod**; `apply` operates on the exact previewed change list.

Examples (all unit-tested against your real strings):
| input | output |
|---|---|
| `science-fiction-fantasy-<uuid>` | `["Science Fiction", "Fantasy"]` |
| `audiobook-<uuid>` | dropped |
| `action-adventure-<uuid>` | `["Action & Adventure"]` (BISAC keeps it one genre) |
| `business-economics` + `Business & Economics` | `["Business & Economics"]` |
| `["fiction", "Fiction", "Fantasy"]` | `["Fantasy"]` |

## Tests
- `test/unit/test_tag_cleaning.py` (23) + `test/unit/test_tag_backfill.py` (6) pass; `db_integration` persist + backfill tests run in CI. Idempotency + the prod-URL guard covered. ruff-format/check clean.

## Review notes (minor, non-blocking — from the final review)
- Persist *update* keeps existing genres when a re-import cleans to `[]` (don't clobber good data); the backfill assigns unconditionally. Divergence only in the safe direction.
- `_bisac_reduce` deepest-segment is a theoretical edge for format-word-tailed BISAC paths (real Google Books paths don't hit it).
- `is_prod_url` rejects the short `postgres://` scheme — fails safe.

## Coordination / rollout
- Complementary to design-work's **PR #59** (`GenreIcon`): they surface + icon-map genres, this cleans them. Icon matching is fuzzy (`canonicalizeGenre`), so no exact-string parity needed.
- Operator rollout (no migration/env): deploy ships the persist hook → new writes auto-clean; then `--inventory` → expand maps (reconcile canonical names with the 13 icon genres) → `--dry-run` → `--apply --yes` against live prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)