### PR TITLE
fix: Phase 6.3a data-integrity code — contributor merge, garbage gate, honest dates, cache upsert, pre-embed (#96 #98 #110 #111 #112 #123)

### DIFF
--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1042,4 +1042,7 @@ This file documents key architectural decisions, their context, and trade-offs.
   trope/style texts before their read session opens — so persist-time
   standardize_trope/style and the search tools' `_get_embedding` calls are cache hits,
   not network round-trips, inside any session. Pool overflow tightened 5 → 2
-  (db/session.py) now that no external call of any kind runs inside a session.
+  (db/session.py); two residuals remain: a warm-FAILURE degrades to in-session embeds via
+  `_safe_standardize` (bounded: enrich queue is 4-concurrent; PR-D's requeue sweep is the
+  recovery), and `/analysis` embeds ~24 radar anchor texts inside its session once per
+  process (first call only, then module-cached).

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1025,10 +1025,9 @@ This file documents key architectural decisions, their context, and trade-offs.
   user-approved contract: the Librarian announces background analysis and never anchors
   trope-based recommendations on a deep-pending work in the same turn. Tool contract
   (`str | None`) unchanged for the pipeline/Claude-backend callers.
-- Pool overflow is 5, not the PR-A interim 10 or a tight 2: embedding calls (search
-  tools, persist-time standardize_trope/style) still run inside sessions, so a Gemini
-  429 burst can stretch sessions to minutes even after #94. Tightening to 2 is tracked
-  by GH #123 (hoist embed calls out of sessions).
+- Pool overflow started at 5, not the PR-A interim 10 or a tight 2: embedding calls
+  (search tools, persist-time standardize_trope/style) still ran inside sessions, so a
+  Gemini 429 burst could stretch sessions to minutes even after #94.
 **Consequences:**
 - One user's enrichment can no longer brown out the instance; chat adds return in seconds.
 - The deep pass now re-scouts outside any transaction: a late transient failure re-pays
@@ -1037,3 +1036,10 @@ This file documents key architectural decisions, their context, and trade-offs.
   (Python's own default is min(32, cpus+4) ≈ 5-6 on Cloud Run's 1 vCPU — too small once
   every auth resolve and tool body shares it); the enrich/import queues (4/5 concurrent)
   remain the heavy-work throttles.
+- GH #123 resolved (2026-07-12): `collect_embedding_texts` (etl/persist.py) warms
+  `get_cached_embedding`'s LRU for every trope/style text a row will standardize BEFORE
+  two_phase's write session opens, and the two mcp search tools warm their target
+  trope/style texts before their read session opens — so persist-time
+  standardize_trope/style and the search tools' `_get_embedding` calls are cache hits,
+  not network round-trips, inside any session. Pool overflow tightened 5 → 2
+  (db/session.py) now that no external call of any kind runs inside a session.

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -77,7 +77,7 @@ This file tracks important project configuration, constants, and environment det
   (full `DATABASE_URL`, Cloud SQL unix socket); schema managed by Alembic (Lift 1+).
   Nightly automated backups (09:00 UTC) + 7-day PITR enabled 2026-07-12 (GH #91; codified in
   `infra/02-cloudsql.sh`).
-  Engine pools: `pool_pre_ping` + 30-min recycle, 5+5 per engine (overflow headroom while embeds still run inside sessions — GH #123), one shared engine per API process (GH #102/#94) — 2 instances × 10 = 20 of db-f1-micro's ~25 connections.
+  Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per API process (GH #102/#94) — 2 instances × 7 = 14 of db-f1-micro's ~25 connections; #123 landed (embeds warmed into the LRU before write/search sessions, so overflow tightened from 5).
 - **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
   `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
   the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.

--- a/docs/superpowers/plans/2026-07-12-phase6-3a-integrity-code.md
+++ b/docs/superpowers/plans/2026-07-12-phase6-3a-integrity-code.md
@@ -1,0 +1,621 @@
+# Phase 6.3 PR-C Integrity Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the code-only integrity fixes (#96 #111 #98 #112 #110 #123) on branch `fix/phase6-3a-integrity-code` — no schema changes; PR-D (migration + gated prod ops) follows.
+
+**Architecture:** persist.py's existing-work branch gains the contributor merge its narrator branch already has; the #69-corrected real-vs-fallback trope predicate becomes one shared helper used by the persist guard (and later PR-D's sweep); ScoutManager returns falsy when no scout contributed (reviving the dead not-found paths); update_reading_status becomes date-honest and dedup-guarded via two_phase.add_read_event; the availability cache gets a real Postgres upsert + piggybacked eviction; embedding calls are hoisted out of DB sessions by LRU-warming, letting the pool tighten to its 5+2 target.
+
+**Tech Stack:** SQLAlchemy 2.0 (+ `sqlalchemy.dialects.postgresql.insert`), pytest (`filterwarnings` error promotion), google-genai LRU cache from #101.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md` (PR-C sections). NO schema/model changes in this PR (PR-D owns migrations).
+- The shared predicate implements EXACTLY the #69 semantics from `trope_backfill.plan_fallback_prune`: `clean_trope_name(name)` case-folded; fallback iff cleaned non-empty AND ⊆ case-folded genres∪moods; real iff cleaned non-empty and not fallback; junk (cleans to []) is neither.
+- `ScoutManager.enrich` returns `{}` (falsy) iff `source_priority` is empty after the scout loop; `LLMTropeScout.search` returns `{}` when its trope list is empty (today's `{"tropes": []}` is truthy and would defeat the gate).
+- `update_reading_status` keeps its public tool name and `str` return; new params are OPTIONAL (`date_completed: str | None = None, year: int | None = None`) — precedence date_completed > year (Jan 1 convention) > today-fallback, with the today-fallback flagged in the reply text.
+- Pool value in `db/session.py` ends at exactly `max_overflow=2` (the #123 condition is met by this PR); update the comment, `test_pool_config.py`, key_facts.md, and the ADR-059 consequence line — mirror how the 5 value was documented.
+- pytest gains `filterwarnings = ["error::sqlalchemy.exc.SAWarning"]` — if the suite surfaces OTHER latent SAWarnings, fix them in-place and report each.
+- Tests: `.venv/Scripts/python -m pytest ...` from repo root; new unit tests DB-free/sqlite, no `db_integration` marker; db_integration suites are CI-gated (collect-check locally, say so). Lint/format every touched file: `uvx ruff check` + `uvx ruff format` (CI pre-commit enforces format).
+- No `[skip ci]` in commit messages. Do not modify `frontend/**`, `alembic/**`, or `db/models.py`.
+
+---
+
+### Task 1: Shared real-vs-fallback trope predicate — #111
+
+**Files:**
+- Create: `src/agentic_librarian/etl/trope_predicate.py`
+- Modify: `src/agentic_librarian/etl/trope_backfill.py:198-215` (plan_fallback_prune inner loop)
+- Modify: `src/agentic_librarian/etl/persist.py:338-343` (has_real_trope guard)
+- Test: `test/unit/test_trope_predicate.py` (new)
+
+**Interfaces:**
+- Produces: `is_fallback_trope_name(name: str, genres: list[str] | None, moods: list[str] | None) -> bool | None` — True = fallback, False = real, **None = junk** (cleans to nothing; callers treat separately). PR-D's `--requeue-unenriched` will consume this exact signature.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/test_trope_predicate.py`:
+
+```python
+"""#111: ONE predicate for real-vs-fallback tropes (the #69-corrected semantics —
+justification is NEVER consulted)."""
+
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
+
+
+def test_genre_reencoded_trope_is_fallback():
+    assert is_fallback_trope_name("Fantasy", ["Fantasy", "Romance"], ["Dark"]) is True
+
+
+def test_mood_reencoded_trope_is_fallback_case_insensitive():
+    assert is_fallback_trope_name("dark", ["Fantasy"], ["Dark"]) is True
+
+
+def test_narrative_trope_is_real():
+    assert is_fallback_trope_name("The Dark Night of the Soul", ["Fantasy"], ["Dark"]) is False
+
+
+def test_junk_name_is_neither():
+    # clean_trope_name("") -> [] — junk names are neither real nor fallback (None)
+    assert is_fallback_trope_name("", ["Fantasy"], []) is None
+
+
+def test_none_genre_mood_lists_tolerated():
+    assert is_fallback_trope_name("Found Family", None, None) is False
+
+
+def test_multi_slug_subset_is_fallback():
+    # a slug that cleans to multiple names, ALL of which are genres/moods, is a fallback
+    # (subset semantics — mirrors plan_fallback_prune's `cleaned_lower <= gm`)
+    assert is_fallback_trope_name("Fantasy / Romance", ["Fantasy", "Romance"], []) is True
+```
+
+(If `clean_trope_name("Fantasy / Romance")` doesn't split on ` / ` in this codebase, adjust that last test's input to a slug form `clean_trope_name` genuinely splits — check `etl/tag_cleaning.py:99-128` — while keeping the multi-name-subset assertion.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_trope_predicate.py -v`
+Expected: `ModuleNotFoundError: ... trope_predicate`.
+
+- [ ] **Step 3: Implement `etl/trope_predicate.py`**
+
+```python
+"""The ONE real-vs-fallback trope predicate (GH #111, semantics from PR #69).
+
+A genre/mood "fallback" trope is one whose CLEANED name is (a subset of) the work's own
+cleaned genres+moods — the two-phase fast pass re-encoded a genre/mood as a trope. The
+justification column is deliberately NEVER consulted: many real scout tropes carry NULL
+justification (semantic-collapse "attractor" tropes), so it conflates real with fallback —
+the exact mistake the #65 prune nearly made (bugs.md 2026-06-24, memory
+verify-backfill-distinguisher). Shared by the persist-time guard, clean_catalog's prune,
+and (PR-D) the enrichment-reconciliation sweep, so the definitions can't diverge again."""
+
+from __future__ import annotations
+
+from agentic_librarian.etl.tag_cleaning import clean_trope_name
+
+
+def is_fallback_trope_name(name: str, genres: list[str] | None, moods: list[str] | None) -> bool | None:
+    """True = fallback (re-encoded genre/mood); False = genuine narrative trope;
+    None = junk (cleans to nothing — neither real nor fallback)."""
+    gm = {s.lower() for s in (set(genres or []) | set(moods or []))}
+    cleaned = clean_trope_name(name)
+    if not cleaned:
+        return None
+    if {c.lower() for c in cleaned} <= gm:
+        return True
+    return False
+```
+
+- [ ] **Step 4: Adopt it in `plan_fallback_prune`** (trope_backfill.py:208-215) — replace the inline clean/subset logic:
+
+```python
+        for trope_id, name in w["links"]:
+            verdict = is_fallback_trope_name(name, list(w["gm"]), [])  # gm is pre-folded; see below
+            ...
+```
+
+CAREFUL: `plan_fallback_prune` pre-folds `gm` once per work; the helper folds internally. To avoid double-lowering subtleties, restructure minimally: keep building `gm` as today, and change the helper adoption to pass the ORIGINAL genres/moods per work instead of the pre-folded set — i.e. store `w["genres"]`/`w["moods"]` (raw lists) in `by_work` and call `is_fallback_trope_name(name, w["genres"], w["moods"])`. The `fallback and real` gating and FallbackPrune construction stay identical (`True` → fallback list, `False` → real += 1, `None` → skip). The function's behavior must be byte-equivalent for the existing CI test `test_fallback_prune.py` — that suite is the pin.
+
+- [ ] **Step 5: Adopt it in persist's guard** (persist.py:338-343):
+
+```python
+            # GH #111: "has a real trope" = any linked trope whose cleaned name is NOT a
+            # re-encoding of this work's genres/moods (the shared #69 predicate) — the old
+            # `justification IS NOT NULL` heuristic misclassified real attractor tropes.
+            linked = (
+                session.query(Trope.name)
+                .join(WorkTrope, WorkTrope.trope_id == Trope.id)
+                .filter(WorkTrope.work_id == work.id)
+                .all()
+            )
+            has_real_trope = any(
+                is_fallback_trope_name(name, work.genres, work.moods) is False for (name,) in linked
+            )
+```
+
+Add the imports (`from agentic_librarian.etl.trope_predicate import is_fallback_trope_name`; `Trope` is already imported — verify).
+
+- [ ] **Step 6: Run tests**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_trope_predicate.py test/unit -q` — all pass; `.venv/Scripts/python -m pytest test/integration/test_fallback_prune.py test/integration/test_persist_fallback_flag.py --collect-only -q` — collects (CI pins behavior).
+
+- [ ] **Step 7: Lint, format, commit**
+
+```bash
+git add src/agentic_librarian/etl/trope_predicate.py src/agentic_librarian/etl/trope_backfill.py src/agentic_librarian/etl/persist.py test/unit/test_trope_predicate.py
+git commit -m "fix(tropes): one shared real-vs-fallback predicate; persist guard drops the justification heuristic (#111)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Contributor merge on existing works + SAWarning-as-error — #96
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/persist.py:103-142,160-187`
+- Modify: `pyproject.toml` (`[tool.pytest.ini_options]` gains filterwarnings)
+- Test: `test/integration/test_two_phase_deep.py` (extend the existing repro test), `test/integration/test_persist_contributor_guard.py` (extend)
+
+**Interfaces:** none new; `persist_enriched_work` signature unchanged.
+
+- [ ] **Step 1: Write the failing tests** (db_integration — they FAIL IN CI today, which is the point; locally verify collection)
+
+Extend `test/integration/test_two_phase_deep.py` — in `test_enrich_deep_updates_same_work_idempotently` (read it first), after the existing assertions add:
+
+```python
+    # GH #96: a co-author discovered by the deep pass must be LINKED on the existing work
+    # (previously the WorkContributor dangled and SQLAlchemy 2.0 silently dropped it), and
+    # no orphan Author rows may accumulate.
+    with manager.get_session() as s:
+        work = s.query(Work).filter_by(title="Dune").one()
+        roles = {(c.author.name, c.role) for c in work.contributors}
+        assert ("Kevin J. Anderson", "Author") in roles  # the co-author the fake deep scout returns
+        orphans = (
+            s.query(Author)
+            .outerjoin(WorkContributor, WorkContributor.author_id == Author.id)
+            .filter(WorkContributor.author_id.is_(None))
+            .count()
+        )
+        assert orphans == 0
+```
+
+AND make the test's fake deep scout return a second contributor (`{"name": "Kevin J. Anderson", "role": "Author"}`) in its `contributors` list — read the test's existing fake/stub mechanism and extend it; adapt names to what the test actually seeds (the assertion intent is binding: newly discovered co-author linked, zero orphan authors).
+
+Extend `test/integration/test_persist_contributor_guard.py` with a direct unit-of-work test:
+
+```python
+def test_existing_work_gains_new_contributor(db_url):
+    """#96: re-persisting an existing work links newly discovered contributors."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s:
+        row1 = {"Title": "CG Work", "Author_1": "Alice", "format": "ebook", "skip_enrichment": False,
+                "date_completed": None, "genres": [], "moods": []}
+        persist_enriched_work(s, row1, TropeManager(session=s), StyleManager(session=s))
+        s.flush()
+    with manager.get_session() as s:
+        row2 = dict(row1)
+        row2["contributors"] = [{"name": "Alice", "role": "Author"}, {"name": "Bob", "role": "Author"}]
+        persist_enriched_work(s, row2, TropeManager(session=s), StyleManager(session=s))
+        s.flush()
+        work = s.query(Work).filter_by(title="CG Work").one()
+        assert {(c.author.name, c.role) for c in work.contributors} == {("Alice", "Author"), ("Bob", "Author")}
+```
+
+(Match the file's existing fixture/manager conventions — read it first; TropeManager/StyleManager may need the api_key kwarg pattern used there.)
+
+- [ ] **Step 2: Verify collection** (they run in CI): `--collect-only` on both files.
+
+- [ ] **Step 3: Restructure `persist_enriched_work`**
+
+Reorder so the Work lookup happens BEFORE contributor materialization, and the existing-work branch merges:
+
+1. Move the Work lookup block (current lines 160-170, keeping `no_autoflush` — now unnecessary for dangling contributors but harmless for other pending state; keep it with an updated comment) ABOVE the contributor loop. It only needs `row["Title"]` and `row.get("Author_1") or row.get("Author")` — available before the loop.
+2. Change the contributor loop to build `desired: list[tuple[Author, str]]` — the Author get-or-create + AuthorStyle handling stay exactly as they are (lines 107-141), but instead of `work_contributors_list.append(WorkContributor(author=author, role=role))` collect `desired.append((author, role))`. Author creation now happens ONLY for entries that will be linked (both branches below link every desired pair, so the orphan side effect dies with the dangling objects).
+3. New-work branch: `work = Work(title=..., contributors=[WorkContributor(author=a, role=r) for a, r in desired], ...)` — unchanged semantics.
+4. Existing-work branch (the #96 fix — mirrors the narrator merge at line 279):
+
+```python
+    elif not row.get("skip_enrichment"):
+        work.original_publication_year = original_publication_year or work.original_publication_year
+        work.description = description or work.description
+        work.genres = genres or work.genres
+        work.moods = moods or work.moods
+        # GH #96: link newly discovered contributors (deep pass / re-import). Previously the
+        # WorkContributor objects dangled off Author.contributions and SQLAlchemy 2.0's removed
+        # backref-cascade silently never flushed them (SAWarning) — co-authors were lost and
+        # their Author rows orphaned. Mirror the narrator merge below.
+        existing_pairs = {(c.author_id, c.role) for c in work.contributors}
+        for author, role in desired:
+            if (author.id, role) not in existing_pairs:
+                work.contributors.append(WorkContributor(author=author, role=role))
+```
+
+NOTE: `author.id` requires the flush at author creation (already present, line 124) — verify existing authors fetched from the DB also have ids (they do). `skip_enrichment` rows previously skipped ALL updates on existing works — preserve that: the merge lives inside the `elif not row.get("skip_enrichment")` branch.
+
+- [ ] **Step 4: Promote SAWarning to error** — in `pyproject.toml` `[tool.pytest.ini_options]` add:
+
+```toml
+filterwarnings = [
+    "error::sqlalchemy.exc.SAWarning",
+]
+```
+
+Run the full local unit suite; if OTHER latent SAWarnings surface, fix each in place (report them). db_integration suites will enforce it in CI.
+
+- [ ] **Step 5: Run tests**
+
+`.venv/Scripts/python -m pytest test/unit -q` (green minus known 5 env failures) and collect-check the two integration files.
+
+- [ ] **Step 6: Lint, format, commit**
+
+```bash
+git add src/agentic_librarian/etl/persist.py pyproject.toml test/integration/test_two_phase_deep.py test/integration/test_persist_contributor_guard.py
+git commit -m "fix(persist): merge newly discovered contributors on existing works; SAWarning is now an error (#96)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Garbage-title gate — #98
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/metadata_scout.py:556-563` (LLMTropeScout.search return), `:~593-616` (ScoutManager.enrich)
+- Test: `test/unit/test_metadata_scout.py` (extend)
+
+**Interfaces:** `ScoutManager.enrich` now returns `{}` when nothing contributed — callers already handle falsy (`_run_scouts`' `if not enriched: return None`; `api/books.py` 404; import `not_found`).
+
+- [ ] **Step 1: Write the failing tests** — append to `test/unit/test_metadata_scout.py` (mirror its existing fake-scout fixtures):
+
+```python
+def test_enrich_returns_empty_when_no_scout_contributes():
+    """#98: a title no scout can confirm must be falsy — revives the 404/not_found paths."""
+    manager = ScoutManager()
+    manager.register_scout(_FailingScout(), priority=1)   # raises
+    manager.register_scout(_EmptyScout(), priority=2)     # returns {}
+    assert manager.enrich(title="asdfjkl", author="Nobody") == {}
+
+
+def test_enrich_truthy_when_a_scout_contributes():
+    manager = ScoutManager()
+    manager.register_scout(_GenreScout(), priority=1)     # returns {"genres": {"Fantasy"}}
+    result = manager.enrich(title="Real Book", author="Real Author")
+    assert result and result["source_priority"] == ["_GenreScout"]
+
+
+def test_trope_scout_empty_tropes_is_falsy(monkeypatch):
+    """An LLM that can't verify the book returns {'tropes': []} — that must NOT count as a
+    contributing source (it was truthy before and defeated the gate)."""
+    scout = LLMTropeScout.__new__(LLMTropeScout)
+    monkeypatch.setattr(scout, "_llm", SimpleNamespace(generate=lambda *a, **k: '{"tropes": []}'))
+    assert scout.search("Ghost Book", "Nobody") == {}
+
+
+def test_trope_prompt_has_unknown_book_escape(monkeypatch):
+    seen = {}
+
+    def fake_generate(prompt, grounded=True):
+        seen["prompt"] = prompt
+        return '{"tropes": []}'
+
+    scout = LLMTropeScout.__new__(LLMTropeScout)
+    monkeypatch.setattr(scout, "_llm", SimpleNamespace(generate=fake_generate))
+    scout.search("X", "Y")
+    assert "cannot verify" in seen["prompt"].lower()
+```
+
+(Adapt fake-scout class names/registration API to the file's existing conventions — read it first; `register_scout` signature may differ. The four assertion intents are binding.)
+
+- [ ] **Step 2: Verify failure** — the source_priority/empty-dict assertions fail against current behavior.
+
+- [ ] **Step 3: Implement**
+
+1. `LLMTropeScout.search`: prompt gains, after the CRITICAL line: `If you cannot verify that this book actually exists, return {"tropes": []}.` And the return becomes:
+
+```python
+        text = self._llm.generate(prompt, grounded=True)
+        data = self._safe_extract_json(text, "Tropes", title) or {}
+        # GH #98: an empty trope list means the model couldn't verify the book — return
+        # falsy so ScoutManager doesn't count this scout as a contributing source.
+        return data if data.get("tropes") else {}
+```
+
+2. `ScoutManager.enrich`: after the scout loop (before the genres/moods finalization/return — read the tail of the method), add:
+
+```python
+        # GH #98: merged_data is seeded from raw caller input, so it is ALWAYS truthy even
+        # when every scout failed or returned nothing. If no scout contributed, return {} so
+        # callers' not-found paths (books.py 404, import outcome, _run_scouts -> None) work.
+        if not merged_data["source_priority"]:
+            return {}
+```
+
+- [ ] **Step 4: Run** `.venv/Scripts/python -m pytest test/unit/test_metadata_scout.py test/unit -q` — green.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```bash
+git add src/agentic_librarian/scouts/metadata_scout.py test/unit/test_metadata_scout.py
+git commit -m "fix(scouts): unverifiable titles return falsy — 404/not_found paths revive; trope prompt gains unknown-book escape (#98)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: update_reading_status correctness — #112
+
+**Files:**
+- Modify: `src/agentic_librarian/mcp/server.py:437-484` (update_reading_status)
+- Modify: `src/agentic_librarian/agents/services.py` (FEEDBACK HANDLING instruction)
+- Test: `test/unit/test_mcp_tools.py` (extend), `test/integration/test_mcp_tools.py` (extend)
+
+**Interfaces:** tool signature becomes `update_reading_status(title, author, status, notes=None, date_completed: str | None = None, year: int | None = None) -> str` (additive — ADK schema regenerates via make_async_tool).
+
+- [ ] **Step 1: Write the failing unit tests** — extend `test/unit/test_mcp_tools.py` (mirror its mocked-db_manager conventions):
+
+```python
+def test_update_reading_status_honors_year(...):
+    # year=2019 -> date_completed == date(2019, 1, 1); reply does NOT contain "assumed"
+def test_update_reading_status_rejects_bad_year(...):
+    # year=1200 -> "Error: year must be between 1900 and <current year>"
+def test_update_reading_status_flags_assumed_today(...):
+    # no date/year -> reply contains "assumed" (the agent-visible flag)
+def test_update_reading_status_rejects_future_date(...):
+    # date_completed tomorrow -> Error (same rule as add_book_to_history)
+```
+
+(Write real bodies following the file's mock pattern; the four intents + exact date precedence are binding. Also extend the CI integration file with: calling it twice with the same resolved date logs ONE ReadingHistory row — the add_read_event dup guard.)
+
+- [ ] **Step 2: Verify failure.**
+
+- [ ] **Step 3: Rewrite the tool** (keep validation + status normalization + SEC-002 comments; replace the lookup/insert body):
+
+```python
+    # date resolution (GH #112): date_completed > year (Jan 1 convention) > today-fallback.
+    assumed_today = False
+    if date_completed is not None:
+        try:
+            completed = date.fromisoformat(str(date_completed))
+        except ValueError:
+            return f"Error: date_completed must be ISO YYYY-MM-DD; got {date_completed!r}."
+        if completed > date.today():
+            return f"Error: date_completed {completed.isoformat()} is in the future."
+    elif year is not None:
+        if isinstance(year, bool) or not isinstance(year, int) or not 1900 <= year <= date.today().year:
+            return f"Error: year must be between 1900 and {date.today().year}; got {year!r}."
+        completed = date(year, 1, 1)  # convention: unknown month/day -> Jan 1 (documented)
+    else:
+        completed = date.today()
+        assumed_today = True
+
+    user_id = get_required_user_id()
+    try:
+        with db_manager.get_session() as session:
+            work = (
+                session.query(Work)
+                .join(WorkContributor)
+                .join(Author)
+                .filter(_normalized_col(Work.title) == _normalize(title))
+                .filter(_normalized_col(Author.name) == _normalize(author))
+                .first()
+            )
+            if not work:
+                return f"Work '{title}' by {author} not found in database."
+            work_id = work.id
+        if canonical == "read":
+            logged = two_phase.add_read_event(work_id, completed=completed, rating=None, notes=notes, fmt="Unknown")
+            if logged["already_logged"]:
+                return f"'{title}' is already logged as completed {completed.isoformat()}. No new entry written."
+        note = " (completion date assumed today — ask the user when they read it if it matters)" if assumed_today else ""
+        return f"Successfully updated status for '{title}' to {status}.{note}"
+    except Exception as e:
+        return f"Error updating status: {str(e)}"
+```
+
+Docstring update: document the params, the Jan-1 convention, and the assumed-today flag. NOTE: `two_phase` and `_normalize`/`_normalized_col` are already imported in this module post-#122 — verify; add_read_event creates the edition get-or-create (format "Unknown" edition may be created — same as the old placeholder behavior, acceptable). The old inline edition/ReadingHistory block is deleted.
+
+- [ ] **Step 4: Librarian instruction** (services.py FEEDBACK HANDLING): change the first bullet to:
+
+```
+            - If user says "I read that", use 'update_reading_status' AND 'update_suggestion_status(Already Read)'.
+              If they indicate it was a while ago ("years ago", "back in college"), ask roughly when —
+              a year is enough — and pass it as 'year'; without a date the entry is logged as today,
+              which wrongly blocks re-read suggestions for 2 years.
+```
+
+- [ ] **Step 5: Run** unit + collect-check integration; ruff both files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentic_librarian/mcp/server.py src/agentic_librarian/agents/services.py test/unit/test_mcp_tools.py test/integration/test_mcp_tools.py
+git commit -m "fix(mcp): update_reading_status — normalized lookup, dup guard via add_read_event, honest dates (#112)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Availability cache upsert + eviction — #110
+
+**Files:**
+- Modify: `src/agentic_librarian/availability/service.py` (`availability_for` write path; `batch_availability` phase 3; new `_upsert_cache_row`, `_evict_stale`)
+- Test: `test/unit/test_availability_batch.py` + `test/unit/test_availability_service.py` (extend)
+
+**Interfaces:** module-private helpers only.
+
+- [ ] **Step 1: Failing tests** — extend `test/unit/test_availability_batch.py`:
+
+```python
+def test_write_back_uses_upsert(monkeypatch):
+    # fake session captures session.execute(stmt) calls; assert the statement is a
+    # postgresql Insert with on_conflict (stmt.__class__ / hasattr(stmt, "on_conflict_do_update")
+    # — assert via str(stmt) containing "ON CONFLICT" after compile with postgresql dialect)
+def test_eviction_runs_after_write_back(monkeypatch):
+    # after a successful phase-3 write, a DELETE for fetched_at < cutoff is executed
+```
+
+(Write real bodies: compile the captured statement with `sqlalchemy.dialects.postgresql.dialect()` and assert `"ON CONFLICT (provider, library_slug, norm_title, norm_author) DO UPDATE"` appears; for eviction assert a delete statement referencing `fetched_at` executes. Binding intents: upsert targets the composite PK; eviction cutoff is 30 days; eviction only after successful write-back.)
+
+- [ ] **Step 2: Verify failure.**
+
+- [ ] **Step 3: Implement** in `availability/service.py`:
+
+```python
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+_EVICT_AFTER_DAYS = 30
+
+
+def _upsert_cache_row(session, slug: str, title: str, author: str, formats: list, now) -> None:
+    """Durable upsert on the composite PK (GH #110) — two concurrent writers can no longer
+    IntegrityError; last write wins, which is fine for a cache."""
+    nt, na = _normalize(title), _normalize(author)
+    stmt = pg_insert(AvailabilityCache).values(
+        provider=_PROVIDER, library_slug=slug, norm_title=nt, norm_author=na,
+        payload={"formats": formats}, fetched_at=now,
+    ).on_conflict_do_update(
+        index_elements=["provider", "library_slug", "norm_title", "norm_author"],
+        set_={"payload": {"formats": formats}, "fetched_at": now},
+    )
+    session.execute(stmt)
+
+
+def _evict_stale(session, now) -> None:
+    """Opportunistic eviction piggybacked on writes (GH #110) — rows are otherwise
+    immortal. Unindexed seq scan is fine at this table's size; revisit if it grows."""
+    from datetime import timedelta
+
+    session.execute(
+        AvailabilityCache.__table__.delete().where(
+            AvailabilityCache.fetched_at < now - timedelta(days=_EVICT_AFTER_DAYS)
+        )
+    )
+```
+
+- `batch_availability` phase 3: replace the per-row add-or-update with `_upsert_cache_row(session, slug, title, author, formats, now)` per fetched item, then `_evict_stale(session, now)` at the end of the same session; the surrounding best-effort try/except stays.
+- `availability_for`: replace its `if row is None: session.add(...) else: update` block with `_upsert_cache_row(...)` (the read-side `session.get` freshness check stays).
+- NOTE sqlite: `pg_insert` compiles only on Postgres — these paths are exercised by unit tests via statement inspection (no execution) and by CI's Postgres. Ensure no local-unit test EXECUTES the statement against sqlite.
+
+- [ ] **Step 4: Run** unit + collect-check `test_availability_service_cache.py`/`test_availability_api.py` (CI pins; they exercise the real upsert against Postgres).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentic_librarian/availability/service.py test/unit/test_availability_batch.py test/unit/test_availability_service.py
+git commit -m "fix(availability): ON CONFLICT upsert + 30-day piggybacked eviction (#110)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Embeds out of sessions + pool 5+2 — #123
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/persist.py` (new module-level `collect_embedding_texts(row)`)
+- Modify: `src/agentic_librarian/enrichment/two_phase.py` (`_persist_row` warms the cache first)
+- Modify: `src/agentic_librarian/mcp/server.py:88-120,186-240` (search tools embed before their sessions)
+- Modify: `src/agentic_librarian/db/session.py` (+ `test/unit/test_pool_config.py`, `docs/project_notes/key_facts.md`, `docs/project_notes/decisions.md` ADR-059 line)
+- Test: `test/unit/test_embed_warming.py` (new)
+
+**Interfaces:**
+- Produces: `collect_embedding_texts(row: dict) -> list[str]` in `etl/persist.py` — trope names from `enriched_tropes[].trope_name`, style strings via `_iter_style_items` over `author_style`/`work_style`/each `narrator_styles` value, plus cleaned genres∪moods fallback tags when `enriched_tropes` is empty and `row.get("write_fallback_tropes", True)`.
+
+- [ ] **Step 1: Failing tests** — create `test/unit/test_embed_warming.py`:
+
+```python
+"""#123: embedding texts are collected from the scout row and warmed BEFORE any session."""
+
+from agentic_librarian.etl.persist import collect_embedding_texts
+
+
+def test_collects_trope_and_style_texts():
+    row = {
+        "enriched_tropes": [{"trope_name": "Found Family"}, {"trope_name": "Slow Burn"}],
+        "author_style": {"pacing": "leisurely"},
+        "work_style": {"tone": "wry"},
+        "narrator_styles": {"Sam": {"accent": "Irish"}},
+        "genres": ["Fantasy"], "moods": ["Cozy"],
+    }
+    texts = collect_embedding_texts(row)
+    assert {"Found Family", "Slow Burn", "leisurely", "wry", "Irish"} <= set(texts)
+    assert "Fantasy" not in texts  # real tropes present -> no fallback tags
+
+
+def test_collects_fallback_tags_when_no_real_tropes():
+    row = {"enriched_tropes": [], "genres": ["Fantasy"], "moods": ["Cozy"],
+           "author_style": {}, "work_style": {}, "narrator_styles": {}}
+    texts = collect_embedding_texts(row)
+    assert set(texts) & {"Fantasy", "Cozy"}  # cleaned fallback tags included
+
+
+def test_persist_row_warms_before_session(monkeypatch):
+    from unittest.mock import MagicMock
+    from agentic_librarian.enrichment import two_phase
+
+    session_state = {"open": 0}
+    warmed_during = []
+
+    class FakeSession:
+        def __enter__(self):
+            session_state["open"] += 1
+            return MagicMock()
+        def __exit__(self, *a):
+            session_state["open"] -= 1
+            return False
+
+    monkeypatch.setattr(two_phase, "db_manager", MagicMock(get_session=lambda: FakeSession()))
+    def fake_embed(model, text):
+        warmed_during.append(session_state["open"])
+        return [0.0]
+    monkeypatch.setattr(two_phase, "get_cached_embedding", fake_embed)
+    monkeypatch.setattr(two_phase, "persist_enriched_work", lambda *a, **k: MagicMock())
+    # drive via the public seam the branch actually exposes — read _persist_row's final
+    # call shape and adapt: the binding assertion is warmed calls all happen with 0 sessions open
+    ...
+    assert warmed_during and all(n == 0 for n in warmed_during)
+```
+
+(Complete the drive mechanics after reading `_persist_row`'s current shape — the warm loop must run before `enrich_fast`/`enrich_deep`'s write session opens, which likely means warming in `enrich_fast`/`enrich_deep` between `_run_scouts` and the write `with`, NOT inside `_persist_row` which receives an open session. Place the warm call there; keep `collect_embedding_texts` as the single source of texts. The test then monkeypatches at the two_phase level and asserts `open == 0` during warming.)
+
+- [ ] **Step 2: Verify failure.**
+
+- [ ] **Step 3: Implement**
+
+1. `etl/persist.py` — `collect_embedding_texts(row)` reusing `_iter_style_items`, `_nan_to_list`, `clean_genres`/`clean_moods`/`clean_trope_name` exactly as the persist path does (fallback tags = the cleaned names `clean_trope_name(tag)` yields over genres∪moods).
+2. `two_phase.py` — in `enrich_fast` and `enrich_deep`, after `row = _run_scouts(...)` and BEFORE the write session:
+
+```python
+    # GH #123: warm the embedding LRU with every text the persist will standardize, so no
+    # network embed happens inside the write session (the pool's 5+2 sizing depends on it).
+    for text in collect_embedding_texts(row):
+        try:
+            get_cached_embedding(EMBED_MODEL, text)
+        except Exception:  # noqa: BLE001 - warming is best-effort; _safe_standardize degrades in-session
+            logger.warning("embed warm failed for %r — persist will retry in-session", text)
+```
+
+with `EMBED_MODEL = "gemini-embedding-001"` (import/define once — match the managers' constant; consider exposing it from scouts/utils to avoid a third copy) and imports for `collect_embedding_texts`/`get_cached_embedding`/logging.
+3. `mcp/server.py` search tools: hoist the target-embedding loops above the `with db_manager.get_session(...)` in `search_internal_database` and `get_unacted_suggestions`: compute `embeddings = [get_cached_embedding(EMBED_MODEL, t) for t in target_tropes]` (and styles) before the session; inside the session, managers are constructed as today for `find_similar_*` but `_get_embedding` is no longer called pre-warmed... simpler and explicit: pass the precomputed vectors to the existing downstream code (read the two tools; the embeddings feed pgvector queries — keep variable names, just move the computation up; on cache hit the in-session path costs nothing, so ALTERNATIVELY warm-only: call get_cached_embedding above the session and leave the in-session code untouched — CHOOSE the warm-only form for minimal diff, mirroring two_phase).
+4. `db/session.py`: `max_overflow` 5 → 2; comment's headroom paragraph replaced with: "5+2 per engine × max-instances=2 = 14 vs db-f1-micro's ~25. Safe since #94 (no scout/LLM/Thunder calls in sessions) and #123 (embeds warmed into the LRU before write sessions; search tools warm before reading)." Update `test_pool_config.py` (== 2), key_facts.md pool sentence ("5+2 per engine … 2 × 7 = 14 …; #123 landed"), ADR-059 consequences line (overflow now 2; #123 resolved).
+
+- [ ] **Step 4: Run** `test/unit/test_embed_warming.py test/unit/test_pool_config.py test/unit -q` — green; collect-check `test_two_phase_fast.py`/`test_two_phase_deep.py`/`test_mcp_tools.py` integration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src test docs/project_notes
+git commit -m "perf(embeddings): warm the LRU outside DB sessions; pool tightens to 5+2 (#123)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope (PR-D, separate plan)
+
+#95 migration + get_or_create helpers + advisory lock + log_suggestion dedup; #97 deep_enriched_at + 503 + --requeue-unenriched; #108 timestamptz; #109 indexes; the gated dedup backfill. PR-D branches from main after PR-C merges; its prod sequence is in the spec.

--- a/docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md
@@ -1,0 +1,220 @@
+# Phase 6.3 — Data Integrity (Design)
+
+**Date:** 2026-07-12 · **Issues:** #95 #96 #97 #98 #108 #109 #110 #111 #112 + #123 (folded in)
+**Roadmap:** plan.md Phase 6.3 · **Ground rule:** prod backfills/migrations require a dry-run
+report → user approval before applying (user directive 2026-07-12).
+
+## Goal
+
+Make the communal catalog trustworthy under concurrent multi-user writes: fix the verified
+data-loss bug (#96), stop garbage entering the catalog (#98), make enrichment failure loud and
+recoverable (#97), back every get-or-create with a real constraint (#95), and pay the cheap
+schema debts now (#108 timestamptz, #109 indexes, #110 upsert, #111 shared predicate,
+#112 tool correctness, #123 embeds out of sessions).
+
+**Delivery shape: two PRs.** The user's dry-run gate cleanly splits risk:
+- **PR-C `fix/phase6-3a-integrity-code`** — pure code, no schema change, deployable
+  immediately. Fixes the pollution sources BEFORE prod data is measured and cleaned.
+- **PR-D `feat/phase6-3b-schema-integrity`** — one migration + constraint-paired code + the
+  gated prod sequence (dedup dry-run → approval → apply → operator alembic → merge).
+
+## Verified findings shaping the design (2026-07-12 exploration)
+
+- persist.py's **narrator branch already implements the #96 fix pattern** (existing-edition
+  merge at persist.py:279); the work-contributor branch simply lacks the parallel merge. The
+  empirical repro test exists (`test_two_phase_deep.py::test_enrich_deep_updates_same_work_idempotently`,
+  the SAWarning source) but asserts only trope counts. #96 also **writes orphan Author rows**
+  (flushed at persist.py:122-124, never linked).
+- The corrected #69 predicate lives inline in `trope_backfill.plan_fallback_prune`
+  (clean-name ⊆ genres∪moods, case-folded) — not yet a reusable helper; persist's
+  `has_real_trope` (persist.py:338-343) still uses `justification IS NOT NULL` (#111).
+- `ScoutManager.enrich` seeds `merged_data` from raw caller input before any scout runs and
+  never returns falsy; `source_priority` (appended per contributing scout) is the natural
+  "did anyone confirm this book" signal (#98). The LLMTropeScout prompt has no unknown-book
+  escape.
+- `enrich_deep` returns True with **zero record-keeping** when scouts find nothing; `Work`
+  has no enrichment status column at all — "enriched, empty" and "never attempted" are
+  indistinguishable (#97). ImportRow's status/outcome/error_detail shape is the house
+  pattern. **No cron/scheduler infra exists anywhere** — clean_catalog.py's
+  plan → refuse-gate → apply CLI is the only bulk-op precedent.
+- Editions have **three** get-or-create sites, one (`etl/ingest.py:88-92`) entirely
+  unguarded; `log_suggestion` (mcp) has **zero dedup** while the import worker's
+  `_upsert_suggestion` is idempotent — this asymmetry is #88's likely root cause (#95).
+- No `__table_args__` exists anywhere in models.py (composite constraints will be a first);
+  migrations are hand-written with explicit names (`ix_<table>_<col>`), symmetric downgrades,
+  nullable-first column adds; **5** migrations exist; CI rebuilds the schema from the full
+  chain every run; the ADR-058 guard enforces migrate-before-merge.
+- All 13 DateTime columns are naive; `availability_cache.fetched_at` deliberately has **no
+  default** (do not add one in #108). The composite-PK-not-leftmost index gap is systemic:
+  #109's list plus `narrator_styles.style_id` and `edition_narrators.narrator_id`.
+- `availability/service.py:168` already carries a `# GH #110 covers the durable upsert`
+  comment; no pg-dialect insert exists in the repo yet.
+- `update_reading_status` is the file's only exact-match (un-normalized) work lookup, writes
+  `date.today()` unconditionally (poisoning the 2-year re-read rule for "read years ago"),
+  and has no dup guard (#112).
+- #123 pre-embed: every tag string the write session will standardize is available in the
+  scout row dict before any session opens (`enriched_tropes[].trope_name`, `author_style`/
+  `work_style`/`narrator_styles` values, plus genres∪moods for the fallback path).
+
+## PR-C design (code only)
+
+### #96 — contributor merge on existing works
+Restructure `persist_enriched_work`: resolve/create Authors and build the desired contributor
+set AFTER the work lookup; new-work branch unchanged; existing-work branch diffs desired
+(author_id, role) pairs against `work.contributors` and appends only missing links (mirroring
+the narrator merge at persist.py:279); Author rows are created only when they will be linked
+(kills the orphan side effect). Regression: extend the existing deep-pass idempotency test to
+assert a newly discovered co-author IS linked on re-persist and no orphan Author rows exist;
+add `filterwarnings = ["error::sqlalchemy.exc.SAWarning"]` to pyproject's pytest config
+(bugs.md's standing recommendation) — any new silent-non-flush bug fails loudly.
+
+### #111 — one real-trope predicate
+New `etl/trope_predicate.py` (or a function in tag_cleaning.py): `is_fallback_trope_name(name,
+genres, moods) -> bool` implementing the #69 semantics (clean_trope_name, case-folded subset of
+genres∪moods; empty-clean = neither). `plan_fallback_prune` and persist's `has_real_trope`
+guard both call it: the guard becomes "work has ≥1 WorkTrope whose name is NOT a fallback for
+this work's genres/moods". #97's sweep (PR-D) reuses it.
+
+### #98 — garbage-title gate
+1. `ScoutManager.enrich` returns `{}` when `source_priority` is empty after the loop (no scout
+   contributed anything) — `two_phase._run_scouts`' existing `if not enriched: return None`
+   and the /books 404 + import `not_found` outcomes revive with no caller changes.
+2. LLMTropeScout prompt gains: "If you cannot verify that this book actually exists, return
+   {\"tropes\": []}." Empty tropes from the deep tier contribute nothing, so a deep-only
+   response no longer marks the book as confirmed (deep scouts still append to
+   source_priority only when returning truthy data — verify and, if the trope scout returns
+   `{"tropes": []}`, treat it as non-contributing).
+3. Confidence gate falls out structurally: fast-pass (API scouts only) creation requires a
+   real metadata source to have contributed; no separate gate needed (YAGNI).
+
+### #112 — update_reading_status correctness
+1. Lookup via `_normalized_col` (match every other path).
+2. Optional `date_completed: str | None` and `year: int | None` params, validated like
+   add_book_to_history (ISO date / plausible year 1900..current; year → Jan 1 convention,
+   documented in the docstring). Precedence: date_completed > year > today-fallback.
+3. Write via `two_phase.add_read_event` (gains the work+date dup guard for free; deletes the
+   inline placeholder-edition/insert block).
+4. When the today-fallback fires, the tool reply says the date was assumed today so the agent
+   knows; the Librarian FEEDBACK HANDLING instruction gains: on "read that years ago"-style
+   feedback, ask roughly when (a year is enough) before calling the tool.
+
+### #110 — availability cache upsert + eviction
+`availability/service.py`: shared `_upsert_cache_row(session, slug, title, author, formats,
+now)` using `sqlalchemy.dialects.postgresql.insert(...).on_conflict_do_update` on the
+composite PK; used by `availability_for` and `batch_availability` phase 3 (per-row: one
+conflict can no longer abort a whole batch write-back; the outer best-effort guard stays as
+defense-in-depth). Eviction: after a successful phase-3 write, `DELETE FROM availability_cache
+WHERE fetched_at < now() - interval '30 days'` (piggybacked, no cron; also run it in
+`availability_for`'s write path cheaply — one indexed-scan delete per write is fine at this
+scale... fetched_at is unindexed; at current row counts a seq scan is fine — note in code).
+
+### #123 — embeds out of sessions, pool to 5+2
+1. `etl/persist.py` gains `collect_embedding_texts(row) -> list[str]` (trope names from
+   `enriched_tropes`, style strings via the `_iter_style_items` validation, fallback tags
+   genres∪moods when the row would write fallbacks).
+2. `two_phase._persist_row` (and the ETL asset path can adopt later) warms the cache before
+   its write session: `for t in collect_embedding_texts(row): get_cached_embedding(EMBED_MODEL, t)`
+   — LRU-1024 makes the in-session `standardize_*` calls cache hits; ZERO signature changes.
+   Note: `standardize_*` only embeds on exact-name miss, so warming embeds some texts that
+   the session wouldn't have — acceptable (cache-priced) and bounded per row.
+3. `mcp/server.py` search tools: compute `tm._get_embedding`/`sm._get_embedding` target lists
+   BEFORE opening their sessions (reorder; managers constructed with session=None? — managers
+   need a session only for find_similar/create; `_get_embedding` doesn't touch it. Construct
+   the managers inside the session as today but hoist the embedding loops above the `with` by
+   calling `get_cached_embedding(model, text)` directly).
+4. `db/session.py`: max_overflow 5 → 2, comment updated (the #123 condition is met); ADR-059
+   consequence line updated; key_facts updated. Closes #123.
+
+## PR-D design (schema + gated ops)
+
+### One migration (`phase 6.3 schema hardening`)
+1. **#95 uniques** (created AFTER the gated dedup cleans prod):
+   - `CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))`
+   - `uq_narrators_name_lower` likewise
+   - `uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT` (PG16)
+   - `uq_reading_history_user_edition_date ON reading_history (user_id, edition_id, date_completed)`
+   - `uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'`
+2. **#109 indexes**: `editions.work_id`, `reading_history.edition_id`, `work_tropes.trope_id`,
+   `work_contributors.author_id`, `suggestions.work_id`, `author_styles.style_id`,
+   `work_styles.style_id`, `usage.conversation_id`, plus the systemic pair the issue missed:
+   `narrator_styles.style_id`, `edition_narrators.narrator_id`. Named `ix_<table>_<col>`.
+3. **#108 timestamptz**: all 13 DateTime columns `ALTER ... TYPE timestamptz USING <col> AT
+   TIME ZONE 'UTC'`; models gain `DateTime(timezone=True)`; the
+   `fetched_at.replace(tzinfo=UTC)` band-aid in availability/service.py is removed;
+   `availability_cache.fetched_at` keeps NO default (deliberate). `Suggestions.suggested_at`
+   is on the list (easy to miss).
+4. **#97 column**: `works.deep_enriched_at TIMESTAMPTZ NULL`.
+Symmetric hand-written downgrade, house naming, single head (ADR-058 guard).
+
+### #95 code (paired with the constraints)
+- `db/get_or_create.py` helper: query → insert → on IntegrityError rollback-to-savepoint and
+  re-query (`session.begin_nested()` so the retry doesn't kill the caller's transaction).
+  Adopted at: authors/narrators (persist.py), all three edition sites (persist.py,
+  two_phase.add_read_event, **ingest.py's unguarded insert**), reading_history
+  (add_read_event keeps its date-guard + gains the constraint backstop), suggestions
+  (worker._upsert_suggestion AND `log_suggestion`, which gains dedup — fixes #88's root
+  cause; note on #88 when closing).
+- `enrich_fast` write session: `SELECT pg_advisory_xact_lock(hashtext(:norm_title || '|' ||
+  :norm_author))` before the dedup re-check (Postgres-only; skip on sqlite test URLs).
+- Works duplicate sweep backstop lands in the dedup tooling below.
+
+### #97 code
+- `_persist_row`/deep path sets `work.deep_enriched_at = now()` when the deep pass persists
+  (including a confirmed-empty result — the timestamp means "deep pass completed", the trope
+  predicate distinguishes fingerprintless works).
+- `api/internal.py` enrich endpoint: when `enrich_deep` completed but the work still has no
+  real trope (shared #111 predicate) AND the scouts yielded nothing → return 503 (Cloud Tasks
+  retries with backoff; retry exhaustion is the poison-task end state, swept below).
+- `clean_catalog.py --requeue-unenriched`: lists works with no real trope (predicate) or
+  NULL deep_enriched_at, prints the plan, `--apply --yes` re-enqueues deep enrichment via
+  `enqueue_enrichment` (operator-run with prod env; Cloud Scheduler automation deferred to
+  6.6/#114). Also absorbs the 6.2b deferral (deep-enqueue failure recovery).
+
+### Dedup backfill (THE USER GATE)
+`clean_catalog.py --dedup-for-constraints`:
+- **Plan (dry-run) report**: case-insensitive duplicate authors + narrators (merge target =
+  oldest row; repoint work_contributors/author_styles, narrator links; then delete);
+  duplicate editions per (work_id, COALESCE(format,'')) (repoint reading_history +
+  edition_narrators; delete); exact-duplicate reading_history rows (keep oldest); duplicate
+  Suggested suggestions (keep oldest); duplicate works by normalized title+author (REPORT
+  ONLY with row details — work merges are complex; if any exist the user decides case by
+  case before the constraint lands... note: no works unique constraint exists in the
+  migration, so work dupes don't block it; the advisory lock prevents new ones);
+  plus the #96 orphan-author list (authors with no work_contributors AND no author_styles —
+  delete after approval).
+- Structural distinguishers only, per the #69 lesson (verify-backfill-distinguisher): every
+  class keys on real relationships/normalized values, never on sometimes-populated columns.
+- **Sequence**: PR-C deployed (pollution stopped) → dry-run on prod → **user reviews report
+  and approves** → `--apply --yes` → user runs `alembic upgrade head` on prod (constraints
+  now succeed) → merge PR-D → deploy (ADR-058 guard passes; new code relies on constraints).
+- pg_dump snapshot before apply (house rule).
+
+## Testing
+
+- PR-C: SAWarning-as-error suite-wide; #96 regression (existing repro test extended);
+  predicate unit tests (fallback vs real vs junk-clean names); #98 unit tests (empty
+  source_priority → {}, prompt text pinned); #112 unit tests (year/date parsing, dup guard
+  via add_read_event, normalized lookup — CI integration for the write path); #110 unit
+  (upsert called; eviction SQL emitted) + CI availability suites; #123 unit (cache warmed
+  before session — reuse the `open_sessions_during_scout`-style probe for embeds).
+- PR-D: migration runs in CI's full-chain rebuild; get_or_create helper unit tests (sqlite
+  IntegrityError path) + CI concurrent-ish tests (sequential double-insert hits constraint →
+  helper recovers); advisory-lock skipped-on-sqlite guard; 503-on-empty-deep CI test;
+  dedup planner unit tests on synthetic duplicates (plan correctness) — apply path exercised
+  in CI against seeded duplicates.
+- Post-deploy: dedup dry-run doubles as the prod data-quality report for the user.
+
+## Decisions delegated to Claude (for user review)
+
+1. Two PRs (code first, schema+gated-ops second); PR-C deploys before prod data is measured.
+2. #97 = `deep_enriched_at` timestamp + 503-retry + operator sweep mode; Cloud Scheduler
+   deferred to 6.6/#114 (no cron infra exists; clean_catalog is the house pattern).
+3. #98 gate = empty `source_priority` → `{}` (structural), not an LLM-judged confidence score.
+4. #112 keeps a today-fallback (flagged in the reply) rather than refusing dateless writes;
+   Librarian instructed to ask for a year.
+5. #95 works-dedup = advisory lock + report-only sweep (no cross-table unique on works).
+6. `NULLS NOT DISTINCT` on the editions unique (PG16 feature; prod is PG16).
+7. #123 via LRU warming (zero signature changes) rather than threading embeddings through
+   persist signatures.
+8. Suggestions partial unique keys on status='Suggested' only (historical rows may repeat).
+9. SAWarning promoted to error suite-wide (may surface latent warnings in CI — fixed as found).

--- a/docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md
@@ -170,6 +170,21 @@ Symmetric hand-written downgrade, house naming, single head (ADR-058 guard).
   `enqueue_enrichment` (operator-run with prod env; Cloud Scheduler automation deferred to
   6.6/#114). Also absorbs the 6.2b deferral (deep-enqueue failure recovery).
 
+### PR-D inputs from PR-C's final review (2026-07-12)
+
+1. The dry-run's **orphan-author list may legitimately be nonzero even post-PR-C**: the
+   Dagster ETL's `skip_enrichment=True` branch can still flush an unlinked Author on an
+   existing work (operator-curated re-runs only; prod paths always set it False).
+2. Expect **"Unknown"-format editions** in the dry-run report — update_reading_status
+   historically minted them (PR-C now reuses a sole existing edition's format, but legacy
+   rows and zero/multi-edition works still produce Unknown).
+3. **#97 absorbs #123's warm-failure hardening**: a persist whose vectors were all skipped
+   (Gemini degradation) leaves a work with no real tropes — `--requeue-unenriched` is the
+   recovery path; no error-class discrimination needed in the warm loop.
+4. Product note for the #97/6.5 bucket: #98 means a real-but-unindexed book (absent from
+   Hardcover/Google Books) now lands `not_found` instead of creating a bare work — the
+   import report and chat messaging should say so in user-facing terms.
+
 ### Dedup backfill (THE USER GATE)
 `clean_catalog.py --dedup-for-constraints`:
 - **Plan (dry-run) report**: case-insensitive duplicate authors + narrators (merge target =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,6 @@ markers = [
     "integration: tests that verify components of the system integrated",
     "live: tests against real external services (operator-run, never CI)",
 ]
+filterwarnings = [
+    "error::sqlalchemy.exc.SAWarning",
+]

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -130,6 +130,9 @@ ask one short confirmation question first.
 
 FEEDBACK HANDLING:
 - "I read that" -> 'update_reading_status' AND 'update_suggestion_status' (Already Read).
+  If the user indicates it was a while ago ("years ago", "back in college"), ask roughly
+  when — a year is enough — and pass it as 'year'; without a date the entry is logged as
+  today, which wrongly blocks re-read suggestions for 2 years.
 - "Not for me" / "I hate this" -> 'update_suggestion_status' (Dismissed).
 - Mood feedback ("not in the mood for X") -> respect it for the rest of the conversation.
 

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -184,6 +184,9 @@ class LibrarianAgent(LlmAgent):
 
             FEEDBACK HANDLING:
             - If user says "I read that", use 'update_reading_status' AND 'update_suggestion_status(Already Read)'.
+              If they indicate it was a while ago ("years ago", "back in college"), ask roughly when —
+              a year is enough — and pass it as 'year'; without a date the entry is logged as today,
+              which wrongly blocks re-read suggestions for 2 years.
             - If user says "Not for me" or "I hate this", use 'update_suggestion_status(Dismissed)'.
             - If user provides mood feedback ("Not in the mood for X"), pass it to the Analyst/Critic.
 

--- a/src/agentic_librarian/availability/service.py
+++ b/src/agentic_librarian/availability/service.py
@@ -12,6 +12,7 @@ import logging
 import os
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from agentic_librarian.availability import overdrive
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 _PROVIDER = "libby"
 _FORMATS = (("ebook", "eBook"), ("audiobook", "Audiobook"))
+_EVICT_AFTER_DAYS = 30
 
 
 def _ttl() -> timedelta:
@@ -73,6 +75,38 @@ def _shape_formats(items: list[dict], title: str, author: str) -> list[dict]:
     return out
 
 
+def _upsert_cache_row(session, slug: str, title: str, author: str, formats: list, now) -> None:
+    """Durable upsert on the composite PK (GH #110) — two concurrent writers can no longer
+    IntegrityError; last write wins, which is fine for a cache."""
+    nt, na = _normalize(title), _normalize(author)
+    stmt = (
+        pg_insert(AvailabilityCache)
+        .values(
+            provider=_PROVIDER,
+            library_slug=slug,
+            norm_title=nt,
+            norm_author=na,
+            payload={"formats": formats},
+            fetched_at=now,
+        )
+        .on_conflict_do_update(
+            index_elements=["provider", "library_slug", "norm_title", "norm_author"],
+            set_={"payload": {"formats": formats}, "fetched_at": now},
+        )
+    )
+    session.execute(stmt)
+
+
+def _evict_stale(session, now) -> None:
+    """Opportunistic eviction piggybacked on writes (GH #110) — rows are otherwise
+    immortal. Unindexed seq scan is fine at this table's size; revisit if it grows."""
+    session.execute(
+        AvailabilityCache.__table__.delete().where(
+            AvailabilityCache.fetched_at < now - timedelta(days=_EVICT_AFTER_DAYS)
+        )
+    )
+
+
 def availability_for(session: Session, library: dict, title: str, author: str) -> list[dict] | None:
     """Single-lookup read-through cache (request paths use batch_availability, GH #94). Read-
     through cache for ONE (library, title, author). Returns the per-format list, or None if
@@ -92,21 +126,8 @@ def availability_for(session: Session, library: dict, title: str, author: str) -
         return None  # degrade: no badge, links unaffected
 
     formats = _shape_formats(items, title, author)
-    payload = {"formats": formats}
-    if row is None:
-        session.add(
-            AvailabilityCache(
-                provider=_PROVIDER,
-                library_slug=slug,
-                norm_title=nt,
-                norm_author=na,
-                payload=payload,
-                fetched_at=now,
-            )
-        )
-    else:
-        row.payload = payload
-        row.fetched_at = now
+    _upsert_cache_row(session, slug, title, author, formats, now)
+    _evict_stale(session, now)
     session.flush()
     return formats
 
@@ -146,26 +167,12 @@ def batch_availability(db_manager, libs: list[dict], items: list[tuple[str, str]
         try:
             with db_manager.get_session() as session:
                 for (slug, title, author), formats in fetched.items():
-                    nt, na = _normalize(title), _normalize(author)
-                    row = session.get(AvailabilityCache, (_PROVIDER, slug, nt, na))
-                    payload = {"formats": formats}
-                    if row is None:
-                        session.add(
-                            AvailabilityCache(
-                                provider=_PROVIDER,
-                                library_slug=slug,
-                                norm_title=nt,
-                                norm_author=na,
-                                payload=payload,
-                                fetched_at=now,
-                            )
-                        )
-                    else:
-                        row.payload = payload
-                        row.fetched_at = now
-                    session.flush()
+                    _upsert_cache_row(session, slug, title, author, formats, now)
+                _evict_stale(session, now)
+                session.flush()
         except Exception as exc:  # noqa: BLE001 - cache write-back is best-effort (ALWAYS-200)
-            # GH #110 covers the durable upsert; until then write-back is best-effort
-            logger.warning("availability cache write-back failed (concurrent insert?): %s", exc)
+            # defense in depth: the upsert (GH #110) makes concurrent writers safe, but
+            # write-back still must never take down the ALWAYS-200 request path.
+            logger.warning("availability cache write-back failed: %s", exc)
         results.update(fetched)
     return results

--- a/src/agentic_librarian/db/session.py
+++ b/src/agentic_librarian/db/session.py
@@ -71,7 +71,10 @@ class DatabaseManager:
             # recycle beats server-side idle kills. 5+2 per engine × max-instances=2 = 14
             # vs db-f1-micro's ~25. Safe since #94 (no scout/LLM/Thunder calls in sessions)
             # and #123 (embeds warmed into the LRU before write sessions; search tools warm
-            # before reading).
+            # before reading) — two residuals remain: a warm-FAILURE degrades to in-session
+            # embeds via _safe_standardize (bounded: enrich queue is 4-concurrent; PR-D's
+            # requeue sweep is the recovery), and /analysis embeds ~24 radar anchor texts
+            # inside its session once per process (first call only, then module-cached).
             # sqlite (tests) uses its own pool class that rejects QueuePool kwargs.
             pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 2}
         self._engine = create_engine(db_url, connect_args=connect_args, **pool_kwargs)

--- a/src/agentic_librarian/db/session.py
+++ b/src/agentic_librarian/db/session.py
@@ -68,14 +68,12 @@ class DatabaseManager:
         pool_kwargs = {}
         if not db_url.startswith("sqlite"):
             # GH #102: pre_ping heals stale connections after Cloud SQL restarts/idle;
-            # recycle beats server-side idle kills. 5+5 per engine × max-instances=2 = 20
-            # peak vs db-f1-micro's ~25. Overflow headroom is deliberate: #94 removed
-            # scout/LLM/Thunder calls from sessions, but embedding calls still run inside
-            # them (search tools + persist-time standardize_trope/style) — under a Gemini
-            # 429 burst those sessions stretch to minutes. Tighten to 5+2 once embeds are
-            # hoisted out of sessions (GH #123).
+            # recycle beats server-side idle kills. 5+2 per engine × max-instances=2 = 14
+            # vs db-f1-micro's ~25. Safe since #94 (no scout/LLM/Thunder calls in sessions)
+            # and #123 (embeds warmed into the LRU before write sessions; search tools warm
+            # before reading).
             # sqlite (tests) uses its own pool class that rejects QueuePool kwargs.
-            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 5}
+            pool_kwargs = {"pool_pre_ping": True, "pool_recycle": 1800, "pool_size": 5, "max_overflow": 2}
         self._engine = create_engine(db_url, connect_args=connect_args, **pool_kwargs)
         self._SessionFactory = sessionmaker(bind=self._engine)
 

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -15,6 +15,7 @@ discovery write tool, left untouched): same persist core, tiered scouts."""
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from sqlalchemy import func
@@ -22,13 +23,16 @@ from sqlalchemy import func
 from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.models import Author, Edition, ReadingHistory, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
-from agentic_librarian.etl.persist import persist_enriched_work
+from agentic_librarian.etl.persist import collect_embedding_texts, persist_enriched_work
 from agentic_librarian.orchestration.definitions import (
     create_deep_scout_manager,
     create_fast_scout_manager,
 )
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
+
+logger = logging.getLogger(__name__)
 
 # Module-level fallback pool for non-API processes; the API lifespan injects its shared
 # manager via set_db_manager (GH #102 consolidation — the old "deferred to Stage 4" note was stale).
@@ -77,6 +81,18 @@ def _persist_row(session, row: dict) -> Work | None:
     return persist_enriched_work(session, row, TropeManager(session=session), StyleManager(session=session))
 
 
+def _warm_embeddings(row: dict) -> None:
+    """GH #123: warm the embedding LRU with every text the persist will standardize, so no
+    network embed happens inside the write session (the pool's 5+2 sizing depends on it).
+    Best-effort — a warm failure just means that item embeds in-session as before
+    (_safe_standardize in etl/persist.py remains the net that degrades gracefully there)."""
+    for text in collect_embedding_texts(row):
+        try:
+            get_cached_embedding(EMBED_MODEL, text)
+        except Exception:  # noqa: BLE001 - warming is best-effort; _safe_standardize degrades in-session
+            logger.warning("embed warm failed for %r — persist will retry in-session", text)
+
+
 def enrich_fast(title: str, author: str, fmt: str = "ebook") -> tuple[UUID, bool] | None:
     """Fast pass: de-dup against the catalog; if new, run the API scouts (no session
     held, #94) and persist in a fresh session that RE-CHECKS the dedup (a concurrent
@@ -103,6 +119,8 @@ def enrich_fast(title: str, author: str, fmt: str = "ebook") -> tuple[UUID, bool
     row = _run_scouts(create_fast_scout_manager(), title=title, author=author, fmt=fmt, write_fallback_tropes=False)
     if row is None:
         return None
+
+    _warm_embeddings(row)
 
     with db_manager.get_session() as session:
         existing = _find_existing(session)  # dedup re-check (#94/#95)
@@ -165,6 +183,8 @@ def enrich_deep(work_id: UUID) -> bool:
     row = _run_scouts(create_deep_scout_manager(), title=title, author=author, fmt=fmt)
     if row is None:
         return True  # scouts found nothing to add; the task is done, not retryable
+
+    _warm_embeddings(row)
 
     with db_manager.get_session() as session:
         _persist_row(session, row)

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -152,7 +152,10 @@ def persist_enriched_work(
 
     # Resolve/Create Authors and collect (author, role) pairs to link below. Author creation
     # happens only for entries that will actually be linked to the work (both the new-work and
-    # existing-work branches below link every desired pair), so no orphan Author rows can result.
+    # existing-work branches below link every desired pair), so orphan Authors can no longer
+    # result from any prod path (two_phase/imports always set skip_enrichment=False); the
+    # Dagster ETL's skip_enrichment=True branch can still flush an unlinked Author for an
+    # existing work — acceptable for operator-curated re-runs, listed in PR-D's dry-run.
     desired: list[tuple[Author, str]] = []
     author_style_data = row.get("author_style", {})
 

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -18,6 +18,7 @@ from agentic_librarian.db.models import (
     Narrator,
     NarratorStyle,
     ReadingHistory,
+    Trope,
     Work,
     WorkContributor,
     WorkStyle,
@@ -25,6 +26,7 @@ from agentic_librarian.db.models import (
 )
 from agentic_librarian.etl.contributor_dedup import norm_name
 from agentic_librarian.etl.tag_cleaning import clean_genres, clean_moods, clean_trope_name
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
 
@@ -335,12 +337,16 @@ def persist_enriched_work(
             # only when the caller wants them — the two-phase fast pass opts out (write_fallback_tropes
             # =False) because its deep pass supplies the real tropes (Spec #65, 2026-06-23). Cleaned the
             # same way as genres/moods so a fallback can never write a UUID-tailed / unsplit slug.
-            has_real_trope = (
-                session.query(WorkTrope)
-                .filter(WorkTrope.work_id == work.id, WorkTrope.justification.isnot(None))
-                .first()
-                is not None
+            # GH #111: "has a real trope" = any linked trope whose cleaned name is NOT a
+            # re-encoding of this work's genres/moods (the shared #69 predicate) — the old
+            # `justification IS NOT NULL` heuristic misclassified real attractor tropes.
+            linked = (
+                session.query(Trope.name)
+                .join(WorkTrope, WorkTrope.trope_id == Trope.id)
+                .filter(WorkTrope.work_id == work.id)
+                .all()
             )
+            has_real_trope = any(is_fallback_trope_name(name, work.genres, work.moods) is False for (name,) in linked)
             if row.get("write_fallback_tropes", True) and not has_real_trope:
                 for tag in all_fallback_tags:
                     for name in clean_trope_name(tag):

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -102,8 +102,25 @@ def persist_enriched_work(
     if not raw_contributors:
         return None
 
-    # Resolve/Create Authors and create WorkContributor objects
-    work_contributors_list = []
+    # 2. Work lookup. Moved above contributor materialization (#96) so the existing-work branch
+    # can merge desired contributors instead of relying on WorkContributor objects built before we
+    # know whether this is a new or existing work. no_autoflush guards this query against
+    # autoflushing other pending session state (e.g. an Author added earlier in this same call for
+    # a prior row in a batch import) mid-lookup.
+    with session.no_autoflush:
+        work = (
+            session.query(Work)
+            .join(WorkContributor)
+            .join(Author)
+            .filter(Work.title == row["Title"])
+            .filter(Author.name == (row.get("Author_1") or row.get("Author")))
+            .first()
+        )
+
+    # Resolve/Create Authors and collect (author, role) pairs to link below. Author creation
+    # happens only for entries that will actually be linked to the work (both the new-work and
+    # existing-work branches below link every desired pair), so no orphan Author rows can result.
+    desired: list[tuple[Author, str]] = []
     author_style_data = row.get("author_style", {})
 
     seen_contributors: set[tuple[str, str]] = set()
@@ -141,7 +158,7 @@ def persist_enriched_work(
                 if not existing_link:
                     session.add(AuthorStyle(author=author, style=standard_style, attribute_type=attr_type))
 
-        work_contributors_list.append(WorkContributor(author=author, role=role))
+        desired.append((author, role))
 
     # Coerce every enrichment/CSV field that pandas may deliver as NaN before it reaches the ORM.
     # Scalars -> None (SQL NULL); list-typed fields -> [] so downstream iteration/set() can't crash
@@ -159,21 +176,10 @@ def persist_enriched_work(
     audio_minutes = _nan_to_none(row.get("audio_minutes"))
     publication_date = _nan_to_none(row.get("publication_date"))
 
-    # 2. Work. no_autoflush: the not-yet-added WorkContributor objects above must not be
-    # cascaded by this query's autoflush (raises a SAWarning and could flush incomplete rows).
-    with session.no_autoflush:
-        work = (
-            session.query(Work)
-            .join(WorkContributor)
-            .join(Author)
-            .filter(Work.title == row["Title"])
-            .filter(Author.name == (row.get("Author_1") or row.get("Author")))
-            .first()
-        )
     if not work:
         work = Work(
             title=row["Title"],
-            contributors=work_contributors_list,
+            contributors=[WorkContributor(author=a, role=r) for a, r in desired],
             original_publication_year=original_publication_year,
             description=description,
             genres=genres,
@@ -187,6 +193,14 @@ def persist_enriched_work(
         work.description = description or work.description
         work.genres = genres or work.genres
         work.moods = moods or work.moods
+        # GH #96: link newly discovered contributors (deep pass / re-import). Previously the
+        # WorkContributor objects dangled off Author.contributions and SQLAlchemy 2.0's removed
+        # backref-cascade silently never flushed them (SAWarning) — co-authors were lost and
+        # their Author rows orphaned. Mirror the narrator merge below.
+        existing_pairs = {(c.author_id, c.role) for c in work.contributors}
+        for author, role in desired:
+            if (author.id, role) not in existing_pairs:
+                work.contributors.append(WorkContributor(author=author, role=role))
 
     # 2.5 Work Styles
     work_style_data = row.get("work_style", {})

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -76,6 +76,39 @@ def _nan_to_list(value):
     return value if isinstance(value, list) else []
 
 
+def collect_embedding_texts(row: dict) -> list[str]:
+    """Every text persist_enriched_work will pass to standardize_trope/standardize_style for
+    this row — trope names, author/work/narrator style strings, plus the cleaned genre∪mood
+    fallback tags IF (and only if) persist would actually fall back to them (no real
+    enriched_tropes AND the caller hasn't opted out via write_fallback_tropes=False). Used to
+    warm the get_cached_embedding LRU BEFORE a write session opens (GH #123) so the in-session
+    standardize_* calls become cache hits instead of network embeds."""
+    texts: list[str] = []
+
+    enriched_tropes = _nan_to_list(row.get("enriched_tropes"))
+    for t_data in enriched_tropes:
+        name = t_data.get("trope_name")
+        if isinstance(name, str) and name.strip():
+            texts.append(name)
+
+    for style_data in (row.get("author_style"), row.get("work_style")):
+        for _attr_type, style_name in _iter_style_items(style_data, "warm"):
+            texts.append(style_name)
+    narrator_styles = row.get("narrator_styles")
+    if isinstance(narrator_styles, dict):
+        for n_style_data in narrator_styles.values():
+            for _attr_type, style_name in _iter_style_items(n_style_data, "warm"):
+                texts.append(style_name)
+
+    if not enriched_tropes and row.get("write_fallback_tropes", True):
+        genres = clean_genres(_nan_to_list(row.get("genres")))
+        moods = clean_moods(_nan_to_list(row.get("moods")))
+        for tag in set(genres) | set(moods):
+            texts.extend(clean_trope_name(tag))
+
+    return texts
+
+
 def persist_enriched_work(
     session: Session, row: dict, trope_manager: TropeManager, style_manager: StyleManager
 ) -> Work | None:

--- a/src/agentic_librarian/etl/trope_backfill.py
+++ b/src/agentic_librarian/etl/trope_backfill.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Trope, Work, WorkTrope
 from agentic_librarian.etl.tag_cleaning import _normalize, clean_trope_name
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,8 @@ def plan_fallback_prune(session: Session) -> list[FallbackPrune]:
 
     The justification column is deliberately NOT used: it is unreliable — many real scout tropes have
     NULL justification (semantic-collapse "attractor" tropes shared across books), so it conflates
-    real tropes with fallbacks. We match by name/genre membership instead. Read-only."""
+    real tropes with fallbacks. We match by name/genre membership instead, via the shared
+    is_fallback_trope_name predicate (GH #111). Read-only."""
     rows = (
         session.query(WorkTrope.work_id, WorkTrope.trope_id, Trope.name, Work.title, Work.genres, Work.moods)
         .join(Trope, Trope.id == WorkTrope.trope_id)
@@ -196,23 +198,19 @@ def plan_fallback_prune(session: Session) -> list[FallbackPrune]:
     )
     by_work: dict[UUID, dict] = {}
     for work_id, trope_id, name, title, genres, moods in rows:
-        # case-fold the genre/mood set so the subset test is robust to casing drift (legacy/manual edits)
-        gm = {s.lower() for s in (set(genres or []) | set(moods or []))}
-        w = by_work.setdefault(work_id, {"title": title, "gm": gm, "links": []})
+        w = by_work.setdefault(work_id, {"title": title, "genres": genres, "moods": moods, "links": []})
         w["links"].append((trope_id, name))
     out: list[FallbackPrune] = []
     for work_id, w in by_work.items():
-        gm = w["gm"]
         fallback: list[tuple[UUID, str]] = []
         real = 0
         for trope_id, name in w["links"]:
-            cleaned = clean_trope_name(name)
-            cleaned_lower = {c.lower() for c in cleaned}
-            if cleaned and cleaned_lower <= gm:  # the trope is (a clean of) one of this work's genres/moods
+            verdict = is_fallback_trope_name(name, w["genres"], w["moods"])
+            if verdict is True:  # the trope is (a clean of) one of this work's genres/moods
                 fallback.append((trope_id, name))
-            elif cleaned:  # cleans to something outside genres/moods -> a genuine narrative trope
+            elif verdict is False:  # cleans to something outside genres/moods -> a genuine narrative trope
                 real += 1
-            # else: cleans to [] (junk) -> leave it; the --tropes pass deletes junk-named tropes
+            # else: verdict is None (junk) -> leave it; the --tropes pass deletes junk-named tropes
         if fallback and real:  # never strip a work below its genuine tropes
             out.append(FallbackPrune(work_id, w["title"], [n for _, n in fallback], [tid for tid, _ in fallback], real))
     return out

--- a/src/agentic_librarian/etl/trope_predicate.py
+++ b/src/agentic_librarian/etl/trope_predicate.py
@@ -1,0 +1,23 @@
+"""The ONE real-vs-fallback trope predicate (GH #111, semantics from PR #69).
+
+A genre/mood "fallback" trope is one whose CLEANED name is (a subset of) the work's own
+cleaned genres+moods — the two-phase fast pass re-encoded a genre/mood as a trope. The
+justification column is deliberately NEVER consulted: many real scout tropes carry NULL
+justification (semantic-collapse "attractor" tropes), so it conflates real with fallback —
+the exact mistake the #65 prune nearly made (bugs.md 2026-06-24, memory
+verify-backfill-distinguisher). Shared by the persist-time guard, clean_catalog's prune,
+and (PR-D) the enrichment-reconciliation sweep, so the definitions can't diverge again."""
+
+from __future__ import annotations
+
+from agentic_librarian.etl.tag_cleaning import clean_trope_name
+
+
+def is_fallback_trope_name(name: str, genres: list[str] | None, moods: list[str] | None) -> bool | None:
+    """True = fallback (re-encoded genre/mood); False = genuine narrative trope;
+    None = junk (cleans to nothing — neither real nor fallback)."""
+    gm = {s.lower() for s in (set(genres or []) | set(moods or []))}
+    cleaned = clean_trope_name(name)
+    if not cleaned:
+        return None
+    return {c.lower() for c in cleaned} <= gm

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -474,10 +474,14 @@ def update_reading_status(
 ) -> str:
     """Updates history based on feedback (e.g. 'I read that years ago'). date_completed
     (ISO YYYY-MM-DD) takes precedence over year (a bare year is written as Jan 1 of that
-    year — the documented convention for an unknown month/day); with neither, the
-    completion date is ASSUMED to be today and the reply says so — the caller should ask
-    the user roughly when they read it if the exact date matters, since an assumed-today
-    date wrongly blocks the 2-year re-read rule for years."""
+    year — the documented convention for an unknown month/day, not a claim the user said
+    "January 1"); with neither, the completion date is ASSUMED to be today and the reply
+    says so — the caller should ask the user roughly when they read it if the exact date
+    matters, since an assumed-today date wrongly blocks the 2-year re-read rule for years.
+    Two 'read' calls with the same year (no exact date) resolve to the same Jan 1 date and
+    dedup to a single row rather than logging a second read. A year-only entry also opens
+    the 2-year re-read window up to ~11 months early, since it is dated Jan 1 regardless of
+    which month the book was actually finished."""
     if not _valid_name(title):
         return "Error: title must be a non-empty string of at most 500 characters."
     if not _valid_name(author):
@@ -520,8 +524,14 @@ def update_reading_status(
             if not work:
                 return f"Work '{title}' by {author} not found in database."
             work_id = work.id
+            # Reuse the work's own edition format when it's unambiguous (exactly one
+            # edition); otherwise "Unknown" as before. Scalar captured before the session
+            # closes to avoid a DetachedInstanceError on the ORM object.
+            editions = session.query(Edition).filter(Edition.work_id == work_id).all()
+            edition_fmt = editions[0].format if len(editions) == 1 else "Unknown"
+            edition_fmt = edition_fmt or "Unknown"
         if canonical == "read":
-            logged = two_phase.add_read_event(work_id, completed=completed, rating=None, notes=notes, fmt="Unknown")
+            logged = two_phase.add_read_event(work_id, completed=completed, rating=None, notes=notes, fmt=edition_fmt)
             if logged["already_logged"]:
                 return f"'{title}' is already logged as completed {completed.isoformat()}. No new entry written."
         note = (

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -31,6 +31,7 @@ from agentic_librarian.enrichment.tasks import enqueue_enrichment
 from agentic_librarian.enrichment.two_phase import _normalize, _normalized_col
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
 from mcp.server.fastmcp import FastMCP
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,20 @@ def search_internal_database(target_tropes: list[str], target_styles: list[str] 
     """
     Performs a pgvector similarity search across tropes and literary styles.
     """
+    # GH #123: warm the embedding LRU before the session opens so the in-session
+    # _get_embedding calls below are cache hits, not network round-trips held under a
+    # pooled connection (the pool's 5+2 sizing depends on no embed calls inside sessions).
+    for t in target_tropes or []:
+        try:
+            get_cached_embedding(EMBED_MODEL, t)
+        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
+            logger.warning("embed warm failed for trope %r — retrying in-session", t)
+    for s in target_styles or []:
+        try:
+            get_cached_embedding(EMBED_MODEL, s)
+        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
+            logger.warning("embed warm failed for style %r — retrying in-session", s)
+
     with db_manager.get_session() as session:
         tm = TropeManager(session=session)
         sm = StyleManager(session=session)
@@ -191,6 +206,19 @@ def get_unacted_suggestions(target_tropes: list[str], target_styles: list[str] =
     ranked by similarity to current target vibes.
     """
     user_id = get_required_user_id()
+    # GH #123: warm before the session opens (see search_internal_database above) — a no-op
+    # cache-hit in-session either way if there turn out to be no suggestions to rank.
+    for t in target_tropes or []:
+        try:
+            get_cached_embedding(EMBED_MODEL, t)
+        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
+            logger.warning("embed warm failed for trope %r — retrying in-session", t)
+    for s in target_styles or []:
+        try:
+            get_cached_embedding(EMBED_MODEL, s)
+        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
+            logger.warning("embed warm failed for style %r — retrying in-session", s)
+
     with db_manager.get_session() as session:
         # 1. Get all unacted suggestions with Eager Loading (Fixes N+1)
         query = (

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -28,6 +28,7 @@ from agentic_librarian.db.models import (
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
 from agentic_librarian.enrichment.tasks import enqueue_enrichment
+from agentic_librarian.enrichment.two_phase import _normalize, _normalized_col
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
 from mcp.server.fastmcp import FastMCP
@@ -435,8 +436,20 @@ def _valid_name(value, max_len: int = 500) -> bool:
 
 
 @mcp.tool()
-def update_reading_status(title: str, author: str, status: str, notes: str | None = None) -> str:
-    """Updates history based on feedback (e.g. 'I read that years ago')."""
+def update_reading_status(
+    title: str,
+    author: str,
+    status: str,
+    notes: str | None = None,
+    date_completed: str | None = None,
+    year: int | None = None,
+) -> str:
+    """Updates history based on feedback (e.g. 'I read that years ago'). date_completed
+    (ISO YYYY-MM-DD) takes precedence over year (a bare year is written as Jan 1 of that
+    year — the documented convention for an unknown month/day); with neither, the
+    completion date is ASSUMED to be today and the reply says so — the caller should ask
+    the user roughly when they read it if the exact date matters, since an assumed-today
+    date wrongly blocks the 2-year re-read rule for years."""
     if not _valid_name(title):
         return "Error: title must be a non-empty string of at most 500 characters."
     if not _valid_name(author):
@@ -447,39 +460,46 @@ def update_reading_status(title: str, author: str, status: str, notes: str | Non
         # false-success). Reject honestly instead (SEC-002).
         return f"Error: status must be one of {', '.join(_READING_STATUSES)}; got {status!r}."
     notes = notes[:2000] if isinstance(notes, str) else None
-    user_id = get_required_user_id()  # before try: unset context must raise, not soft-fail (ADR-048)
+
+    # date resolution (GH #112): date_completed > year (Jan 1 convention) > today-fallback.
+    assumed_today = False
+    if date_completed is not None:
+        try:
+            completed = date.fromisoformat(str(date_completed))
+        except ValueError:
+            return f"Error: date_completed must be ISO YYYY-MM-DD; got {date_completed!r}."
+        if completed > date.today():
+            return f"Error: date_completed {completed.isoformat()} is in the future."
+    elif year is not None:
+        if isinstance(year, bool) or not isinstance(year, int) or not 1900 <= year <= date.today().year:
+            return f"Error: year must be between 1900 and {date.today().year}; got {year!r}."
+        completed = date(year, 1, 1)  # convention: unknown month/day -> Jan 1 (documented)
+    else:
+        completed = date.today()
+        assumed_today = True
+
+    get_required_user_id()  # before try: unset context must raise, not soft-fail (ADR-048)
     try:
         with db_manager.get_session() as session:
-            # Find the work/edition first
             work = (
                 session.query(Work)
                 .join(WorkContributor)
                 .join(Author)
-                .filter(Work.title == title, Author.name == author)
+                .filter(_normalized_col(Work.title) == _normalize(title))
+                .filter(_normalized_col(Author.name) == _normalize(author))
                 .first()
             )
             if not work:
                 return f"Work '{title}' by {author} not found in database."
-
-            # Find first edition
-            edition = session.query(Edition).filter_by(work_id=work.id).first()
-            if not edition:
-                # Create a placeholder edition if none exists
-                edition = Edition(work=work, format="Unknown")
-                session.add(edition)
-                session.flush()
-
-            if canonical == "read":
-                history = ReadingHistory(
-                    edition=edition,
-                    user_id=user_id,
-                    date_completed=date.today(),  # Placeholder for manual addition
-                    user_notes=notes,
-                )
-                session.add(history)
-
-            session.flush()  # ADR-016
-            return f"Successfully updated status for '{title}' to {status}."
+            work_id = work.id
+        if canonical == "read":
+            logged = two_phase.add_read_event(work_id, completed=completed, rating=None, notes=notes, fmt="Unknown")
+            if logged["already_logged"]:
+                return f"'{title}' is already logged as completed {completed.isoformat()}. No new entry written."
+        note = (
+            " (completion date assumed today — ask the user when they read it if it matters)" if assumed_today else ""
+        )
+        return f"Successfully updated status for '{title}' to {status}.{note}"
     except Exception as e:
         return f"Error updating status: {str(e)}"
 

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -557,10 +557,14 @@ class LLMTropeScout(LLMScout):
         - justification: (how this trope manifests in this specific book)
 
         CRITICAL: Focus on narrative devices and archetypes. Avoid broad genres (Fantasy, Sci-Fi) or simple moods.
+        If you cannot verify that this book actually exists, return {{"tropes": []}}.
         Return ONLY a raw JSON object with a 'tropes' key containing a list of these trope objects.
         """
         text = self._llm.generate(prompt, grounded=True)
-        return self._safe_extract_json(text, "Tropes", title) or {"tropes": []}
+        data = self._safe_extract_json(text, "Tropes", title) or {}
+        # GH #98: an empty trope list means the model couldn't verify the book — return
+        # falsy so ScoutManager doesn't count this scout as a contributing source.
+        return data if data.get("tropes") else {}
 
 
 # --- THE MANAGER ---
@@ -667,4 +671,11 @@ class ScoutManager:
         # Final clean up
         merged_data["genres"] = list(merged_data["genres"])
         merged_data["moods"] = list(merged_data["moods"])
+
+        # GH #98: merged_data is seeded from raw caller input, so it is ALWAYS truthy even
+        # when every scout failed or returned nothing. If no scout contributed, return {} so
+        # callers' not-found paths (books.py 404, import outcome, _run_scouts -> None) work.
+        if not merged_data["source_priority"]:
+            return {}
+
         return merged_data

--- a/src/agentic_librarian/scouts/style_manager.py
+++ b/src/agentic_librarian/scouts/style_manager.py
@@ -3,7 +3,7 @@ import os
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Style
-from agentic_librarian.scouts.utils import get_cached_embedding
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
 
 
 class StyleManager:
@@ -14,7 +14,7 @@ class StyleManager:
         self._api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         if not self._api_key:
             raise ValueError("Google API key not set for StyleManager.")
-        self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
+        self.model_name = EMBED_MODEL
 
     def _get_embedding(self, text: str) -> list[float]:
         """Fetch embedding from Gemini via the shared module-level client + cache (#101)."""

--- a/src/agentic_librarian/scouts/trope_manager.py
+++ b/src/agentic_librarian/scouts/trope_manager.py
@@ -3,7 +3,7 @@ import os
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Trope
-from agentic_librarian.scouts.utils import get_cached_embedding
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
 
 
 class TropeManager:
@@ -14,7 +14,7 @@ class TropeManager:
         self._api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         if not self._api_key:
             raise ValueError("Google API key not set for TropeManager.")
-        self.model_name = "gemini-embedding-001"  # Current GA Gemini embedding model
+        self.model_name = EMBED_MODEL
 
     def _get_embedding(self, text: str) -> list[float]:
         """Fetch embedding from Gemini via the shared module-level client + cache (#101)."""

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -6,6 +6,10 @@ from functools import lru_cache
 from google import genai
 from google.genai import types
 
+# Current GA Gemini embedding model — the single source of truth for the model name (managers
+# and the #123 warm-before-session callers all reference this instead of copying the string).
+EMBED_MODEL = "gemini-embedding-001"
+
 # Match the pgvector column dimension (Vector(1536) on Style/Trope). gemini-embedding-001
 # defaults to 3072, so we must request 1536 explicitly.
 EMBEDDING_DIMENSIONS = 1536

--- a/test/integration/test_mcp_tools.py
+++ b/test/integration/test_mcp_tools.py
@@ -224,6 +224,27 @@ def test_update_reading_status_validates_title_author_shape(db_url):
     assert "Error" in mcp_server.update_reading_status(title="x" * 501, author="A", status="read")
 
 
+@pytest.mark.db_integration
+def test_update_reading_status_dup_guard_same_resolved_date(db_url, seeded_work_id):
+    """GH #112: calling update_reading_status twice with the SAME resolved completion
+    date (here, the same year -> same Jan-1 convention date) must log only ONE
+    ReadingHistory row — the add_read_event dup guard, inherited for free."""
+    with mcp_server.db_manager.get_session() as session:
+        work = session.get(Work, UUID(seeded_work_id))
+        title = work.title
+        author = work.contributors[0].author.name
+
+    out1 = mcp_server.update_reading_status(title=title, author=author, status="read", year=2019)
+    assert "Successfully updated" in out1
+    out2 = mcp_server.update_reading_status(title=title, author=author, status="read", year=2019)
+    assert "already logged" in out2
+
+    with mcp_server.db_manager.get_session() as session:
+        rows = session.query(ReadingHistory).join(Edition).filter(Edition.work_id == UUID(seeded_work_id)).all()
+        assert len(rows) == 1
+        assert rows[0].date_completed.isoformat() == "2019-01-01"
+
+
 # ---------------------------------------------------------------------------
 # add_book_to_history tests
 # ---------------------------------------------------------------------------

--- a/test/integration/test_persist_contributor_guard.py
+++ b/test/integration/test_persist_contributor_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from agentic_librarian.db.models import Author, WorkContributor
+from agentic_librarian.db.models import Author, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl.persist import persist_enriched_work
 
@@ -49,3 +49,27 @@ def test_persist_reuses_existing_author_case_insensitively(db_url):
         session.flush()
         # the existing row is reused, not duplicated
         assert session.query(Author).filter(Author.name.ilike("casualfarmer")).count() == 1
+
+
+def test_existing_work_gains_new_contributor(db_url):
+    """#96: re-persisting an existing work links newly discovered contributors."""
+    manager = DatabaseManager(db_url)
+    row1 = {
+        "Title": "CG Work",
+        "Author_1": "Alice",
+        "format": "ebook",
+        "skip_enrichment": False,
+        "date_completed": None,
+        "genres": [],
+        "moods": [],
+    }
+    with manager.get_session() as s:
+        persist_enriched_work(s, row1, _NullManager(), _NullManager())
+        s.flush()
+    with manager.get_session() as s:
+        row2 = dict(row1)
+        row2["contributors"] = [{"name": "Alice", "role": "Author"}, {"name": "Bob", "role": "Author"}]
+        persist_enriched_work(s, row2, _NullManager(), _NullManager())
+        s.flush()
+        work = s.query(Work).filter_by(title="CG Work").one()
+        assert {(c.author.name, c.role) for c in work.contributors} == {("Alice", "Author"), ("Bob", "Author")}

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 import pytest
 
 from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user
-from agentic_librarian.db.models import Edition, ReadingHistory, Work, WorkContributor, WorkTrope
+from agentic_librarian.db.models import Author, Edition, ReadingHistory, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -43,7 +43,14 @@ def test_enrich_deep_updates_same_work_idempotently(db_url, monkeypatch):
 
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(two_phase, "db_manager", manager)
-    deep = {"enriched_tropes": [{"trope_name": "Found Family", "relevance_score": 0.9}], "narrator_names": []}
+    deep = {
+        "enriched_tropes": [{"trope_name": "Found Family", "relevance_score": 0.9}],
+        "narrator_names": [],
+        "contributors": [
+            {"name": "Frank Herbert", "role": "Author"},
+            {"name": "Kevin J. Anderson", "role": "Author"},  # deep pass discovers a co-author
+        ],
+    }
     monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
 
     work_id = _seed_work(manager, title="Dune", author="Frank Herbert")
@@ -54,6 +61,20 @@ def test_enrich_deep_updates_same_work_idempotently(db_url, monkeypatch):
     with manager.get_session() as s:
         links = s.query(WorkTrope).filter_by(work_id=work_id).all()
         assert len(links) == 1  # single trope link despite two runs
+
+        # GH #96: a co-author discovered by the deep pass must be LINKED on the existing work
+        # (previously the WorkContributor dangled and SQLAlchemy 2.0 silently dropped it), and
+        # no orphan Author rows may accumulate.
+        work = s.query(Work).filter_by(title="Dune").one()
+        roles = {(c.author.name, c.role) for c in work.contributors}
+        assert ("Kevin J. Anderson", "Author") in roles  # the co-author the fake deep scout returns
+        orphans = (
+            s.query(Author)
+            .outerjoin(WorkContributor, WorkContributor.author_id == Author.id)
+            .filter(WorkContributor.author_id.is_(None))
+            .count()
+        )
+        assert orphans == 0
 
 
 def test_enrich_deep_returns_false_for_unknown_work(db_url, monkeypatch):

--- a/test/unit/test_availability_batch.py
+++ b/test/unit/test_availability_batch.py
@@ -1,6 +1,9 @@
 """#94: Thunder fetches happen with NO session open; cache reads/writes use short sessions."""
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
+
+from sqlalchemy.dialects import postgresql
 
 from agentic_librarian.availability import service
 
@@ -71,3 +74,127 @@ def test_batch_availability_write_back_failure_still_returns_results(monkeypatch
     monkeypatch.setattr(service.overdrive, "fetch_media", lambda slug, title: [])
     out = service.batch_availability(fake_db, [{"slug": "l", "name": "L"}], [("T", "A")])
     assert out[("l", "T", "A")] == []  # fetched result survives the failed write-back
+
+
+def test_write_back_uses_upsert(monkeypatch):
+    """GH #110: the phase-3 write-back must be a durable postgresql ON CONFLICT upsert on
+    the composite PK, not a racy add-or-update. We never execute the statement against
+    sqlite — only compile it (postgresql dialect) and inspect the resulting SQL text."""
+    executed = []
+
+    class FakeSession:
+        def get(self, *a, **kw):
+            return None  # every row is a miss -> phase 3 always writes
+
+        def execute(self, stmt):
+            executed.append(stmt)
+
+        def flush(self):
+            pass
+
+    class FakeSessionCtx:
+        def __enter__(self):
+            return FakeSession()
+
+        def __exit__(self, *a):
+            return False
+
+    fake_db = MagicMock()
+    fake_db.get_session = lambda: FakeSessionCtx()
+    monkeypatch.setattr(service.overdrive, "fetch_media", lambda slug, title: [])
+
+    out = service.batch_availability(fake_db, [{"slug": "l", "name": "L"}], [("T", "A")])
+    assert out[("l", "T", "A")] == []
+
+    # exactly one upsert statement was executed for the single fetched row (eviction is a
+    # separate DELETE, asserted in test_eviction_runs_after_write_back)
+    upserts = [s for s in executed if type(s).__name__ == "Insert" and hasattr(s, "on_conflict_do_update")]
+    assert upserts, f"expected an INSERT..ON CONFLICT statement, got: {executed}"
+
+    compiled = str(upserts[0].compile(dialect=postgresql.dialect()))
+    assert "INSERT INTO availability_cache" in compiled
+    assert "ON CONFLICT (provider, library_slug, norm_title, norm_author) DO UPDATE" in compiled
+
+
+def test_eviction_runs_after_write_back(monkeypatch):
+    """GH #110: after a successful phase-3 write, stale rows (fetched_at older than 30 days)
+    are opportunistically evicted in the same session."""
+    executed = []
+
+    class FakeSession:
+        def get(self, *a, **kw):
+            return None
+
+        def execute(self, stmt):
+            executed.append(stmt)
+
+        def flush(self):
+            pass
+
+    class FakeSessionCtx:
+        def __enter__(self):
+            return FakeSession()
+
+        def __exit__(self, *a):
+            return False
+
+    fake_db = MagicMock()
+    fake_db.get_session = lambda: FakeSessionCtx()
+    monkeypatch.setattr(service.overdrive, "fetch_media", lambda slug, title: [])
+
+    service.batch_availability(fake_db, [{"slug": "l", "name": "L"}], [("T", "A")])
+
+    deletes = [s for s in executed if type(s).__name__ == "Delete"]
+    assert deletes, f"expected a DELETE statement for eviction, got: {executed}"
+
+    compiled_sql = str(deletes[0].compile(dialect=postgresql.dialect()))
+    assert "DELETE FROM availability_cache" in compiled_sql
+    assert "fetched_at" in compiled_sql
+
+    # the cutoff bind value is ~30 days before "now" (compile with literal binds to inspect it)
+    literal_sql = str(deletes[0].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    # extract the timestamp literal and confirm it is close to now - 30 days
+    import re
+
+    m = re.search(r"fetched_at < '([^']+)'", literal_sql)
+    assert m, f"could not find cutoff literal in: {literal_sql}"
+    cutoff = datetime.fromisoformat(m.group(1))
+    if cutoff.tzinfo is None:
+        cutoff = cutoff.replace(tzinfo=UTC)
+    expected = datetime.now(UTC) - timedelta(days=30)
+    assert abs((cutoff - expected).total_seconds()) < 60  # within a minute of "now - 30d"
+
+
+def test_eviction_does_not_run_when_write_back_fails(monkeypatch):
+    """GH #110: eviction is piggybacked on a *successful* write-back only — if the upsert
+    raises, no DELETE should be issued in that session."""
+    executed = []
+
+    class FakeSession:
+        def get(self, *a, **kw):
+            return None
+
+        def execute(self, stmt):
+            executed.append(stmt)
+            if type(stmt).__name__ == "Insert":
+                raise RuntimeError("boom")
+
+        def flush(self):
+            pass
+
+    class FakeSessionCtx:
+        def __enter__(self):
+            return FakeSession()
+
+        def __exit__(self, *a):
+            return False
+
+    fake_db = MagicMock()
+    fake_db.get_session = lambda: FakeSessionCtx()
+    monkeypatch.setattr(service.overdrive, "fetch_media", lambda slug, title: [])
+
+    out = service.batch_availability(fake_db, [{"slug": "l", "name": "L"}], [("T", "A")])
+    assert out[("l", "T", "A")] == []  # best-effort: fetched result still returned
+
+    deletes = [s for s in executed if type(s).__name__ == "Delete"]
+    assert not deletes, "eviction must not run after a failed write-back"

--- a/test/unit/test_embed_warming.py
+++ b/test/unit/test_embed_warming.py
@@ -1,0 +1,100 @@
+"""#123: embedding texts are collected from the scout row and warmed BEFORE any session."""
+
+from unittest.mock import MagicMock, patch
+
+from agentic_librarian.etl.persist import collect_embedding_texts
+
+
+def test_collects_trope_and_style_texts():
+    row = {
+        "enriched_tropes": [{"trope_name": "Found Family"}, {"trope_name": "Slow Burn"}],
+        "author_style": {"pacing": "leisurely"},
+        "work_style": {"tone": "wry"},
+        "narrator_styles": {"Sam": {"accent": "Irish"}},
+        "genres": ["Fantasy"],
+        "moods": ["Cozy"],
+    }
+    texts = collect_embedding_texts(row)
+    assert {"Found Family", "Slow Burn", "leisurely", "wry", "Irish"} <= set(texts)
+    assert "Fantasy" not in texts  # real tropes present -> no fallback tags
+
+
+def test_collects_fallback_tags_when_no_real_tropes():
+    row = {
+        "enriched_tropes": [],
+        "genres": ["Fantasy"],
+        "moods": ["Cozy"],
+        "author_style": {},
+        "work_style": {},
+        "narrator_styles": {},
+    }
+    texts = collect_embedding_texts(row)
+    assert set(texts) & {"Fantasy", "Cozy"}  # cleaned fallback tags included
+
+
+def test_no_fallback_tags_when_write_fallback_tropes_false():
+    """The two-phase fast pass opts out of fallback tropes (#65) — warming must not embed
+    genre/mood tags it will never persist as tropes."""
+    row = {
+        "enriched_tropes": [],
+        "genres": ["Fantasy"],
+        "moods": ["Cozy"],
+        "author_style": {},
+        "work_style": {},
+        "narrator_styles": {},
+        "write_fallback_tropes": False,
+    }
+    texts = collect_embedding_texts(row)
+    assert texts == []
+
+
+def test_persist_row_warms_before_session(monkeypatch):
+    from agentic_librarian.enrichment import two_phase
+
+    session_state = {"open": 0}
+    warmed_during = []
+
+    class FakeSession:
+        def __enter__(self):
+            session_state["open"] += 1
+            m = MagicMock()
+            # dedup query chain returns None (no existing work) so enrich_fast proceeds to scouts
+            m.query.return_value.join.return_value.join.return_value.filter.return_value.filter.return_value.first.return_value = None
+            return m
+
+        def __exit__(self, *a):
+            session_state["open"] -= 1
+            return False
+
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: FakeSession()
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+
+    row = {
+        "Title": "New Book",
+        "Author_1": "New Author",
+        "format": "ebook",
+        "enriched_tropes": [{"trope_name": "Found Family"}],
+        "author_style": {},
+        "work_style": {},
+        "narrator_styles": {},
+        "genres": [],
+        "moods": [],
+        "write_fallback_tropes": False,
+    }
+
+    def fake_run_scouts(manager, **kwargs):
+        return row
+
+    def fake_embed(model, text):
+        warmed_during.append(session_state["open"])
+        return [0.0]
+
+    monkeypatch.setattr(two_phase, "_run_scouts", fake_run_scouts)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", fake_embed)
+    monkeypatch.setattr(two_phase, "persist_enriched_work", lambda *a, **k: MagicMock())
+
+    with patch.object(two_phase, "create_fast_scout_manager", return_value=MagicMock()):
+        two_phase.enrich_fast("New Book", "New Author")
+
+    assert warmed_during and all(n == 0 for n in warmed_during)

--- a/test/unit/test_mcp_tools.py
+++ b/test/unit/test_mcp_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -127,22 +128,64 @@ def test_check_reading_history_mock(mock_db_manager):
 
 def test_update_reading_status_mock(mock_db_manager):
     session = mock_db_manager.get_session.return_value.__enter__.return_value
+    _mock_work_lookup(session)
 
-    mock_work = Work(id="work-uuid", title="Test Book")
+    with patch("agentic_librarian.mcp.server.two_phase.add_read_event") as mock_add_read_event:
+        mock_add_read_event.return_value = {"read_number": 1, "already_logged": False}
+        resp = update_reading_status("Test Book", "Author", "read")
 
-    # Mock the work query
+    assert "Successfully updated" in resp
+    mock_add_read_event.assert_called_once()
+
+
+def _mock_work_lookup(session, work_id="work-uuid"):
+    """update_reading_status's rewritten body only needs the work lookup to resolve an
+    id — the read-event write itself goes through two_phase.add_read_event (mocked
+    separately per test), not this session."""
+    mock_work = Work(id=work_id, title="Test Book")
     mock_query = session.query.return_value
     mock_query.join.return_value = mock_query
     mock_query.filter.return_value = mock_query
     mock_query.first.return_value = mock_work
+    return mock_work
 
-    # Mock the edition query (filter_by)
-    mock_query.filter_by.return_value.first.return_value = MagicMock()
 
-    resp = update_reading_status("Test Book", "Author", "read")
+def test_update_reading_status_honors_year(mock_db_manager):
+    session = mock_db_manager.get_session.return_value.__enter__.return_value
+    _mock_work_lookup(session)
+
+    with patch("agentic_librarian.mcp.server.two_phase.add_read_event") as mock_add_read_event:
+        mock_add_read_event.return_value = {"read_number": 1, "already_logged": False}
+        resp = update_reading_status("Test Book", "Author", "read", year=2019)
+
+    assert mock_add_read_event.call_args.kwargs["completed"] == date(2019, 1, 1)
+    assert "assumed" not in resp
     assert "Successfully updated" in resp
-    session.add.assert_called()
-    session.flush.assert_called()
+
+
+def test_update_reading_status_rejects_bad_year(mock_db_manager):
+    resp = update_reading_status("Test Book", "Author", "read", year=1200)
+    assert "Error" in resp
+    assert f"1900 and {date.today().year}" in resp
+
+
+def test_update_reading_status_flags_assumed_today(mock_db_manager):
+    session = mock_db_manager.get_session.return_value.__enter__.return_value
+    _mock_work_lookup(session)
+
+    with patch("agentic_librarian.mcp.server.two_phase.add_read_event") as mock_add_read_event:
+        mock_add_read_event.return_value = {"read_number": 1, "already_logged": False}
+        resp = update_reading_status("Test Book", "Author", "read")
+
+    assert mock_add_read_event.call_args.kwargs["completed"] == date.today()
+    assert "assumed" in resp
+
+
+def test_update_reading_status_rejects_future_date(mock_db_manager):
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    resp = update_reading_status("Test Book", "Author", "read", date_completed=tomorrow)
+    assert "Error" in resp
+    assert "future" in resp
 
 
 def test_get_user_trope_preferences_mock(mock_db_manager):

--- a/test/unit/test_mcp_tools.py
+++ b/test/unit/test_mcp_tools.py
@@ -138,15 +138,17 @@ def test_update_reading_status_mock(mock_db_manager):
     mock_add_read_event.assert_called_once()
 
 
-def _mock_work_lookup(session, work_id="work-uuid"):
-    """update_reading_status's rewritten body only needs the work lookup to resolve an
-    id — the read-event write itself goes through two_phase.add_read_event (mocked
-    separately per test), not this session."""
+def _mock_work_lookup(session, work_id="work-uuid", editions=()):
+    """update_reading_status's rewritten body needs the work lookup to resolve an id, plus
+    an edition-format lookup (same session, same mocked query chain) — the read-event write
+    itself goes through two_phase.add_read_event (mocked separately per test), not this
+    session. `editions` stubs the edition-format query's .all() result."""
     mock_work = Work(id=work_id, title="Test Book")
     mock_query = session.query.return_value
     mock_query.join.return_value = mock_query
     mock_query.filter.return_value = mock_query
     mock_query.first.return_value = mock_work
+    mock_query.all.return_value = list(editions)
     return mock_work
 
 
@@ -186,6 +188,40 @@ def test_update_reading_status_rejects_future_date(mock_db_manager):
     resp = update_reading_status("Test Book", "Author", "read", date_completed=tomorrow)
     assert "Error" in resp
     assert "future" in resp
+
+
+def test_update_reading_status_reuses_sole_edition_format(mock_db_manager):
+    """Exactly one edition on the work -> its format is reused instead of "Unknown"."""
+    session = mock_db_manager.get_session.return_value.__enter__.return_value
+    sole_edition = MagicMock(format="audiobook")
+    _mock_work_lookup(session, editions=[sole_edition])
+
+    with patch("agentic_librarian.mcp.server.two_phase.add_read_event") as mock_add_read_event:
+        mock_add_read_event.return_value = {"read_number": 1, "already_logged": False}
+        resp = update_reading_status("Test Book", "Author", "read")
+
+    assert mock_add_read_event.call_args.kwargs["fmt"] == "audiobook"
+    assert "Successfully updated" in resp
+
+
+@pytest.mark.parametrize(
+    "editions",
+    [
+        [],
+        [MagicMock(format="ebook"), MagicMock(format="audiobook")],
+    ],
+    ids=["zero_editions", "two_editions"],
+)
+def test_update_reading_status_falls_back_to_unknown_format(mock_db_manager, editions):
+    """Zero or multiple (ambiguous) editions -> "Unknown", same as before the fix."""
+    session = mock_db_manager.get_session.return_value.__enter__.return_value
+    _mock_work_lookup(session, editions=editions)
+
+    with patch("agentic_librarian.mcp.server.two_phase.add_read_event") as mock_add_read_event:
+        mock_add_read_event.return_value = {"read_number": 1, "already_logged": False}
+        update_reading_status("Test Book", "Author", "read")
+
+    assert mock_add_read_event.call_args.kwargs["fmt"] == "Unknown"
 
 
 def test_get_user_trope_preferences_mock(mock_db_manager):

--- a/test/unit/test_metadata_scout.py
+++ b/test/unit/test_metadata_scout.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -373,3 +374,54 @@ def test_claude_grounded_scouts_produce_styles_and_tropes(monkeypatch):
     assert tropes.get("tropes"), "expected non-empty tropes from the Claude LLMTropeScout"
     style = StyleScout(api_key="x").scout_author_style("Brandon Sanderson")
     assert style, "expected non-empty author style from the Claude StyleScout"
+
+
+def test_enrich_returns_empty_when_no_scout_contributes():
+    """#98: a title no scout can confirm must be falsy — revives the 404/not_found paths."""
+
+    class FailingScout(md_scout.BaseScout):
+        def search(self, title, author, **kwargs):
+            raise RuntimeError("boom")
+
+    class EmptyScout(md_scout.BaseScout):
+        def search(self, title, author, **kwargs):
+            return {}
+
+    manager = md_scout.ScoutManager()
+    manager.register_scout(FailingScout(), priority=1)
+    manager.register_scout(EmptyScout(), priority=2)
+
+    assert manager.enrich(title="asdfjkl", author="Nobody") == {}
+
+
+def test_enrich_truthy_when_a_scout_contributes():
+    class GenreScout(md_scout.BaseScout):
+        def search(self, title, author, **kwargs):
+            return {"genres": {"Fantasy"}}
+
+    manager = md_scout.ScoutManager()
+    manager.register_scout(GenreScout(), priority=1)
+
+    result = manager.enrich(title="Real Book", author="Real Author")
+    assert result and result["source_priority"] == ["GenreScout"]
+
+
+def test_trope_scout_empty_tropes_is_falsy(monkeypatch):
+    """An LLM that can't verify the book returns {'tropes': []} — that must NOT count as a
+    contributing source (it was truthy before and defeated the gate)."""
+    scout = md_scout.LLMTropeScout.__new__(md_scout.LLMTropeScout)
+    monkeypatch.setattr(scout, "_llm", SimpleNamespace(generate=lambda *a, **k: '{"tropes": []}'), raising=False)
+    assert scout.search("Ghost Book", "Nobody") == {}
+
+
+def test_trope_prompt_has_unknown_book_escape(monkeypatch):
+    seen = {}
+
+    def fake_generate(prompt, grounded=True):
+        seen["prompt"] = prompt
+        return '{"tropes": []}'
+
+    scout = md_scout.LLMTropeScout.__new__(md_scout.LLMTropeScout)
+    monkeypatch.setattr(scout, "_llm", SimpleNamespace(generate=fake_generate), raising=False)
+    scout.search("X", "Y")
+    assert "cannot verify" in seen["prompt"].lower()

--- a/test/unit/test_pool_config.py
+++ b/test/unit/test_pool_config.py
@@ -14,7 +14,7 @@ def test_engine_pool_flags():
     assert e.pool._pre_ping is True
     assert e.pool._recycle == 1800
     assert e.pool.size() == 5
-    assert e.pool._max_overflow == 5
+    assert e.pool._max_overflow == 2
 
 
 def test_lifespan_shares_one_manager_everywhere():

--- a/test/unit/test_trope_predicate.py
+++ b/test/unit/test_trope_predicate.py
@@ -1,0 +1,33 @@
+"""#111: ONE predicate for real-vs-fallback tropes (the #69-corrected semantics —
+justification is NEVER consulted)."""
+
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
+
+
+def test_genre_reencoded_trope_is_fallback():
+    assert is_fallback_trope_name("Fantasy", ["Fantasy", "Romance"], ["Dark"]) is True
+
+
+def test_mood_reencoded_trope_is_fallback_case_insensitive():
+    assert is_fallback_trope_name("dark", ["Fantasy"], ["Dark"]) is True
+
+
+def test_narrative_trope_is_real():
+    assert is_fallback_trope_name("The Dark Night of the Soul", ["Fantasy"], ["Dark"]) is False
+
+
+def test_junk_name_is_neither():
+    # clean_trope_name("") -> [] — junk names are neither real nor fallback (None)
+    assert is_fallback_trope_name("", ["Fantasy"], []) is None
+
+
+def test_none_genre_mood_lists_tolerated():
+    assert is_fallback_trope_name("Found Family", None, None) is False
+
+
+def test_multi_slug_subset_is_fallback():
+    # a slug that cleans to multiple names (via tag_maps.COMBO_MAP), ALL of which are genres/moods,
+    # is a fallback (subset semantics — mirrors plan_fallback_prune's `cleaned_lower <= gm`).
+    # "science-fiction-fantasy" normalizes to "science fiction fantasy", a COMBO_MAP entry that
+    # splits into ["Science Fiction", "Fantasy"] regardless of casing (etl/tag_cleaning.py:99-128).
+    assert is_fallback_trope_name("science-fiction-fantasy", ["Science Fiction", "Fantasy"], []) is True


### PR DESCRIPTION
## What (first of two PRs from the 6.3 spec; PR-D = migrations + the gated prod dedup)

- **#96 — the verified data-loss bug**: re-persisting an existing work (every deep pass, every re-import) silently dropped newly discovered co-authors and orphaned their Author rows. The existing-work branch now merges contributors exactly like the narrator branch always has; Authors are only created when they'll be linked. **SAWarning is now a test error suite-wide** so this bug class can't scroll past again.
- **#111 — one real-vs-fallback trope predicate** (`etl/trope_predicate.py`): the #69-corrected genre/mood-membership semantics, now shared by the prune tool and persist's guard (which had silently kept the unreliable `justification` heuristic). PR-D's reconciliation sweep consumes the same helper.
- **#98 — garbage titles can no longer enter the catalog**: `enrich()` returns falsy when no scout contributed (reviving the dead /books 404 and import `not_found` paths), and the trope scout has an unknown-book escape so the LLM can't hallucinate tropes for nonexistent titles. Product note: real-but-unindexed books now land `not_found` instead of creating bare works — messaging line queued for the #97/6.5 bucket.
- **#112 — update_reading_status tells the truth**: normalized lookup (the file's last exact-match), optional `date_completed`/`year` params (Jan-1 convention, documented), the same dup guard as add_book_to_history, an "assumed today" flag when no date is given, edition-format reuse instead of always minting "Unknown", and both agent prompts now ask for a year on "read that years ago" feedback.
- **#110 — availability cache races closed**: first `ON CONFLICT DO UPDATE` in the repo on the composite PK (both write paths), plus 30-day eviction piggybacked on writes. The `# GH #110` TODO in the code is retired.
- **#123 — embeds out of DB sessions**: the embedding LRU is warmed before write sessions (persist paths) and before the search tools' query sessions — zero signature changes — and the pool tightens to its 5+2 target. The final review verified the warm strings match the in-session requests string-for-string, and found the warm-before-session ordering acts as a circuit breaker under a hard Gemini outage (the request dies before any session opens). Documented residuals honestly this time (warm-failure degradation; /analysis one-time anchors).

## ⚠️ Merge gate

**Wait for CI green**: this run is the first real-Postgres execution of the SAWarning-as-error promotion, the #96 regression tests, the #112 dup-guard test, and the #110 upsert.

## Review trail

6 tasks × (implementer + spec/quality review), whole-branch final review (verdict: with fixes — 3 doc/consistency items + 1 adopted improvement, all landed and re-reviewed). Outage math for the 5+2 pool was reasoned end-to-end: hard outage self-defeats pre-session; the intermittent-429 bruise is a degraded blip bounded by queue concurrency, with PR-D's requeue sweep as recovery.

## After merge

Deploy watch → PR-D: one migration (uniques + FK indexes + timestamptz + `deep_enriched_at`), get-or-create constraint backstops (incl. `log_suggestion` dedup — #88's root cause), advisory lock, #97 status/sweep — and the **user-gated dedup dry-run** on prod before the constraints land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUR4CLRn6yCUWV4Nubkhtb