### PR TITLE
feat(tags): expand cleaning maps from prod inventory

### DIFF
--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -10,6 +10,7 @@ from agentic_librarian.etl import tag_maps
 _UUID_RE = re.compile(r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 _HAS_DIGIT_RE = re.compile(r"\d")
 _BISAC_FILLER = {"general", "fiction", "nonfiction", "non fiction", "books", "miscellaneous"}
+_JUNK_SUBSTRINGS = ("fictitious character", "imaginary place", "motion picture")
 
 
 def _strip_uuid(tag: object) -> str:
@@ -38,16 +39,28 @@ def _titlecase(norm: str) -> str:
     return " ".join(w.capitalize() for w in norm.split())
 
 
-def _clean_one(tag: str, *, alias: dict[str, str], combo: dict[str, list[str]], denylist: set[str]) -> list[str]:
+def _clean_one(
+    tag: str, *, alias: dict[str, str], combo: dict[str, list[str]], denylist: set[str], _depth: int = 0
+) -> list[str]:
     n = _normalize(_bisac_reduce(_strip_uuid(tag)))
     if not n:
         return []
     if n in combo:
-        return list(combo[n])  # already canonical
+        return list(combo[n])  # explicit combo wins (e.g. multi-token leaves)
     if n in alias:
         return [alias[n]]
     if n in denylist or _HAS_DIGIT_RE.search(n) or len(n) <= 1:
         return []
+    if any(j in n for j in _JUNK_SUBSTRINGS):  # entity/tie-in noise, e.g. "* fictitious character"
+        return []
+    if n.startswith("fiction ") and _depth < 4:
+        # BISAC "fiction" umbrella: drop it, split the leaf on the first token, canonicalise each
+        # piece recursively (so e.g. "fiction fantasy military" -> [Fantasy, Military]).
+        first, _, tail = n[len("fiction ") :].partition(" ")
+        out = _clean_one(first, alias=alias, combo=combo, denylist=denylist, _depth=_depth + 1)
+        if tail:
+            out += _clean_one(tail, alias=alias, combo=combo, denylist=denylist, _depth=_depth + 1)
+        return out
     return [_titlecase(n)]  # unknown-but-valid: keep, cleaned
 
 

--- a/src/agentic_librarian/etl/tag_maps.py
+++ b/src/agentic_librarian/etl/tag_maps.py
@@ -45,6 +45,7 @@ ALIAS_MAP: dict[str, str] = {
     "classique": "Classics",
     "adulte": "Adult",
     "policier": "Crime",
+    "thrillers": "Thriller",
 }
 
 # normalized true-combo slug -> list of canonical genres (split)
@@ -60,6 +61,7 @@ COMBO_MAP: dict[str, list[str]] = {
     "fiction fantasy action adventure": ["Fantasy", "Action & Adventure"],
     "fiction fantasy urban": ["Fantasy"],
     "fiction action adventure": ["Action & Adventure"],
+    "fantasy young adult": ["Fantasy", "Young Adult"],
 }
 
 # normalized tags dropped always (non-genres: formats, fillers)
@@ -85,6 +87,10 @@ DENYLIST: set[str] = {
     "novella",
     "genre fiction",
     "movie",
+    "geary",
+    "poirot",
+    "christopher",
+    "dresden",
 }
 
 # canonical genres dropped iff other genres remain in the list

--- a/src/agentic_librarian/etl/tag_maps.py
+++ b/src/agentic_librarian/etl/tag_maps.py
@@ -14,16 +14,52 @@ ALIAS_MAP: dict[str, str] = {
     "scifi": "Science Fiction",
     "sf": "Science Fiction",
     "science fiction": "Science Fiction",
+    "sciencefiction": "Science Fiction",
+    "sciense fiction": "Science Fiction",
     "action adventure": "Action & Adventure",
     "business economics": "Business & Economics",
     "business & economics": "Business & Economics",
     "epic": "Epic",
     "fantasy": "Fantasy",
+    "lgbtq": "LGBTQ",
+    "lgbt": "LGBTQ",
+    "queer": "LGBTQ",
+    "gay": "LGBTQ",
+    "lesbian": "LGBTQ",
+    "literary fiction": "Literary",
+    "literature fiction": "Literary",
+    "literary": "Literary",
+    "literature": "Literary",
+    "thriller suspense": "Thriller",
+    "suspense": "Thriller",
+    "fantasy fiction": "Fantasy",
+    "young adult fiction": "Young Adult",
+    "teen young adult": "Young Adult",
+    "historical fiction": "Historical",
+    "humour": "Humor",
+    "humorous": "Humor",
+    "comedy humor": "Humor",
+    "aventure": "Adventure",
+    "mystere": "Mystery",
+    "guerre": "War",
+    "classique": "Classics",
+    "adulte": "Adult",
+    "policier": "Crime",
 }
 
 # normalized true-combo slug -> list of canonical genres (split)
 COMBO_MAP: dict[str, list[str]] = {
     "science fiction fantasy": ["Science Fiction", "Fantasy"],
+    "fiction sci fi fantasy": ["Science Fiction", "Fantasy"],
+    "science fiction et fantasy": ["Science Fiction", "Fantasy"],
+    "thriller suspense science fiction fantasy": ["Thriller", "Science Fiction", "Fantasy"],
+    "literature fiction science fiction fantasy": ["Literary", "Science Fiction", "Fantasy"],
+    "literature fiction mystery": ["Literary", "Mystery"],
+    "fiction fantasy epic": ["Fantasy", "Epic"],
+    "fiction fantasy general": ["Fantasy"],
+    "fiction fantasy action adventure": ["Fantasy", "Action & Adventure"],
+    "fiction fantasy urban": ["Fantasy"],
+    "fiction action adventure": ["Action & Adventure"],
 }
 
 # normalized tags dropped always (non-genres: formats, fillers)
@@ -43,6 +79,12 @@ DENYLIST: set[str] = {
     "miscellaneous",
     "uncategorized",
     "other",
+    "downloadable e books",
+    "etc",
+    "novels",
+    "novella",
+    "genre fiction",
+    "movie",
 }
 
 # canonical genres dropped iff other genres remain in the list
@@ -53,4 +95,4 @@ MOOD_ALIAS_MAP: dict[str, str] = {
     "lighthearted": "Lighthearted",
     "light hearted": "Lighthearted",
 }
-MOOD_DENYLIST: set[str] = {"audiobook", "ebook", "general", "n a", "na"}
+MOOD_DENYLIST: set[str] = {"audiobook", "ebook", "general", "n a", "na", "series cradle"}

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -81,3 +81,48 @@ def test_clean_moods(raw, expected):
 def test_clean_moods_no_combo_split():
     # moods never split on the genre COMBO_MAP
     assert tc.clean_moods(["science fiction fantasy"]) == ["Science Fiction Fantasy"]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (["lgbtq"], ["LGBTQ"]),  # icon casing (title-case would give "Lgbtq")
+        (["lgbt"], ["LGBTQ"]),
+        (["queer"], ["LGBTQ"]),
+        (["literature-fiction"], ["Literary"]),
+        (["literary-fiction"], ["Literary"]),
+        (["thriller-suspense"], ["Thriller"]),
+        (["fantasy-fiction"], ["Fantasy"]),
+        (["young-adult-fiction"], ["Young Adult"]),
+        (["historical-fiction"], ["Historical"]),
+        (["humour"], ["Humor"]),
+        (["aventure"], ["Adventure"]),
+        (["mystere"], ["Mystery"]),
+        (["guerre"], ["War"]),
+        (["sciense-fiction"], ["Science Fiction"]),  # typo
+        (["fiction-fantasy-epic"], ["Fantasy", "Epic"]),  # drop fiction umbrella, split leaf
+        (["fiction-fantasy-general"], ["Fantasy"]),  # "general" is filler
+        (["fiction-action-adventure"], ["Action & Adventure"]),
+        (["thriller-suspense-science-fiction-fantasy"], ["Thriller", "Science Fiction", "Fantasy"]),
+        (["literature-fiction-science-fiction-fantasy"], ["Literary", "Science Fiction", "Fantasy"]),
+        (["downloadable-e-books"], []),  # denylisted
+        (["novella"], []),  # denylisted
+        (["read-2023"], []),  # digit-rejected (no map entry needed)
+        ([f"egypt-{UUID}"], ["Egypt"]),  # 1-count subject KEPT, title-cased
+        (["adult"], ["Adult"]),  # audience marker KEPT (per operator)
+    ],
+)
+def test_clean_genres_inventory_curation(raw, expected):
+    assert tc.clean_genres(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ([f"fast-paced-{UUID}"], ["Fast Paced"]),  # pace KEPT (per operator)
+        ([f"medium-paced-{UUID}"], ["Medium Paced"]),
+        (["series-cradle"], []),  # mood denylisted (not a mood)
+    ],
+)
+def test_clean_moods_inventory_curation(raw, expected):
+    assert tc.clean_moods(raw) == expected

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -126,3 +126,34 @@ def test_clean_genres_inventory_curation(raw, expected):
 )
 def test_clean_moods_inventory_curation(raw, expected):
     assert tc.clean_moods(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # generic "fiction-" umbrella: strip + split the leaf (handles unmapped fiction-fantasy-* generically)
+        (["fiction-fantasy-military"], ["Fantasy", "Military"]),
+        (["fiction-fantasy-paranormal"], ["Fantasy", "Paranormal"]),
+        (["fiction-horror"], ["Horror"]),
+        (["fiction-fantasy-general"], ["Fantasy"]),  # "general" self-drops (denylist)
+        # explicit combos still win over the generic rule (multi-token leaves the naive split would break)
+        (["fiction-sci-fi-fantasy"], ["Science Fiction", "Fantasy"]),
+        (["fiction-action-adventure"], ["Action & Adventure"]),
+        # #2: no fiction prefix -> explicit combo
+        (["fantasy-young-adult"], ["Fantasy", "Young Adult"]),
+        (["thrillers"], ["Thriller"]),  # plural alias
+        # entity / tie-in noise dropped
+        ([f"john-fictitious-character-{UUID}"], []),
+        (["death-fictitious-character-pratchett"], []),
+        (["hogfather-motion-picture"], []),
+        (["Hogfather. (Motion picture)"], []),
+        (["dune-imaginary-place"], []),
+        (["geary"], []),
+        (["poirot"], []),
+        # genuine subject tags still KEPT (title-cased)
+        (["anti-racism"], ["Anti Racism"]),
+        (["brigands-and-robbers"], ["Brigands And Robbers"]),
+    ],
+)
+def test_clean_genres_round2(raw, expected):
+    assert tc.clean_genres(raw) == expected


### PR DESCRIPTION
## What
Expands `tag_maps.py` with curated alias/combo/deny entries derived from the **2026-06-22 prod DB inventory** (330 works), per operator review. Follow-up to #60 (the cleaning engine).

## Curation (from the real distinct values)
- **Collapses (ALIAS):** sci-fi variants + typo (`sciense-fiction`) → Science Fiction; `lgbtq`/`lgbt`/`queer`/`gay`/`lesbian` → LGBTQ (icon casing); literary variants → Literary; `thriller-suspense`/`suspense` → Thriller; `fantasy-fiction` → Fantasy; YA/historical/humor variants; French tags (`aventure`→Adventure, `mystere`→Mystery, `guerre`→War, `classique`→Classics, `policier`→Crime).
- **Splits (COMBO):** the BISAC-flattened `fiction-fantasy-*` family (drop the `fiction` umbrella, split the leaf — e.g. `fiction-fantasy-epic` → `[Fantasy, Epic]`), and multi-genre slugs (`thriller-suspense-science-fiction-fantasy` → `[Thriller, Science Fiction, Fantasy]`).
- **Drops (DENYLIST):** `downloadable-e-books`, `etc`, `novels`, `novella`, `genre-fiction`, `movie`; mood `series-cradle`.

Per operator decisions: pace tags (`fast-paced`…) and single-count subject tags are **kept** (title-cased); `adult` **kept** as `Adult`; numeric junk (`read-2023`, reading-export timestamps) is already digit-rejected.

## Tests
27 new parametrized cases (51/51 total) asserting the new aliases/combos/denials end-to-end, plus that kept tags (pace, subjects, `Adult`) survive. ruff clean. Canonical names verified against design-work's 13-icon `canonicalizeGenre` set.

## Rollout
Maps are data-only (graceful — unknown tags still clean generically). After merge + deploy, the operator runs `scripts/clean_tags.py --dry-run` (eyeball the full before→after over all 330 works) → `--apply --yes` on live prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)