### PR TITLE
fix(#65): two-phase fast pass skips fallback tropes + one-time prune

### DIFF
--- a/docs/superpowers/plans/2026-06-23-fallback-trope-prune.md
+++ b/docs/superpowers/plans/2026-06-23-fallback-trope-prune.md
@@ -1,0 +1,504 @@
+# Fallback-Trope Prune & Two-Phase Persist Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop two-phase imports double-layering genre/mood fallback tropes (Shape B: the fast pass
+opts out of fallbacks; the deep pass is the single authoritative trope write) and provide a one-time
+prune of the existing pollution.
+
+**Architecture:** Part A — a `write_fallback_tropes` flag through `persist_enriched_work` +
+`two_phase._scout_and_persist`, with a `has_real` guard. Part B — `plan/apply_fallback_prune` in
+`etl/trope_backfill.py` + a `--prune-fallbacks` mode on `scripts/clean_catalog.py`. No schema change.
+
+**Tech Stack:** Python 3, SQLAlchemy ORM, pytest (`db_integration` → CI Postgres), uv.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md`
+
+**Conventions:** TDD per task. `uv run pytest <path> -v`. Before each commit: `uv run ruff check`
+**and** `uvx ruff@0.15.16 format`. `db_integration` tests skip locally (no Postgres), run on CI;
+reuse the `db_url` fixture + `DatabaseManager(db_url)` + `with manager.get_session() as session:`
+pattern from `test/integration/test_persist_tag_cleaning.py`.
+
+---
+
+## Task 1: Persist Shape-B fallback guard (`persist.py`)
+
+**Files:** Modify `src/agentic_librarian/etl/persist.py`; Test `test/integration/test_persist_fallback_flag.py`
+
+- [ ] **Step 1: Write the failing test** `test/integration/test_persist_fallback_flag.py`:
+```python
+import pytest
+
+from agentic_librarian.db.models import Trope, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl.persist import persist_enriched_work
+
+pytestmark = pytest.mark.db_integration
+
+
+class _PassthroughTrope:
+    """standardize_trope returns an exact-name Trope (no embedding) so names are assertable."""
+
+    def __init__(self, session):
+        self.session = session
+
+    def standardize_trope(self, name, *a, **k):
+        t = self.session.query(Trope).filter_by(name=name).first()
+        if t is None:
+            t = Trope(name=name)
+            self.session.add(t)
+            self.session.flush()
+        return t
+
+    def standardize_style(self, *a, **k):
+        return None
+
+
+def _row(**over):
+    r = {
+        "Title": "FB Flag Test",
+        "Author_1": "A. Author",
+        "format": "ebook",
+        "genres": ["fantasy"],
+        "moods": ["dark"],
+    }
+    r.update(over)
+    return r
+
+
+def _trope_names(session, work):
+    return {
+        session.get(Trope, wt.trope_id).name
+        for wt in session.query(WorkTrope).filter_by(work_id=work.id).all()
+    }
+
+
+def test_fast_pass_writes_no_fallback_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(session, _row(write_fallback_tropes=False), tm, tm)
+        session.flush()
+        assert session.query(WorkTrope).filter_by(work_id=work.id).count() == 0  # no fallback tropes
+        assert work.genres  # genres still written (still displayed)
+
+
+def test_default_writes_fallback_when_no_real_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(session, _row(Title="FB Default"), tm, tm)  # flag defaults True
+        session.flush()
+        assert "Fantasy" in _trope_names(session, work)  # fallback stopgap preserved
+
+
+def test_fallback_skipped_when_work_already_has_real_trope(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(
+            session,
+            _row(Title="FB HasReal", enriched_tropes=[{"trope_name": "Chosen One", "justification": "x"}]),
+            tm,
+            tm,
+        )
+        session.flush()
+        # a later fallback-style persist (no enriched_tropes) for the SAME work adds NO fallback layer
+        persist_enriched_work(session, _row(Title="FB HasReal"), tm, tm)
+        session.flush()
+        assert _trope_names(session, work) == {"Chosen One"}
+```
+
+- [ ] **Step 2: Run** `uv run pytest test/integration/test_persist_fallback_flag.py -v` — SKIP locally / FAIL on CI.
+
+- [ ] **Step 3: Implement.** In `src/agentic_librarian/etl/persist.py`, replace the fallback `else`
+block (currently starting `# Fallback to simple tags if no enriched tropes found …`) with:
+```python
+        else:
+            # Fallback genre/mood tropes are a stopgap ONLY for a work with no real (scout) trope, and
+            # only when the caller wants them — the two-phase fast pass opts out (write_fallback_tropes
+            # =False) because its deep pass supplies the real tropes (Spec #65, 2026-06-23). Cleaned the
+            # same way as genres/moods so a fallback can never write a UUID-tailed / unsplit slug.
+            has_real_trope = (
+                session.query(WorkTrope)
+                .filter(WorkTrope.work_id == work.id, WorkTrope.justification.isnot(None))
+                .first()
+                is not None
+            )
+            if row.get("write_fallback_tropes", True) and not has_real_trope:
+                for tag in all_fallback_tags:
+                    for name in clean_trope_name(tag):
+                        standardized_trope = _safe_standardize(
+                            trope_manager.standardize_trope, name, label=f"trope {name!r}"
+                        )
+                        if standardized_trope is None:
+                            continue
+                        existing_link = (
+                            session.query(WorkTrope)
+                            .filter_by(work_id=work.id, trope_id=standardized_trope.id)
+                            .first()
+                        )
+                        if not existing_link:
+                            session.add(WorkTrope(work=work, trope=standardized_trope))
+```
+Leave the `if enriched_tropes:` (real) branch unchanged.
+
+- [ ] **Step 4: Run** `uv run pytest test/integration/test_persist_fallback_flag.py test/integration/test_persist_trope_guard.py -v` (CI). Expect pass / no regression.
+
+- [ ] **Step 5: Format + commit:**
+```bash
+uv run ruff check src/agentic_librarian/etl/persist.py test/integration/test_persist_fallback_flag.py
+uvx ruff@0.15.16 format src/agentic_librarian/etl/persist.py test/integration/test_persist_fallback_flag.py
+git add src/agentic_librarian/etl/persist.py test/integration/test_persist_fallback_flag.py
+git commit -m "feat(persist): fast pass opts out of fallback tropes (write_fallback_tropes flag)"
+```
+
+---
+
+## Task 2: Two-phase fast pass opts out (`two_phase.py`)
+
+**Files:** Modify `src/agentic_librarian/enrichment/two_phase.py`; Test `test/unit/test_two_phase_fallback_flag.py`
+
+- [ ] **Step 1: Write the failing test** `test/unit/test_two_phase_fallback_flag.py`:
+```python
+from uuid import uuid4
+
+from agentic_librarian.enrichment import two_phase
+
+
+def test_scout_and_persist_forwards_fallback_flag(monkeypatch):
+    captured = {}
+
+    def fake_persist(session, row, tm, sm):
+        captured.update(row)
+        return object()
+
+    monkeypatch.setattr(two_phase, "persist_enriched_work", fake_persist)
+    monkeypatch.setattr(two_phase, "TropeManager", lambda session: None)
+    monkeypatch.setattr(two_phase, "StyleManager", lambda session: None)
+    mgr = type("M", (), {"enrich": lambda self, **k: {"genres": ["x"], "moods": []}})()
+
+    two_phase._scout_and_persist(None, mgr, title="T", author="A", fmt="ebook", write_fallback_tropes=False)
+    assert captured["write_fallback_tropes"] is False
+
+
+def test_enrich_fast_opts_out_of_fallback_tropes(monkeypatch):
+    seen = {}
+
+    def fake_sap(session, manager, *, title, author, fmt, write_fallback_tropes=True):
+        seen["wft"] = write_fallback_tropes
+        return type("W", (), {"id": uuid4()})()
+
+    class _Sess:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def query(self, *a, **k):
+            return self
+
+        def join(self, *a, **k):
+            return self
+
+        def filter(self, *a, **k):
+            return self
+
+        def first(self):
+            return None  # no existing work -> proceed to scout
+
+        def flush(self):
+            pass
+
+    monkeypatch.setattr(two_phase, "_scout_and_persist", fake_sap)
+    monkeypatch.setattr(two_phase, "create_fast_scout_manager", lambda: None)
+    two_phase.set_db_manager(type("M", (), {"get_session": lambda s: _Sess()})())
+
+    two_phase.enrich_fast("Some Title", "Some Author", "ebook")
+    assert seen["wft"] is False
+```
+
+- [ ] **Step 2: Run** `uv run pytest test/unit/test_two_phase_fallback_flag.py -v` — FAIL (param/flag not present).
+
+- [ ] **Step 3: Implement.** In `src/agentic_librarian/enrichment/two_phase.py`:
+
+(a) Add the `write_fallback_tropes` param to `_scout_and_persist` and pass it into the row:
+```python
+def _scout_and_persist(
+    session, manager, *, title: str, author: str, fmt: str, write_fallback_tropes: bool = True
+) -> Work | None:
+```
+and in the `row = { ... }` dict add (alongside `"skip_enrichment": False,`):
+```python
+        "write_fallback_tropes": write_fallback_tropes,
+```
+
+(b) In `enrich_fast`, pass `write_fallback_tropes=False` on the fast-tier call:
+```python
+        work = _scout_and_persist(
+            session,
+            create_fast_scout_manager(),
+            title=title,
+            author=author,
+            fmt=fmt,
+            write_fallback_tropes=False,
+        )
+```
+Leave `enrich_deep`'s `_scout_and_persist` call as-is (default `True` → real tropes, or the genre/mood
+fallback only if the deep scout returns none).
+
+- [ ] **Step 4: Run** `uv run pytest test/unit/test_two_phase_fallback_flag.py -v` — PASS.
+
+- [ ] **Step 5: Format + commit:**
+```bash
+uv run ruff check src/agentic_librarian/enrichment/two_phase.py test/unit/test_two_phase_fallback_flag.py
+uvx ruff@0.15.16 format src/agentic_librarian/enrichment/two_phase.py test/unit/test_two_phase_fallback_flag.py
+git add src/agentic_librarian/enrichment/two_phase.py test/unit/test_two_phase_fallback_flag.py
+git commit -m "feat(two-phase): fast pass passes write_fallback_tropes=False"
+```
+
+---
+
+## Task 3: Fallback-prune backfill logic (`trope_backfill.py`)
+
+**Files:** Modify `src/agentic_librarian/etl/trope_backfill.py`; Test `test/integration/test_fallback_prune.py`
+
+- [ ] **Step 1: Write the failing test** `test/integration/test_fallback_prune.py`:
+```python
+import pytest
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import trope_backfill as tb
+
+pytestmark = pytest.mark.db_integration
+
+
+def _link(session, work, name, justification):
+    t = Trope(name=name)
+    session.add(t)
+    session.flush()
+    session.add(WorkTrope(work_id=work.id, trope_id=t.id, justification=justification))
+
+
+def test_prune_removes_fallbacks_only_on_works_with_real_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        polluted = Work(title="Polluted")
+        clean_only = Work(title="Fallback Only")
+        session.add_all([polluted, clean_only])
+        session.flush()
+        _link(session, polluted, "Chosen One", "scout says so")  # real
+        _link(session, polluted, "science-fiction-fantasy", None)  # fallback
+        _link(session, polluted, "tense", None)  # fallback
+        _link(session, clean_only, "literary-fiction", None)  # fallback, but NO real -> keep
+        session.flush()
+
+        deleted = tb.apply_fallback_prune(session)
+        session.flush()
+
+        assert deleted == 2
+        pol = {session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=polluted.id).all()}
+        assert pol == {"Chosen One"}  # only the real trope remains
+        co = session.query(WorkTrope).filter_by(work_id=clean_only.id).count()
+        assert co == 1  # fallback-only work untouched (stopgap preserved)
+
+        assert tb.apply_fallback_prune(session) == 0  # idempotent
+```
+
+- [ ] **Step 2: Run** `uv run pytest test/integration/test_fallback_prune.py -v` — SKIP locally / FAIL on CI.
+
+- [ ] **Step 3: Implement.** In `src/agentic_librarian/etl/trope_backfill.py`:
+
+(a) Add `Work` to the models import:
+```python
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+```
+(b) Append:
+```python
+@dataclass
+class FallbackPrune:
+    work_id: UUID
+    title: str
+    deleted: list[str]  # fallback trope names removed from this work
+    real_kept: int
+
+
+def plan_fallback_prune(session: Session) -> list[FallbackPrune]:
+    """Works that carry BOTH a real (justification IS NOT NULL) and a fallback (justification IS NULL)
+    trope — preview the fallback links that would be deleted. Read-only."""
+    real_work_ids = {
+        wid for (wid,) in session.query(WorkTrope.work_id).filter(WorkTrope.justification.isnot(None)).distinct()
+    }
+    if not real_work_ids:
+        return []
+    by_work: dict[UUID, list[WorkTrope]] = {}
+    for wt in (
+        session.query(WorkTrope)
+        .filter(WorkTrope.justification.is_(None), WorkTrope.work_id.in_(real_work_ids))
+        .all()
+    ):
+        by_work.setdefault(wt.work_id, []).append(wt)
+    out: list[FallbackPrune] = []
+    for wid, links in by_work.items():
+        work = session.get(Work, wid)
+        names = [session.get(Trope, wt.trope_id).name for wt in links]
+        real_kept = (
+            session.query(WorkTrope)
+            .filter(WorkTrope.work_id == wid, WorkTrope.justification.isnot(None))
+            .count()
+        )
+        out.append(FallbackPrune(wid, work.title if work else str(wid), names, real_kept))
+    return out
+
+
+def apply_fallback_prune(session: Session, changes: list[FallbackPrune] | None = None) -> int:
+    """Delete the fallback (NULL-justification) links on each planned work. Link deletion only — no
+    Trope rows, no embeddings. Idempotent (a second run finds no work with both layers)."""
+    if changes is None:
+        changes = plan_fallback_prune(session)
+    n = 0
+    for c in changes:
+        for wt in (
+            session.query(WorkTrope)
+            .filter(WorkTrope.work_id == c.work_id, WorkTrope.justification.is_(None))
+            .all()
+        ):
+            session.delete(wt)
+            n += 1
+    session.flush()
+    return n
+
+
+def fallback_prune_inventory(session: Session) -> tuple[int, int]:
+    """(polluted works, total fallback links that would be pruned)."""
+    plan = plan_fallback_prune(session)
+    return len(plan), sum(len(c.deleted) for c in plan)
+```
+(`dataclass`, `UUID`, `Session`, `WorkTrope` are already imported in this module.)
+
+- [ ] **Step 4: Run** `uv run pytest test/integration/test_fallback_prune.py test/integration/test_trope_backfill.py -v` (CI). Expect pass / no regression.
+
+- [ ] **Step 5: Format + commit:**
+```bash
+uv run ruff check src/agentic_librarian/etl/trope_backfill.py test/integration/test_fallback_prune.py
+uvx ruff@0.15.16 format src/agentic_librarian/etl/trope_backfill.py test/integration/test_fallback_prune.py
+git add src/agentic_librarian/etl/trope_backfill.py test/integration/test_fallback_prune.py
+git commit -m "feat(tropes): fallback-prune backfill (delete NULL tropes on works with real tropes)"
+```
+
+---
+
+## Task 4: `--prune-fallbacks` CLI mode (`clean_catalog.py`)
+
+**Files:** Modify `scripts/clean_catalog.py`; Test `test/unit/test_clean_catalog_prune_cli.py`
+
+- [ ] **Step 1: Write the failing test** `test/unit/test_clean_catalog_prune_cli.py`:
+```python
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def query(self, *a, **k):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def filter_by(self, *a, **k):
+        return self
+
+    def distinct(self):
+        return self
+
+    def all(self):
+        return []
+
+    def count(self):
+        return 0
+
+    def __iter__(self):
+        return iter([])
+
+
+def test_prune_fallbacks_refused_without_yes(monkeypatch, capsys):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: "postgresql://u:p@prod-host/db")
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+    rc = clean_catalog.main(["--prune-fallbacks", "--apply"])  # no --yes
+    assert rc == 2
+    assert "REFUSING --apply without --yes" in capsys.readouterr().out
+```
+
+- [ ] **Step 2: Run** `uv run pytest test/unit/test_clean_catalog_prune_cli.py -v` — FAIL (`--prune-fallbacks` unknown / branch missing).
+
+- [ ] **Step 3: Implement.** In `scripts/clean_catalog.py`:
+
+(a) Add the arg (next to the other `add_argument` calls):
+```python
+    ap.add_argument("--prune-fallbacks", action="store_true")
+```
+(b) In the `if args.inventory:` block, after the dirty-trope print and before `return 0`, add:
+```python
+            pw, pl = trope_backfill.fallback_prune_inventory(session)
+            print(f"\n=== fallback-trope POLLUTION ===\n  {pw} works with real+fallback layers, {pl} fallback links prunable")
+```
+(c) Add a new branch (place it before the `if args.tropes:` branch so the prune runs first by convention):
+```python
+        if args.prune_fallbacks:
+            changes = trope_backfill.plan_fallback_prune(session)
+            total = sum(len(c.deleted) for c in changes)
+            print(f"\n{len(changes)} works would have {total} fallback tropes pruned.")
+            for c in changes[:80]:
+                print(f"  [{c.title[:40]:40}] -{len(c.deleted)} fallback (keep {c.real_kept} real): {c.deleted}")
+            early = _refuse(args, url, safe)
+            if early is not None:
+                return early
+            print(f"\napplied: pruned {trope_backfill.apply_fallback_prune(session, changes)} fallback links.")
+            return 0
+```
+
+- [ ] **Step 4: Run** `uv run pytest test/unit/test_clean_catalog_prune_cli.py test/unit/test_clean_catalog_cli.py -v` — PASS (new + existing).
+
+- [ ] **Step 5: Format + commit:**
+```bash
+uv run ruff check scripts/clean_catalog.py test/unit/test_clean_catalog_prune_cli.py
+uvx ruff@0.15.16 format scripts/clean_catalog.py test/unit/test_clean_catalog_prune_cli.py
+git add scripts/clean_catalog.py test/unit/test_clean_catalog_prune_cli.py
+git commit -m "feat(cli): clean_catalog --prune-fallbacks mode"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `uv run pytest test/unit -q` — all unit tests green.
+- [ ] `uv run ruff check src/agentic_librarian/etl src/agentic_librarian/enrichment scripts/clean_catalog.py` — clean.
+- [ ] Dispatch a final whole-branch reviewer (db_integration runs on CI Postgres).
+- [ ] superpowers:finishing-a-development-branch → push + open PR (Gemini review).
+
+## Rollout (operator, after merge + deploy)
+
+Proxy up (`-e PYTHONPATH=/app/src`), against live prod:
+1. `python scripts/clean_catalog.py --inventory` — confirm the pollution count.
+2. `python scripts/clean_catalog.py --prune-fallbacks --dry-run` → `--prune-fallbacks --apply --yes`.
+3. *then* `python scripts/clean_catalog.py --tropes --dry-run` → `--tropes --apply --yes` (the deferred
+   trope-name cleaning, now on a smaller, un-muddied set).
+
+Both convergent / retry-safe.

--- a/docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md
+++ b/docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md
@@ -1,0 +1,120 @@
+# Fallback-Trope Prune & Two-Phase Persist Fix — Design
+
+**Date:** 2026-06-23
+**Status:** Draft for review
+**Issue:** #65 — two-phase import leaves a genre/mood-as-trope fallback layer on imported works.
+**Scope:** Backend-only. A persist logic fix + a one-time data prune. Sibling of the author/trope
+cleanup (PR #63/#64).
+
+## Problem
+
+Books added via the bulk-import / two-phase enrichment path accumulate a large layer of genre/mood
+"fallback" tropes that the original single-pass catalog never produced. Prod audit
+(`scripts/trope_audit.py`): the most recent import averages **7.58 fallback tropes/work** vs **1.01**
+for the rest of the catalog, on top of a healthy ~7 real tropes/work. The deep enrichment works
+correctly — this is an *excess of redundant fallback rows*, not thin enrichment.
+
+## Root cause
+
+Tropes persist as `if enriched_tropes: <real> else: <write genres|moods as fallback tropes>`
+(`persist.py:310` / `:333`) — one persist writes **either** real **or** fallback tropes.
+
+- **Two-phase import** calls persist twice: the **fast pass** (no trope scout) hits the `else` and
+  writes a genre/mood fallback layer; the **deep pass** then takes the `if` branch and *adds* real
+  scout tropes **without removing** the fallbacks. Imported works carry **both** layers.
+- The **original 330-book catalog** was built **single-pass** (full scout manager in one persist), so
+  works with real tropes took the `if` branch and the `else` never fired → ~0 fallback/work.
+
+## Key principle (why this is safe, not the deferred refactor)
+
+In the single-pass catalog, a work got **either** real tropes **or** fallbacks — never both. So
+**real-trope works have never had a genre/mood-as-trope layer**, and their matching has always run on
+real tropes + styles with zero genre/mood signal. The two-phase bug bolted an *extra* layer onto
+works that already have real tropes — a layer their single-pass siblings lack.
+
+Therefore: **prune the fallback layer only on works that have ≥1 real trope.** This restores parity
+with the rest of the catalog and removes no signal that comparable works ever had. The
+work-representation gap (genres/moods reach matching *only* via fallbacks — see memory
+`work-representation-embedding-gap`) still applies, but **only to works with no real tropes**, which
+keep their fallbacks as the stopgap. This fix is **not** the deferred refactor.
+
+## Goals / Non-goals
+
+**Goals:**
+- Imported works with real tropes end up with **only** real tropes (parity with single-pass catalog).
+- The two-phase persist path can never re-accumulate the double layer, regardless of pass order.
+- A previewable, prod-safe one-time prune of the existing pollution.
+
+**Non-goals:**
+- The work-representation refactor (deferred). Works with **no** real tropes keep their fallbacks.
+- Deleting orphaned `Trope` rows (a fallback Trope still linked to fallback-only works stays; a
+  fully-orphaned one is harmless dead weight — left for the `--tropes` pass / a later sweep).
+
+## Distinguisher
+
+`work_tropes.justification`: scout (real) tropes set it (`persist.py:327`); genre/mood fallbacks
+leave it `NULL` (`persist.py:347`, no justification arg). The `trope_audit.py` rollup validates this
+holds in prod (real tropes consistently carry justification). **Safety net:** the data prune is
+dry-run-previewable per work, so the operator eyeballs the exact trope names being deleted before
+applying — a genuine trope that somehow lacked a justification would be visible in the preview.
+
+---
+
+## Part A — Persist logic fix (`persist.py`, both directions)
+
+Make the two-phase passes converge to "real tropes win, fallbacks are the stopgap":
+
+- **Real branch (`if enriched_tropes:`):** *before* adding the scout tropes, delete the work's
+  existing fallback links — `WorkTrope` rows for this work with `justification IS NULL`. (Delete
+  first, then add, so a scout trope that itself happens to lack a justification — added in this same
+  pass — survives.) Net: the deep pass clears the fast pass's fallback layer.
+- **Fallback branch (`else:`):** only write fallbacks if the work has **no** real trope yet — i.e.
+  skip the loop when a `WorkTrope` with `justification IS NOT NULL` already exists for this work. Net:
+  a fast pass can't bolt a fallback layer onto a work that already has real tropes (covers the
+  deep-then-fast order too).
+
+This keeps the stopgap intact: a work that only ever gets a fast pass (no real tropes) still receives
+its genre/mood fallback layer.
+
+## Part B — One-time data prune
+
+New backfill logic (mirrors `etl/tag_backfill.py` / `etl/trope_backfill.py`; session-in, summary-out):
+
+- **Criterion:** delete `work_tropes` rows where `justification IS NULL` **and** the same `work_id`
+  has ≥1 `work_tropes` row with `justification IS NOT NULL`. Pure link deletion — no `Trope` rows, no
+  embeddings touched.
+- `plan_fallback_prune(session)` → preview: per polluted work, `(title, [fallback trope names being
+  deleted], #real_kept)`. Read-only. `apply_fallback_prune(session, changes=None)` → deletes the
+  links individually (`session.delete`, keeping the identity map consistent), returns the count.
+- Idempotent/convergent: after a run, no work has both a real and a NULL trope → a second run is a no-op.
+- **CLI:** add a `--prune-fallbacks` mode to `scripts/clean_catalog.py` — `--inventory` reports the
+  count of polluted works + total fallback links; `--prune-fallbacks --dry-run` previews; `--apply
+  --yes` writes. Reuses the `is_prod_url` guard, `--yes` gate, and credential-stripped target print.
+
+## Sequencing (operator)
+
+Run the prune **before** `clean_catalog --tropes`:
+
+1. (deploy this PR — the persist fix stops future imports re-polluting)
+2. `clean_catalog.py --prune-fallbacks --dry-run` → `--prune-fallbacks --apply --yes`
+3. *then* `clean_catalog.py --tropes --dry-run` → `--tropes --apply --yes` (the trope-name cleaning,
+   now operating on a much smaller, un-muddied set)
+
+Rationale: the `--tropes` name-cleaning migrates/merges links (`_move_links` folds NULL justification
+into a real row on a name collision) — running it first would corrupt the `justification IS NULL`
+distinguisher and waste embedding calls on fallback rows about to be deleted.
+
+## Testing
+
+- **db_integration** (`test/integration/`): seed a work with real (justified) + fallback (NULL) tropes
+  → `apply_fallback_prune` deletes only the NULL ones, keeps the real; a work with **only** fallbacks
+  is untouched; a second apply is a no-op. Persist: a deep pass after a fast pass leaves only real
+  tropes; a fast pass on a work that already has real tropes adds no fallback layer; a fast-pass-only
+  work keeps its fallbacks.
+- **Unit** where pure logic is extractable (e.g. the polluted-work selection).
+- `uvx ruff@0.15.16 format` before each commit (CI gate).
+
+## Rollout
+
+After merge + deploy: proxy up → `--prune-fallbacks` (dry-run → apply --yes) → then the deferred
+`--tropes` cleaning. Both convergent / retry-safe.

--- a/docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md
+++ b/docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md
@@ -60,21 +60,40 @@ applying — a genuine trope that somehow lacked a justification would be visibl
 
 ---
 
-## Part A — Persist logic fix (`persist.py`, both directions)
+## Part A — Persist logic fix (Shape B: the fast pass writes no throwaway fallbacks)
 
-Make the two-phase passes converge to "real tropes win, fallbacks are the stopgap":
+The pollution is purely the fast pass writing genre/mood fallback tropes that the deep pass always
+supersedes. Rather than write-then-delete, the fast pass **opts out** of fallback tropes and the deep
+pass is the single authoritative trope write — no churn, no "delete NULL links inside persist".
 
-- **Real branch (`if enriched_tropes:`):** *before* adding the scout tropes, delete the work's
-  existing fallback links — `WorkTrope` rows for this work with `justification IS NULL`. (Delete
-  first, then add, so a scout trope that itself happens to lack a justification — added in this same
-  pass — survives.) Net: the deep pass clears the fast pass's fallback layer.
-- **Fallback branch (`else:`):** only write fallbacks if the work has **no** real trope yet — i.e.
-  skip the loop when a `WorkTrope` with `justification IS NOT NULL` already exists for this work. Net:
-  a fast pass can't bolt a fallback layer onto a work that already has real tropes (covers the
-  deep-then-fast order too).
+- **`persist_enriched_work` honours a `write_fallback_tropes` row flag (default `True`).** The `else`
+  (fallback) branch fires only when (a) the caller wants fallbacks **and** (b) the work has no real
+  (`justification IS NOT NULL`) trope yet:
+  ```python
+  else:
+      has_real = (
+          session.query(WorkTrope)
+          .filter(WorkTrope.work_id == work.id, WorkTrope.justification.isnot(None))
+          .first()
+          is not None
+      )
+      if row.get("write_fallback_tropes", True) and not has_real:
+          <write genre/mood fallback tropes, exactly as today>
+  ```
+  The `has_real` guard is cheap defence against re-enrichment ordering — a later tropes-less deep pass
+  can't bolt a fallback layer onto a work that already has real tropes.
+- **`two_phase._scout_and_persist` gains `write_fallback_tropes` (default `True`); `enrich_fast`
+  passes `False`.** The fast pass still writes the work's genres/moods (displayed) but **no** fallback
+  tropes; the deep pass (default `True`) writes real scout tropes — or, only if the deep scout returns
+  none, the genre/mood fallback (the legit stopgap, now produced by the authoritative pass).
+- **Single-pass / non-import callers** (`mcp/server.py:690`, `orchestration/assets.py:117`) don't pass
+  the flag → default `True` → unchanged behaviour (fallback stopgap when a one-shot enrichment yields
+  no tropes; the original 330-book catalog build relied on this).
 
-This keeps the stopgap intact: a work that only ever gets a fast pass (no real tropes) still receives
-its genre/mood fallback layer.
+Result: imported works never accumulate a throwaway fallback layer. The only behaviour change: during
+the fast→deep gap (or if a deep pass *permanently* fails) an imported book shows its genres/moods but
+no tropes — the deferred work-representation refactor is the eventual home for genre/mood matching
+signal on trope-less works.
 
 ## Part B — One-time data prune
 
@@ -108,9 +127,10 @@ distinguisher and waste embedding calls on fallback rows about to be deleted.
 
 - **db_integration** (`test/integration/`): seed a work with real (justified) + fallback (NULL) tropes
   → `apply_fallback_prune` deletes only the NULL ones, keeps the real; a work with **only** fallbacks
-  is untouched; a second apply is a no-op. Persist: a deep pass after a fast pass leaves only real
-  tropes; a fast pass on a work that already has real tropes adds no fallback layer; a fast-pass-only
-  work keeps its fallbacks.
+  is untouched; a second apply is a no-op. Persist (Shape B): a fast pass (`write_fallback_tropes=False`)
+  writes genres/moods but **no** tropes; a following deep pass leaves only real tropes (no fallback
+  layer ever existed). A deep/one-shot pass whose scout returns no tropes writes the genre/mood
+  fallback (default flag); a fallback write is skipped when the work already has a real trope.
 - **Unit** where pure logic is extractable (e.g. the polluted-work selection).
 - `uvx ruff@0.15.16 format` before each commit (CI gate).
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -37,6 +37,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--inventory", action="store_true")
     ap.add_argument("--contributors", action="store_true")
     ap.add_argument("--tropes", action="store_true")
+    ap.add_argument("--prune-fallbacks", action="store_true")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
@@ -63,6 +64,10 @@ def main(argv: list[str] | None = None) -> int:
             for before, after, wc in dirty:
                 print(f"  {wc:4d}  {before!r} -> {after}")
             print(f"\nembedding calls a --tropes --apply would make: {trope_backfill.embedding_call_estimate(session)}")
+            pw, pl = trope_backfill.fallback_prune_inventory(session)
+            print(
+                f"\n=== fallback-trope POLLUTION ===\n  {pw} works with real+fallback layers, {pl} fallback links prunable"
+            )
             return 0
 
         if args.contributors:
@@ -75,6 +80,18 @@ def main(argv: list[str] | None = None) -> int:
                 return early
             applied = contributor_dedup.apply_contributor_changes(session)
             print(f"\napplied: merged {len(applied)} groups.")
+            return 0
+
+        if args.prune_fallbacks:
+            changes = trope_backfill.plan_fallback_prune(session)
+            total = sum(len(c.deleted) for c in changes)
+            print(f"\n{len(changes)} works would have {total} fallback tropes pruned.")
+            for c in changes[:80]:
+                print(f"  [{c.title[:40]:40}] -{len(c.deleted)} fallback (keep {c.real_kept} real): {c.deleted}")
+            early = _refuse(args, url, safe)
+            if early is not None:
+                return early
+            print(f"\napplied: pruned {trope_backfill.apply_fallback_prune(session, changes)} fallback links.")
             return 0
 
         if args.tropes:

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -109,7 +109,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\napplied: {trope_backfill.apply_trope_changes(session, tm, changes)} trope rows cleaned.")
             return 0
 
-        print("Nothing to do. Pass --inventory, --contributors, or --tropes.")
+        print("Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, or --tropes.")
         return 1
 
 

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -45,7 +45,9 @@ def _normalized_col(col):
     return func.trim(func.regexp_replace(func.lower(col), r"\s+", " ", "g"))
 
 
-def _scout_and_persist(session, manager, *, title: str, author: str, fmt: str) -> Work | None:
+def _scout_and_persist(
+    session, manager, *, title: str, author: str, fmt: str, write_fallback_tropes: bool = True
+) -> Work | None:
     """Run a scout tier and persist via the shared function. Returns the Work, or None
     if the scouts found nothing / the row had no usable contributors. date_completed=None
     so persist writes NO reading_history (and needs no user context) — the read-event is
@@ -58,6 +60,7 @@ def _scout_and_persist(session, manager, *, title: str, author: str, fmt: str) -
         "Author_1": author,
         "format": fmt,
         "skip_enrichment": False,
+        "write_fallback_tropes": write_fallback_tropes,
         "date_completed": None,
         **enriched,
         "genres": list(enriched.get("genres") or []),
@@ -84,7 +87,14 @@ def enrich_fast(title: str, author: str, fmt: str = "ebook") -> tuple[UUID, bool
         if existing:
             return existing.id, False
 
-        work = _scout_and_persist(session, create_fast_scout_manager(), title=title, author=author, fmt=fmt)
+        work = _scout_and_persist(
+            session,
+            create_fast_scout_manager(),
+            title=title,
+            author=author,
+            fmt=fmt,
+            write_fallback_tropes=False,
+        )
         if work is None:
             return None
         session.flush()

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -60,11 +60,12 @@ def _scout_and_persist(
         "Author_1": author,
         "format": fmt,
         "skip_enrichment": False,
-        "write_fallback_tropes": write_fallback_tropes,
         "date_completed": None,
         **enriched,
         "genres": list(enriched.get("genres") or []),
         "moods": list(enriched.get("moods") or []),
+        # after **enriched so a scout payload can never clobber the caller's choice
+        "write_fallback_tropes": write_fallback_tropes,
     }
     return persist_enriched_work(session, row, TropeManager(session=session), StyleManager(session=session))
 

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -331,19 +331,28 @@ def persist_enriched_work(
                     existing_link.relevance_score = score
                     existing_link.justification = existing_link.justification or just
         else:
-            # Fallback to simple tags if no enriched tropes found — cleaned the same way as
-            # genres/moods so the fallback can never write a UUID-tailed / unsplit slug (Spec 2026-06-23).
-            for tag in all_fallback_tags:
-                for name in clean_trope_name(tag):
-                    standardized_trope = _safe_standardize(
-                        trope_manager.standardize_trope, name, label=f"trope {name!r}"
-                    )
-                    if standardized_trope is None:
-                        continue
-                    existing_link = (
-                        session.query(WorkTrope).filter_by(work_id=work.id, trope_id=standardized_trope.id).first()
-                    )
-                    if not existing_link:
-                        session.add(WorkTrope(work=work, trope=standardized_trope))
+            # Fallback genre/mood tropes are a stopgap ONLY for a work with no real (scout) trope, and
+            # only when the caller wants them — the two-phase fast pass opts out (write_fallback_tropes
+            # =False) because its deep pass supplies the real tropes (Spec #65, 2026-06-23). Cleaned the
+            # same way as genres/moods so a fallback can never write a UUID-tailed / unsplit slug.
+            has_real_trope = (
+                session.query(WorkTrope)
+                .filter(WorkTrope.work_id == work.id, WorkTrope.justification.isnot(None))
+                .first()
+                is not None
+            )
+            if row.get("write_fallback_tropes", True) and not has_real_trope:
+                for tag in all_fallback_tags:
+                    for name in clean_trope_name(tag):
+                        standardized_trope = _safe_standardize(
+                            trope_manager.standardize_trope, name, label=f"trope {name!r}"
+                        )
+                        if standardized_trope is None:
+                            continue
+                        existing_link = (
+                            session.query(WorkTrope).filter_by(work_id=work.id, trope_id=standardized_trope.id).first()
+                        )
+                        if not existing_link:
+                            session.add(WorkTrope(work=work, trope=standardized_trope))
 
     return work

--- a/src/agentic_librarian/etl/trope_backfill.py
+++ b/src/agentic_librarian/etl/trope_backfill.py
@@ -9,6 +9,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Trope, Work, WorkTrope
@@ -178,26 +179,32 @@ class FallbackPrune:
 
 def plan_fallback_prune(session: Session) -> list[FallbackPrune]:
     """Works that carry BOTH a real (justification IS NOT NULL) and a fallback (justification IS NULL)
-    trope — preview the fallback links that would be deleted. Read-only."""
-    real_work_ids = {
-        wid for (wid,) in session.query(WorkTrope.work_id).filter(WorkTrope.justification.isnot(None)).distinct()
-    }
-    if not real_work_ids:
+    trope — preview the fallback links that would be deleted. Read-only. Two queries (no N+1)."""
+    real_works = session.query(WorkTrope.work_id).filter(WorkTrope.justification.isnot(None)).distinct().subquery()
+    # All fallback links on real-trope works, joined to the Work title + Trope name in one query.
+    rows = (
+        session.query(WorkTrope.work_id, Work.title, Trope.name)
+        .join(Work, Work.id == WorkTrope.work_id)
+        .join(Trope, Trope.id == WorkTrope.trope_id)
+        .join(real_works, real_works.c.work_id == WorkTrope.work_id)
+        .filter(WorkTrope.justification.is_(None))
+        .all()
+    )
+    if not rows:
         return []
-    by_work: dict[UUID, list[WorkTrope]] = {}
-    for wt in (
-        session.query(WorkTrope).filter(WorkTrope.justification.is_(None), WorkTrope.work_id.in_(real_work_ids)).all()
-    ):
-        by_work.setdefault(wt.work_id, []).append(wt)
-    out: list[FallbackPrune] = []
-    for wid, links in by_work.items():
-        work = session.get(Work, wid)
-        names = [session.get(Trope, wt.trope_id).name for wt in links]
-        real_kept = (
-            session.query(WorkTrope).filter(WorkTrope.work_id == wid, WorkTrope.justification.isnot(None)).count()
-        )
-        out.append(FallbackPrune(wid, work.title if work else str(wid), names, real_kept))
-    return out
+    # Real-trope counts for every affected work in one grouped query.
+    real_counts = dict(
+        session.query(WorkTrope.work_id, func.count())
+        .filter(WorkTrope.justification.isnot(None))
+        .group_by(WorkTrope.work_id)
+        .all()
+    )
+    names: dict[UUID, list[str]] = {}
+    titles: dict[UUID, str] = {}
+    for wid, title, tname in rows:
+        names.setdefault(wid, []).append(tname)
+        titles[wid] = title
+    return [FallbackPrune(wid, titles[wid], n, real_counts.get(wid, 0)) for wid, n in names.items()]
 
 
 def apply_fallback_prune(session: Session, changes: list[FallbackPrune] | None = None) -> int:
@@ -205,15 +212,14 @@ def apply_fallback_prune(session: Session, changes: list[FallbackPrune] | None =
     Trope rows, no embeddings. Idempotent (a second run finds no work with both layers)."""
     if changes is None:
         changes = plan_fallback_prune(session)
-    n = 0
-    for c in changes:
-        for wt in (
-            session.query(WorkTrope).filter(WorkTrope.work_id == c.work_id, WorkTrope.justification.is_(None)).all()
-        ):
-            session.delete(wt)
-            n += 1
+    work_ids = [c.work_id for c in changes]
+    if not work_ids:
+        return 0
+    links = session.query(WorkTrope).filter(WorkTrope.justification.is_(None), WorkTrope.work_id.in_(work_ids)).all()
+    for wt in links:
+        session.delete(wt)
     session.flush()
-    return n
+    return len(links)
 
 
 def fallback_prune_inventory(session: Session) -> tuple[int, int]:

--- a/src/agentic_librarian/etl/trope_backfill.py
+++ b/src/agentic_librarian/etl/trope_backfill.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from agentic_librarian.db.models import Trope, WorkTrope
+from agentic_librarian.db.models import Trope, Work, WorkTrope
 from agentic_librarian.etl.tag_cleaning import _normalize, clean_trope_name
 
 logger = logging.getLogger(__name__)
@@ -166,3 +166,57 @@ def trope_inventory(session: Session) -> tuple[Counter, list]:
         if cleaned != [t.name]:
             dirty.append((t.name, cleaned, wc))
     return counts, dirty
+
+
+@dataclass
+class FallbackPrune:
+    work_id: UUID
+    title: str
+    deleted: list[str]  # fallback trope names removed from this work
+    real_kept: int
+
+
+def plan_fallback_prune(session: Session) -> list[FallbackPrune]:
+    """Works that carry BOTH a real (justification IS NOT NULL) and a fallback (justification IS NULL)
+    trope — preview the fallback links that would be deleted. Read-only."""
+    real_work_ids = {
+        wid for (wid,) in session.query(WorkTrope.work_id).filter(WorkTrope.justification.isnot(None)).distinct()
+    }
+    if not real_work_ids:
+        return []
+    by_work: dict[UUID, list[WorkTrope]] = {}
+    for wt in (
+        session.query(WorkTrope).filter(WorkTrope.justification.is_(None), WorkTrope.work_id.in_(real_work_ids)).all()
+    ):
+        by_work.setdefault(wt.work_id, []).append(wt)
+    out: list[FallbackPrune] = []
+    for wid, links in by_work.items():
+        work = session.get(Work, wid)
+        names = [session.get(Trope, wt.trope_id).name for wt in links]
+        real_kept = (
+            session.query(WorkTrope).filter(WorkTrope.work_id == wid, WorkTrope.justification.isnot(None)).count()
+        )
+        out.append(FallbackPrune(wid, work.title if work else str(wid), names, real_kept))
+    return out
+
+
+def apply_fallback_prune(session: Session, changes: list[FallbackPrune] | None = None) -> int:
+    """Delete the fallback (NULL-justification) links on each planned work. Link deletion only — no
+    Trope rows, no embeddings. Idempotent (a second run finds no work with both layers)."""
+    if changes is None:
+        changes = plan_fallback_prune(session)
+    n = 0
+    for c in changes:
+        for wt in (
+            session.query(WorkTrope).filter(WorkTrope.work_id == c.work_id, WorkTrope.justification.is_(None)).all()
+        ):
+            session.delete(wt)
+            n += 1
+    session.flush()
+    return n
+
+
+def fallback_prune_inventory(session: Session) -> tuple[int, int]:
+    """(polluted works, total fallback links that would be pruned)."""
+    plan = plan_fallback_prune(session)
+    return len(plan), sum(len(c.deleted) for c in plan)

--- a/test/integration/test_fallback_prune.py
+++ b/test/integration/test_fallback_prune.py
@@ -1,0 +1,40 @@
+import pytest
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import trope_backfill as tb
+
+pytestmark = pytest.mark.db_integration
+
+
+def _link(session, work, name, justification):
+    t = Trope(name=name)
+    session.add(t)
+    session.flush()
+    session.add(WorkTrope(work_id=work.id, trope_id=t.id, justification=justification))
+
+
+def test_prune_removes_fallbacks_only_on_works_with_real_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        polluted = Work(title="Polluted")
+        clean_only = Work(title="Fallback Only")
+        session.add_all([polluted, clean_only])
+        session.flush()
+        _link(session, polluted, "Chosen One", "scout says so")  # real
+        _link(session, polluted, "science-fiction-fantasy", None)  # fallback
+        _link(session, polluted, "tense", None)  # fallback
+        _link(session, clean_only, "literary-fiction", None)  # fallback, but NO real -> keep
+        session.flush()
+
+        deleted = tb.apply_fallback_prune(session)
+        session.flush()
+
+        assert deleted == 2
+        pol = {
+            session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=polluted.id).all()
+        }
+        assert pol == {"Chosen One"}
+        assert session.query(WorkTrope).filter_by(work_id=clean_only.id).count() == 1  # untouched
+
+        assert tb.apply_fallback_prune(session) == 0  # idempotent

--- a/test/integration/test_persist_fallback_flag.py
+++ b/test/integration/test_persist_fallback_flag.py
@@ -1,0 +1,70 @@
+import pytest
+
+from agentic_librarian.db.models import Trope, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl.persist import persist_enriched_work
+
+pytestmark = pytest.mark.db_integration
+
+
+class _PassthroughTrope:
+    """standardize_trope returns an exact-name Trope (no embedding) so names are assertable."""
+
+    def __init__(self, session):
+        self.session = session
+
+    def standardize_trope(self, name, *a, **k):
+        t = self.session.query(Trope).filter_by(name=name).first()
+        if t is None:
+            t = Trope(name=name)
+            self.session.add(t)
+            self.session.flush()
+        return t
+
+    def standardize_style(self, *a, **k):
+        return None
+
+
+def _row(**over):
+    r = {"Title": "FB Flag Test", "Author_1": "A. Author", "format": "ebook", "genres": ["fantasy"], "moods": ["dark"]}
+    r.update(over)
+    return r
+
+
+def _trope_names(session, work):
+    return {session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=work.id).all()}
+
+
+def test_fast_pass_writes_no_fallback_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(session, _row(write_fallback_tropes=False), tm, tm)
+        session.flush()
+        assert session.query(WorkTrope).filter_by(work_id=work.id).count() == 0
+        assert work.genres
+
+
+def test_default_writes_fallback_when_no_real_tropes(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(session, _row(Title="FB Default"), tm, tm)
+        session.flush()
+        assert "Fantasy" in _trope_names(session, work)
+
+
+def test_fallback_skipped_when_work_already_has_real_trope(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        work = persist_enriched_work(
+            session,
+            _row(Title="FB HasReal", enriched_tropes=[{"trope_name": "Chosen One", "justification": "x"}]),
+            tm,
+            tm,
+        )
+        session.flush()
+        persist_enriched_work(session, _row(Title="FB HasReal"), tm, tm)
+        session.flush()
+        assert _trope_names(session, work) == {"Chosen One"}

--- a/test/unit/test_clean_catalog_prune_cli.py
+++ b/test/unit/test_clean_catalog_prune_cli.py
@@ -1,0 +1,47 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def query(self, *a, **k):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def filter_by(self, *a, **k):
+        return self
+
+    def distinct(self):
+        return self
+
+    def all(self):
+        return []
+
+    def count(self):
+        return 0
+
+    def __iter__(self):
+        return iter([])
+
+
+def test_prune_fallbacks_refused_without_yes(monkeypatch, capsys):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: "postgresql://u:p@prod-host/db")
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+    rc = clean_catalog.main(["--prune-fallbacks", "--apply"])  # no --yes
+    assert rc == 2
+    assert "REFUSING --apply without --yes" in capsys.readouterr().out

--- a/test/unit/test_clean_catalog_prune_cli.py
+++ b/test/unit/test_clean_catalog_prune_cli.py
@@ -42,6 +42,9 @@ def test_prune_fallbacks_refused_without_yes(monkeypatch, capsys):
     monkeypatch.setattr(
         clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
     )
+    # plan does real SQLAlchemy query construction (subquery/joins) — stub it; this test is about the
+    # CLI's --apply/--yes guard, not the query.
+    monkeypatch.setattr(clean_catalog.trope_backfill, "plan_fallback_prune", lambda session: [])
     rc = clean_catalog.main(["--prune-fallbacks", "--apply"])  # no --yes
     assert rc == 2
     assert "REFUSING --apply without --yes" in capsys.readouterr().out

--- a/test/unit/test_two_phase_fallback_flag.py
+++ b/test/unit/test_two_phase_fallback_flag.py
@@ -1,0 +1,56 @@
+from uuid import uuid4
+
+from agentic_librarian.enrichment import two_phase
+
+
+def test_scout_and_persist_forwards_fallback_flag(monkeypatch):
+    captured = {}
+
+    def fake_persist(session, row, tm, sm):
+        captured.update(row)
+        return object()
+
+    monkeypatch.setattr(two_phase, "persist_enriched_work", fake_persist)
+    monkeypatch.setattr(two_phase, "TropeManager", lambda session: None)
+    monkeypatch.setattr(two_phase, "StyleManager", lambda session: None)
+    mgr = type("M", (), {"enrich": lambda self, **k: {"genres": ["x"], "moods": []}})()
+
+    two_phase._scout_and_persist(None, mgr, title="T", author="A", fmt="ebook", write_fallback_tropes=False)
+    assert captured["write_fallback_tropes"] is False
+
+
+def test_enrich_fast_opts_out_of_fallback_tropes(monkeypatch):
+    seen = {}
+
+    def fake_sap(session, manager, *, title, author, fmt, write_fallback_tropes=True):
+        seen["wft"] = write_fallback_tropes
+        return type("W", (), {"id": uuid4()})()
+
+    class _Sess:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def query(self, *a, **k):
+            return self
+
+        def join(self, *a, **k):
+            return self
+
+        def filter(self, *a, **k):
+            return self
+
+        def first(self):
+            return None
+
+        def flush(self):
+            pass
+
+    monkeypatch.setattr(two_phase, "_scout_and_persist", fake_sap)
+    monkeypatch.setattr(two_phase, "create_fast_scout_manager", lambda: None)
+    two_phase.set_db_manager(type("M", (), {"get_session": lambda s: _Sess()})())
+
+    two_phase.enrich_fast("Some Title", "Some Author", "ebook")
+    assert seen["wft"] is False


### PR DESCRIPTION
## Summary

Fixes #65 — books added via the two-phase bulk-import path accumulate an excess genre/mood-as-trope **fallback layer** (prod audit: ~7.58 fallback tropes/work on the recent import vs ~1.01 for the single-pass catalog, *on top of* real scout tropes).

**Root cause:** `persist_enriched_work` writes *either* real *or* fallback tropes. Two-phase import calls it twice — the **fast pass** (no trope scout) writes a genre/mood fallback layer; the **deep pass** *adds* real scout tropes without removing the fallbacks. The single-pass catalog never hit the `else`, so real-trope works there have ~0 fallbacks.

## Fix (Shape B — fast pass writes no throwaway fallbacks)

Rather than write-then-delete, the fast pass **opts out** and the deep pass is the single authoritative trope write:

- **`persist_enriched_work`** honors a `write_fallback_tropes` row flag (default `True`); the fallback `else` branch fires only when the flag is set **and** the work has no real (`justification IS NOT NULL`) trope yet.
- **`two_phase._scout_and_persist`** gains the flag; **`enrich_fast` passes `False`**. The fast pass still writes genres/moods (displayed); the deep pass writes real tropes — or the genre/mood fallback only if the scout returns none.
- Single-pass / one-shot callers (`mcp/server.py`, `orchestration/assets.py`) don't pass the flag → unchanged stopgap behavior.

**Why it's safe (not the deferred work-representation refactor):** real-trope works in the single-pass catalog never had a fallback layer, so imported real-trope works shouldn't either. Works with **no** real tropes keep their fallbacks as the stopgap; the genre/mood matching-signal refactor stays deferred (see memory `work-representation-embedding-gap`).

## One-time prune of existing pollution

`scripts/clean_catalog.py --prune-fallbacks` — deletes `justification IS NULL` `work_tropes` on works that also have ≥1 real trope (pure link deletion; no Trope rows, no embeddings). Dry-run previews per work; same `is_prod_url`/`--yes` guards; idempotent. `--inventory` reports the pollution count.

**Operator sequence:** `--prune-fallbacks` (dry-run → apply) **before** `--tropes` (the deferred name cleaning), so the `justification` distinguisher stays pristine and no embedding is wasted on fallbacks about to be deleted.

## Test Plan
- [x] db_integration (CI Postgres): fast pass writes no fallback tropes; default writes fallback when no real trope; fallback skipped when a real trope exists; prune deletes only NULL links on works with real tropes, leaves fallback-only works, idempotent.
- [x] Unit: two_phase flag forwarding + `enrich_fast` opt-out; CLI `--prune-fallbacks` refuse-without-yes. 416 unit pass (5 pre-existing env failures unrelated).
- [x] ruff check + format clean.

Spec: `docs/superpowers/specs/2026-06-23-fallback-trope-prune-design.md` · Plan: `docs/superpowers/plans/2026-06-23-fallback-trope-prune.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
