### PR TITLE
perf: Phase 6.2a quick wins — working embedding cache, pool tuning, outbound timeouts (#101 #102 #103)

### DIFF
--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -77,6 +77,8 @@ This file tracks important project configuration, constants, and environment det
   (full `DATABASE_URL`, Cloud SQL unix socket); schema managed by Alembic (Lift 1+).
   Nightly automated backups (09:00 UTC) + 7-day PITR enabled 2026-07-12 (GH #91; codified in
   `infra/02-cloudsql.sh`).
+  Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per
+  API process (GH #102) — 2 instances × 7 ≈ 14 of db-f1-micro's ~25 connections.
 - **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
   `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
   the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -77,8 +77,8 @@ This file tracks important project configuration, constants, and environment det
   (full `DATABASE_URL`, Cloud SQL unix socket); schema managed by Alembic (Lift 1+).
   Nightly automated backups (09:00 UTC) + 7-day PITR enabled 2026-07-12 (GH #91; codified in
   `infra/02-cloudsql.sh`).
-  Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per
-  API process (GH #102) — 2 instances × 7 ≈ 14 of db-f1-micro's ~25 connections.
+  Engine pools: `pool_pre_ping` + 30-min recycle, 5+10 per engine (max_overflow interim
+  until #94 shortens sessions — then 5+2), one shared engine per API process (GH #102).
 - **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
   `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
   the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.

--- a/docs/superpowers/plans/2026-07-12-phase6-2a-quick-wins.md
+++ b/docs/superpowers/plans/2026-07-12-phase6-2a-quick-wins.md
@@ -1,0 +1,505 @@
+# Phase 6.2 PR-A Quick Wins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the low-risk capacity fixes — a working embedding cache (#101), tuned/consolidated connection pools (#102), and outbound timeouts (#103) — on branch `perf/phase6-2a-quick-wins`.
+
+**Architecture:** One process-wide `genai.Client` singleton in `scouts/utils.py` lets the embedding LRU key on `(model_name, text)`; `db/session.py` gains pool flags and three straggler modules join the lifespan's shared-pool fan-out; the shared `genai_http_options()` factory gains a timeout and the Audible page fetch gets a retrying session with a timeout. PR-B (#93/#94) builds on this branch after it merges.
+
+**Tech Stack:** google-genai 2.8.0 (`HttpOptions.timeout` is **milliseconds**), SQLAlchemy QueuePool, requests + urllib3 Retry, pytest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-phase6-2-concurrency-capacity-design.md` (PR-A sections).
+- Exact values: genai timeout `120_000` (ms); page-fetch timeout `15` (seconds); pool flags exactly `pool_pre_ping=True, pool_recycle=1800, pool_size=5, max_overflow=2`.
+- `get_cached_embedding(model_name: str, text: str)` — client param REMOVED, no back-compat shim; all three callers updated in the same task.
+- Shared client helper: `get_shared_genai_client()` in `scouts/utils.py`, double-checked lock, key from `GOOGLE_SEARCH_API_KEY`, `http_options=genai_http_options()`.
+- Managers keep their existing no-API-key `ValueError` in `__init__` (existing behavior).
+- New unit tests are DB-free and run locally: `.venv/Scripts/python -m pytest ...` from repo root. Lint: `uvx ruff check <files>`; format: `uvx ruff format <files>` then re-run check (CI pre-commit enforces format — the 6.1 lesson).
+- LRU caches are process-global: tests MUST call `get_cached_embedding.cache_clear()` and reset `scouts.utils._shared_client` (monkeypatch) to avoid cross-test leakage.
+- No `[skip ci]` anywhere in commit messages. Do not modify `frontend/**` or any file not listed in a task.
+
+---
+
+### Task 1: Shared genai client + (model, text)-keyed embedding cache — #101
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/utils.py:39-56`
+- Modify: `src/agentic_librarian/scouts/trope_manager.py:14-24`
+- Modify: `src/agentic_librarian/scouts/style_manager.py:14-24`
+- Modify: `src/agentic_librarian/api/analysis_style.py:99-135`
+- Test: `test/unit/test_embedding_cache.py` (new)
+
+**Interfaces:**
+- Consumes: existing `genai_http_options()` from `agentic_librarian.llm_retry`.
+- Produces: `get_shared_genai_client() -> genai.Client` and `get_cached_embedding(model_name: str, text: str) -> list[float]` in `agentic_librarian.scouts.utils` — PR-B relies on these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/test_embedding_cache.py`:
+
+```python
+"""#101: the embedding cache must hit across manager instances (keyed (model, text))."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentic_librarian.scouts import utils
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    utils.get_cached_embedding.cache_clear()
+    monkeypatch.setattr(utils, "_shared_client", None)
+    yield
+    utils.get_cached_embedding.cache_clear()
+
+
+def _fake_client(counter):
+    def embed_content(model, contents, config):
+        counter.append(contents)
+        return SimpleNamespace(embeddings=[SimpleNamespace(values=[0.1] * utils.EMBEDDING_DIMENSIONS)])
+
+    return SimpleNamespace(models=SimpleNamespace(embed_content=embed_content))
+
+
+def test_cache_hits_across_callers(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    v1 = utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    v2 = utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    assert v1 == v2
+    assert len(calls) == 1  # second call was a cache hit
+
+
+def test_cache_misses_on_different_text(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    utils.get_cached_embedding("gemini-embedding-001", "Slow Burn")
+    assert len(calls) == 2
+
+
+def test_shared_client_is_singleton(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "test-key")
+    built = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            built.append(kwargs)
+
+    monkeypatch.setattr(utils.genai, "Client", FakeClient)
+    c1 = utils.get_shared_genai_client()
+    c2 = utils.get_shared_genai_client()
+    assert c1 is c2
+    assert len(built) == 1
+    assert built[0]["api_key"] == "test-key"
+
+
+def test_shared_client_requires_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_SEARCH_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="GOOGLE_SEARCH_API_KEY"):
+        utils.get_shared_genai_client()
+
+
+def test_managers_share_the_module_cache(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    from agentic_librarian.scouts.style_manager import StyleManager
+    from agentic_librarian.scouts.trope_manager import TropeManager
+
+    tm = TropeManager(session=MagicMock(), api_key="k")
+    sm = StyleManager(session=MagicMock(), api_key="k")
+    tm._get_embedding("Enemies to Lovers")
+    sm._get_embedding("Enemies to Lovers")  # same model+text -> cache hit
+    assert len(calls) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_embedding_cache.py -v`
+Expected: failures/errors — `utils` has no `_shared_client` / `get_shared_genai_client`, and `get_cached_embedding` takes 3 args.
+
+- [ ] **Step 3: Implement in `scouts/utils.py`**
+
+Replace lines 39-56 (the decorated `get_cached_embedding`) with:
+
+```python
+# Process-wide genai client (GH #101). One client per process means the lru_cache below
+# keys purely on (model_name, text) and actually hits across manager instances / tool
+# calls — previously each TropeManager/StyleManager built its own client and the client
+# identity in the cache key defeated the cache. Double-checked lock: build at most one
+# client under concurrency (same pattern api/analysis_style.py pioneered).
+_shared_client: genai.Client | None = None
+_client_lock = threading.Lock()
+
+
+def get_shared_genai_client() -> genai.Client:
+    global _shared_client
+    if _shared_client is None:
+        with _client_lock:
+            if _shared_client is None:
+                from agentic_librarian.llm_retry import genai_http_options
+
+                key = os.environ.get("GOOGLE_SEARCH_API_KEY")
+                if not key:
+                    raise ValueError("GOOGLE_SEARCH_API_KEY is not set — cannot build the shared genai client.")
+                _shared_client = genai.Client(api_key=key, http_options=genai_http_options())
+    return _shared_client
+
+
+@lru_cache(maxsize=128)
+def get_cached_embedding(model_name: str, text: str) -> list[float]:
+    """Shared embed chokepoint for ETL ingestion, MCP tools, and the recommendation flow.
+    Cached on (model_name, text) so identical tags embed over the network once per process
+    (GH #101). task_type SEMANTIC_SIMILARITY keeps stored vectors and query vectors in one
+    representation space; changing task_type invalidates previously-stored vectors."""
+    _throttle_embedding()
+    client = get_shared_genai_client()
+    response = client.models.embed_content(
+        model=model_name,
+        contents=text,
+        config=types.EmbedContentConfig(
+            task_type="SEMANTIC_SIMILARITY",
+            output_dimensionality=EMBEDDING_DIMENSIONS,
+        ),
+    )
+    if not response or not response.embeddings:
+        raise ValueError(f"Embedding generation returned no result for text: {text!r}")
+    return response.embeddings[0].values
+```
+
+(The `from agentic_librarian.llm_retry import genai_http_options` import is deliberately inside the function — `llm_retry` imports `google.genai.types` and utils is imported by lightweight modules.)
+
+- [ ] **Step 4: Update `trope_manager.py`**
+
+Lines 14-24 — remove the client construction and `genai` import; keep the key validation:
+
+```python
+    def __init__(self, session: Session, api_key: str = None):
+        self.session = session
+        self._api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
+        if not self._api_key:
+            raise ValueError("Google API key not set for TropeManager.")
+        self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
+
+    def _get_embedding(self, text: str) -> list[float]:
+        """Fetch embedding from Gemini via the shared module-level client + cache (#101)."""
+        return get_cached_embedding(self.model_name, text)
+```
+
+Delete the now-unused imports `from google import genai` and `from agentic_librarian.llm_retry import genai_http_options` at the top of the file (ruff will flag them if you forget).
+
+- [ ] **Step 5: Update `style_manager.py`** — the identical change (same lines, `StyleManager` message in the ValueError stays).
+
+- [ ] **Step 6: Update `api/analysis_style.py`**
+
+Replace `default_embedder()` (lines 119-135) and remove the `_genai_client` global (line 99):
+
+```python
+def default_embedder() -> Callable[[str], list[float]] | None:
+    """Real embedder using the same model/space as the stored Style vectors, or
+    None when no API key is configured (radar then degrades to all-null)."""
+    if not os.environ.get("GOOGLE_SEARCH_API_KEY"):
+        return None
+    return lambda text: get_cached_embedding(_EMBED_MODEL, text)
+```
+
+Keep `_lock` (line 100) — the anchor cache still uses it. Delete the `_genai_client: object | None = None` line.
+
+- [ ] **Step 7: Run the tests + affected suites**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_embedding_cache.py -v` — Expected: 6 passed.
+Run: `.venv/Scripts/python -m pytest test/unit -q` — Expected: all pass (analysis-style unit tests exercise `default_embedder`).
+
+- [ ] **Step 8: Lint, format, commit**
+
+Run: `uvx ruff check src/agentic_librarian/scouts/utils.py src/agentic_librarian/scouts/trope_manager.py src/agentic_librarian/scouts/style_manager.py src/agentic_librarian/api/analysis_style.py test/unit/test_embedding_cache.py` and `uvx ruff format src/agentic_librarian/scouts/utils.py src/agentic_librarian/scouts/trope_manager.py src/agentic_librarian/scouts/style_manager.py src/agentic_librarian/api/analysis_style.py test/unit/test_embedding_cache.py`, then re-run the check.
+
+```bash
+git add -A src test
+git commit -m "perf(embeddings): shared genai client; cache keyed on (model, text) (#101)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Gemini HTTP timeout — #103a
+
+**Files:**
+- Modify: `src/agentic_librarian/llm_retry.py:25-27`
+- Test: `test/unit/test_llm_retry.py` (extend)
+
+**Interfaces:**
+- Produces: `GENAI_TIMEOUT_MS = 120_000` module constant (documentation value; PR-B does not depend on it).
+
+- [ ] **Step 1: Write the failing test** — append to `test/unit/test_llm_retry.py`:
+
+```python
+def test_genai_http_options_sets_timeout():
+    """#103: every Gemini call must carry a client-side timeout. HttpOptions.timeout is
+    MILLISECONDS (google-genai 2.8.0) — 120s accommodates grounded deep-scout calls."""
+    from agentic_librarian.llm_retry import GENAI_TIMEOUT_MS, genai_http_options
+
+    assert GENAI_TIMEOUT_MS == 120_000
+    assert genai_http_options().timeout == 120_000
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_llm_retry.py -v`
+Expected: FAIL — `ImportError: cannot import name 'GENAI_TIMEOUT_MS'`.
+
+- [ ] **Step 3: Implement** — in `llm_retry.py`, after `RETRY_OPTIONS`:
+
+```python
+# Client-side request timeout in MILLISECONDS (HttpOptions.timeout unit — NOT seconds;
+# the requests-based scouts use seconds, don't copy values between the two). 120s
+# accommodates grounded deep-scout generations that legitimately run ~a minute; without
+# it a hung Gemini call pins its thread + DB connection until Cloud Run kills the request.
+GENAI_TIMEOUT_MS = 120_000
+
+
+def genai_http_options() -> types.HttpOptions:
+    """HttpOptions carrying the shared retry config + timeout, for `genai.Client(http_options=...)`."""
+    return types.HttpOptions(retry_options=RETRY_OPTIONS, timeout=GENAI_TIMEOUT_MS)
+```
+
+- [ ] **Step 4: Run to verify it passes** — same command, Expected: all pass (including the two pre-existing tests).
+
+- [ ] **Step 5: Lint, format, commit**
+
+```bash
+git add src/agentic_librarian/llm_retry.py test/unit/test_llm_retry.py
+git commit -m "fix(llm): 120s client-side timeout on every Gemini call (#103)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Audible page-fetch timeout via retrying session — #103b
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/metadata_scout.py:33-39` (module level, after `_API_RETRY`) and `:350-360` (`fetch_page_content`)
+- Test: `test/unit/test_metadata_scout_fetch.py` (new)
+
+**Interfaces:** none new (module-private `_page_session`, `_PAGE_TIMEOUT`).
+
+- [ ] **Step 1: Write the failing test** — create `test/unit/test_metadata_scout_fetch.py`:
+
+```python
+"""#103: the Audible page fetch must use the retrying session WITH a timeout."""
+
+from unittest.mock import MagicMock, patch
+
+from agentic_librarian.scouts import metadata_scout
+
+
+def test_fetch_page_content_uses_session_with_timeout():
+    scout = metadata_scout.AudiobookScout.__new__(metadata_scout.AudiobookScout)  # skip __init__ (needs keys)
+    fake_response = MagicMock(content=b"<html><body>Audible page</body></html>")
+    with (
+        patch.object(metadata_scout.AudiobookScout, "search_audible_link", return_value="https://audible.com/x"),
+        patch.object(metadata_scout._page_session, "get", return_value=fake_response) as mock_get,
+    ):
+        text = scout.fetch_page_content("Some Title")
+    assert "Audible page" in text
+    kwargs = mock_get.call_args.kwargs
+    assert kwargs["timeout"] == metadata_scout._PAGE_TIMEOUT == 15
+
+
+def test_page_session_mounts_retry_adapter():
+    adapter = metadata_scout._page_session.get_adapter("https://audible.com")
+    assert adapter.max_retries.total == metadata_scout._API_RETRY.total
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_metadata_scout_fetch.py -v`
+Expected: FAIL — `module ... has no attribute '_page_session'`.
+
+- [ ] **Step 3: Implement** — in `metadata_scout.py`, after the `_API_RETRY` block (line 39):
+
+```python
+# Shared session for raw page scrapes (AudiobookScout extends LLMScout, which has no
+# APIScout session/timeout machinery — GH #103). Same retry policy as the API scouts;
+# timeout in SECONDS (requests convention — the genai HttpOptions timeout is milliseconds).
+_PAGE_TIMEOUT = 15
+_page_session = requests.Session()
+_page_session.mount("https://", HTTPAdapter(max_retries=_API_RETRY))
+_page_session.mount("http://", HTTPAdapter(max_retries=_API_RETRY))
+```
+
+And in `fetch_page_content` (line 356), replace the bare get:
+
+```python
+        response = _page_session.get(url, headers=headers, timeout=_PAGE_TIMEOUT)
+```
+
+- [ ] **Step 4: Run to verify it passes** — same command, Expected: 2 passed.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```bash
+git add src/agentic_librarian/scouts/metadata_scout.py test/unit/test_metadata_scout_fetch.py
+git commit -m "fix(scouts): Audible page fetch via retrying session with 15s timeout (#103)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Pool flags + engine consolidation — #102
+
+**Files:**
+- Modify: `src/agentic_librarian/db/session.py:55-69`
+- Modify: `src/agentic_librarian/imports/worker.py:19-22` (add seam)
+- Modify: `src/agentic_librarian/api/main.py:48-67` (lifespan fan-out + docstring)
+- Modify: `src/agentic_librarian/enrichment/two_phase.py:28-29` (stale comment)
+- Modify: `docs/project_notes/key_facts.md` (Database bullet)
+- Test: `test/unit/test_pool_config.py` (new)
+
+**Interfaces:**
+- Produces: `imports.worker.set_db_manager(new_manager)` (standard seam signature) — PR-B relies on it.
+
+- [ ] **Step 1: Write the failing tests** — create `test/unit/test_pool_config.py`:
+
+```python
+"""#102: pool flags on the engine; all in-process modules share the lifespan pool."""
+
+from fastapi.testclient import TestClient
+
+from agentic_librarian.db.session import DatabaseManager
+
+
+def test_engine_pool_flags():
+    # Postgres URL, lazily initialized: create_engine builds the pool WITHOUT connecting.
+    m = DatabaseManager("postgresql+psycopg2://x:x@nohost:1/x")
+    e = m.engine
+    assert e.pool._pre_ping is True
+    assert e.pool._recycle == 1800
+    assert e.pool.size() == 5
+    assert e.pool._max_overflow == 2
+
+
+def test_lifespan_shares_one_manager_everywhere():
+    from agentic_librarian.api import main as main_mod
+    from agentic_librarian.enrichment import two_phase
+    from agentic_librarian.imports import worker
+    from agentic_librarian.mcp import server as mcp_server
+
+    with TestClient(main_mod.app):
+        shared = main_mod.app.state.db_manager
+        assert main_mod.db_manager is shared
+        assert mcp_server.db_manager is shared
+        assert two_phase.db_manager is shared
+        assert worker.db_manager is shared
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_pool_config.py -v`
+Expected: `test_engine_pool_flags` fails on `_pre_ping`; the lifespan test fails on `worker`/`mcp_server`/`two_phase` not sharing.
+
+- [ ] **Step 3: `db/session.py`** — replace line 68:
+
+```python
+        # GH #102: pre_ping heals stale connections after Cloud SQL restarts/idle;
+        # recycle beats server-side idle kills; 5+2 per engine × max-instances=2 = 14
+        # connections, safely under db-f1-micro's ~25-connection budget. Viable because
+        # sessions no longer idle across external calls (#94).
+        self._engine = create_engine(
+            db_url,
+            connect_args=connect_args,
+            pool_pre_ping=True,
+            pool_recycle=1800,
+            pool_size=5,
+            max_overflow=2,
+        )
+```
+
+Note: sqlite URLs use SingletonThreadPool/NullPool and reject QueuePool kwargs — SQLAlchemy ignores pool sizing for sqlite via its dialect defaults? It does NOT — `create_engine("sqlite://", pool_size=5)` raises `TypeError`. Guard: only pass the pool kwargs for non-sqlite URLs:
+
+```python
+        pool_kwargs = {}
+        if not db_url.startswith("sqlite"):
+            # GH #102: pre_ping heals stale connections after Cloud SQL restarts/idle;
+            # recycle beats server-side idle kills; 5+2 per engine × max-instances=2 = 14
+            # connections, safely under db-f1-micro's ~25-connection budget. Viable because
+            # sessions no longer idle across external calls (#94). sqlite (tests) uses its
+            # own pool class that rejects QueuePool kwargs.
+            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 2}
+        self._engine = create_engine(db_url, connect_args=connect_args, **pool_kwargs)
+```
+
+Use the guarded version (the migration-guard unit tests build sqlite managers).
+
+- [ ] **Step 4: `imports/worker.py`** — after line 21 (`db_manager = DatabaseManager()`):
+
+```python
+def set_db_manager(new_manager: DatabaseManager) -> None:
+    """Override the module db_manager (tests / shared-pool lifespan) — mcp/server.py pattern."""
+    global db_manager
+    db_manager = new_manager
+```
+
+- [ ] **Step 5: `api/main.py` lifespan** — add imports near the existing api imports:
+
+```python
+from agentic_librarian.enrichment import two_phase
+from agentic_librarian.imports import worker as imports_worker
+from agentic_librarian.mcp import server as mcp_server
+```
+
+Extend the fan-out (after `libraries_api.set_db_manager(shared)`):
+
+```python
+        # GH #102: the in-process chat tools (mcp/server), the enrichment paths
+        # (two_phase), and the import worker previously each held their own lazy pool —
+        # up to ~9 engines/process. One pool per process keeps the connection math sane.
+        mcp_server.set_db_manager(shared)
+        two_phase.set_db_manager(shared)
+        imports_worker.set_db_manager(shared)
+```
+
+Update the lifespan docstring's module list to mention them (replace "enrichment/two_phase keeps its own pool (separate path/test seam)." with "mcp/server, enrichment/two_phase, and imports/worker join the fan-out (GH #102); their module-level managers remain as fallbacks for non-API processes (Dagster, CLI).").
+
+- [ ] **Step 6: `enrichment/two_phase.py`** — replace the stale comment at lines 28-29:
+
+```python
+# Module-level fallback pool for non-API processes; the API lifespan injects its shared
+# manager via set_db_manager (GH #102 consolidation — the old "deferred to Stage 4" note was stale).
+```
+
+- [ ] **Step 7: `docs/project_notes/key_facts.md`** — in the Production **Database** bullet, append after the backups sentence:
+
+```markdown
+  Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per
+  API process (GH #102) — 2 instances × 7 ≈ 14 of db-f1-micro's ~25 connections.
+```
+
+- [ ] **Step 8: Run the tests + full local suite**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_pool_config.py test/unit/test_migration_guard.py -v` — Expected: all pass (guard's sqlite managers unaffected by the guard clause).
+Run: `.venv/Scripts/python -m pytest test/unit -q` — Expected: all pass.
+
+- [ ] **Step 9: Lint, format, commit**
+
+```bash
+git add -A src docs/project_notes/key_facts.md test/unit/test_pool_config.py
+git commit -m "perf(db): pool pre_ping/recycle/sizing; consolidate mcp+two_phase+worker onto the lifespan pool (#102)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope (PR-B, separate plan)
+
+#93 (to_thread wrappers, auth, enqueue loops, cached CloudTasksClient) and #94 (session
+splits, availability three-phase, chat two-phase re-route + Librarian contract). PR-B
+branches from main after PR-A merges.

--- a/docs/superpowers/plans/2026-07-12-phase6-2a-quick-wins.md
+++ b/docs/superpowers/plans/2026-07-12-phase6-2a-quick-wins.md
@@ -211,7 +211,7 @@ Keep `_lock` (line 100) — the anchor cache still uses it. Delete the `_genai_c
 
 - [ ] **Step 7: Run the tests + affected suites**
 
-Run: `.venv/Scripts/python -m pytest test/unit/test_embedding_cache.py -v` — Expected: 6 passed.
+Run: `.venv/Scripts/python -m pytest test/unit/test_embedding_cache.py -v` — Expected: 5 passed.
 Run: `.venv/Scripts/python -m pytest test/unit -q` — Expected: all pass (analysis-style unit tests exercise `default_embedder`).
 
 - [ ] **Step 8: Lint, format, commit**

--- a/docs/superpowers/specs/2026-07-12-phase6-2-concurrency-capacity-design.md
+++ b/docs/superpowers/specs/2026-07-12-phase6-2-concurrency-capacity-design.md
@@ -1,0 +1,205 @@
+# Phase 6.2 — Concurrency & Capacity (Design)
+
+**Date:** 2026-07-12 · **Issues:** #93, #94, #101, #102, #103 · **Roadmap:** plan.md Phase 6.2
+
+## Goal
+
+Make one Cloud Run instance safely serve dozens of concurrent users: stop parking blocking
+work on the uvicorn event loop (#93), stop holding DB sessions across external LLM/scout/
+Thunder calls (#94), consolidate and tune the connection pools (#102), make the embedding
+cache actually hit (#101), and bound every outbound call (#103).
+
+**Delivery shape: two PRs from this one spec** (decision under the "unless large enough to
+stand alone" ground rule — #93+#94 together are an architectural restructure):
+- **PR-A `perf/phase6-2a-quick-wins`**: #101 + #102 + #103. Small, independent, low-risk.
+- **PR-B `refactor/phase6-2b-async-sessions`**: #93 + #94, built on PR-A's consolidated pool.
+
+## Verified findings (2026-07-12 exploration; deltas from the issue bodies)
+
+- All 11 mesh tools registered via `FunctionTool` in `agents/services.py` are sync `def`s
+  running inline on the ADK event loop; ADK builds tool schemas from the function
+  **signature**, so any async wrapper must preserve `__signature__`/`__name__`/`__doc__`.
+- `add_book_to_history` (mcp/server.py:484-552) calls `enrich_and_persist_work` inline —
+  the full `create_scout_manager()` (fast + deep tiers) synchronously on the chat path;
+  its error path is `print()`, not logger.
+- `get_current_user` (api/auth.py:65-125): JWT verify is **offline** (CPU, not network —
+  milder than the issue claimed) but the DB query/insert block is sync on the loop; the
+  ContextVar set at line 124 is the only part that must stay in the coroutine.
+- Both `imports/tasks.py` and `enrichment/tasks.py` build a **fresh `CloudTasksClient`
+  (new gRPC channel) per enqueue**; `commit()` loops that up to 2000× inside `async def`.
+  `retry()` has the same loop shape.
+- `imports/worker.py` is an **unlisted 7th engine-sprawl instance** (module-level
+  `DatabaseManager()`, no `set_db_manager` seam, not in the lifespan fan-out) — and it
+  already works around #94 by calling `enrich_fast` *outside* its own session, with a
+  comment saying why. That convention becomes the rule.
+- The `_record_event_usage` pattern (agents/runtime.py:51-68) is the sanctioned template:
+  `await asyncio.to_thread(...)` copies context, so `get_required_user_id()` ContextVars
+  survive.
+- `get_cached_embedding(client, model, text)` keys its LRU on the client instance;
+  `TropeManager`/`StyleManager` build a fresh `genai.Client` per instantiation and are
+  instantiated per MCP tool call / per persisted row → near-zero hit rate. The correct
+  singleton pattern already exists at `api/analysis_style.py:119-135` (double-checked lock).
+- `genai_http_options()` (llm_retry.py) threads retries into **all four** `genai.Client`
+  sites but sets no timeout. `HttpOptions.timeout` exists in installed google-genai 2.8.0
+  and is in **milliseconds** (the requests-based scout convention is seconds — unit trap).
+- `AudiobookScout.fetch_page_content` (metadata_scout.py:356) is a bare `requests.get`;
+  the class extends `LLMScout`, which has **no** `timeout`/`_session` attribute — it cannot
+  reuse `APIScout`'s machinery without restructuring.
+- Nothing in the current test suite exercises the cache hit-rate, timeout presence, or
+  loop-blocking — all three bug classes are structurally invisible today.
+
+## PR-A design
+
+### #101 — shared genai client + working embedding cache
+
+1. `scouts/utils.py` gains `get_shared_genai_client()` — module-level singleton with
+   double-checked locking, `api_key` from `GOOGLE_SEARCH_API_KEY`, `http_options=
+   genai_http_options()` (mirrors `analysis_style.py`, which migrates to this helper).
+2. `get_cached_embedding(model_name, text)` — **client param removed**; the LRU keys on
+   `(model_name, text)`; on miss it embeds via the shared client. Throttle behavior
+   (`_throttle_embedding`) unchanged. `functools.lru_cache` is thread-safe (matters once
+   PR-B moves tool bodies to threads).
+3. `TropeManager`/`StyleManager` stop constructing their own clients; `_get_embedding`
+   calls the new signature. `analysis_style.default_embedder()` delegates to the shared
+   helper (its local singleton and lock are removed).
+4. Managers keep their `session` param — only the client moves.
+
+### #102 — pool flags + engine consolidation
+
+1. `db/session.py:68`: `create_engine(db_url, connect_args=connect_args,
+   pool_pre_ping=True, pool_recycle=1800, pool_size=5, max_overflow=2)`.
+   Math: 2 max instances × (5+2) = 14 connections, safely under db-f1-micro's ~25.
+   `pool_pre_ping` kills the post-maintenance "server closed the connection" class.
+2. Lifespan fan-out (api/main.py) additionally injects the shared manager into
+   `mcp/server` (chat tools run in-process), `enrichment/two_phase`, and
+   `imports/worker` (which gains the standard `set_db_manager` seam). Their module-level
+   fallback managers remain for non-API processes (Dagster/CLI construct their own).
+3. Stale comments corrected: two_phase's "deferred to Stage 4" note; main.py's lifespan
+   docstring lists the new modules.
+
+### #103 — outbound timeouts
+
+1. `llm_retry.py`: `types.HttpOptions(retry_options=RETRY_OPTIONS, timeout=120_000)` —
+   **milliseconds**; 120s accommodates grounded deep-scout calls that legitimately run
+   ~a minute. Propagates to all four client sites via the existing factory.
+2. `metadata_scout.py`: module-level `_page_session = requests.Session()` mounting the
+   existing `_API_RETRY` adapter; `fetch_page_content` uses
+   `_page_session.get(url, headers=headers, timeout=15)` (seconds). AudiobookScout keeps
+   its `LLMScout` base — no hierarchy change.
+
+## PR-B design
+
+### #93 — off-loop execution
+
+1. **Mesh tools**: `agents/services.py` gains `make_async_tool(fn)` → an `async def`
+   wrapper doing `return await asyncio.to_thread(fn, *args, **kwargs)`, with
+   `functools.wraps` + explicit `__signature__ = inspect.signature(fn)` so ADK's schema
+   generation is unchanged. All 11 `FunctionTool(...)` registrations become
+   `FunctionTool(make_async_tool(...))`. ContextVars survive (`to_thread` copies context —
+   the `_record_event_usage` precedent). The implementation plan must verify against
+   installed google-adk 2.2.0 that `FunctionTool` awaits coroutine functions.
+2. **Auth**: `get_current_user` stays `async def` (documented ContextVar constraint); the
+   JWT verify + the entire DB resolve/provision block move into one sync helper called via
+   `await asyncio.to_thread(...)`; `current_user_id.set(result.id)` remains in the
+   coroutine.
+3. **Cloud Tasks**: both `tasks.py` modules cache the client at module level
+   (`_client()` stays as the test seam, now returning the cached instance; reset seam for
+   tests). `commit()` and `retry()` wrap their enqueue loops in
+   `await asyncio.to_thread(_enqueue_all, ids)`.
+
+### #94 — sessions never span external calls
+
+The rule (promoted from imports/worker's existing convention): **read-session → external
+work with no session held → fresh write-session that re-checks dedup before persisting.**
+
+1. `enrichment/two_phase.py` `enrich_fast` / `enrich_deep`: split each into
+   (a) short dedup/read session; (b) `manager.enrich(...)` with no session open;
+   (c) fresh session: re-run the dedup query (the #95 TOCTOU window shrinks back to
+   milliseconds), construct `TropeManager`/`StyleManager` on that session,
+   `persist_enriched_work`, flush. On deep: a transient LLM failure no longer rolls back
+   (and re-pays) completed scout work *held in a transaction* — scouts finished before the
+   write transaction opens.
+2. `api/availability.py` + `availability/service.py`: three-phase batch —
+   (a) session: read `UserLibrary`, works, and all fresh cache rows;
+   (b) no session: Thunder fetches for the misses only;
+   (c) session: write-through cache updates. `availability_for` splits into a pure
+   cache-read helper and a fetch/write pair so `mcp/server.check_availability` uses the
+   same shape. The "ALWAYS 200 / badge is best-effort" contract is unchanged.
+3. `mcp/server.enrich_and_persist_work` — **re-routed through two-phase** (see chat
+   contract below): short-session dedup → `enrich_fast(...)` (which is now session-split
+   itself) → `enqueue_enrichment(work_id)` for the deep pass. The full-scout inline path
+   is removed from the chat surface; error path switches from `print()` to
+   `logger.exception`.
+
+### Chat contract for async deep enrichment (user decision, 2026-07-12)
+
+The user requires: new books still get the **full** enrichment before the mesh treats them
+as recommendation-grade (the Critic must verify matches against the deep trope/style
+fingerprint — shallow-only would be "no better than Goodreads"), async is acceptable, and
+**the Librarian must tell the user it is investigating in the background** and surface the
+result on a later turn.
+
+Mechanics (no frontend changes):
+1. `enrich_and_persist_work` / `add_book_to_history` return payloads gain
+   `"enrichment": "deep_pending"` (or `"complete"` when the work was already cataloged)
+   plus a human-oriented note: deep analysis is running in the background (~1–2 min) and
+   tropes/styles will be available on the next turn.
+2. The Librarian instruction (services.py) is extended: when a tool reports
+   `deep_pending`, (a) tell the user the Librarian is still investigating the book in the
+   background; (b) do NOT present trope/style-based conclusions or recommendations anchored
+   on that book this turn — offer to follow up next turn; (c) on a later turn, tools
+   naturally see the enriched data (`get_work_details`, `search_internal_database`).
+3. A freshly fast-passed work cannot silently pollute recommendations: candidate scoring
+   runs on trope/style vectors, which the work lacks until the deep pass lands; the
+   instruction change makes the Librarian say so instead of guessing.
+4. **Deferred (frontend follow-up, not this phase):** a visual "enriching…" indicator
+   (SSE status event + UI affordance). Noted for the 6.5 frontend-resilience grouping.
+
+## Testing
+
+- **PR-A units (local, DB-free):** cache hits across two manager instances (count embed
+  calls via monkeypatched client); shared-client singleton identity; `genai_http_options()
+  .timeout == 120_000`; `fetch_page_content` passes `timeout=15` (mocked session);
+  engine kwargs asserted via a `DatabaseManager` engine inspection test (sqlite ignores
+  pool args — assert against `create_engine` call or use a Postgres-URL lazy engine's pool
+  class attributes without connecting).
+- **PR-B units:** `make_async_tool` returns a coroutine function whose `__signature__`/
+  `__name__`/`__doc__` match the wrapped tool; wrapper executes off the event loop (assert
+  thread identity differs); auth dependency still sets the ContextVar (existing
+  `test_api_requires_auth` + CI `test_api_auth`); Cloud Tasks client cached (two enqueues,
+  one construction) with seam reset.
+- **CI (db_integration):** existing two_phase fast/deep, availability, mcp-tool, and auth
+  integration suites must stay green — they pin the behavior the restructure must preserve.
+  Extend two_phase tests: persist still happens when dedup re-check finds no row; work is
+  NOT duplicated when a concurrent insert lands between read and write sessions (simulated
+  by pre-inserting between phases via the test seam).
+- **Post-deploy smoke (operator/Claude):** live chat turn with an add-book flow; verify the
+  "investigating in the background" message and next-turn trope availability.
+
+## Risks & rollout
+
+- PR-B touches the chat hot path. Mitigations: behavior pinned by the CI integration
+  suites; PR-A lands first and deploys independently; post-merge smoke on prod chat.
+- to_thread moves tool bodies onto the default executor (cap ~32 threads) — fine at
+  dozens-of-users scale; the enrich/import queues (4/5 concurrent) remain the heavy-work
+  throttles.
+- Pool sizing: 7 connections per instance shared by more concurrent threads than before —
+  `pool_timeout` defaults (30s) apply; the #94 session-shortening is what makes the
+  smaller pool viable (sessions no longer idle for minutes).
+
+## Decisions delegated to Claude (for user review)
+
+1. Two PRs from one spec (quick wins vs restructure), PR-A first.
+2. Shared genai client helper lives in `scouts/utils.py`; `analysis_style.py` migrates to
+   it (one singleton per process, not two).
+3. `get_cached_embedding` signature change (client param dropped) — all three callers
+   updated in the same PR; no back-compat shim.
+4. Pool numbers: `pool_size=5, max_overflow=2, pool_recycle=1800, pool_pre_ping=True`.
+5. Gemini HTTP timeout 120s (120_000 ms); page-fetch timeout 15s via a retrying session.
+6. `make_async_tool` wrapper approach (signature-preserving) over hand-written per-tool
+   async wrappers or an ADK version bump.
+7. Chat add-book re-routed through two-phase with the chat contract above (user-approved
+   2026-07-12: async OK if communicated + no shallow-data recommendations); visual
+   indicator deferred to the frontend grouping.
+8. `imports/worker.py` added to the consolidation set (exploration finding, not in the
+   issue text).

--- a/src/agentic_librarian/api/analysis_style.py
+++ b/src/agentic_librarian/api/analysis_style.py
@@ -96,7 +96,6 @@ class _StyleLike(Protocol):
 # Module-level anchor cache: axis -> (low_vec, high_vec). Filled once per process.
 # Guarded by _lock so concurrent requests don't double-embed or read a half-filled cache.
 _anchor_cache: dict[str, tuple[list[float], list[float]]] = {}
-_genai_client: object | None = None  # genai.Client; typed as object to avoid an import-time genai dependency
 _lock = threading.Lock()
 
 
@@ -119,20 +118,9 @@ def get_anchor_vectors(embed: Callable[[str], list[float]]) -> dict[str, tuple[l
 def default_embedder() -> Callable[[str], list[float]] | None:
     """Real embedder using the same model/space as the stored Style vectors, or
     None when no API key is configured (radar then degrades to all-null)."""
-    global _genai_client
-    key = os.environ.get("GOOGLE_SEARCH_API_KEY")
-    if not key:
+    if not os.environ.get("GOOGLE_SEARCH_API_KEY"):
         return None
-    if _genai_client is None:
-        with _lock:  # double-checked: build at most one client under concurrency
-            if _genai_client is None:
-                from google import genai
-
-                from agentic_librarian.llm_retry import genai_http_options
-
-                _genai_client = genai.Client(api_key=key, http_options=genai_http_options())
-    client = _genai_client
-    return lambda text: get_cached_embedding(client, _EMBED_MODEL, text)
+    return lambda text: get_cached_embedding(_EMBED_MODEL, text)
 
 
 def aggregate_radar(

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -36,6 +36,9 @@ from agentic_librarian.db.models import (
     WorkTrope,
 )
 from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.enrichment import two_phase
+from agentic_librarian.imports import worker as imports_worker
+from agentic_librarian.mcp import server as mcp_server
 
 db_manager = DatabaseManager()
 
@@ -50,10 +53,11 @@ def set_db_manager(new_manager: DatabaseManager) -> None:
 async def lifespan(app: FastAPI):
     """Build ONE DatabaseManager at startup and inject it into the API-request-path
     modules that each owned a lazy pool (main, auth, transcript, usage, recommendations,
-    analysis) — Lift 2 Stage 4 consolidation. enrichment/two_phase keeps its own pool
-    (separate path/test seam). Lazy construction means no DB connection happens here.
-    Tests that use TestClient WITHOUT a `with` block skip lifespan and keep their own
-    monkeypatched managers."""
+    analysis) — Lift 2 Stage 4 consolidation. mcp/server, enrichment/two_phase, and
+    imports/worker join the fan-out (GH #102); their module-level managers remain as
+    fallbacks for non-API processes (Dagster, CLI). Lazy construction means no DB
+    connection happens here. Tests that use TestClient WITHOUT a `with` block skip
+    lifespan and keep their own monkeypatched managers."""
     shared = DatabaseManager()
     # ADR-058 (#92): refuse to serve when the DB schema is behind this code's migration
     # head — the failed revision keeps traffic on the previous one. Unreachable DB only
@@ -69,6 +73,12 @@ async def lifespan(app: FastAPI):
     imports_api.set_db_manager(shared)
     availability_api.set_db_manager(shared)
     libraries_api.set_db_manager(shared)
+    # GH #102: the in-process chat tools (mcp/server), the enrichment paths
+    # (two_phase), and the import worker previously each held their own lazy pool —
+    # up to ~9 engines/process. One pool per process keeps the connection math sane.
+    mcp_server.set_db_manager(shared)
+    two_phase.set_db_manager(shared)
+    imports_worker.set_db_manager(shared)
     yield
 
 

--- a/src/agentic_librarian/db/session.py
+++ b/src/agentic_librarian/db/session.py
@@ -65,7 +65,15 @@ class DatabaseManager:
         if ssl_mode:
             connect_args["sslmode"] = ssl_mode
 
-        self._engine = create_engine(db_url, connect_args=connect_args)
+        pool_kwargs = {}
+        if not db_url.startswith("sqlite"):
+            # GH #102: pre_ping heals stale connections after Cloud SQL restarts/idle;
+            # recycle beats server-side idle kills; 5+2 per engine × max-instances=2 = 14
+            # connections, safely under db-f1-micro's ~25-connection budget. Viable because
+            # sessions no longer idle across external calls (#94). sqlite (tests) uses its
+            # own pool class that rejects QueuePool kwargs.
+            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 2}
+        self._engine = create_engine(db_url, connect_args=connect_args, **pool_kwargs)
         self._SessionFactory = sessionmaker(bind=self._engine)
 
     @property

--- a/src/agentic_librarian/db/session.py
+++ b/src/agentic_librarian/db/session.py
@@ -68,11 +68,15 @@ class DatabaseManager:
         pool_kwargs = {}
         if not db_url.startswith("sqlite"):
             # GH #102: pre_ping heals stale connections after Cloud SQL restarts/idle;
-            # recycle beats server-side idle kills; 5+2 per engine × max-instances=2 = 14
-            # connections, safely under db-f1-micro's ~25-connection budget. Viable because
-            # sessions no longer idle across external calls (#94). sqlite (tests) uses its
-            # own pool class that rejects QueuePool kwargs.
-            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 2}
+            # recycle beats server-side idle kills. INTERIM sizing: sessions are still
+            # held across external LLM/scout calls until #94 (PR-B) lands, and the mcp/
+            # two_phase/worker paths now share THIS pool — max_overflow=10 keeps a bulk
+            # import (4 enrich + 5 import queue-concurrent long sessions) from starving
+            # auth's per-request query. Revert to max_overflow=2 in PR-B when sessions
+            # no longer idle across external calls (2×15=30 peak vs db-f1-micro's ~25 is
+            # tolerable because overflow connections close on release; steady state ≤10).
+            # sqlite (tests) uses its own pool class that rejects QueuePool kwargs.
+            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 10}
         self._engine = create_engine(db_url, connect_args=connect_args, **pool_kwargs)
         self._SessionFactory = sessionmaker(bind=self._engine)
 

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -25,8 +25,8 @@ from agentic_librarian.orchestration.definitions import (
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
 
-# Per-module lazy pool (the recommendations.py/analysis.py Stage 2 pattern). Pool
-# consolidation across the API modules is deferred to Stage 4.
+# Module-level fallback pool for non-API processes; the API lifespan injects its shared
+# manager via set_db_manager (GH #102 consolidation — the old "deferred to Stage 4" note was stale).
 db_manager = DatabaseManager()
 
 

--- a/src/agentic_librarian/imports/worker.py
+++ b/src/agentic_librarian/imports/worker.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 db_manager = DatabaseManager()
 
 
+def set_db_manager(new_manager: DatabaseManager) -> None:
+    """Override the module db_manager (tests / shared-pool lifespan) — mcp/server.py pattern."""
+    global db_manager
+    db_manager = new_manager
+
+
 def _upsert_suggestion(session, *, work_id: UUID, user_id: UUID, context: str) -> bool:
     """Get-or-create the user's wishlist suggestion. Returns True if created, False if it
     already existed (re-import safe — mirrors add_read_event's idempotency)."""

--- a/src/agentic_librarian/llm_retry.py
+++ b/src/agentic_librarian/llm_retry.py
@@ -21,7 +21,13 @@ RETRY_OPTIONS = types.HttpRetryOptions(
     http_status_codes=[429, 500, 502, 503, 504],
 )
 
+# Client-side request timeout in MILLISECONDS (HttpOptions.timeout unit — NOT seconds;
+# the requests-based scouts use seconds, don't copy values between the two). 120s
+# accommodates grounded deep-scout generations that legitimately run ~a minute; without
+# it a hung Gemini call pins its thread + DB connection until Cloud Run kills the request.
+GENAI_TIMEOUT_MS = 120_000
+
 
 def genai_http_options() -> types.HttpOptions:
-    """HttpOptions carrying the shared retry config, for `genai.Client(http_options=...)`."""
-    return types.HttpOptions(retry_options=RETRY_OPTIONS)
+    """HttpOptions carrying the shared retry config + timeout, for `genai.Client(http_options=...)`."""
+    return types.HttpOptions(retry_options=RETRY_OPTIONS, timeout=GENAI_TIMEOUT_MS)

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -38,6 +38,14 @@ _API_RETRY = Retry(
     respect_retry_after_header=False,
 )
 
+# Shared session for raw page scrapes (AudiobookScout extends LLMScout, which has no
+# APIScout session/timeout machinery — GH #103). Same retry policy as the API scouts;
+# timeout in SECONDS (requests convention — the genai HttpOptions timeout is milliseconds).
+_PAGE_TIMEOUT = 15
+_page_session = requests.Session()
+_page_session.mount("https://", HTTPAdapter(max_retries=_API_RETRY))
+_page_session.mount("http://", HTTPAdapter(max_retries=_API_RETRY))
+
 _gbooks_nokey_warned = False
 
 
@@ -353,7 +361,7 @@ class AudiobookScout(LLMScout):
             raise ValueError(f"No Audible link found for title: {title}")
 
         headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/91.0.4472.124 Safari/537.36"}
-        response = requests.get(url, headers=headers)
+        response = _page_session.get(url, headers=headers, timeout=_PAGE_TIMEOUT)
         soup = BeautifulSoup(response.content, "html.parser")
         for script in soup(["script", "style"]):
             script.extract()

--- a/src/agentic_librarian/scouts/style_manager.py
+++ b/src/agentic_librarian/scouts/style_manager.py
@@ -1,10 +1,8 @@
 import os
 
-from google import genai
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Style
-from agentic_librarian.llm_retry import genai_http_options
 from agentic_librarian.scouts.utils import get_cached_embedding
 
 
@@ -16,12 +14,11 @@ class StyleManager:
         self._api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         if not self._api_key:
             raise ValueError("Google API key not set for StyleManager.")
-        self.client = genai.Client(api_key=self._api_key, http_options=genai_http_options())
         self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
 
     def _get_embedding(self, text: str) -> list[float]:
-        """Fetch embedding from Gemini. Uses shared module-level cache."""
-        return get_cached_embedding(self.client, self.model_name, text)
+        """Fetch embedding from Gemini via the shared module-level client + cache (#101)."""
+        return get_cached_embedding(self.model_name, text)
 
     def find_similar_style(self, embedding: list[float], category: str, threshold: float = 0.85) -> Style | None:
         """Find an existing style in the same category with cosine similarity above threshold using SQL-level search."""

--- a/src/agentic_librarian/scouts/trope_manager.py
+++ b/src/agentic_librarian/scouts/trope_manager.py
@@ -1,10 +1,8 @@
 import os
 
-from google import genai
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Trope
-from agentic_librarian.llm_retry import genai_http_options
 from agentic_librarian.scouts.utils import get_cached_embedding
 
 
@@ -16,12 +14,11 @@ class TropeManager:
         self._api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         if not self._api_key:
             raise ValueError("Google API key not set for TropeManager.")
-        self.client = genai.Client(api_key=self._api_key, http_options=genai_http_options())
         self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
 
     def _get_embedding(self, text: str) -> list[float]:
-        """Fetch embedding from Gemini. Uses shared module-level cache."""
-        return get_cached_embedding(self.client, self.model_name, text)
+        """Fetch embedding from Gemini via the shared module-level client + cache (#101)."""
+        return get_cached_embedding(self.model_name, text)
 
     def find_similar_trope(self, embedding: list[float], threshold: float = 0.85) -> Trope | None:
         """Find an existing trope with cosine similarity above threshold using SQL-level search."""

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -59,7 +59,8 @@ def get_shared_genai_client() -> genai.Client:
     return _shared_client
 
 
-@lru_cache(maxsize=128)
+# 1024 × ~12KB/vector ≈ 13MB — sized so a bulk import's trope churn doesn't evict the analysis anchors.
+@lru_cache(maxsize=1024)
 def get_cached_embedding(model_name: str, text: str) -> list[float]:
     """Shared embed chokepoint for ETL ingestion, MCP tools, and the recommendation flow.
     Cached on (model_name, text) so identical tags embed over the network once per process

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -36,13 +36,37 @@ def _throttle_embedding() -> None:
         time.sleep(wait)
 
 
+# Process-wide genai client (GH #101). One client per process means the lru_cache below
+# keys purely on (model_name, text) and actually hits across manager instances / tool
+# calls — previously each TropeManager/StyleManager built its own client and the client
+# identity in the cache key defeated the cache. Double-checked lock: build at most one
+# client under concurrency (same pattern api/analysis_style.py pioneered).
+_shared_client: genai.Client | None = None
+_client_lock = threading.Lock()
+
+
+def get_shared_genai_client() -> genai.Client:
+    global _shared_client
+    if _shared_client is None:
+        with _client_lock:
+            if _shared_client is None:
+                from agentic_librarian.llm_retry import genai_http_options
+
+                key = os.environ.get("GOOGLE_SEARCH_API_KEY")
+                if not key:
+                    raise ValueError("GOOGLE_SEARCH_API_KEY is not set — cannot build the shared genai client.")
+                _shared_client = genai.Client(api_key=key, http_options=genai_http_options())
+    return _shared_client
+
+
 @lru_cache(maxsize=128)
-def get_cached_embedding(client: genai.Client, model_name: str, text: str) -> list[float]:
-    """Shared helper to safely cache embeddings without leaking self. task_type
-    SEMANTIC_SIMILARITY keeps stored vectors and query vectors in one representation space:
-    this is the single embed chokepoint for both ETL ingestion and the recommendation flow,
-    so both sides match. Changing task_type invalidates previously-stored vectors."""
+def get_cached_embedding(model_name: str, text: str) -> list[float]:
+    """Shared embed chokepoint for ETL ingestion, MCP tools, and the recommendation flow.
+    Cached on (model_name, text) so identical tags embed over the network once per process
+    (GH #101). task_type SEMANTIC_SIMILARITY keeps stored vectors and query vectors in one
+    representation space; changing task_type invalidates previously-stored vectors."""
     _throttle_embedding()
+    client = get_shared_genai_client()
     response = client.models.embed_content(
         model=model_name,
         contents=text,

--- a/test/integration/test_db_ingestion.py
+++ b/test/integration/test_db_ingestion.py
@@ -8,6 +8,7 @@ from sqlalchemy import text
 from agentic_librarian.core.user_context import DEFAULT_USER_ID
 from agentic_librarian.db.models import Author, Edition, ReadingHistory, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.scouts import utils
 from agentic_librarian.scouts.trope_manager import TropeManager
 
 
@@ -61,13 +62,15 @@ def test_trope_manager_real_db(db_url):
         # Ensure pgvector extension is available in the test environment
         session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
-        # Mock the Gemini client to avoid external API dependency
-        with patch("agentic_librarian.scouts.trope_manager.genai.Client") as mock_genai:
-            mock_client = mock_genai.return_value
-            mock_response = MagicMock()
-            mock_response.embeddings = [MagicMock(values=[0.1] * 1536)]
-            mock_client.models.embed_content.return_value = mock_response
+        # Mock the shared Gemini client (scouts.utils, #101) to avoid external API
+        # dependency; clear the process-global LRU so no cached vector leaks in/out.
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.embeddings = [MagicMock(values=[0.1] * 1536)]
+        mock_client.models.embed_content.return_value = mock_response
 
+        utils.get_cached_embedding.cache_clear()
+        with patch.object(utils, "_shared_client", mock_client):
             tm = TropeManager(session=session, api_key="fake_key")
 
             # 1. Create a new trope
@@ -91,3 +94,4 @@ def test_trope_manager_real_db(db_url):
             saved_link = session.query(WorkTrope).filter_by(work_id=work.id, trope_id=trope.id).first()
             assert saved_link is not None
             assert saved_link.work.title == work.title
+        utils.get_cached_embedding.cache_clear()

--- a/test/unit/test_embedding_cache.py
+++ b/test/unit/test_embedding_cache.py
@@ -1,0 +1,76 @@
+"""#101: the embedding cache must hit across manager instances (keyed (model, text))."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentic_librarian.scouts import utils
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    utils.get_cached_embedding.cache_clear()
+    monkeypatch.setattr(utils, "_shared_client", None)
+    yield
+    utils.get_cached_embedding.cache_clear()
+
+
+def _fake_client(counter):
+    def embed_content(model, contents, config):
+        counter.append(contents)
+        return SimpleNamespace(embeddings=[SimpleNamespace(values=[0.1] * utils.EMBEDDING_DIMENSIONS)])
+
+    return SimpleNamespace(models=SimpleNamespace(embed_content=embed_content))
+
+
+def test_cache_hits_across_callers(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    v1 = utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    v2 = utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    assert v1 == v2
+    assert len(calls) == 1  # second call was a cache hit
+
+
+def test_cache_misses_on_different_text(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    utils.get_cached_embedding("gemini-embedding-001", "Found Family")
+    utils.get_cached_embedding("gemini-embedding-001", "Slow Burn")
+    assert len(calls) == 2
+
+
+def test_shared_client_is_singleton(monkeypatch):
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "test-key")
+    built = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            built.append(kwargs)
+
+    monkeypatch.setattr(utils.genai, "Client", FakeClient)
+    c1 = utils.get_shared_genai_client()
+    c2 = utils.get_shared_genai_client()
+    assert c1 is c2
+    assert len(built) == 1
+    assert built[0]["api_key"] == "test-key"
+
+
+def test_shared_client_requires_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_SEARCH_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="GOOGLE_SEARCH_API_KEY"):
+        utils.get_shared_genai_client()
+
+
+def test_managers_share_the_module_cache(monkeypatch):
+    calls = []
+    monkeypatch.setattr(utils, "_shared_client", _fake_client(calls))
+    from agentic_librarian.scouts.style_manager import StyleManager
+    from agentic_librarian.scouts.trope_manager import TropeManager
+
+    tm = TropeManager(session=MagicMock(), api_key="k")
+    sm = StyleManager(session=MagicMock(), api_key="k")
+    tm._get_embedding("Enemies to Lovers")
+    sm._get_embedding("Enemies to Lovers")  # same model+text -> cache hit
+    assert len(calls) == 1

--- a/test/unit/test_llm_retry.py
+++ b/test/unit/test_llm_retry.py
@@ -10,3 +10,12 @@ def test_retry_options_cover_transient_codes():
 def test_genai_http_options_carries_retry():
     ho = genai_http_options()
     assert ho.retry_options is RETRY_OPTIONS
+
+
+def test_genai_http_options_sets_timeout():
+    """#103: every Gemini call must carry a client-side timeout. HttpOptions.timeout is
+    MILLISECONDS (google-genai 2.8.0) — 120s accommodates grounded deep-scout calls."""
+    from agentic_librarian.llm_retry import GENAI_TIMEOUT_MS, genai_http_options
+
+    assert GENAI_TIMEOUT_MS == 120_000
+    assert genai_http_options().timeout == 120_000

--- a/test/unit/test_metadata_scout_fetch.py
+++ b/test/unit/test_metadata_scout_fetch.py
@@ -1,0 +1,23 @@
+"""#103: the Audible page fetch must use the retrying session WITH a timeout."""
+
+from unittest.mock import MagicMock, patch
+
+from agentic_librarian.scouts import metadata_scout
+
+
+def test_fetch_page_content_uses_session_with_timeout():
+    scout = metadata_scout.AudiobookScout.__new__(metadata_scout.AudiobookScout)  # skip __init__ (needs keys)
+    fake_response = MagicMock(content=b"<html><body>Audible page</body></html>")
+    with (
+        patch.object(metadata_scout.AudiobookScout, "search_audible_link", return_value="https://audible.com/x"),
+        patch.object(metadata_scout._page_session, "get", return_value=fake_response) as mock_get,
+    ):
+        text = scout.fetch_page_content("Some Title")
+    assert "Audible page" in text
+    kwargs = mock_get.call_args.kwargs
+    assert kwargs["timeout"] == metadata_scout._PAGE_TIMEOUT == 15
+
+
+def test_page_session_mounts_retry_adapter():
+    adapter = metadata_scout._page_session.get_adapter("https://audible.com")
+    assert adapter.max_retries.total == metadata_scout._API_RETRY.total

--- a/test/unit/test_pool_config.py
+++ b/test/unit/test_pool_config.py
@@ -1,0 +1,29 @@
+"""#102: pool flags on the engine; all in-process modules share the lifespan pool."""
+
+from fastapi.testclient import TestClient
+
+from agentic_librarian.db.session import DatabaseManager
+
+
+def test_engine_pool_flags():
+    # Postgres URL, lazily initialized: create_engine builds the pool WITHOUT connecting.
+    m = DatabaseManager("postgresql+psycopg2://x:x@nohost:1/x")
+    e = m.engine
+    assert e.pool._pre_ping is True
+    assert e.pool._recycle == 1800
+    assert e.pool.size() == 5
+    assert e.pool._max_overflow == 2
+
+
+def test_lifespan_shares_one_manager_everywhere():
+    from agentic_librarian.api import main as main_mod
+    from agentic_librarian.enrichment import two_phase
+    from agentic_librarian.imports import worker
+    from agentic_librarian.mcp import server as mcp_server
+
+    with TestClient(main_mod.app):
+        shared = main_mod.app.state.db_manager
+        assert main_mod.db_manager is shared
+        assert mcp_server.db_manager is shared
+        assert two_phase.db_manager is shared
+        assert worker.db_manager is shared

--- a/test/unit/test_pool_config.py
+++ b/test/unit/test_pool_config.py
@@ -12,7 +12,7 @@ def test_engine_pool_flags():
     assert e.pool._pre_ping is True
     assert e.pool._recycle == 1800
     assert e.pool.size() == 5
-    assert e.pool._max_overflow == 2
+    assert e.pool._max_overflow == 10
 
 
 def test_lifespan_shares_one_manager_everywhere():

--- a/test/unit/test_style_manager.py
+++ b/test/unit/test_style_manager.py
@@ -12,14 +12,15 @@ def mock_session():
 
 
 @pytest.fixture
-def mock_genai_client():
-    with patch("agentic_librarian.scouts.style_manager.genai.Client") as mock:
-        client_inst = mock.return_value
-        # Default embedding return
-        mock_embedding = MagicMock()
-        mock_embedding.values = [0.1] * 1536
-        client_inst.models.embed_content.return_value.embeddings = [mock_embedding]
-        yield client_inst
+def mock_genai_client(monkeypatch):
+    # Mock the shared genai client in utils to avoid actual network calls
+    mock_client = MagicMock()
+    # Default embedding return
+    mock_embedding = MagicMock()
+    mock_embedding.values = [0.1] * 1536
+    mock_client.models.embed_content.return_value.embeddings = [mock_embedding]
+    monkeypatch.setattr("agentic_librarian.scouts.utils._shared_client", mock_client)
+    yield mock_client
 
 
 def test_standardize_style_exact_match(mock_session, mock_genai_client):

--- a/test/unit/test_style_manager.py
+++ b/test/unit/test_style_manager.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from agentic_librarian.db.models import Style
+from agentic_librarian.scouts import utils
 from agentic_librarian.scouts.style_manager import StyleManager
 
 
@@ -14,6 +15,7 @@ def mock_session():
 @pytest.fixture
 def mock_genai_client(monkeypatch):
     # Mock the shared genai client in utils to avoid actual network calls
+    utils.get_cached_embedding.cache_clear()
     mock_client = MagicMock()
     # Default embedding return
     mock_embedding = MagicMock()
@@ -21,6 +23,7 @@ def mock_genai_client(monkeypatch):
     mock_client.models.embed_content.return_value.embeddings = [mock_embedding]
     monkeypatch.setattr("agentic_librarian.scouts.utils._shared_client", mock_client)
     yield mock_client
+    utils.get_cached_embedding.cache_clear()
 
 
 def test_standardize_style_exact_match(mock_session, mock_genai_client):

--- a/test/unit/test_trope_manager.py
+++ b/test/unit/test_trope_manager.py
@@ -12,9 +12,11 @@ def mock_session():
 
 
 @pytest.fixture
-def mock_genai_client():
-    with patch("agentic_librarian.scouts.trope_manager.genai.Client") as mock:
-        yield mock.return_value
+def mock_genai_client(monkeypatch):
+    # Mock the shared genai client in utils to avoid actual network calls
+    mock_client = MagicMock()
+    monkeypatch.setattr("agentic_librarian.scouts.utils._shared_client", mock_client)
+    yield mock_client
 
 
 @pytest.fixture

--- a/test/unit/test_trope_manager.py
+++ b/test/unit/test_trope_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agentic_librarian.db.models import Trope
+from agentic_librarian.scouts import utils
 from agentic_librarian.scouts.trope_manager import TropeManager
 
 
@@ -14,9 +15,11 @@ def mock_session():
 @pytest.fixture
 def mock_genai_client(monkeypatch):
     # Mock the shared genai client in utils to avoid actual network calls
+    utils.get_cached_embedding.cache_clear()
     mock_client = MagicMock()
     monkeypatch.setattr("agentic_librarian.scouts.utils._shared_client", mock_client)
     yield mock_client
+    utils.get_cached_embedding.cache_clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

First of two PRs from the Phase 6.2 concurrency & capacity spec (`docs/superpowers/specs/2026-07-12-phase6-2-concurrency-capacity-design.md`); PR-B (#93 event-loop + #94 session restructuring) follows.

- **#101 — the embedding cache now actually caches**: one process-wide `genai.Client` (double-checked-lock singleton in `scouts/utils.py`); the LRU keys on `(model_name, text)` instead of including a per-call client instance, so identical tags embed over the network once per process instead of once per tool call/import row. LRU sized 1024 (~13MB) so bulk-import trope churn doesn't evict the analysis anchors. Likely the single cheapest chat-latency win available.
- **#103 — every outbound call is bounded**: `genai_http_options()` gains `timeout=120_000` **ms** (propagates to all four client sites; unit deliberately documented vs the requests scouts' seconds), and `AudiobookScout.fetch_page_content` swaps its bare `requests.get` for a module-level retrying session with `timeout=15` s.
- **#102 — pool hygiene + consolidation**: `pool_pre_ping` + 30-min recycle on the engine (sqlite-guarded for tests); `mcp/server`, `enrichment/two_phase`, and `imports/worker` (an unlisted sprawl instance found in exploration) join the lifespan's shared-pool fan-out.

## Sequencing note (from the whole-branch review)

Pool overflow is deliberately `max_overflow=10` **interim**: sessions are still held across external LLM/scout calls until PR-B lands #94, and this PR routes those long-session paths onto the one shared pool — 5+2 would have let a bulk import starve auth's per-request query. PR-B reverts to `max_overflow=2` when sessions shorten (comment in `db/session.py` says exactly this).

## Tests

New DB-free unit suites: embedding cache hit/miss/singleton semantics (incl. cross-manager hit), pool flags + lifespan sharing, timeout presence on both paths. Existing manager fixtures hardened against LRU cross-test leakage. Full local unit suite green; genai 2.8.0 client thread-safety verified against the installed SDK during review. Each task passed an independent spec+quality review; whole-branch review verdict: ready to merge after the interim-overflow fix (applied).

## Post-merge

Watch deep-scout retry logs (tenacity INFO) — if grounded p99 crowds the 120s ceiling, raise it. #101/#102/#103 close when PR-B completes the grouping (or #101/#103 can close on this PR — they're fully addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUR4CLRn6yCUWV4Nubkhtb