### PR TITLE
chore: repo-rename follow-ups — WIF docs + infra config (#79)

### DIFF
--- a/docs/runbooks/gcp-walking-skeleton.md
+++ b/docs/runbooks/gcp-walking-skeleton.md
@@ -169,7 +169,7 @@ if the SA isn't ready immediately; that is normal.
 
 **Workload Identity Federation:** instead of a long-lived JSON key for CI, the
 workflow exchanges a short-lived GitHub OIDC token for GCP credentials at runtime.
-The pool is pinned to exactly `jaydee829/agentic_librarian` via an
+The pool is pinned to exactly `jaydee829/shelfwright` via an
 `attribute.repository` condition — a fork or another repo cannot impersonate the
 deployer SA. Nothing to rotate, nothing to leak.
 

--- a/infra/00-config.sh
+++ b/infra/00-config.sh
@@ -19,7 +19,7 @@ export DEPLOYER_SA_NAME="github-deployer"
 export RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 export DEPLOYER_SA="${DEPLOYER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 export SERVICE="librarian-api"
-export GITHUB_REPO="jaydee829/agentic_librarian"
+export GITHUB_REPO="jaydee829/shelfwright"
 export DUMP_FILE="agentic_librarian_FINAL_20260605_014912.sql.gz"
 
 # --- Lift 2 Stage 4: async enrichment (Cloud Tasks) + deep-scout key secrets ---


### PR DESCRIPTION
Post-rename follow-ups (Task 5 Step 7 of the Shelfwright launch plan):

- `docs/runbooks/gcp-walking-skeleton.md`: WIF pool pinning description now says `jaydee829/shelfwright` (matches the live provider condition updated via gcloud after the rename)
- `infra/00-config.sh`: `GITHUB_REPO` updated so a re-run of `05-iam-wif.sh` can't re-pin the old repo path

Left alone deliberately: historical spec/plan/issue links (GitHub redirects them) and all `agentic_librarian` DB/dump names (the code-level rename is explicitly out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUR4CLRn6yCUWV4Nubkhtb