### PR TITLE
fix(tropes): preserve genuine free-text trope names verbatim

### DIFF
--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -11,6 +11,9 @@ _UUID_RE = re.compile(r"-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 _HAS_DIGIT_RE = re.compile(r"\d")
 _BISAC_FILLER = {"general", "fiction", "nonfiction", "non fiction", "books", "miscellaneous"}
 _JUNK_SUBSTRINGS = ("fictitious character", "imaginary place", "motion picture")
+# Precomputed once at import (clean_trope_name runs in a hot ETL loop): union of the genre + mood maps.
+_TROPE_ALIAS = {**tag_maps.ALIAS_MAP, **tag_maps.MOOD_ALIAS_MAP}
+_TROPE_DENYLIST = tag_maps.DENYLIST | tag_maps.MOOD_DENYLIST
 
 
 def _strip_uuid(tag: object) -> str:
@@ -112,15 +115,13 @@ def clean_trope_name(name: str) -> list[str]:
     norm = _normalize(stripped)
     if not norm:
         return []
-    alias = {**tag_maps.ALIAS_MAP, **tag_maps.MOOD_ALIAS_MAP}
-    denylist = tag_maps.DENYLIST | tag_maps.MOOD_DENYLIST
     if norm in tag_maps.COMBO_MAP:
         return _dedup(list(tag_maps.COMBO_MAP[norm]))
-    if norm in alias:
-        return [alias[norm]]
+    if norm in _TROPE_ALIAS:
+        return [_TROPE_ALIAS[norm]]
     if any(c.isupper() for c in stripped):  # genuine free-text trope -> preserve verbatim
         return [stripped]
-    if norm in denylist or _HAS_DIGIT_RE.search(norm) or len(norm) <= 1:
+    if norm in _TROPE_DENYLIST or _HAS_DIGIT_RE.search(norm) or len(norm) <= 1:
         return []
     if any(j in norm for j in _JUNK_SUBSTRINGS):  # entity/tie-in noise
         return []

--- a/src/agentic_librarian/etl/tag_cleaning.py
+++ b/src/agentic_librarian/etl/tag_cleaning.py
@@ -94,10 +94,34 @@ def clean_moods(raw: list[str] | None) -> list[str]:
 
 
 def clean_trope_name(name: str) -> list[str]:
-    """Clean one Trope.name with the UNION of the genre + mood maps: UUID-strip + combo-split +
-    canonicalize + denylist drop + title-case. A genuine narrative trope (no map hit) just gets
-    UUID-stripped + title-cased (e.g. 'enemies-to-lovers' -> 'Enemies To Lovers'). Returns 0..N
-    canonical names, de-duped, order-preserving."""
+    """Clean one Trope.name. The table mixes genuine narrative tropes (free text from the LLM, e.g.
+    'The Chosen One (Subverted)', 'Mirror / Shadow Self') with genre/mood-slug fallbacks
+    ('science-fiction-fantasy-<uuid>', 'literary-fiction', 'tense'). The two are told apart by
+    casing: a real trope always has an uppercase letter; the slugs are all-lowercase.
+
+    - KNOWN genre/mood tag (combo/alias match after normalising) -> split / canonicalise, regardless
+      of casing (so 'science-fiction-fantasy-<uuid>' -> ['Science Fiction', 'Fantasy']).
+    - Has an uppercase letter -> a genuine trope: keep it VERBATIM (only the UUID tail stripped), so
+      '/', 'vs.', '(...)', em-dashes and original capitalisation all survive intact.
+    - Otherwise a bare lowercase slug -> drop if junk/numeric/denylisted/entity-noise, else title-case.
+
+    Returns 0..N names, de-duped."""
+    if not isinstance(name, str):
+        return []
+    stripped = _strip_uuid(name).strip()
+    norm = _normalize(stripped)
+    if not norm:
+        return []
     alias = {**tag_maps.ALIAS_MAP, **tag_maps.MOOD_ALIAS_MAP}
     denylist = tag_maps.DENYLIST | tag_maps.MOOD_DENYLIST
-    return _dedup(_clean_one(name, alias=alias, combo=tag_maps.COMBO_MAP, denylist=denylist))
+    if norm in tag_maps.COMBO_MAP:
+        return _dedup(list(tag_maps.COMBO_MAP[norm]))
+    if norm in alias:
+        return [alias[norm]]
+    if any(c.isupper() for c in stripped):  # genuine free-text trope -> preserve verbatim
+        return [stripped]
+    if norm in denylist or _HAS_DIGIT_RE.search(norm) or len(norm) <= 1:
+        return []
+    if any(j in norm for j in _JUNK_SUBSTRINGS):  # entity/tie-in noise
+        return []
+    return [_titlecase(norm)]  # bare lowercase slug

--- a/test/unit/test_tag_cleaning.py
+++ b/test/unit/test_tag_cleaning.py
@@ -174,7 +174,31 @@ def test_clean_trope_name(raw, expected):
     assert tc.clean_trope_name(raw[0]) == expected
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # genuine free-text tropes (have an uppercase letter) -> preserved VERBATIM
+        (["Mirror / Shadow Self"], ["Mirror / Shadow Self"]),  # keep the slash pairing
+        (["The Trickster/Loyal Rogue"], ["The Trickster/Loyal Rogue"]),
+        (["The Chosen One (Subverted)"], ["The Chosen One (Subverted)"]),  # keep caps + parens
+        (["Fish Out of Water"], ["Fish Out of Water"]),  # keep lowercase 'of'
+        (["Free Will vs. Fate"], ["Free Will vs. Fate"]),
+        (["Legacy and Father–Son Dynamic"], ["Legacy and Father–Son Dynamic"]),  # keep em-dash + caps
+        ([f"Latent Power-{UUID}"], ["Latent Power"]),  # UUID stripped, rest verbatim
+        # known genre/mood slugs still canonicalize/split even with mixed source casing
+        (["literary-fiction"], ["Literary"]),
+        (["policier"], ["Crime"]),
+        (["general"], []),  # denylist
+        (["movie"], []),
+        ([f"occult-{UUID}"], ["Occult"]),  # bare slug title-cased
+        (["fic028010"], []),  # has digit
+    ],
+)
+def test_clean_trope_name_preserves_genuine_and_cleans_slugs(raw, expected):
+    assert tc.clean_trope_name(raw[0]) == expected
+
+
 def test_clean_trope_name_is_idempotent():
-    for raw in ["science-fiction-fantasy", "enemies-to-lovers", "Chosen One"]:
+    for raw in ["science-fiction-fantasy", "enemies-to-lovers", "Chosen One", "Mirror / Shadow Self"]:
         once = tc.clean_trope_name(raw)
         assert once == [x for v in once for x in tc.clean_trope_name(v)]


### PR DESCRIPTION
## Summary

Follow-up to #63. The trope-name cleaner was running **genuine narrative tropes** through the *genre* pipeline (`_bisac_reduce` + `_normalize` + `_titlecase`), which mangled them:

- `Mirror / Shadow Self` → `Shadow Self` (split on `/`, kept one half)
- `The Chosen One (Subverted)` → `The Chosen One (subverted)` (lost the capital)
- `Fish Out of Water` → `Fish Out Of Water` (capitalized "of")
- `Free Will vs. Fate` → `Free Will Vs. Fate`
- `Legacy and Father–Son Dynamic` → `Father–son Dynamic`

That pipeline is correct for genre/mood **slugs** (`science-fiction-fantasy-{uuid}`) but wrong for the LLM's free-text trope names.

## Fix

`clean_trope_name` now distinguishes genuine tropes from fallback slugs by **casing** — every real trope has an uppercase letter; the slugs are all-lowercase:

- **Known genre/mood tag** (combo/alias match after normalising) → split / canonicalise (`science-fiction-fantasy-{uuid}` → `[Science Fiction, Fantasy]`, `literary-fiction` → `Literary`).
- **Has an uppercase letter** → genuine trope → keep **verbatim** (only the UUID tail stripped), so `/`, `vs.`, `(...)`, em-dashes and capitalization survive.
- **Bare lowercase slug** → drop if junk/numeric/denylisted/entity-noise, else title-case (`tense` → `Tense`, `comics-graphic-novels` → `Comics Graphic Novels`).

Validated against a live-prod dry-run: the dirty-trope set dropped from **506 → 35** (only the actual slug/junk rows) and embedding calls from **308 → 16**, with the `/` pairings and proper casing intact in the "after" column.

## Test Plan
- [x] Unit: verbatim preservation (`Mirror / Shadow Self`, `The Chosen One (Subverted)`, `Fish Out of Water`, em-dash, UUID-stripped) + slug cleanups (`literary-fiction`→`Literary`, `policier`→`Crime`, `general`/`movie`/`fic028010`→`[]`) + idempotency. 88/88 green.
- [x] ruff check + format clean.
- [x] Operator dry-run on live prod confirmed the 35-row changeset is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
