### PR TITLE
chore(scripts): add trope audit diagnostic (real vs fallback tropes)

### DIFF
--- a/scripts/trope_audit.py
+++ b/scripts/trope_audit.py
@@ -1,0 +1,70 @@
+"""Read-only trope audit: real (scout) vs fallback (genre/mood) tropes for the most
+recent import vs the rest of the catalog. Distinguisher: work_tropes.justification
+(scout tropes carry one; genre/mood fallbacks don't)."""
+from sqlalchemy import text
+from agentic_librarian.db.session import DatabaseManager
+
+dbm = DatabaseManager()
+
+Q1 = """
+SELECT j.id AS job_id, j.created_at, u.email, j.total_rows,
+        count(*) FILTER (WHERE r.outcome = 'created')   AS created,
+        count(*) FILTER (WHERE r.outcome = 'linked')    AS linked,
+        count(*) FILTER (WHERE r.outcome = 'duplicate') AS duplicate,
+        count(*) FILTER (WHERE r.outcome = 'not_found') AS not_found,
+        count(*) FILTER (WHERE r.status  = 'failed')    AS failed
+FROM import_jobs j
+JOIN import_rows r ON r.import_job_id = j.id
+JOIN users u ON u.id = j.user_id
+GROUP BY j.id, j.created_at, u.email, j.total_rows
+ORDER BY j.created_at DESC
+LIMIT 10
+"""
+
+Q2 = """
+WITH job AS (SELECT id FROM import_jobs ORDER BY created_at DESC LIMIT 1)
+SELECT w.title,
+        r.outcome,
+        count(wt.*) FILTER (WHERE wt.justification IS NOT NULL) AS real_tropes,
+        count(wt.*) FILTER (WHERE wt.justification IS NULL)     AS fallback_tropes,
+        coalesce(array_length(w.genres, 1), 0)                  AS genres
+FROM import_rows r
+JOIN works w ON w.id = r.work_id
+LEFT JOIN work_tropes wt ON wt.work_id = w.id
+WHERE r.import_job_id = (SELECT id FROM job) AND r.work_id IS NOT NULL
+GROUP BY w.id, w.title, r.outcome
+ORDER BY real_tropes ASC, w.title
+"""
+
+Q3 = """
+WITH job AS (SELECT id FROM import_jobs ORDER BY created_at DESC LIMIT 1),
+    per_work AS (
+        SELECT w.id,
+            (SELECT count(*) FROM work_tropes wt WHERE wt.work_id = w.id AND wt.justification IS NOT NULL) AS real_cnt,
+            (SELECT count(*) FROM work_tropes wt WHERE wt.work_id = w.id AND wt.justification IS NULL)     AS fb_cnt,
+            EXISTS (SELECT 1 FROM import_rows r WHERE r.import_job_id = (SELECT id FROM job) AND r.work_id = w.id) AS in_recent
+        FROM works w
+    )
+SELECT CASE WHEN in_recent THEN 'recent import' ELSE 'rest of catalog' END AS bucket,
+        count(*) AS works,
+        count(*) FILTER (WHERE real_cnt > 0) AS works_with_real_tropes,
+        round(avg(real_cnt), 2) AS avg_real_tropes,
+        round(avg(fb_cnt), 2)   AS avg_fallback_tropes
+FROM per_work
+GROUP BY 1
+ORDER BY 1
+"""
+
+def run(label, sql):
+    print(f"\n===== {label} =====")
+    with dbm.get_session() as s:
+        res = s.execute(text(sql))
+        cols = list(res.keys())
+        print(" | ".join(cols))
+        print("-" * 60)
+        for row in res:
+            print(" | ".join("" if v is None else str(v) for v in row))
+
+run("1) recent import jobs", Q1)
+run("2) per-book real vs fallback tropes (latest job)", Q2)
+run("3) rollup: recent import vs rest of catalog", Q3)

--- a/scripts/trope_audit.py
+++ b/scripts/trope_audit.py
@@ -1,7 +1,9 @@
 """Read-only trope audit: real (scout) vs fallback (genre/mood) tropes for the most
 recent import vs the rest of the catalog. Distinguisher: work_tropes.justification
 (scout tropes carry one; genre/mood fallbacks don't)."""
+
 from sqlalchemy import text
+
 from agentic_librarian.db.session import DatabaseManager
 
 dbm = DatabaseManager()
@@ -55,6 +57,7 @@ GROUP BY 1
 ORDER BY 1
 """
 
+
 def run(label, sql):
     print(f"\n===== {label} =====")
     with dbm.get_session() as s:
@@ -64,6 +67,7 @@ def run(label, sql):
         print("-" * 60)
         for row in res:
             print(" | ".join("" if v is None else str(v) for v in row))
+
 
 run("1) recent import jobs", Q1)
 run("2) per-book real vs fallback tropes (latest job)", Q2)

--- a/scripts/trope_audit.py
+++ b/scripts/trope_audit.py
@@ -27,8 +27,8 @@ Q2 = """
 WITH job AS (SELECT id FROM import_jobs ORDER BY created_at DESC LIMIT 1)
 SELECT w.title,
         r.outcome,
-        count(wt.*) FILTER (WHERE wt.justification IS NOT NULL) AS real_tropes,
-        count(wt.*) FILTER (WHERE wt.justification IS NULL)     AS fallback_tropes,
+        count(wt.trope_id) FILTER (WHERE wt.justification IS NOT NULL) AS real_tropes,
+        count(wt.trope_id) FILTER (WHERE wt.justification IS NULL)     AS fallback_tropes,
         coalesce(array_length(w.genres, 1), 0)                  AS genres
 FROM import_rows r
 JOIN works w ON w.id = r.work_id
@@ -69,6 +69,7 @@ def run(label, sql):
             print(" | ".join("" if v is None else str(v) for v in row))
 
 
-run("1) recent import jobs", Q1)
-run("2) per-book real vs fallback tropes (latest job)", Q2)
-run("3) rollup: recent import vs rest of catalog", Q3)
+if __name__ == "__main__":
+    run("1) recent import jobs", Q1)
+    run("2) per-book real vs fallback tropes (latest job)", Q2)
+    run("3) rollup: recent import vs rest of catalog", Q3)


### PR DESCRIPTION
Adds `scripts/trope_audit.py` — a read-only diagnostic that quantifies **real (scout) vs fallback (genre/mood) tropes** per work, comparing the most recent import against the rest of the catalog. Distinguisher: `work_tropes.justification` (scout tropes set it; genre/mood fallbacks leave it NULL).

Output (3 queries): recent import jobs (created/linked/dedup split), per-book real vs fallback tropes, and a recent-import-vs-catalog rollup.

### Why
Used to diagnose the "imported books show more genres-as-tropes" report — see **#65** and `docs/project_notes/bugs.md` (2026-06-23). It confirmed the deep enrichment + Gemini trope scout worked (120/122 import works got 6–10 real tropes) and isolated the cause to the two-phase import's genre/mood fallback layer (avg 7.58 vs 1.01 catalog-wide). Keeping it on `main` so the backend bench can re-measure before/after their fix.

### Notes
- Read-only `SELECT`s; run via the Cloud SQL proxy (`DATABASE_URL`) using the app's `DatabaseManager`.
- ruff `0.15.16` clean; Python CI green on the branch.

Relates to #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
