### PR TITLE
feat: Phase 6.3b schema integrity — constraints, timestamptz, enrichment status, gated dedup (#95 #97 #108 #109)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This project maintains institutional knowledge in `docs/project_notes/` for cons
 ## Memory-Aware Protocols
 
 **Before starting implementation:**
-- Review [testing_strategy.md](file:///c:/Users/Justin.Merrick/Python_Code/Projects/agentic_librarian/agentic_librarian/docs/testing_strategy.md) to ensure adherence to TDD, coverage, and the **Anti-Hardcoding** mandate.
+- Review [testing_strategy.md](docs/testing_strategy.md) to ensure adherence to TDD, coverage, and the **Anti-Hardcoding** mandate.
 - **NEVER** implement logic that only satisfies specific test inputs; logic must be generalized and verified with parameterized tests.
 
 **Before proposing architectural changes:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ that every single-pass review missed.
     "CI is the gate for X" is a fine sentence; claiming an unrun test passed is not.
     Comments and ADRs must not overclaim invariants the code doesn't have — name the
     residuals (this bit us three times on one pool-sizing premise before we learned).
+11. **Rehearse operator tooling against the PRE-state schema, not just the post-state.**
+    A migration-gating tool (dedup, backfill, pre-flight check) runs by design against
+    the schema that exists BEFORE the migration it clears the way for — but the branch's
+    ORM models already describe the AFTER. Every test environment that runs the full
+    migration chain first will pass while prod fails with UndefinedColumn on the first
+    entity load (found live, phase 6.3: the dedup gate selected `deep_enriched_at` from
+    a prod that didn't have it yet). Rules: gate-path queries are column-explicit for any
+    model the same branch alters (never entity-load it — state the invariant in a module
+    comment), and the tool gets a fixture test that DROPS the new columns/constraints to
+    mirror the true pre-migration schema.
 
 ## Mechanics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md — Shelfwright (agentic_librarian)
+
+Institutional memory lives in `docs/project_notes/` (bugs, decisions/ADRs, key_facts,
+issues) — read AGENTS.md for the memory protocols. Testing fundamentals (TDD, pyramid,
+anti-hardcoding, dual-verification) live in `docs/testing_strategy.md`. This file adds the
+verification mentality proven during the Phase 6 hardening (2026-07): it caught a verified
+data-loss bug, a cold-start auth race, a review-gate bypass, and an operation-flip hole
+that every single-pass review missed.
+
+## Verification mentality (additions to testing_strategy.md)
+
+1. **Assertion completeness beats test level.** The #96 contributor-loss bug lived for
+   weeks inside a test that executed the exact buggy path but asserted only trope counts.
+   When you write or extend a test, assert on EVERY side effect the operation promises —
+   not just the one the task is about. A test that runs the right code and checks the
+   wrong things is worse than no test: it certifies the bug.
+2. **Warnings are errors.** `filterwarnings = ["error::sqlalchemy.exc.SAWarning"]` is
+   suite policy. Never downgrade it; when a warning appears, it has already found a bug
+   twice (silent non-flush #96; backref-append-before-add in new code). Extend the policy
+   to new warning classes when a framework starts telling you something.
+3. **Test invariants directly.** The house pattern for "no session may be open during X":
+   a counting fixture asserting `open_sessions_during_scout == 0` (see
+   `test_two_phase_sessions.py`, `test_embed_warming.py`). When a design rule matters,
+   write the probe that measures the rule itself, not a proxy.
+4. **Dialect-specific SQL: compile-inspect locally, execute in CI.** App models are
+   Postgres-only (pgvector, JSONB) — never run them on sqlite. pg-dialect statements
+   (ON CONFLICT, advisory locks) get local unit tests that compile with
+   `postgresql.dialect()` and assert the SQL, plus `db_integration` tests that execute
+   for real. Guard pg-only runtime calls behind `session.get_bind().dialect.name`.
+5. **`db_integration` tests execute FIRST in CI — treat the PR's first CI run as a merge
+   gate, not a formality.** Local runs deselect them (no Postgres) unless the compose db
+   is up (`POSTGRES_HOST=localhost` override works). If you re-seam a mocked boundary,
+   grep the integration suites for patches of the OLD seam — they break in CI first.
+6. **Operator tools that mutate prod data get e2e-shaped workflow tests.** The
+   dedup gate's same-second report-overwrite bug was caught by a test that drove the real
+   dry-run→apply CLI round-trip. For anything with a review→apply workflow: plan and
+   apply must be tested as the operator will actually run them, and apply must consume
+   (and cross-check against) exactly what was reviewed — refuse on ANY drift, including
+   operation changes on the same row (tag tokens with their operation).
+7. **Destructive data operations use structural distinguishers only** (the #69 lesson,
+   memory `verify-backfill-distinguisher`): never classify rows by a sometimes-populated
+   column. Plan → print/persist the full id list → apply exactly the plan. Dry-run
+   reports are the artifact the human approves; the gate is only real if apply refuses
+   when reality drifted from the report.
+8. **Adversarial review passes pay for themselves on concurrency and time-window code.**
+   Tests structurally cannot see: races (cold-start init, thread-pool contention), what
+   an event loop's accidental serialization used to protect, drift between two CLI
+   invocations, retry×timeout arithmetic vs platform deadlines. After the per-task and
+   whole-branch reviews, run one more pass with an explicit "assume something was missed;
+   hunt runtime failure modes tests can't see" charter — in Phase 6 it found real bugs
+   twice after both human-configured reviewers and Gemini came back clean.
+9. **Verify claimed baselines with `git stash`.** "These test failures are pre-existing"
+   is a claim: prove it by stashing the diff and re-running. The suite has a small set of
+   known env-dependent failures (live-network, `db` hostname, optional `claude_agent_sdk`)
+   — name them explicitly in reports instead of hand-waving "some failures".
+10. **Report honestly.** State what was executed vs collected vs reasoned-by-inspection.
+    "CI is the gate for X" is a fine sentence; claiming an unrun test passed is not.
+    Comments and ADRs must not overclaim invariants the code doesn't have — name the
+    residuals (this bit us three times on one pool-sizing premise before we learned).
+
+## Mechanics
+
+- Tests: `.venv/Scripts/python -m pytest ...` from the repo root (Windows host venv).
+- Lint AND format before every commit: `uvx ruff check <files>` **and**
+  `uvx ruff format <files>` — CI pre-commit enforces format; check alone is not enough.
+- Full unit suite before each commit; focused tests while iterating.
+- No `[skip ci]` anywhere in commit messages (see bugs.md 2026-06-17 / GH #90).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,7 +13,7 @@ This project maintains institutional knowledge in `docs/project_notes/` for cons
 ## Memory-Aware Protocols
 
 **Before starting implementation:**
-- Review [testing_strategy.md](file:///c:/Users/Justin.Merrick/Python_Code/Projects/agentic_librarian/agentic_librarian/docs/testing_strategy.md) to ensure adherence to TDD, coverage, and the **Anti-Hardcoding** mandate.
+- Review [testing_strategy.md](docs/testing_strategy.md) to ensure adherence to TDD, coverage, and the **Anti-Hardcoding** mandate.
 - **NEVER** implement logic that only satisfies specific test inputs; logic must be generalized and verified with parameterized tests.
 - **Single With Statements**: Always combine multiple context managers into a single `with` statement (e.g., `with A, B:`) to avoid SIM117 errors.
 - **No Broad Except-Pass**: Never use `except Exception: pass`. Handle specific exceptions or log errors to ensure visibility of failures.

--- a/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
+++ b/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
@@ -34,9 +34,12 @@ TIMESTAMPTZ_COLUMNS: list[tuple[str, str]] = [
     ("import_rows", "updated_at"),
 ]
 
-# GH #109: FK/join-column indexes missing on the hot query paths.
+# GH #109: FK/join-column indexes missing on the hot query paths. NOTE (final-review Minor 5):
+# editions.work_id deliberately does NOT get its own ix_editions_work_id here — the
+# uq_editions_work_format unique index below is (work_id, format), and a leading column of a
+# composite/multi-column index already serves lookups on that column alone (standard btree
+# behavior), so a separate single-column index would be redundant.
 FK_INDEXES: list[tuple[str, str]] = [
-    ("editions", "work_id"),
     ("reading_history", "edition_id"),
     ("work_tropes", "trope_id"),
     ("work_contributors", "author_id"),

--- a/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
+++ b/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
@@ -1,0 +1,105 @@
+"""phase 6.3 schema hardening — uniques, FK indexes, timestamptz, deep_enriched_at
+
+Revision ID: 48e3762d6c0c
+Revises: c4f81a2d9b6e
+Create Date: 2026-07-12 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "48e3762d6c0c"
+down_revision: str | None = "c4f81a2d9b6e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# GH #108: 13 naive DateTime columns promoted to timestamptz (UTC-assumed on convert).
+TIMESTAMPTZ_COLUMNS: list[tuple[str, str]] = [
+    ("suggestions", "suggested_at"),
+    ("conversations", "created_at"),
+    ("conversations", "updated_at"),
+    ("messages", "created_at"),
+    ("users", "created_at"),
+    ("usage", "created_at"),
+    ("user_credentials", "created_at"),
+    ("user_credentials", "updated_at"),
+    ("user_libraries", "created_at"),
+    ("availability_cache", "fetched_at"),
+    ("import_jobs", "created_at"),
+    ("import_rows", "created_at"),
+    ("import_rows", "updated_at"),
+]
+
+# GH #109: FK/join-column indexes missing on the hot query paths.
+FK_INDEXES: list[tuple[str, str]] = [
+    ("editions", "work_id"),
+    ("reading_history", "edition_id"),
+    ("work_tropes", "trope_id"),
+    ("work_contributors", "author_id"),
+    ("suggestions", "work_id"),
+    ("author_styles", "style_id"),
+    ("work_styles", "style_id"),
+    ("usage", "conversation_id"),
+    ("narrator_styles", "style_id"),
+    ("edition_narrators", "narrator_id"),
+]
+
+# GH #95: dedup-backstop unique constraints/indexes. Functional/partial/NULLS-NOT-DISTINCT
+# ones can't be expressed via op.create_index — raw DDL via op.execute (both directions).
+UNIQUE_INDEXES: list[tuple[str, str, str]] = [
+    ("uq_authors_name_lower", "authors", "CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))"),
+    (
+        "uq_narrators_name_lower",
+        "narrators",
+        "CREATE UNIQUE INDEX uq_narrators_name_lower ON narrators (lower(name))",
+    ),
+    (
+        "uq_editions_work_format",
+        "editions",
+        "CREATE UNIQUE INDEX uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT",
+    ),
+    (
+        "uq_reading_history_user_edition_date",
+        "reading_history",
+        "CREATE UNIQUE INDEX uq_reading_history_user_edition_date "
+        "ON reading_history (user_id, edition_id, date_completed)",
+    ),
+    (
+        "uq_suggestions_active",
+        "suggestions",
+        "CREATE UNIQUE INDEX uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'",
+    ),
+]
+
+
+def upgrade() -> None:
+    for table, column in TIMESTAMPTZ_COLUMNS:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN {column} TYPE timestamptz USING {column} AT TIME ZONE 'UTC'")
+
+    op.add_column("works", sa.Column("deep_enriched_at", sa.DateTime(timezone=True), nullable=True))
+
+    for table, column in FK_INDEXES:
+        op.create_index(f"ix_{table}_{column}", table, [column])
+
+    for _name, _table, create_sql in UNIQUE_INDEXES:
+        op.execute(create_sql)
+
+
+def downgrade() -> None:
+    for name, _table, _create_sql in reversed(UNIQUE_INDEXES):
+        op.execute(f"DROP INDEX {name}")
+
+    for table, column in reversed(FK_INDEXES):
+        op.drop_index(f"ix_{table}_{column}", table_name=table)
+
+    op.drop_column("works", "deep_enriched_at")
+
+    for table, column in reversed(TIMESTAMPTZ_COLUMNS):
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN {column} TYPE timestamp without time zone "
+            f"USING {column} AT TIME ZONE 'UTC'"
+        )

--- a/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
+++ b/alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
@@ -82,6 +82,13 @@ def upgrade() -> None:
 
     op.add_column("works", sa.Column("deep_enriched_at", sa.DateTime(timezone=True), nullable=True))
 
+    # Backfill: works that already carry ANY trope link were built by the full ETL/deep
+    # pipeline — stamp them so the first --requeue-unenriched sweep is signal, not the
+    # whole catalog. Works with zero trope links stay NULL (genuinely never deep-enriched);
+    # fallback-only works are stamped here but correctly surface under the sweep's
+    # no_real_trope reason (the predicate runs in app code, not here).
+    op.execute("UPDATE works SET deep_enriched_at = now() WHERE id IN (SELECT DISTINCT work_id FROM work_tropes)")
+
     for table, column in FK_INDEXES:
         op.create_index(f"ix_{table}_{column}", table, [column])
 

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1046,3 +1046,103 @@ This file documents key architectural decisions, their context, and trade-offs.
   `_safe_standardize` (bounded: enrich queue is 4-concurrent; PR-D's requeue sweep is the
   recovery), and `/analysis` embeds ~24 radar anchor texts inside its session once per
   process (first call only, then module-cached).
+
+### ADR-060: Constraint-backed get-or-create + advisory-lock works dedup + gated backfill (2026-07-12)
+**Context:**
+- Every "look up or create" site in the codebase was a bare SELECT-then-INSERT with no DB
+  backstop — a race between two concurrent writers (two chat sessions adding the same book,
+  a bulk import overlapping a fast-add) could both miss the SELECT and both INSERT,
+  producing duplicate Authors/Narrators/Editions/reading_history/suggestions rows. `log_suggestion`
+  (mcp) had ZERO dedup while the import worker's `_upsert_suggestion` was idempotent — this
+  asymmetry is #88's likely root cause. Editions had three get-or-create sites, one
+  (`etl/ingest.py`'s `to_models` generator) entirely unguarded. The corrected #69 fallback-trope
+  predicate (structural: clean-name ⊆ genres∪moods, case-folded) had already taught the
+  project's hardest lesson about backfills — never trust a sometimes-populated column as a
+  class label; group on real relationships or normalized values instead.
+- Works have no natural cross-table unique key (title+author spans the Work/Author/
+  WorkContributor tables), so a DB-level unique constraint isn't directly expressible the
+  way it is for Authors/Narrators/Editions.
+- Spec: `docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md` (PR-D design,
+  "Dedup backfill (THE USER GATE)"); user ground rule (2026-07-12): prod backfills/migrations
+  require a dry-run report + user approval before applying.
+**Decision:**
+- **Five unique indexes** added in migration `48e3762d6c0c`: `uq_authors_name_lower`
+  (`lower(name)`), `uq_narrators_name_lower` (`lower(name)`), `uq_editions_work_format`
+  (`work_id, format` with `NULLS NOT DISTINCT`, PG16), `uq_reading_history_user_edition_date`
+  (`user_id, edition_id, date_completed`), `uq_suggestions_active` (`user_id, work_id` WHERE
+  `status = 'Suggested'` — partial, so historical non-active suggestions can repeat).
+- **`db/get_or_create.py`** — two helpers, both SAVEPOINT-scoped (`session.begin_nested()`)
+  so a rolled-back insert doesn't kill the caller's outer transaction: `get_or_create`
+  (query → insert → on `IntegrityError` re-query with the SAME `filter_by(**filters)`
+  predicate — correct when the DB constraint matches the filter 1:1, e.g. editions,
+  reading_history, suggestions) and `insert_or_requery` (for sites where the constraint is
+  NOT an exact-match predicate, e.g. authors/narrators' `lower(name)` unique fires on a
+  case-variant that an exact `filter_by(name=...)` re-query would miss — callers keep their
+  existing case-insensitive first-query and supply a matching `requery` callable for the
+  recovery path). Adopted at: authors/narrators and all edition sites in `persist.py`,
+  `two_phase.add_read_event`, reading_history (date-guard plus the constraint as backstop),
+  suggestions (worker's `_upsert_suggestion` AND `log_suggestion`, which gains dedup for the
+  first time — closes #88's root cause).
+- **Works dedup = advisory lock, not a unique constraint**: `enrich_fast`'s write session
+  runs `SELECT pg_advisory_xact_lock(hashtext(:k))` (key = normalized `title|author`,
+  Postgres-only, skipped on sqlite test URLs) before its dedup re-check, serializing
+  concurrent same-book creators without needing a cross-table DB constraint. Xact-scoped —
+  released on commit.
+- **The gated backfill** (`etl/dedup_backfill.py` + `scripts/clean_catalog.py
+  --dedup-for-constraints`): a `plan_dedup`/`apply_dedup` split, read-only plan then apply-
+  exactly-what-was-planned (never re-derived at apply time, so a row that vanished between
+  plan and apply is skipped and counted, not silently re-planned). Seven structural
+  classes — duplicate authors/narrators (survivor = most-linked row, ties broken by lowest
+  id; Author/Narrator have no `created_at` so "oldest" isn't available), duplicate editions
+  (per `(work_id, COALESCE(format,''))`), exact-duplicate reading_history and Suggested
+  suggestions (keep oldest), orphan authors (zero `work_contributors` AND zero
+  `author_styles` — computed against CURRENT state, not simulated against this run's own
+  not-yet-applied author merges, by design), and `duplicate_works_report_only` (normalized
+  title+author collisions — REPORT ONLY, never applied; work merges are complex enough that
+  the operator triages case by case). Every class groups on real relationships or
+  normalized values — never a sometimes-populated column — the #69 lesson made structural
+  policy here, not just a one-off fix.
+- **Apply-time drift cross-check** (added after PR-D's own dedup-planner review surfaced
+  the gap): `--apply` is a separate invocation from the reviewed dry-run and re-plans from
+  scratch against prod's live state. `plan_id_set`/`plan_delta` turn a plan into a per-class,
+  **operation-tagged** id set (`merge:`/`repoint:`/`delete:`/`report:` prefixes, so an id
+  whose operation flipped between the reviewed report and the fresh plan — e.g. a concurrent
+  write turns a reviewed `repoint` into a `delete` — surfaces as a new token, not an
+  unchanged bare id) and the CLI refuses `--apply` outright if the fresh plan contains
+  anything the operator's reviewed report doesn't cover, writing a fresh report for
+  re-review instead of proceeding. Ids that only vanished (rows deleted/changed since
+  review) are fine and apply normally under ordinary `skipped_stale` accounting.
+- Full rollout mechanics (pg_dump, dry-run review, apply, `alembic upgrade head`, merge,
+  post-checks): `docs/runbooks/phase6-3-schema-rollout.md`.
+**Alternatives Considered:**
+- A cross-table unique constraint on works (normalized title+author) → rejected: the
+  natural key spans Work/Author/WorkContributor, so it isn't expressible as a single-table
+  index the way editions/authors/narrators are; the advisory lock plus a report-only sweep
+  covers the concurrency risk without a schema contortion.
+- Simulating orphan-author detection ahead of this run's own not-yet-applied merges →
+  rejected: would make the plan's ids depend on the plan's own outcome, breaking "apply
+  exactly what plan showed"; a documented re-run-until-clean loop is simpler and honest
+  about the ordering.
+- Trusting the dry-run's in-memory plan at apply time (no re-plan, no drift check) →
+  rejected during PR-D's own review: the two invocations are minutes apart in practice and
+  live traffic could create genuinely new duplicates in the gap: applying blind would defeat
+  the user-gate's purpose.
+**Consequences:**
+- `IntegrityError` on a get-or-create race is now a recoverable re-query, not a crash or (in
+  request-serving code) a 500 — the exact bug class the SELECT-then-INSERT pattern always
+  risked.
+- `log_suggestion` deduplicates for the first time, closing #88's likely root cause; note
+  left on #88 when closing.
+- The gate refuses to apply a stale or drifted plan rather than silently including duplicates
+  the operator never reviewed — the review step is load-bearing, not decorative.
+- `etl/ingest.py`'s `to_models()` generator remains intentionally unguarded: it's exercised
+  only by `test_ingest.py`, has no live call site (the real ETL write path is
+  `enriched_metadata` → `persist_enriched_work`, already constraint-backed), and is
+  adjudicated dead code rather than retrofitted — a future removal is a cheap, safe cleanup,
+  not urgent.
+- The `duplicate_works_report_only` class is a standing, not-yet-actioned list after this
+  rollout — a genuine work-merge tool is future work if the list proves large enough to
+  matter in practice.
+- Orphan-author counts can recur after any future author-merge (this rollout's own dedup
+  apply included) — the runbook documents a re-run-until-clean loop rather than promising a
+  single pass is sufficient.

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1071,6 +1071,11 @@ This file documents key architectural decisions, their context, and trade-offs.
   (`work_id, format` with `NULLS NOT DISTINCT`, PG16), `uq_reading_history_user_edition_date`
   (`user_id, edition_id, date_completed`), `uq_suggestions_active` (`user_id, work_id` WHERE
   `status = 'Suggested'` — partial, so historical non-active suggestions can repeat).
+- **`works.deep_enriched_at` backfill** — the same migration structurally stamps
+  `deep_enriched_at = now()` for every work with any `work_tropes` row (evidence it already
+  went through the deep pipeline) immediately after adding the column, so the #97
+  `--requeue-unenriched` sweep's first run reports only genuine gaps instead of the entire
+  pre-existing catalog.
 - **`db/get_or_create.py`** — two helpers, both SAVEPOINT-scoped (`session.begin_nested()`)
   so a rolled-back insert doesn't kill the caller's outer transaction: `get_or_create`
   (query → insert → on `IntegrityError` re-query with the SAME `filter_by(**filters)`

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -78,7 +78,7 @@ This file tracks important project configuration, constants, and environment det
   Nightly automated backups (09:00 UTC) + 7-day PITR enabled 2026-07-12 (GH #91; codified in
   `infra/02-cloudsql.sh`).
   Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per API process (GH #102/#94) — 2 instances × 7 = 14 of db-f1-micro's ~25 connections; #123 landed (embeds warmed into the LRU before write/search sessions, so overflow tightened from 5).
-  5 unique indexes (authors/narrators case-insensitive name, editions work+format, reading_history, active suggestions), 10 FK indexes, 13 timestamptz columns, and `works.deep_enriched_at` live as of the Phase 6.3 migration (`48e3762d6c0c`, GH #95/#97/#108/#109) — see ADR-060 and `docs/runbooks/phase6-3-schema-rollout.md`.
+  5 unique indexes (authors/narrators case-insensitive name, editions work+format, reading_history, active suggestions), 9 FK indexes (editions.work_id deliberately excluded — uq_editions_work_format's leading column already serves it), 13 timestamptz columns, and `works.deep_enriched_at` live as of the Phase 6.3 migration (`48e3762d6c0c`, GH #95/#97/#108/#109) — see ADR-060 and `docs/runbooks/phase6-3-schema-rollout.md`.
 - **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
   `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
   the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.

--- a/docs/project_notes/key_facts.md
+++ b/docs/project_notes/key_facts.md
@@ -78,6 +78,7 @@ This file tracks important project configuration, constants, and environment det
   Nightly automated backups (09:00 UTC) + 7-day PITR enabled 2026-07-12 (GH #91; codified in
   `infra/02-cloudsql.sh`).
   Engine pools: `pool_pre_ping` + 30-min recycle, 5+2 per engine, one shared engine per API process (GH #102/#94) — 2 instances × 7 = 14 of db-f1-micro's ~25 connections; #123 landed (embeds warmed into the LRU before write/search sessions, so overflow tightened from 5).
+  5 unique indexes (authors/narrators case-insensitive name, editions work+format, reading_history, active suggestions), 10 FK indexes, 13 timestamptz columns, and `works.deep_enriched_at` live as of the Phase 6.3 migration (`48e3762d6c0c`, GH #95/#97/#108/#109) — see ADR-060 and `docs/runbooks/phase6-3-schema-rollout.md`.
 - **Deploys**: automatic on merge to `main` touching `src/**`/`pyproject.toml`/
   `Dockerfile.api` (`.github/workflows/deploy.yml`, WIF keyless); manual redeploy via
   the Actions tab (`workflow_dispatch`). Images in Artifact Registry, tags = git SHAs.

--- a/docs/runbooks/phase6-3-schema-rollout.md
+++ b/docs/runbooks/phase6-3-schema-rollout.md
@@ -233,9 +233,11 @@ docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gate
   `user_libraries.created_at`, `availability_cache.fetched_at`, `import_jobs.created_at`,
   `import_rows.created_at`/`updated_at`. (`availability_cache.fetched_at` deliberately
   keeps NO column default — don't be alarmed it's the one without.)
-- **`works.deep_enriched_at`** — new nullable `timestamptz` column, NULL for every
-  pre-existing row (they haven't been (re)stamped by a deep pass since this landed; the
-  step 6 requeue report is exactly the tool for backfilling that).
+- **`works.deep_enriched_at`** — new nullable `timestamptz` column. The migration itself
+  backfills it to `now()` for every pre-existing work with at least one `work_tropes` row
+  (evidence it already went through the full deep pipeline); only works with zero trope
+  links stay NULL. The step 6 requeue report surfaces those NULLs plus any stamped work
+  whose only tropes are fallback/junk — see step 6 for what to expect.
 
 **Since ADR-058**, the startup migration guard tolerates a migrated-ahead DB during this
 window — the still-running old revision keeps cold-starting normally (its
@@ -295,18 +297,22 @@ for the works that need a deep pass (re)run.
      python scripts/clean_catalog.py --requeue-unenriched --dry-run
    ```
 
-   Expect every pre-existing work to show up under `never_deep_enriched` (the new column
-   is NULL for all of them — that's expected, not a bug; it doesn't mean their tropes were
-   lost, just that `deep_enriched_at` didn't exist to be stamped before now). Works that
-   already have real tropes from before this migration are still fine to leave as-is —
-   `--apply --yes` re-enqueues deep enrichment via Cloud Tasks (`CLOUD_TASKS_QUEUE`,
-   `ENRICH_TARGET_BASE_URL`, `ENRICH_INVOKER_SA` — already set in the prod container env,
-   nothing extra to configure), which is a live decision for you: applying it against the
-   full catalog re-runs deep enrichment (LLM cost) for every work, which may or may not be
-   worth it purely to backfill the timestamp. Recommendation: treat this first report as
-   informational baseline, and reserve `--apply` for the `no_real_trope` subset (the actual
-   poison-task recovery #97 exists for) unless you specifically want a full re-enrichment
-   pass.
+   The migration's `upgrade()` backfills `deep_enriched_at = now()` for every work that
+   already carries at least one `work_tropes` row (the structural signal that it was built
+   by the full ETL/deep pipeline before this column existed — see the migration's inline
+   comment) — so this first report should be SMALL, not the whole catalog. Expect only:
+   - **`never_deep_enriched`**: works with zero trope links at all (never ran through the
+     deep pass, or a #123-style warm failure that skipped every embedding).
+   - **`no_real_trope`**: works the backfill stamped (they had *a* trope link) but every
+     linked trope is fallback/junk per the #111 predicate — a poison task that exhausted
+     Cloud Tasks retries without ever landing a genuine narrative trope.
+
+   Both classes are genuinely actionable — this is the actual #97 poison-task recovery list,
+   not a baseline artifact to set aside. `--apply --yes` re-enqueues deep enrichment via
+   Cloud Tasks (`CLOUD_TASKS_QUEUE`, `ENRICH_TARGET_BASE_URL`, `ENRICH_INVOKER_SA` — already
+   set in the prod container env, nothing extra to configure) for exactly these works; it is
+   safe to apply directly against the full report rather than reserving it for a subset,
+   since the backfill already excluded already-enriched works from appearing at all.
 3. **Close the issues** — after acceptance, close #95 #96 #97 #98 #108 #109 #110 #111 #112
    with references to the resolving PRs (#124 for PR-C's #96/#98/#110/#111/#112/#123; this
    PR for #95/#97/#108/#109), and comment on #88 noting `log_suggestion` dedup closes its

--- a/docs/runbooks/phase6-3-schema-rollout.md
+++ b/docs/runbooks/phase6-3-schema-rollout.md
@@ -191,6 +191,17 @@ zero), you're done; if it finds a fresh, small orphan-author batch, that's expec
 follow-on cleanup, not a sign something went wrong. Loop steps 2→3 until a dry-run comes
 back clean.
 
+**Deferred-intersections note:** the report's `deferred_intersections` section lists
+`duplicate_editions`/`duplicate_reading_history` groups the planner deliberately DROPPED
+from this run because they intersect a `duplicate_narrators`/`duplicate_editions` group
+also in play — applying both compositions from the same plan snapshot could lose rows (a
+narrator-merge repoint living on a loser edition; an edition-merge's own reading_history
+collision-delete colliding with class 4's independent pick). **A nonzero
+`deferred_intersections` count is EXPECTED on intersecting data, not an error** — it is
+resolved the exact same way as a fresh orphan-author batch: this same steps 2→3 loop.
+Once the intersecting class (narrators, or editions) has applied, the deferred group no
+longer intersects anything on the next dry-run and applies normally.
+
 **Done when:** the apply command exits 0, prints per-class applied counts, and a
 follow-up dry-run (step 2) comes back with all classes empty except
 `duplicate_works_report_only` (never applied, expected to persist until a future manual

--- a/docs/runbooks/phase6-3-schema-rollout.md
+++ b/docs/runbooks/phase6-3-schema-rollout.md
@@ -234,10 +234,12 @@ docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gate
 - **5 unique indexes**: `uq_authors_name_lower`, `uq_narrators_name_lower`,
   `uq_editions_work_format`, `uq_reading_history_user_edition_date`,
   `uq_suggestions_active`.
-- **10 new FK indexes** (`ix_<table>_<column>`): `editions.work_id`,
-  `reading_history.edition_id`, `work_tropes.trope_id`, `work_contributors.author_id`,
-  `suggestions.work_id`, `author_styles.style_id`, `work_styles.style_id`,
-  `usage.conversation_id`, `narrator_styles.style_id`, `edition_narrators.narrator_id`.
+- **9 new FK indexes** (`ix_<table>_<column>`): `reading_history.edition_id`,
+  `work_tropes.trope_id`, `work_contributors.author_id`, `suggestions.work_id`,
+  `author_styles.style_id`, `work_styles.style_id`, `usage.conversation_id`,
+  `narrator_styles.style_id`, `edition_narrators.narrator_id`. (No standalone
+  `ix_editions_work_id` — the `uq_editions_work_format` unique index below is
+  `(work_id, format)`, and its leading column already serves lookups on `work_id` alone.)
 - **13 columns converted to timestamptz**: `suggestions.suggested_at`,
   `conversations.created_at`/`updated_at`, `messages.created_at`, `users.created_at`,
   `usage.created_at`, `user_credentials.created_at`/`updated_at`,
@@ -268,6 +270,14 @@ behind DB fails the new revision outright.
 **How:** normal squash-merge via GitHub (title = PR title, blank body — the #90 durable
 fix, no `[skip ci]` risk).
 
+**Proceed to merge promptly after migrating** (final-review Minor 4): in the window between
+step 4 (constraints landed) and this PR's deploy going live, the STILL-DEPLOYED (pre-PR-D)
+code runs against the NEW constraints — its unguarded get-or-create races now hit real
+`IntegrityError`s where they previously silently created duplicate rows. This is SAFE (no
+data corruption; the new unique constraints are exactly what's supposed to reject the race)
+but user-visible (a 500 on an unlucky concurrent write) until PR-D's constraint-backed
+`get_or_create`/`insert_or_requery` code deploys. Don't linger in this window.
+
 **Done when:** merged; the deploy workflow fires automatically (path-filtered on
 `src/**`/`pyproject.toml`/`Dockerfile.api`).
 
@@ -295,7 +305,7 @@ for the works that need a deep pass (re)run.
 **How:**
 
 1. **Constraint sanity** — a `\di` (or equivalent `information_schema.pg_indexes`) listing
-   confirms the 5 unique indexes + 10 FK indexes from step 4 exist with the expected
+   confirms the 5 unique indexes + 9 FK indexes from step 4 exist with the expected
    definitions (`lower(name)` expressions, the `NULLS NOT DISTINCT` composite, the partial
    `WHERE status = 'Suggested'` predicate). No need to attempt actual duplicate-insert
    probes — the migration's own `op.execute`d DDL either applied or the migration would
@@ -324,20 +334,34 @@ for the works that need a deep pass (re)run.
    set in the prod container env, nothing extra to configure) for exactly these works; it is
    safe to apply directly against the full report rather than reserving it for a subset,
    since the backfill already excluded already-enriched works from appearing at all.
-3. **Close the issues** — after acceptance, close #95 #96 #97 #98 #108 #109 #110 #111 #112
+3. **Apply the enrich-queue retry-attempts cap** — `infra/08-cloud-tasks.sh` now pins
+   `--max-attempts=12` on the enrich queue (defense in depth: the internal enrich endpoint
+   already gives up loudly at 8 retries via `X-CloudTasks-TaskRetryCount` and returns 200,
+   so this queue-level cap should rarely if ever bind — it's a backstop, not the primary
+   mechanism). `infra/08-cloud-tasks.sh` is idempotent (`gcloud tasks queues update` when the
+   queue already exists), so simply re-running it applies the new flag to the live queue:
+
+   ```bash
+   ./infra/08-cloud-tasks.sh
+   ```
+
+   **Done when:** `gcloud tasks queues describe "$TASKS_QUEUE_NAME" --location="$REGION"
+   --format='value(rateLimits,retryConfig.maxAttempts)'` reports `maxAttempts: 12`.
+4. **Close the issues** — after acceptance, close #95 #96 #97 #98 #108 #109 #110 #111 #112
    with references to the resolving PRs (#124 for PR-C's #96/#98/#110/#111/#112/#123; this
    PR for #95/#97/#108/#109), and comment on #88 noting `log_suggestion` dedup closes its
    root cause.
 
-**Done when:** index listing confirms all 15 new objects; the first requeue report is
-generated and reviewed; issues closed with PR references.
+**Done when:** index listing confirms all 14 new objects (5 unique + 9 FK indexes); the
+first requeue report is generated and reviewed; the enrich queue's `maxAttempts` reads 12;
+issues closed with PR references.
 
 ---
 
 ## Rollback
 
 - **Migration:** the migration has a symmetric hand-written `downgrade()` — drops the 5
-  unique indexes, drops the 10 FK indexes, drops `deep_enriched_at`, converts the 13
+  unique indexes, drops the 9 FK indexes, drops `deep_enriched_at`, converts the 13
   timestamptz columns back to naive `timestamp` (`AT TIME ZONE 'UTC'` both directions).
   `alembic downgrade -1` from this revision if needed.
 - **Dedup apply (step 3):** not naturally reversible (rows were merged/deleted) — this is

--- a/docs/runbooks/phase6-3-schema-rollout.md
+++ b/docs/runbooks/phase6-3-schema-rollout.md
@@ -127,8 +127,13 @@ Open `data/reports/dedup-<ts>.txt` and check:
   `--apply` (works carry no cross-table unique constraint; see ADR-060 decision 5). Read
   through the listed title/author groups. These are candidates for a future manual/case-by-
   case work merge, not something this rollout touches — just confirm nothing here looks
-  like it should have been blocking (it isn't; the advisory lock in PR-C prevents *new*
-  work duplicates going forward, this list is just visibility into what already exists).
+  like it should have been blocking (it isn't). **Note on timing:** the advisory lock that
+  will prevent *new* work duplicates going forward ships in THIS branch but only starts
+  serving once step 5's deploy is live — during steps 2–4 the still-deployed serving code
+  has only the milliseconds-window TOCTOU re-check PR-C shipped, not the lock. Fresh
+  work-duplicates ARE possible during this window and are harmless (works carry no unique
+  constraint to violate); if you see one appear, it'll just show up in a later
+  `duplicate_works_report_only` list, not a sign of a problem.
 - **Expected, not-a-bug artifacts** (per PR-C's final review, folded into this design):
   - **`orphan_authors` may legitimately be nonzero even post-PR-C.** The Dagster ETL's
     `skip_enrichment=True` branch (operator-curated re-runs only; prod's normal paths
@@ -182,6 +187,14 @@ the flagged new/changed ids), and if it still looks right, re-run step 3 pointin
 `--report` at the new file. This is not a bug — it's the gate doing its job. In a
 quiet-ish window (step 0) this should be rare.
 
+**If `--apply` crashes mid-run** (an `IntegrityError`/`AssertionError` instead of a clean
+exit): a concurrent write landed in the narrow window between the fresh re-plan and this
+run's execution — the exact same race the drift-refuse above is designed to catch, just
+caught later, by the database itself, instead of by the id cross-check. Nothing was
+applied: the whole apply runs in a single transaction, so a mid-run crash rolls back
+completely, not partially. **Loop back to step 2** — re-run the dry-run, review the fresh
+report, and re-apply. Not a sign of data corruption or a bug in the tool.
+
 **Orphan-author note:** a merge in this same run can create a NEW orphan author (e.g. two
 authors merge, and the loser was the only thing keeping some third row's join alive) —
 `_plan_orphan_authors` computes against current state, not simulated ahead of this run's
@@ -228,6 +241,13 @@ docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gate
   -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest alembic upgrade head
 # expect: now at 48e3762d6c0c
 ```
+
+**If `CREATE UNIQUE INDEX` fails with a duplicate-key error:** this is the KNOWN race — a
+duplicate row was minted between the last clean dry-run/apply pass (step 2/3) and this
+migration by the still-serving PR-C code (its TOCTOU window, same root cause as the step 3
+crash note above). The whole migration is one transaction, so this rolls back cleanly —
+nothing is broken, no partial DDL, no need to downgrade. **Loop back to step 2**: re-run
+the dry-run, review the fresh (now-nonzero) report, re-apply (step 3), then re-run step 4.
 
 **Verify the objects landed** (`\d` output or `information_schema`), expected:
 
@@ -334,6 +354,17 @@ for the works that need a deep pass (re)run.
    set in the prod container env, nothing extra to configure) for exactly these works; it is
    safe to apply directly against the full report rather than reserving it for a subset,
    since the backfill already excluded already-enriched works from appearing at all.
+
+   **Repeat-cost warning (this sweep is not one-and-done):** on REPEAT runs of this same
+   `--requeue-unenriched` dry-run, watch for a `no_real_trope` entry that keeps showing up
+   across multiple applies — each printed candidate now includes its `deep_enriched_at`
+   stamp specifically so you can see this ("already re-attempted after X"). A work that
+   still lands in `no_real_trope` after a prior re-enqueue has already had its shot; it is
+   likely a genuinely unknowable title (garbage/unindexed metadata the deep pass can't work
+   with, not a transient failure) rather than something that'll succeed on attempt N+1.
+   **Fix or remove the work instead of re-enqueuing it again** — every re-enqueue costs up
+   to 9 paid deep passes (the enrich queue's per-task retry budget) for a work that's
+   unlikely to convert.
 3. **Apply the enrich-queue retry-attempts cap** — `infra/08-cloud-tasks.sh` now pins
    `--max-attempts=12` on the enrich queue (defense in depth: the internal enrich endpoint
    already gives up loudly at 8 retries via `X-CloudTasks-TaskRetryCount` and returns 200,

--- a/docs/runbooks/phase6-3-schema-rollout.md
+++ b/docs/runbooks/phase6-3-schema-rollout.md
@@ -1,0 +1,332 @@
+# Runbook — Phase 6.3 schema rollout (GH #95 #97 #108 #109)
+
+**Spec:** [2026-07-12 Phase 6.3 — Data Integrity (Design)](../superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md)
+**Audience:** the operator. Every step explains *what you're doing, why, how, and what
+"done" looks like*. Steps marked **[Claude]** are done in-session; steps marked **[You]**
+need your accounts/browser/approval and can't be delegated.
+
+## The big picture (read this first)
+
+PR-C (`fix/phase6-3a-integrity-code`) already shipped and is live in prod — it stopped the
+pollution sources (#96 contributor-merge, #98 garbage-title gate, #111 one real-trope
+predicate, #112 reading-status correctness, #110 availability upsert, #123 embeds out of
+sessions). PR-D (`feat/phase6-3b-schema-integrity`, this branch) adds the migration that
+finally backs get-or-create with real unique constraints (#95), two systemic schema debts
+(#108 timestamptz, #109 FK indexes), and the #97 enrichment-completion column
+(`deep_enriched_at`).
+
+The catch: years of races under the old unguarded get-or-create almost certainly left
+**duplicate rows in prod** that the new unique constraints would reject outright — the
+migration would fail to apply. So this rollout has **THE USER GATE** in the middle: a
+dry-run dedup plan that you review and approve BEFORE anything is deleted or merged, per
+the 2026-07-12 ground rule that prod backfills/migrations require a dry-run report +
+user approval before applying. Sequence, at a glance:
+
+```
+PR-C already deployed (pollution stopped)
+        |
+        v
+  [0] preconditions check
+        |
+        v
+  [1] pg_dump snapshot                              [You/Claude]
+        |
+        v
+  [2] dedup DRY-RUN --dedup-for-constraints           [Claude]
+        |
+        v
+  [ You review the report file ]                      [You]
+        |
+        v
+  [3] dedup --apply --yes --report <file>             [Claude]  (refuses on drift -> loop to [2])
+        |
+        v
+  [4] alembic upgrade head (lands the #95 uniques)     [You]
+        |
+        v
+  [5] merge PR-D -> deploy -> ADR-058 guard passes     [You]
+        |
+        v
+  [6] post-checks + first #97 requeue report          [Claude]
+```
+
+---
+
+## Step 0 — Preconditions **[You/Claude]**
+
+**What:** confirm the ground under this rollout is solid before touching prod data.
+**Why:** the dedup gate assumes PR-C's pollution sources are already closed off — running
+the dry-run before PR-C is live would count duplicates that are still actively being
+created, making the report stale before you finish reading it.
+**How, check all three:**
+
+1. PR #124 (PR-C) is deployed and serving — confirm the running revision is `00031-p29`
+   or later (`gcloud run services describe librarian-api --region us-central1
+   --format='value(status.latestReadyRevisionName)'`).
+2. This branch's CI is green (migration `48e3762d6c0c` runs cleanly in CI's full-chain
+   schema rebuild; `get_or_create`/dedup unit tests pass).
+3. Pick a quiet-ish window. Nothing here takes the app offline, but the dedup apply step
+   (step 3) merges/deletes rows — a lower-traffic window shrinks the odds of a drift-refuse
+   loop in step 3 caused by concurrent writes.
+
+**Done when:** all three confirmed.
+
+## Step 1 — pg_dump snapshot **[You or Claude]**
+
+**What:** export prod to `gs://agentic-librarian-prod-backups/` before any write.
+**Why:** house rule since Lift 2 (prod's first write) — back up before every migration,
+and doubly so here since step 3 deletes/merges rows. Nightly automated backups + 7-day
+PITR exist (GH #91) but a fresh named snapshot immediately before this operation is the
+one you'd actually reach for on rollback, and it's cheap.
+**How:**
+
+```bash
+gcloud sql export sql librarian-sql \
+  gs://agentic-librarian-prod-backups/pre-phase6-3-$(date +%Y%m%d).sql.gz \
+  --database=agentic_librarian
+```
+
+**Done when:** the export command completes (can take a few minutes) and the object
+appears in the bucket (`gcloud storage ls gs://agentic-librarian-prod-backups/`).
+
+## Step 2 — Dedup dry-run **[Claude]**
+
+**What:** run `scripts/clean_catalog.py --dedup-for-constraints --dry-run` against prod to
+compute the merge/delete plan the incoming unique constraints require, without writing
+anything.
+**Why:** this is the read-only half of THE USER GATE — it's the report you (the operator)
+review before anything is touched. `--dedup-for-constraints` is read-only by default;
+nothing is written to the database on this invocation regardless of `--apply`/`--yes`
+flags (they're for step 3).
+**How:** from a plain WSL shell with the Cloud SQL proxy running and `PROD_DB_URL` set
+(same pattern as the lift1/lift2 runbooks — proxy on the WSL host, docker-wrapped
+Python):
+
+```bash
+docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest \
+  python scripts/clean_catalog.py --dedup-for-constraints --dry-run
+```
+
+The tool prints a summary to stdout AND writes the FULL plan (every id involved) to
+`data/reports/dedup-<UTC-timestamp-with-microseconds>.txt` — that file is what you
+actually review; stdout only shows the first 10 of each class.
+
+**Done when:** the command exits 0 and prints the path to the written report.
+
+### WHAT TO REVIEW **[You]**
+
+Open `data/reports/dedup-<ts>.txt` and check:
+
+- **Per-class counts** (`duplicate_authors`, `duplicate_narrators`, `duplicate_editions`,
+  `duplicate_reading_history`, `duplicate_suggestions`, `orphan_authors`,
+  `duplicate_works_report_only`) — do the magnitudes look plausible for a catalog this
+  size? A number in the thousands for author/narrator dedup, on a catalog of a few hundred
+  works, would be a red flag worth investigating before approving.
+- **`duplicate_works_report_only`** — this class is REPORT ONLY and is never applied by
+  `--apply` (works carry no cross-table unique constraint; see ADR-060 decision 5). Read
+  through the listed title/author groups. These are candidates for a future manual/case-by-
+  case work merge, not something this rollout touches — just confirm nothing here looks
+  like it should have been blocking (it isn't; the advisory lock in PR-C prevents *new*
+  work duplicates going forward, this list is just visibility into what already exists).
+- **Expected, not-a-bug artifacts** (per PR-C's final review, folded into this design):
+  - **`orphan_authors` may legitimately be nonzero even post-PR-C.** The Dagster ETL's
+    `skip_enrichment=True` branch (operator-curated re-runs only; prod's normal paths
+    always set it False) can still flush an unlinked Author on an existing work. Don't
+    treat a small nonzero orphan count as evidence PR-C didn't ship correctly.
+  - **"Unknown"-format editions** may appear among `duplicate_editions` groups.
+    `update_reading_status` historically minted editions with `format="Unknown"` when no
+    real format was known. PR-C's fix reuses a sole existing edition's format going
+    forward, but legacy rows — and any work with zero or multiple editions at the time —
+    can still produce an `Unknown`-format edition that collides with another under the
+    incoming `(work_id, format)` unique index. This is expected; the plan's survivor
+    selection (most-linked, tie-break lowest id) handles it the same as any other
+    duplicate-format group.
+- **Sample rows within a few groups** — spot-check that a `duplicate_authors`/
+  `duplicate_narrators` survivor pick looks right (same person, not a same-surname
+  coincidence — the class keys on `lower(name)` exact match, so false positives would
+  require two contributors sharing an identical case-folded name, which is unlikely but
+  worth a glance).
+
+**Approve or don't.** If anything looks wrong, stop here — do not proceed to step 3. Come
+back with questions/corrections; the plan can be re-run any time (it's read-only) as prod
+data or your understanding changes.
+
+## Step 3 — Apply **[Claude, only after You approve]**
+
+**What:** re-run the same tool with `--apply --yes --report <the file you reviewed>` to
+actually merge/delete the planned rows.
+**Why:** `--apply` is a SEPARATE invocation from the dry-run — it re-plans from scratch
+against prod's current state (not a replay of the dry-run's in-memory plan), because
+minutes may have passed and live traffic could have created new rows. To keep your review
+meaningful, `--apply` cross-checks the FRESH plan's id set against the id set parsed back
+out of the report you reviewed, and **refuses (exit 1) if the fresh plan contains any id
+you never saw** — including an id that changed *operation* (e.g. something that was a
+`repoint` in your reviewed report shows up as a `delete` in the fresh plan; a concurrent
+write flipped which case applies). A plan that merely lost ids since your review (rows
+deleted/changed in the gap) is fine and applies normally under ordinary `skipped_stale`
+accounting.
+**How:**
+
+```bash
+docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest \
+  python scripts/clean_catalog.py --dedup-for-constraints --apply --yes \
+  --report data/reports/dedup-<the-ts-you-reviewed>.txt
+```
+
+**If it refuses with "plan changed since review":** the tool prints exactly which ids are
+new (with their operation tag) and writes a FRESH report from the same re-plan it just
+refused to apply. **Loop back to step 2's review** — read the new report (particularly
+the flagged new/changed ids), and if it still looks right, re-run step 3 pointing
+`--report` at the new file. This is not a bug — it's the gate doing its job. In a
+quiet-ish window (step 0) this should be rare.
+
+**Orphan-author note:** a merge in this same run can create a NEW orphan author (e.g. two
+authors merge, and the loser was the only thing keeping some third row's join alive) —
+`_plan_orphan_authors` computes against current state, not simulated ahead of this run's
+own not-yet-applied merges, by design (see `etl/dedup_backfill.py`'s docstring). **Re-run
+the dry-run again after applying** (step 2) — if it comes back clean (all per-class counts
+zero), you're done; if it finds a fresh, small orphan-author batch, that's expected
+follow-on cleanup, not a sign something went wrong. Loop steps 2→3 until a dry-run comes
+back clean.
+
+**Done when:** the apply command exits 0, prints per-class applied counts, and a
+follow-up dry-run (step 2) comes back with all classes empty except
+`duplicate_works_report_only` (never applied, expected to persist until a future manual
+work-merge effort).
+
+## Step 4 — Migrate **[You]**
+
+**What:** run `alembic upgrade head` from this branch against prod. This lands the #95
+unique constraints (now safe — prod has no more duplicates to violate them), the #109 FK
+indexes, the #108 timestamptz conversions, and the #97 `works.deep_enriched_at` column.
+**Why manual, not part of deploy.yml:** migrations in this project are always
+operator-run before merge (lift1 runbook §3 mechanics) — deploy.yml deliberately has no
+alembic step; ADR-058's startup guard is what makes the ordering safe rather than a race.
+**How:** mirrors lift1 runbook §3 exactly — same proxy, same docker-wrapped alembic
+invocation, on THIS branch's checkout:
+
+```bash
+# proxy already running from step 1/2 (or start it: ./cloud-sql-proxy --port 5433 <CONNECTION_NAME>)
+docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest alembic current
+# expect: c4f81a2d9b6e (this migration's down_revision)
+
+docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+  -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest alembic upgrade head
+# expect: now at 48e3762d6c0c
+```
+
+**Verify the objects landed** (`\d` output or `information_schema`), expected:
+
+- **5 unique indexes**: `uq_authors_name_lower`, `uq_narrators_name_lower`,
+  `uq_editions_work_format`, `uq_reading_history_user_edition_date`,
+  `uq_suggestions_active`.
+- **10 new FK indexes** (`ix_<table>_<column>`): `editions.work_id`,
+  `reading_history.edition_id`, `work_tropes.trope_id`, `work_contributors.author_id`,
+  `suggestions.work_id`, `author_styles.style_id`, `work_styles.style_id`,
+  `usage.conversation_id`, `narrator_styles.style_id`, `edition_narrators.narrator_id`.
+- **13 columns converted to timestamptz**: `suggestions.suggested_at`,
+  `conversations.created_at`/`updated_at`, `messages.created_at`, `users.created_at`,
+  `usage.created_at`, `user_credentials.created_at`/`updated_at`,
+  `user_libraries.created_at`, `availability_cache.fetched_at`, `import_jobs.created_at`,
+  `import_rows.created_at`/`updated_at`. (`availability_cache.fetched_at` deliberately
+  keeps NO column default — don't be alarmed it's the one without.)
+- **`works.deep_enriched_at`** — new nullable `timestamptz` column, NULL for every
+  pre-existing row (they haven't been (re)stamped by a deep pass since this landed; the
+  step 6 requeue report is exactly the tool for backfilling that).
+
+**Since ADR-058**, the startup migration guard tolerates a migrated-ahead DB during this
+window — the still-running old revision keeps cold-starting normally (its
+`alembic_version` is merely unknown to it, not behind). Emergency bypass if the guard ever
+misfires: `MIGRATION_GUARD=off`.
+
+**Done when:** `alembic current` on prod reports `48e3762d6c0c` and the objects above are
+confirmed present.
+
+## Step 5 — Merge PR-D **[You]**
+
+**What:** merge the `feat/phase6-3b-schema-integrity` PR to `main` (after CI green +
+Gemini review, per the house PR workflow).
+**Why:** the migration must land BEFORE the merge (step 4 already did that) so that
+ADR-058's guard sees a DB at-or-ahead of the deploying image's head, not behind it — a
+behind DB fails the new revision outright.
+**How:** normal squash-merge via GitHub (title = PR title, blank body — the #90 durable
+fix, no `[skip ci]` risk).
+
+**Done when:** merged; the deploy workflow fires automatically (path-filtered on
+`src/**`/`pyproject.toml`/`Dockerfile.api`).
+
+### Verify the deploy **[You]**
+
+- Watch the Actions run go green, including the smoke test.
+- Confirm the new revision is ready and serving (`gcloud run services describe
+  librarian-api --region us-central1 --format='value(status.latestReadyRevisionName,
+  status.conditions)'`) — ADR-058's guard should pass silently (DB is at head, not
+  behind).
+- Confirm memory is still pinned at **2Gi** (ADR-051/GH #89 — deploy.yml drift class);
+  `gcloud run services describe librarian-api --region us-central1
+  --format='value(spec.template.spec.containers[0].resources.limits.memory)'` should read
+  `2Gi`.
+
+**Done when:** revision ready, guard passed (no forced rollback), memory confirmed 2Gi.
+
+## Step 6 — Post-checks **[Claude]**
+
+**What:** confirm the new constraints/indexes are live and kick off the first #97
+enrichment-completeness report.
+**Why:** cheap, fast confirmation that the migration is exactly what was intended, plus
+turning `deep_enriched_at`/the real-trope predicate into an operator-actionable backlog
+for the works that need a deep pass (re)run.
+**How:**
+
+1. **Constraint sanity** — a `\di` (or equivalent `information_schema.pg_indexes`) listing
+   confirms the 5 unique indexes + 10 FK indexes from step 4 exist with the expected
+   definitions (`lower(name)` expressions, the `NULLS NOT DISTINCT` composite, the partial
+   `WHERE status = 'Suggested'` predicate). No need to attempt actual duplicate-insert
+   probes — the migration's own `op.execute`d DDL either applied or the migration would
+   have failed outright in step 4; a listing is enough to confirm what's live.
+2. **First `--requeue-unenriched` dry-run** — this doubles as the very first #97 report:
+
+   ```bash
+   docker run --rm -v "$PWD":/app -w /app --add-host=host.docker.internal:host-gateway \
+     -e DATABASE_URL="$PROD_DB_URL" agentic_librarian-app:latest \
+     python scripts/clean_catalog.py --requeue-unenriched --dry-run
+   ```
+
+   Expect every pre-existing work to show up under `never_deep_enriched` (the new column
+   is NULL for all of them — that's expected, not a bug; it doesn't mean their tropes were
+   lost, just that `deep_enriched_at` didn't exist to be stamped before now). Works that
+   already have real tropes from before this migration are still fine to leave as-is —
+   `--apply --yes` re-enqueues deep enrichment via Cloud Tasks (`CLOUD_TASKS_QUEUE`,
+   `ENRICH_TARGET_BASE_URL`, `ENRICH_INVOKER_SA` — already set in the prod container env,
+   nothing extra to configure), which is a live decision for you: applying it against the
+   full catalog re-runs deep enrichment (LLM cost) for every work, which may or may not be
+   worth it purely to backfill the timestamp. Recommendation: treat this first report as
+   informational baseline, and reserve `--apply` for the `no_real_trope` subset (the actual
+   poison-task recovery #97 exists for) unless you specifically want a full re-enrichment
+   pass.
+3. **Close the issues** — after acceptance, close #95 #96 #97 #98 #108 #109 #110 #111 #112
+   with references to the resolving PRs (#124 for PR-C's #96/#98/#110/#111/#112/#123; this
+   PR for #95/#97/#108/#109), and comment on #88 noting `log_suggestion` dedup closes its
+   root cause.
+
+**Done when:** index listing confirms all 15 new objects; the first requeue report is
+generated and reviewed; issues closed with PR references.
+
+---
+
+## Rollback
+
+- **Migration:** the migration has a symmetric hand-written `downgrade()` — drops the 5
+  unique indexes, drops the 10 FK indexes, drops `deep_enriched_at`, converts the 13
+  timestamptz columns back to naive `timestamp` (`AT TIME ZONE 'UTC'` both directions).
+  `alembic downgrade -1` from this revision if needed.
+- **Dedup apply (step 3):** not naturally reversible (rows were merged/deleted) — this is
+  exactly why steps 1 (pg_dump) and 2 (review-before-apply) exist. Restore from the
+  step 1 snapshot if a mistaken apply needs undoing (`gcloud sql import sql`, same pattern
+  as the walking-skeleton runbook's restore script).
+- **Deploy:** ADR-058's guard already covers the ordinary case (an old image tolerates a
+  migrated-ahead DB, so a bad PR-D deploy can be rolled back to the pre-merge image without
+  `MIGRATION_GUARD=off`).

--- a/docs/superpowers/plans/2026-07-12-phase6-3b-schema-integrity.md
+++ b/docs/superpowers/plans/2026-07-12-phase6-3b-schema-integrity.md
@@ -1,0 +1,280 @@
+# Phase 6.3 PR-D Schema Integrity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the schema hardening (#95 #97 #108 #109) and the gated dedup tooling on branch `feat/phase6-3b-schema-integrity` — one migration, constraint-paired code, the #97 status/sweep, and the `--dedup-for-constraints` planner whose dry-run report the user must approve before prod apply.
+
+**Architecture:** One hand-written alembic migration (house style: explicit names, symmetric downgrade) adds the five unique constraints, ~10 FK/composite indexes, converts all 13 naive DateTime columns to timestamptz, and adds `works.deep_enriched_at`. A `get_or_create` helper (SAVEPOINT + IntegrityError re-query) backs every get-or-create site including `log_suggestion` (which gains dedup — #88's root cause) and `ingest.py`'s unguarded edition insert; `enrich_fast`'s write session takes a normalized-title+author advisory lock. `enrich_deep` stamps `deep_enriched_at`; the internal endpoint 503s (retryable) when a fingerprint-less work's deep pass yields nothing; `clean_catalog.py` gains `--requeue-unenriched` and `--dedup-for-constraints` following its existing plan → refuse-gate → apply pattern.
+
+**Tech Stack:** alembic (5-migration chain, CI rebuilds from scratch every run), SQLAlchemy 2.0 (`begin_nested`, pg advisory locks), Postgres 16 (`NULLS NOT DISTINCT`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-phase6-3-data-integrity-design.md` (PR-D sections + "PR-D inputs from PR-C's final review" + "Dedup backfill (THE USER GATE)").
+- **The prod sequence is operator-gated and OUT of plan scope**: dedup dry-run → user approval → apply → user runs `alembic upgrade head` → merge. Nothing in this plan touches prod.
+- Exact schema objects (names binding):
+  - Uniques: `uq_authors_name_lower` on `(lower(name))`; `uq_narrators_name_lower`; `uq_editions_work_format` on `(work_id, format)` **NULLS NOT DISTINCT**; `uq_reading_history_user_edition_date` on `(user_id, edition_id, date_completed)`; `uq_suggestions_active` partial on `(user_id, work_id) WHERE status = 'Suggested'`.
+  - Indexes (`ix_<table>_<col>`): `editions.work_id`, `reading_history.edition_id`, `work_tropes.trope_id`, `work_contributors.author_id`, `suggestions.work_id`, `author_styles.style_id`, `work_styles.style_id`, `usage.conversation_id`, `narrator_styles.style_id`, `edition_narrators.narrator_id`.
+  - timestamptz: all 13 DateTime columns from the spec inventory (suggestions.suggested_at; conversations.created_at/updated_at; messages.created_at; users.created_at; usage.created_at; user_credentials.created_at/updated_at; user_libraries.created_at; availability_cache.fetched_at; import_jobs.created_at; import_rows.created_at/updated_at) via `ALTER ... TYPE timestamptz USING <col> AT TIME ZONE 'UTC'`; models gain `DateTime(timezone=True)`; **`availability_cache.fetched_at` keeps NO default** (deliberate); `Suggestions.suggested_at` must not be missed.
+  - `works.deep_enriched_at` TIMESTAMPTZ NULL.
+- Migration: single new head (ADR-058 guard), hand-written, symmetric downgrade, no application-code imports; CI's conftest full-chain upgrade is the proof it runs.
+- `get_or_create(session, model, defaults=None, **filters)` semantics: query → miss → `begin_nested()` + insert + release → on IntegrityError rollback nested + re-query (must find the row) — the caller's outer transaction survives.
+- Advisory lock: `SELECT pg_advisory_xact_lock(hashtext(:key))` with `key = norm_title + '|' + norm_author`, executed in `enrich_fast`'s WRITE session before the dedup re-check; skipped when the bind dialect isn't postgresql (sqlite guard-style check, mirroring `db/session.py`'s pool-kwargs guard).
+- Dedup planner uses STRUCTURAL distinguishers only (the #69 lesson): case/normalized-value groupings and relationship repoints; never a sometimes-populated column. Works duplicates are REPORT-ONLY. Orphan authors = no work_contributors AND no author_styles.
+- Tests: `.venv/Scripts/python -m pytest ...`; new unit tests DB-free/sqlite where possible; constraint/dedup behavior tests are `db_integration` (CI-gated — collect-check locally, say so). Lint/format every touched file (`uvx ruff check` / `uvx ruff format`).
+- No `[skip ci]`. Do not modify `frontend/**`.
+
+---
+
+### Task 1: The migration + model updates — #108 #109 #95-schema #97-column
+
+**Files:**
+- Create: `alembic/versions/<newrev>_phase6_3_schema_hardening.py` (revises `c4f81a2d9b6e`)
+- Modify: `src/agentic_librarian/db/models.py` (13× `DateTime(timezone=True)`; `Work.deep_enriched_at`; `index=True` on the 10 index columns where expressible — composite/functional uniques stay migration-only per the no-`__table_args__` house style, with a models.py comment pointing at the migration)
+- Modify: `src/agentic_librarian/availability/service.py` (remove the `.replace(tzinfo=UTC)` band-aids — grep for them; timestamptz reads back aware)
+- Test: `test/integration/test_schema_hardening.py` (new, db_integration)
+
+**Interfaces:**
+- Produces: `Work.deep_enriched_at: Mapped[datetime | None]` (Task 3 stamps it); the five unique constraints (Task 2's helper relies on them; Task 4 dedups ahead of them).
+
+- [ ] **Step 1: Write the failing test** — `test/integration/test_schema_hardening.py` (db_integration; CI executes):
+
+```python
+"""PR-D migration: constraints, indexes, timestamptz, deep_enriched_at (#95 #97 #108 #109)."""
+
+import pytest
+from sqlalchemy import inspect, text
+
+pytestmark = pytest.mark.db_integration
+
+
+def test_unique_indexes_exist(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    author_uniques = {i["name"] for i in insp.get_indexes("authors") if i.get("unique")}
+    assert "uq_authors_name_lower" in author_uniques
+    edition_uniques = {i["name"] for i in insp.get_indexes("editions") if i.get("unique")}
+    assert "uq_editions_work_format" in edition_uniques
+    rh = {i["name"] for i in insp.get_indexes("reading_history") if i.get("unique")}
+    assert "uq_reading_history_user_edition_date" in rh
+    sugg = {i["name"] for i in insp.get_indexes("suggestions") if i.get("unique")}
+    assert "uq_suggestions_active" in sugg
+
+
+def test_fk_indexes_exist(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    for table, col in [
+        ("editions", "work_id"), ("reading_history", "edition_id"), ("work_tropes", "trope_id"),
+        ("work_contributors", "author_id"), ("suggestions", "work_id"), ("author_styles", "style_id"),
+        ("work_styles", "style_id"), ("usage", "conversation_id"), ("narrator_styles", "style_id"),
+        ("edition_narrators", "narrator_id"),
+    ]:
+        names = {i["name"] for i in insp.get_indexes(table)}
+        assert f"ix_{table}_{col}" in names, f"missing ix_{table}_{col}"
+
+
+def test_timestamps_are_timestamptz(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    m = DatabaseManager(db_url)
+    with m.get_session() as s:
+        rows = s.execute(text(
+            "SELECT table_name, column_name FROM information_schema.columns "
+            "WHERE data_type = 'timestamp without time zone' AND table_schema = 'public'"
+        )).all()
+    assert rows == [], f"still naive: {rows}"
+
+
+def test_works_deep_enriched_at(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    cols = {c["name"] for c in insp.get_columns("works")}
+    assert "deep_enriched_at" in cols
+```
+
+- [ ] **Step 2: Verify collection** (locally these skip; CI's conftest runs the full chain then these assert).
+
+- [ ] **Step 3: Write the migration** — follow `c4f81a2d9b6e`'s structure (docstring header, typed module constants, hand-written upgrade/downgrade). Upgrade order: (1) timestamptz ALTERs via `op.execute` loops (13 exact `ALTER TABLE x ALTER COLUMN y TYPE timestamptz USING y AT TIME ZONE 'UTC'` statements); (2) `works.deep_enriched_at` via `op.add_column(sa.Column("deep_enriched_at", sa.DateTime(timezone=True), nullable=True))`; (3) the 10 `op.create_index` calls; (4) the 5 uniques — functional/partial/NULLS-NOT-DISTINCT ones via `op.execute` raw DDL (alembic's create_index doesn't express NULLS NOT DISTINCT):
+
+```python
+op.execute("CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))")
+op.execute("CREATE UNIQUE INDEX uq_narrators_name_lower ON narrators (lower(name))")
+op.execute("CREATE UNIQUE INDEX uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT")
+op.execute(
+    "CREATE UNIQUE INDEX uq_reading_history_user_edition_date "
+    "ON reading_history (user_id, edition_id, date_completed)"
+)
+op.execute("CREATE UNIQUE INDEX uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'")
+```
+
+Downgrade: drop the 5 uniques, the 10 indexes, `deep_enriched_at`, and revert the 13 columns to `timestamp without time zone` (`USING <col> AT TIME ZONE 'UTC'`), in reverse order.
+
+- [ ] **Step 4: models.py** — the 13 columns get `DateTime(timezone=True)` (defaults/onupdate lambdas unchanged; fetched_at keeps no default); `Work` gains `deep_enriched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)`; simple single-column FK indexes get `index=True` ONLY where the migration name matches alembic's default (it won't — migration uses explicit `ix_<table>_<col>`, which IS SQLAlchemy's default naming for `index=True`; verify one; if they align, add `index=True` for documentation parity; if not, leave models untouched for indexes and add a comment block referencing the migration). Functional/partial/composite uniques: models.py comment only.
+
+- [ ] **Step 5: Remove the fetched_at band-aids** — grep `replace(tzinfo=UTC)` in `availability/service.py` (freshness checks in `availability_for` + `batch_availability`); replace `row.fetched_at.replace(tzinfo=UTC)` with `row.fetched_at` (aware post-migration). CI's availability suites pin behavior.
+
+- [ ] **Step 6: Run** the DB-free suite (`test/unit -q`, green minus known failures); collect-check the new integration file; `.venv/Scripts/python -c "from agentic_librarian.db import models"` sanity import.
+
+- [ ] **Step 7: Lint, format, commit**
+
+```bash
+git add alembic/versions src/agentic_librarian/db/models.py src/agentic_librarian/availability/service.py test/integration/test_schema_hardening.py
+git commit -m "feat(db): phase 6.3 schema hardening — uniques, FK indexes, timestamptz, deep_enriched_at (#95 #97 #108 #109)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: get_or_create helper + adoption + advisory lock — #95-code
+
+**Files:**
+- Create: `src/agentic_librarian/db/get_or_create.py`
+- Modify: `src/agentic_librarian/etl/persist.py` (authors ~L120-124 in the desired-loop, narrators ~L233-237, editions ~L207, reading_history guard ~L288-292), `src/agentic_librarian/enrichment/two_phase.py` (add_read_event edition site; enrich_fast advisory lock), `src/agentic_librarian/etl/ingest.py:88-92` (the UNGUARDED edition insert), `src/agentic_librarian/imports/worker.py` (`_upsert_suggestion`), `src/agentic_librarian/mcp/server.py` (`log_suggestion` gains dedup — note #88 in the comment)
+- Test: `test/unit/test_get_or_create.py` (new, sqlite), `test/integration/test_constraint_backstops.py` (new, db_integration)
+
+**Interfaces:**
+- Produces: `get_or_create(session, model, defaults: dict | None = None, **filters) -> tuple[obj, bool]` (obj, created).
+
+- [ ] **Step 1: Failing unit tests** — `test/unit/test_get_or_create.py` (sqlite, file-based; define a tiny standalone Table/model with a unique column inside the test — do NOT use app models on sqlite):
+
+```python
+def test_returns_existing(...):        # pre-inserted row -> (row, False), no insert
+def test_creates_when_missing(...):    # empty -> (row, True)
+def test_integrity_race_recovers(...): # monkeypatch flush to raise IntegrityError once after a
+                                       # concurrent insert is simulated -> helper re-queries -> (existing, False),
+                                       # outer transaction still usable (a subsequent query works)
+```
+
+(Write real bodies; the third test simulates the race by inserting the conflicting row via a second connection/session before calling the helper with a stubbed first-query-miss — e.g. patch the helper's initial query path or insert between an explicit pre-check. Keep it honest: the SAVEPOINT recovery and outer-transaction survival are the binding assertions.)
+
+- [ ] **Step 2: Implement the helper**
+
+```python
+"""Constraint-backed get-or-create (GH #95). The SELECT-then-INSERT races that used to
+create duplicates are now backstopped by unique constraints; this helper turns the
+IntegrityError loser into a clean re-query instead of a 500. SAVEPOINT (begin_nested)
+so the caller's outer transaction survives the rolled-back insert."""
+
+from sqlalchemy.exc import IntegrityError
+
+
+def get_or_create(session, model, defaults=None, **filters):
+    instance = session.query(model).filter_by(**filters).first()
+    if instance is not None:
+        return instance, False
+    params = dict(filters)
+    params.update(defaults or {})
+    try:
+        with session.begin_nested():
+            instance = model(**params)
+            session.add(instance)
+            session.flush()
+        return instance, True
+    except IntegrityError:
+        instance = session.query(model).filter_by(**filters).first()
+        if instance is None:  # constraint fired but filters don't match it (e.g. case-variant name)
+            raise
+        return instance, False
+```
+
+NOTE the case-variant nuance: `uq_authors_name_lower` fires on `lower(name)` but `filter_by(name=name)` is exact — for authors/narrators the ADOPTION SITES must keep their existing `func.lower(...)` first-query AND pass a lower-aware re-query. Design: sites with non-trivial predicates call the helper with a `query=` escape? NO — keep the helper simple; authors/narrators keep their existing case-insensitive query-first code and only wrap the INSERT in the same begin_nested/IntegrityError-requery pattern via a second tiny helper `insert_or_requery(session, instance, requery: Callable)`. Implement BOTH helpers in the module; simple sites (editions, reading_history, suggestions) use `get_or_create`; authors/narrators use `insert_or_requery` with their `func.lower` requery lambda.
+
+- [ ] **Step 3: Adopt at every site** (read each first; preserve surrounding behavior/comments):
+  - persist.py authors + narrators → `insert_or_requery` with the existing lower() lookup as requery.
+  - persist.py editions (~L207 region) + two_phase.add_read_event edition + **ingest.py:88-92** (currently NO guard — becomes `get_or_create(session, Edition, defaults={...page_count...}, work_id=..., format=...)`).
+  - persist.py reading_history guard + add_read_event's insert → keep their date-guards, wrap inserts.
+  - worker.`_upsert_suggestion` → `get_or_create(..., user_id=..., work_id=..., status="Suggested", defaults={"context": context})` preserving the bool return.
+  - mcp `log_suggestion` → dedup: `get_or_create` on (user_id, work_id, status="Suggested") with context/justification/conversation_id in defaults; when not created, return "Already an active suggestion for work {id} — not duplicated." (comment: closes #88's root cause; the partial unique backs it).
+  - `enrich_fast` write session, before `_find_existing` re-check:
+
+```python
+        if session.get_bind().dialect.name == "postgresql":
+            # GH #95: works can't carry a cross-table unique (title+author spans tables) —
+            # serialize concurrent same-book creators instead. xact-scoped: released on commit.
+            session.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+                {"k": f"{_normalize(title)}|{_normalize(author)}"},
+            )
+```
+
+- [ ] **Step 4: Failing integration tests** — `test/integration/test_constraint_backstops.py` (db_integration): sequential double-insert of same-cased and case-variant authors resolves to one row; duplicate active suggestion via `log_suggestion` twice → one row + "not duplicated" message; duplicate edition via ingest path → one row. (CI executes against the Task-1 constraints.)
+
+- [ ] **Step 5: Run** unit suite; collect-checks; lint/format; commit:
+
+```bash
+git commit -m "feat(db): constraint-backed get-or-create everywhere; advisory lock on work creation; log_suggestion dedup (#95, #88 root cause)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Enrichment status + retry + sweep — #97
+
+**Files:**
+- Modify: `src/agentic_librarian/enrichment/two_phase.py` (`enrich_deep` stamps `deep_enriched_at`), `src/agentic_librarian/api/internal.py` (503-on-empty), `scripts/clean_catalog.py` + `src/agentic_librarian/etl/enrichment_sweep.py` (new: the queryable planner)
+- Test: `test/unit/test_enrichment_sweep.py` (new), `test/integration/test_internal_enrich_api.py` (extend)
+
+**Interfaces:**
+- Produces: `plan_requeue(session) -> list[RequeueCandidate]` (work_id, title, reason: "no_real_trope" | "never_deep_enriched") in `etl/enrichment_sweep.py`, consuming `is_fallback_trope_name` (#111).
+
+- [ ] **Step 1:** `enrich_deep`: in the write session (and on the row-is-None path, which needs a SHORT session now) set `work.deep_enriched_at = datetime.now(UTC)` — the timestamp means "the deep pass COMPLETED", including confirmed-empty; the predicate distinguishes fingerprint-less works. On the scouts-found-nothing path open a brief session solely to stamp (read the current shape first — post-#94 it returns True with no session; add `with db_manager.get_session() as s: s.get(Work, work_id).deep_enriched_at = ...`).
+- [ ] **Step 2:** `api/internal.py` enrich endpoint: after a True return, evaluate: work has NO real trope (shared predicate over its links) AND `_run_scouts` yielded nothing this pass → respond 503 `{"work_id":..., "status": "empty_deep_pass"}` so Cloud Tasks retries with backoff. Mechanically: `enrich_deep` must surface "yielded nothing" — change its return to `bool | str`? NO — keep `-> bool` for compat and add a second function OR return an Enum-like str... **Decision: `enrich_deep` returns `"done" | "empty" | "missing"`** (str literals; internal.py maps missing→404, empty→503 when the work still has no real trope, done→200). Update the ONE caller (internal.py) — grep for others (tests). Document in both docstrings.
+- [ ] **Step 3:** `etl/enrichment_sweep.py`: `plan_requeue(session)` — works where `deep_enriched_at IS NULL`, plus works whose every linked trope is fallback/junk (reuse the predicate; join pattern from trope_backfill). `clean_catalog.py` gains `--requeue-unenriched` (plan prints table; `--apply --yes` calls `enqueue_enrichment(str(work_id))` per candidate, reusing the existing refuse-gate; requires Cloud Tasks env — document in the mode's help text).
+- [ ] **Step 4:** Tests: unit — `plan_requeue` against a mocked/sqlite-free session? (needs query shapes → make it db_integration instead, seeded: one work with real trope + stamped (excluded), one unstamped (included, "never_deep_enriched"), one stamped-but-fallback-only (included, "no_real_trope")). Extend `test_internal_enrich_api.py`: empty-deep-pass on a trope-less work → 503; empty on a work WITH real tropes → 200.
+- [ ] **Step 5:** Run/lint/commit:
+
+```bash
+git commit -m "feat(enrichment): deep_enriched_at stamping, retryable empty-pass 503, requeue sweep (#97)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Dedup planner — the USER-GATE tooling
+
+**Files:**
+- Create: `src/agentic_librarian/etl/dedup_backfill.py`
+- Modify: `scripts/clean_catalog.py` (`--dedup-for-constraints` mode)
+- Test: `test/integration/test_dedup_backfill.py` (new, db_integration, seeded duplicates)
+
+**Interfaces:**
+- Produces: `plan_dedup(session) -> DedupPlan` (dataclass: per-class lists with row details + counts) and `apply_dedup(session, plan) -> dict` (per-class applied counts). Classes: `duplicate_authors` (group by lower(name); keep oldest id; repoint work_contributors + author_styles — mind PK collisions: a repoint that would duplicate an existing (work_id, author_id, role) link DELETES the loser link instead), `duplicate_narrators` (same; narrator_styles + edition_narrators), `duplicate_editions` (group by (work_id, COALESCE(format,'')); keep oldest; repoint reading_history + edition_narrators with the same collision rule), `duplicate_reading_history` (exact (user_id, edition_id, date_completed) groups; keep oldest), `duplicate_suggestions` (per (user_id, work_id) with status='Suggested'; keep oldest), `orphan_authors` (no work_contributors AND no author_styles; delete), `duplicate_works_REPORT_ONLY` (normalized title+author groups; details only, never applied).
+
+- [ ] **Step 1: Failing integration tests** — seed each duplicate class synthetically; assert the PLAN identifies exactly the seeded groups (and nothing else) and `apply_dedup` converges: post-apply, re-plan is empty (minus report-only works), FK repoints verified (a reading_history row moved to the surviving edition), collision rule verified (duplicate link deleted, not duplicated).
+- [ ] **Step 2: Implement** planner + applier (pure structural SQL/ORM; every deletion in the plan lists the exact ids; `apply_dedup` takes the PLAN as input — apply-what-was-shown, the #69 discipline).
+- [ ] **Step 3: clean_catalog mode** — `--dedup-for-constraints` prints the plan grouped by class with counts + samples (and the full id lists to a timestamped report file under `data/reports/dedup-<ts>.txt` for the user's review); `--apply --yes` + refuse-gate applies THE SAME computed plan. Mode help documents the sequence (PR-C deployed → dry-run → approval → apply → alembic → merge).
+- [ ] **Step 4:** Run/collect-check/lint/commit:
+
+```bash
+git commit -m "feat(catalog): dedup-for-constraints planner + applier — the gated pre-constraint backfill (#95)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Rollout runbook + docs
+
+**Files:**
+- Create: `docs/runbooks/phase6-3-schema-rollout.md` (operator What/Why/How/Done-when, the house runbook style — see `docs/runbooks/shelfwright-launch.md`): sequence = verify PR-C deployed → pg_dump snapshot (command) → `--dedup-for-constraints` dry-run ([Claude] runs, [You] review the report file) → `--apply --yes` → `alembic upgrade head` from the branch ([You], per lift1 runbook §3 mechanics) → merge PR-D → deploy guard passes → post-checks (constraint sanity queries; `--requeue-unenriched` dry-run as the first #97 report).
+- Modify: `docs/project_notes/decisions.md` (ADR-060: constraint-backed get-or-create + advisory-lock works dedup + gated backfill sequence — Context/Decision/Consequences, citing #95/#88/#69), `docs/project_notes/key_facts.md` (Database bullet: constraints + timestamptz + deep_enriched_at noted).
+- [ ] Write all three; lint markdown by eye; commit:
+
+```bash
+git commit -m "docs: phase 6.3 schema rollout runbook + ADR-060 + key facts (#95 #97 #108 #109)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope (operator-gated, post-plan)
+
+The prod sequence itself (dry-run → approval → apply → alembic → merge) and closing #95 #96 #97 #98 #108 #109 #110 #111 #112 (+#88 comment) after acceptance.

--- a/docs/testing_strategy.md
+++ b/docs/testing_strategy.md
@@ -11,7 +11,7 @@ This document outlines the mandatory testing standards for all agents and contri
     -   Maintain a minimum of **80% code coverage** for all new features.
     -   Critical core logic should target **100% coverage**.
 3.  **Use Case Driven**:
-    -   Tests should be derived from specific use cases defined in [use_cases.md](file:///c:/Users/Justin.Merrick/Python_Code/Projects/agentic_librarian/agentic_librarian/docs/use_cases.md).
+    -   Tests should be derived from specific use cases defined in [use_cases.md](use_cases.md).
 4.  **The Testing Pyramid**:
     -   **Unit Tests (70-80%)**: Fast, isolated logic tests.
     -   **Integration Tests (15-20%)**: Testing interactions between components (DB, Scouts, LLM providers).

--- a/infra/08-cloud-tasks.sh
+++ b/infra/08-cloud-tasks.sh
@@ -27,7 +27,14 @@ gcloud services enable cloudtasks.googleapis.com
 #    remediation (deep scouts ≈ ½GiB each; 4 concurrent fits the 2Gi service): defaults
 #    (1000 concurrent / 500 per sec) caused the 2026-06-23 OOM storm. The update branch
 #    converges a pre-existing queue (created with defaults or hand-tuned) to the same state.
-ENRICH_QUEUE_FLAGS=(--max-concurrent-dispatches=4 --max-dispatches-per-second=5)
+#    --max-attempts=12 (final-review Important, defense in depth): the default is 100 attempts
+#    with backoff maxing out around an hour between tries — an unbounded 503 loop on a
+#    genuinely poison book would cost ~100 PAID deep-LLM passes before anyone notices. The
+#    internal enrich endpoint (api/internal.py) already gives up loudly at 8 retries via the
+#    X-CloudTasks-TaskRetryCount header and returns 200, so Cloud Tasks normally never even
+#    reaches attempt 12 — this queue-level cap is a backstop in case that in-app logic is ever
+#    bypassed or misconfigured, not the primary mechanism.
+ENRICH_QUEUE_FLAGS=(--max-concurrent-dispatches=4 --max-dispatches-per-second=5 --max-attempts=12)
 if gcloud tasks queues describe "${TASKS_QUEUE_NAME}" --location="${REGION}" >/dev/null 2>&1; then
   gcloud tasks queues update "${TASKS_QUEUE_NAME}" --location="${REGION}" "${ENRICH_QUEUE_FLAGS[@]}"
 else

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -33,10 +33,17 @@ def _write_dedup_report(plan) -> Path:
     operator reviews before approving --apply (THE USER GATE, Spec 2026-07-12).
 
     Filename includes microseconds: a scripted dry-run -> apply sequence (or a test) can
-    complete both invocations within the same second, and the apply gate's cross-check
-    (Spec 2026-07-12 follow-up to #95) depends on the dry-run's report file NOT being
-    overwritten by apply's own fresh-plan write before it's read back — a second-resolution
-    timestamp would silently make that overwrite happen and the cross-check trivially pass."""
+    complete both invocations within the same second. With a second-resolution timestamp, both
+    writes would resolve to the IDENTICAL path, so apply's fresh-plan write would overwrite the
+    dry-run's report file on disk before it's ever read back — the second write clobbers the
+    first file, full stop, not a "which one is newest" lookup ambiguity: the path to read back
+    is captured (`existing_report = args.report or _newest_dedup_report()`, in main() below) up
+    front, BEFORE this same invocation's fresh write happens, so at read-back time there is only
+    ever one candidate path in play. Microsecond resolution avoids the collision at its root by
+    keeping the two filenames from ever being identical in the first place, making the
+    apply gate's cross-check (Spec 2026-07-12 follow-up to #95) compare the dry-run's real
+    reviewed content against the fresh plan instead of trivially comparing the fresh plan
+    against itself."""
     reports_dir = Path("data/reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
     now = datetime.now(UTC)
@@ -108,21 +115,33 @@ def _write_dedup_report(plan) -> Path:
 def _parse_plan_ids(report_text: str) -> dict[str, set[str]]:
     """Parse the '== PLAN IDS ==' block written by _write_dedup_report back into the same
     per-class id-set shape dedup_backfill.plan_id_set produces, so a fresh plan can be
-    cross-checked against what the operator actually reviewed. Raises ValueError if the block
-    is missing (an old-format report, or the wrong file) — --apply should refuse loudly rather
-    than silently treat a missing section as an empty (i.e. maximally strict) reviewed set."""
+    cross-checked against what the operator actually reviewed.
+
+    Fail-closed is an explicit, tested contract here, not an accident of subtraction semantics
+    (an empty/partial reviewed set would otherwise make plan_delta look "safe" just because
+    there's nothing to diff against): raises ValueError if the '== PLAN IDS ==' start marker is
+    missing (an old-format report, or the wrong file); if the '== END PLAN IDS ==' terminator is
+    missing (a truncated report — e.g. a write that got cut off mid-file); or if a line that
+    looks like a class header (starts with '[') doesn't actually parse as one (a malformed
+    header must not be silently absorbed as a plain id token). --apply catches this ValueError
+    and refuses rather than proceeding against a corrupt or incomplete reviewed set."""
     lines = report_text.splitlines()
     try:
         start = lines.index("== PLAN IDS ==")
     except ValueError as exc:
         raise ValueError("report has no '== PLAN IDS ==' section — not a dedup report, or an old-format one") from exc
 
+    try:
+        end = lines.index("== END PLAN IDS ==", start + 1)
+    except ValueError as exc:
+        raise ValueError("report has no '== END PLAN IDS ==' terminator — truncated or corrupt report") from exc
+
     out: dict[str, set[str]] = {name: set() for name in dedup_backfill.PLAN_ID_SET_CLASSES}
     current: str | None = None
-    for line in lines[start + 1 :]:
-        if line == "== END PLAN IDS ==":
-            break
-        if line.startswith("[") and "]" in line:
+    for line in lines[start + 1 : end]:
+        if line.startswith("["):
+            if "]" not in line:
+                raise ValueError(f"malformed class-header line in PLAN IDS block: {line!r}")
             current = line[1 : line.index("]")]
             if current not in out:
                 out[current] = set()

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -94,6 +94,26 @@ def _write_dedup_report(plan) -> Path:
         lines.append(f"  key={w.norm_key!r}  work_ids={w.work_ids}  titles={w.titles}")
     lines.append("")
 
+    # Final-review Critical (GH #95 follow-up): groups dropped from their class because they
+    # intersect another class's plan in a way that would compose into row loss if both applied
+    # from this SAME snapshot (narrator x edition cascade; edition x reading_history
+    # double-delete — see etl/dedup_backfill.py's _defer_intersecting_groups docstring). This is
+    # EXPECTED on intersecting data, not an error: the runbook's existing dry-run/apply LOOP
+    # re-plans after the intersecting class has already applied, resolving these on the next pass.
+    total_deferred = sum(len(v) for v in plan.deferred_intersections.values())
+    lines.append(f"deferred_intersections: {total_deferred} groups deferred to the next dry-run pass")
+    if total_deferred:
+        lines.append(
+            "  (EXPECTED on intersecting data, not an error — re-run --dedup-for-constraints "
+            "--dry-run after this apply and these will resolve; see docs/runbooks/"
+            "phase6-3-schema-rollout.md step 3.)"
+        )
+    for class_name, entries in plan.deferred_intersections.items():
+        lines.append(f"  [{class_name}] {len(entries)} deferred")
+        for entry in entries:
+            lines.append(f"    {entry}")
+    lines.append("")
+
     # Machine-readable section (Spec 2026-07-12 follow-up to #95): the exact per-class id set
     # this plan is "about", one id per line, sorted for a stable diff-friendly file. --apply
     # parses this back into a dict[str, set[str]] (see _parse_plan_ids) and cross-checks a
@@ -341,6 +361,15 @@ def main(argv: list[str] | None = None) -> int:
             print("--- duplicate_works_report_only samples (NEVER applied — operator triage) ---")
             for w in plan.duplicate_works_report_only[:10]:
                 print(f"  {w.titles}  ({w.work_ids})")
+
+            total_deferred = sum(len(v) for v in plan.deferred_intersections.values())
+            if total_deferred:
+                print(
+                    f"\n--- deferred_intersections: {total_deferred} groups deferred "
+                    "(EXPECTED on intersecting data — resolves on the next dry-run pass) ---"
+                )
+                for class_name, entries in plan.deferred_intersections.items():
+                    print(f"  [{class_name}] {len(entries)} deferred")
 
             report_path = _write_dedup_report(plan)
             print(f"\nfull plan (every id) written to {report_path} — review this before approving --apply.")

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -22,6 +22,8 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
+from sqlalchemy import func
+
 from agentic_librarian.db.models import Trope, Work
 from agentic_librarian.db.session import DatabaseManager, resolve_database_url
 from agentic_librarian.etl import contributor_dedup, dedup_backfill, enrichment_sweep, trope_backfill
@@ -253,7 +255,15 @@ def main(argv: list[str] | None = None) -> int:
 
     with manager.get_session() as session:
         print(f"DB target: …@{safe}")
-        print(f"recency probe: works={session.query(Work).count()} tropes={session.query(Trope).count()}")
+        # Column-explicit counts, not session.query(Work).count() / session.query(Trope).count()
+        # (entity loads): this probe runs for EVERY mode, including --dedup-for-constraints,
+        # which by design runs BEFORE `alembic upgrade head` lands migration 48e3762d6c0c. An
+        # entity load SELECTs every mapped column, including deep_enriched_at — a column that
+        # migration hasn't added to prod yet — and dies with UndefinedColumn (caught live against
+        # prod, GH #95). func.count(Work.id) never references it.
+        works_count = session.query(func.count(Work.id)).scalar()
+        tropes_count = session.query(func.count(Trope.id)).scalar()
+        print(f"recency probe: works={works_count} tropes={tropes_count}")
 
         if args.inventory:
             inv = contributor_dedup.contributor_inventory(session)

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -5,6 +5,8 @@
   python scripts/clean_catalog.py --contributors --apply --yes
   python scripts/clean_catalog.py --tropes --dry-run
   python scripts/clean_catalog.py --tropes --apply --yes
+  python scripts/clean_catalog.py --requeue-unenriched --dry-run
+  python scripts/clean_catalog.py --requeue-unenriched --apply --yes
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost."""
 
@@ -15,7 +17,7 @@ import sys
 
 from agentic_librarian.db.models import Trope, Work
 from agentic_librarian.db.session import DatabaseManager, resolve_database_url
-from agentic_librarian.etl import contributor_dedup, trope_backfill
+from agentic_librarian.etl import contributor_dedup, enrichment_sweep, trope_backfill
 from agentic_librarian.etl.tag_backfill import is_prod_url
 
 
@@ -38,6 +40,18 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--contributors", action="store_true")
     ap.add_argument("--tropes", action="store_true")
     ap.add_argument("--prune-fallbacks", action="store_true")
+    ap.add_argument(
+        "--requeue-unenriched",
+        action="store_true",
+        help=(
+            "GH #97 recovery path: list works that never completed a deep-enrichment pass "
+            "(deep_enriched_at IS NULL) or completed one without landing a real trope (poison "
+            "tasks that exhausted Cloud Tasks retries on the 503 empty-pass path). --apply --yes "
+            "re-enqueues each via enqueue_enrichment — requires Cloud Tasks env "
+            "(CLOUD_TASKS_QUEUE, ENRICH_TARGET_BASE_URL, ENRICH_INVOKER_SA) set, i.e. run this "
+            "from the prod operator context, not local dev."
+        ),
+    )
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
@@ -109,7 +123,21 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\napplied: {trope_backfill.apply_trope_changes(session, tm, changes)} trope rows cleaned.")
             return 0
 
-        print("Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, or --tropes.")
+        if args.requeue_unenriched:
+            candidates = enrichment_sweep.plan_requeue(session)
+            print(f"\n{len(candidates)} works would be requeued for deep enrichment.")
+            for c in candidates[:80]:
+                print(f"  [{c.reason:20}] {c.title[:60]}  ({c.work_id})")
+            early = _refuse(args, url, safe)
+            if early is not None:
+                return early
+            from agentic_librarian.enrichment.tasks import enqueue_enrichment
+
+            enqueued = sum(1 for c in candidates if enqueue_enrichment(str(c.work_id)))
+            print(f"\napplied: enqueued {enqueued}/{len(candidates)} works (see logs for any that skipped).")
+            return 0
+
+        print("Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, or --requeue-unenriched.")
         return 1
 
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -9,8 +9,11 @@
   python scripts/clean_catalog.py --requeue-unenriched --apply --yes
   python scripts/clean_catalog.py --dedup-for-constraints --dry-run
   python scripts/clean_catalog.py --dedup-for-constraints --apply --yes
+  python scripts/clean_catalog.py --dedup-for-constraints --apply --yes --report data/reports/dedup-<ts>.txt
 
-Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost."""
+Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost.
+--dedup-for-constraints --apply re-plans from scratch and cross-checks the fresh plan against
+the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if the plan drifted."""
 
 from __future__ import annotations
 
@@ -27,10 +30,17 @@ from agentic_librarian.etl.tag_backfill import is_prod_url
 
 def _write_dedup_report(plan) -> Path:
     """Every id in the plan, always written (dry-run AND apply) — this file is what the
-    operator reviews before approving --apply (THE USER GATE, Spec 2026-07-12)."""
+    operator reviews before approving --apply (THE USER GATE, Spec 2026-07-12).
+
+    Filename includes microseconds: a scripted dry-run -> apply sequence (or a test) can
+    complete both invocations within the same second, and the apply gate's cross-check
+    (Spec 2026-07-12 follow-up to #95) depends on the dry-run's report file NOT being
+    overwritten by apply's own fresh-plan write before it's read back — a second-resolution
+    timestamp would silently make that overwrite happen and the cross-check trivially pass."""
     reports_dir = Path("data/reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    now = datetime.now(UTC)
+    ts = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
     path = reports_dir / f"dedup-{ts}.txt"
 
     lines: list[str] = [f"Dedup plan report — {ts}", "=" * 60, ""]
@@ -77,8 +87,57 @@ def _write_dedup_report(plan) -> Path:
         lines.append(f"  key={w.norm_key!r}  work_ids={w.work_ids}  titles={w.titles}")
     lines.append("")
 
+    # Machine-readable section (Spec 2026-07-12 follow-up to #95): the exact per-class id set
+    # this plan is "about", one id per line, sorted for a stable diff-friendly file. --apply
+    # parses this back into a dict[str, set[str]] (see _parse_plan_ids) and cross-checks a
+    # FRESH re-plan against it via dedup_backfill.plan_delta — refusing if anything new shows
+    # up. Keep this block below the human-readable summary above, not instead of it.
+    lines.append("== PLAN IDS ==")
+    id_set = dedup_backfill.plan_id_set(plan)
+    for class_name in dedup_backfill.PLAN_ID_SET_CLASSES:
+        ids = sorted(id_set.get(class_name, set()))
+        lines.append(f"[{class_name}] {len(ids)}")
+        lines.extend(ids)
+    lines.append("== END PLAN IDS ==")
+    lines.append("")
+
     path.write_text("\n".join(lines), encoding="utf-8")
     return path
+
+
+def _parse_plan_ids(report_text: str) -> dict[str, set[str]]:
+    """Parse the '== PLAN IDS ==' block written by _write_dedup_report back into the same
+    per-class id-set shape dedup_backfill.plan_id_set produces, so a fresh plan can be
+    cross-checked against what the operator actually reviewed. Raises ValueError if the block
+    is missing (an old-format report, or the wrong file) — --apply should refuse loudly rather
+    than silently treat a missing section as an empty (i.e. maximally strict) reviewed set."""
+    lines = report_text.splitlines()
+    try:
+        start = lines.index("== PLAN IDS ==")
+    except ValueError as exc:
+        raise ValueError("report has no '== PLAN IDS ==' section — not a dedup report, or an old-format one") from exc
+
+    out: dict[str, set[str]] = {name: set() for name in dedup_backfill.PLAN_ID_SET_CLASSES}
+    current: str | None = None
+    for line in lines[start + 1 :]:
+        if line == "== END PLAN IDS ==":
+            break
+        if line.startswith("[") and "]" in line:
+            current = line[1 : line.index("]")]
+            if current not in out:
+                out[current] = set()
+            continue
+        if current is not None and line:
+            out[current].add(line)
+    return out
+
+
+def _newest_dedup_report() -> Path | None:
+    reports_dir = Path("data/reports")
+    if not reports_dir.is_dir():
+        return None
+    candidates = sorted(reports_dir.glob("dedup-*.txt"))
+    return candidates[-1] if candidates else None
 
 
 def _refuse(args, url, safe) -> int | None:
@@ -124,12 +183,29 @@ def main(argv: list[str] | None = None) -> int:
             "and approves -> --apply --yes -> operator runs `alembic upgrade head` (lands the #95 "
             "unique constraints, now safe) -> merge PR-D -> deploy. Every id in the plan is always "
             "written to data/reports/dedup-<UTC timestamp>.txt for review, on both dry-run and "
-            "apply. See docs/runbooks/phase6-3-schema-rollout.md."
+            "apply. See docs/runbooks/phase6-3-schema-rollout.md. IMPORTANT: --apply --yes is a "
+            "SEPARATE invocation that RE-PLANS from scratch — it does not reuse the dry-run's "
+            "in-memory plan. To keep the review meaningful, --apply cross-checks the fresh plan's "
+            "id set against the reviewed report (--report) and REFUSES (exit 1) if the fresh plan "
+            "contains any id the operator never reviewed (e.g. a new duplicate from live traffic "
+            "in the gap between dry-run and apply) — it prints the delta and writes a fresh report "
+            "for re-review instead of applying. A plan that lost ids (rows deleted/changed since "
+            "review) is fine and applies normally (ordinary skipped_stale)."
         ),
     )
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
+    ap.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help=(
+            "--dedup-for-constraints --apply only: path to the reviewed dry-run report to "
+            "cross-check the fresh plan against (THE USER GATE). Defaults to the newest "
+            "data/reports/dedup-*.txt — the tool prints which one it used."
+        ),
+    )
     args = ap.parse_args(argv)
 
     url = resolve_database_url()
@@ -213,6 +289,12 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.dedup_for_constraints:
+            # Capture the reviewed report BEFORE this run writes its own — the default
+            # --report resolution must point at the operator's PRIOR reviewed dry-run, never
+            # at the report this same invocation is about to write from the fresh plan below
+            # (which would make the cross-check trivially always pass against itself).
+            existing_report = args.report or _newest_dedup_report()
+
             plan = dedup_backfill.plan_dedup(session)
             summary = plan.summary()
             print("\n=== dedup-for-constraints plan (THE USER GATE) ===")
@@ -247,6 +329,36 @@ def main(argv: list[str] | None = None) -> int:
             early = _refuse(args, url, safe)
             if early is not None:
                 return early
+
+            # THE USER GATE, cross-check half (Spec 2026-07-12 follow-up to #95): --apply is a
+            # separate invocation and just computed a FRESH plan above (`plan`) — re-planned from
+            # scratch against current DB state, not reused from the operator's reviewed dry-run.
+            # Cross-check the fresh plan's id set against the reviewed report's id set; refuse on
+            # any addition rather than silently applying duplicates the operator never saw.
+            report_arg = existing_report
+            if report_arg is None:
+                print("\nREFUSING --apply: no dedup report found (data/reports/dedup-*.txt) — run --dry-run first.")
+                return 1
+            print(f"\ncross-checking fresh plan against reviewed report: {report_arg}")
+            try:
+                reviewed_ids = _parse_plan_ids(report_arg.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                print(f"\nREFUSING --apply: could not read/parse --report {report_arg}: {exc}")
+                return 1
+
+            delta = dedup_backfill.plan_delta(reviewed_ids, plan)
+            if any(delta.values()):
+                print("\nREFUSING --apply: plan changed since review — re-review the new report.")
+                print("New ids present in the fresh plan but NOT in the reviewed report:")
+                for class_name in dedup_backfill.PLAN_ID_SET_CLASSES:
+                    new_ids = sorted(delta.get(class_name, set()))
+                    if new_ids:
+                        print(f"  [{class_name}] +{len(new_ids)}: {new_ids}")
+                # report_path (written unconditionally above, from this SAME fresh plan) already
+                # IS the fresh report the operator needs to re-review — no need to write another.
+                print(f"\nre-review {report_path}, then re-run --apply --yes --report {report_path}")
+                return 1
+
             applied = dedup_backfill.apply_dedup(session, plan)
             print("\napplied:")
             for key, count in applied.items():

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -317,7 +317,13 @@ def main(argv: list[str] | None = None) -> int:
             candidates = enrichment_sweep.plan_requeue(session)
             print(f"\n{len(candidates)} works would be requeued for deep enrichment.")
             for c in candidates[:80]:
-                print(f"  [{c.reason:20}] {c.title[:60]}  ({c.work_id})")
+                # Adversarial-pass finding (#95 #97): show deep_enriched_at next to no_real_trope
+                # entries so a REPEAT sweep lets the operator see "already re-attempted after X"
+                # — see the runbook's step 6 repeat-cost warning (each re-enqueue costs up to 9
+                # paid deep passes; a persistently-unknowable title should be fixed/removed, not
+                # re-enqueued forever).
+                stamp = f"  (deep_enriched_at={c.deep_enriched_at})" if c.deep_enriched_at else ""
+                print(f"  [{c.reason:20}] {c.title[:60]}  ({c.work_id}){stamp}")
             early = _refuse(args, url, safe)
             if early is not None:
                 return early

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -7,6 +7,8 @@
   python scripts/clean_catalog.py --tropes --apply --yes
   python scripts/clean_catalog.py --requeue-unenriched --dry-run
   python scripts/clean_catalog.py --requeue-unenriched --apply --yes
+  python scripts/clean_catalog.py --dedup-for-constraints --dry-run
+  python scripts/clean_catalog.py --dedup-for-constraints --apply --yes
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost."""
 
@@ -14,11 +16,69 @@ from __future__ import annotations
 
 import argparse
 import sys
+from datetime import UTC, datetime
+from pathlib import Path
 
 from agentic_librarian.db.models import Trope, Work
 from agentic_librarian.db.session import DatabaseManager, resolve_database_url
-from agentic_librarian.etl import contributor_dedup, enrichment_sweep, trope_backfill
+from agentic_librarian.etl import contributor_dedup, dedup_backfill, enrichment_sweep, trope_backfill
 from agentic_librarian.etl.tag_backfill import is_prod_url
+
+
+def _write_dedup_report(plan) -> Path:
+    """Every id in the plan, always written (dry-run AND apply) — this file is what the
+    operator reviews before approving --apply (THE USER GATE, Spec 2026-07-12)."""
+    reports_dir = Path("data/reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = reports_dir / f"dedup-{ts}.txt"
+
+    lines: list[str] = [f"Dedup plan report — {ts}", "=" * 60, ""]
+    lines.append(f"duplicate_authors: {len(plan.duplicate_authors)} groups")
+    for g in plan.duplicate_authors:
+        lines.append(f"  survivor={g.survivor_id} ({g.survivor_name!r})  losers={g.loser_ids} ({g.loser_names!r})")
+        lines.append(f"    repoint_links={g.repoint_links}  delete_links={g.delete_links}")
+        lines.append(f"    repoint_styles={g.repoint_styles}  delete_styles={g.delete_styles}")
+    lines.append("")
+
+    lines.append(f"duplicate_narrators: {len(plan.duplicate_narrators)} groups")
+    for g in plan.duplicate_narrators:
+        lines.append(f"  survivor={g.survivor_id} ({g.survivor_name!r})  losers={g.loser_ids} ({g.loser_names!r})")
+        lines.append(f"    repoint_links={g.repoint_links}  delete_links={g.delete_links}")
+        lines.append(f"    repoint_styles={g.repoint_styles}  delete_styles={g.delete_styles}")
+    lines.append("")
+
+    lines.append(f"duplicate_editions: {len(plan.duplicate_editions)} groups")
+    for g in plan.duplicate_editions:
+        lines.append(f"  survivor={g.survivor_id}  work_id={g.work_id}  format={g.fmt!r}  losers={g.loser_ids}")
+        lines.append(
+            f"    repoint_reading_history={g.repoint_reading_history}  "
+            f"delete_reading_history={g.delete_reading_history}"
+        )
+        lines.append(f"    repoint_narrators={g.repoint_narrators}  delete_narrators={g.delete_narrators}")
+    lines.append("")
+
+    lines.append(f"duplicate_reading_history: {len(plan.duplicate_reading_history)} groups")
+    for g in plan.duplicate_reading_history:
+        lines.append(f"  survivor={g.survivor_id}  losers={g.loser_ids}  ({g.detail})")
+    lines.append("")
+
+    lines.append(f"duplicate_suggestions: {len(plan.duplicate_suggestions)} groups")
+    for g in plan.duplicate_suggestions:
+        lines.append(f"  survivor={g.survivor_id}  losers={g.loser_ids}  ({g.detail})")
+    lines.append("")
+
+    lines.append(f"orphan_authors: {len(plan.orphan_authors)} ids (deleted on apply)")
+    lines.append(f"  {plan.orphan_authors}")
+    lines.append("")
+
+    lines.append(f"duplicate_works_report_only: {len(plan.duplicate_works_report_only)} groups (NEVER applied)")
+    for w in plan.duplicate_works_report_only:
+        lines.append(f"  key={w.norm_key!r}  work_ids={w.work_ids}  titles={w.titles}")
+    lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
 
 
 def _refuse(args, url, safe) -> int | None:
@@ -50,6 +110,21 @@ def main(argv: list[str] | None = None) -> int:
             "re-enqueues each via enqueue_enrichment — requires Cloud Tasks env "
             "(CLOUD_TASKS_QUEUE, ENRICH_TARGET_BASE_URL, ENRICH_INVOKER_SA) set, i.e. run this "
             "from the prod operator context, not local dev."
+        ),
+    )
+    ap.add_argument(
+        "--dedup-for-constraints",
+        action="store_true",
+        help=(
+            "Phase 6.3 THE USER GATE (#95): plan+apply the pre-constraint dedup backfill "
+            "(duplicate_authors/narrators/editions/reading_history/suggestions + orphan_authors; "
+            "duplicate_works_report_only is a report-only detail list, never applied). Structural "
+            "distinguishers only (the #69 lesson) — see etl/dedup_backfill.py. Sequence: PR-C "
+            "deployed (pollution stopped) -> this dry-run on prod -> operator reviews the report "
+            "and approves -> --apply --yes -> operator runs `alembic upgrade head` (lands the #95 "
+            "unique constraints, now safe) -> merge PR-D -> deploy. Every id in the plan is always "
+            "written to data/reports/dedup-<UTC timestamp>.txt for review, on both dry-run and "
+            "apply. See docs/runbooks/phase6-3-schema-rollout.md."
         ),
     )
     ap.add_argument("--dry-run", action="store_true")
@@ -137,7 +212,55 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\napplied: enqueued {enqueued}/{len(candidates)} works (see logs for any that skipped).")
             return 0
 
-        print("Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, or --requeue-unenriched.")
+        if args.dedup_for_constraints:
+            plan = dedup_backfill.plan_dedup(session)
+            summary = plan.summary()
+            print("\n=== dedup-for-constraints plan (THE USER GATE) ===")
+            for key, count in summary.items():
+                print(f"  {key:32} {count}")
+
+            print("\n--- duplicate_authors samples ---")
+            for g in plan.duplicate_authors[:10]:
+                print(f"  keep {g.survivor_name!r} ({g.survivor_id})  merge {g.loser_names!r} ({g.loser_ids})")
+            print("--- duplicate_narrators samples ---")
+            for g in plan.duplicate_narrators[:10]:
+                print(f"  keep {g.survivor_name!r} ({g.survivor_id})  merge {g.loser_names!r} ({g.loser_ids})")
+            print("--- duplicate_editions samples ---")
+            for g in plan.duplicate_editions[:10]:
+                print(f"  work={g.work_id} format={g.fmt!r}  keep {g.survivor_id}  merge {g.loser_ids}")
+            print("--- duplicate_reading_history samples ---")
+            for g in plan.duplicate_reading_history[:10]:
+                print(f"  keep {g.survivor_id}  delete {g.loser_ids}  ({g.detail})")
+            print("--- duplicate_suggestions samples ---")
+            for g in plan.duplicate_suggestions[:10]:
+                print(f"  keep {g.survivor_id}  delete {g.loser_ids}  ({g.detail})")
+            print("--- orphan_authors samples ---")
+            for aid in plan.orphan_authors[:10]:
+                print(f"  {aid}")
+            print("--- duplicate_works_report_only samples (NEVER applied — operator triage) ---")
+            for w in plan.duplicate_works_report_only[:10]:
+                print(f"  {w.titles}  ({w.work_ids})")
+
+            report_path = _write_dedup_report(plan)
+            print(f"\nfull plan (every id) written to {report_path} — review this before approving --apply.")
+
+            early = _refuse(args, url, safe)
+            if early is not None:
+                return early
+            applied = dedup_backfill.apply_dedup(session, plan)
+            print("\napplied:")
+            for key, count in applied.items():
+                print(f"  {key:32} {count}")
+            print(
+                "\nNext: operator runs `alembic upgrade head` on prod to land the #95 unique "
+                "constraints, then merge PR-D and deploy."
+            )
+            return 0
+
+        print(
+            "Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, "
+            "--requeue-unenriched, or --dedup-for-constraints."
+        )
         return 1
 
 

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -136,6 +136,6 @@ FEEDBACK HANDLING:
 - "Not for me" / "I hate this" -> 'update_suggestion_status' (Dismissed).
 - Mood feedback ("not in the mood for X") -> respect it for the rest of the conversation.
 
-When you commit to a recommendation, log it with 'log_suggestion'. Keep replies concise and
+When you commit to a recommendation, log it with 'log_suggestion'. If it reports an existing active suggestion, treat it as already logged — do not retry or apologize for a duplicate. Keep replies concise and
 conversational; ask at most one clarifying question when the request is too vague to act on.
 """

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -190,7 +190,7 @@ class LibrarianAgent(LlmAgent):
             - If user says "Not for me" or "I hate this", use 'update_suggestion_status(Dismissed)'.
             - If user provides mood feedback ("Not in the mood for X"), pass it to the Analyst/Critic.
 
-            Always log the final result using 'log_suggestion'.
+            Always log the final result using 'log_suggestion'. If it reports an existing active suggestion, treat it as already logged — do not retry or apologize for a duplicate.
             """,
             tools=[
                 AgentTool(analyst),

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from fastapi import APIRouter, Header, HTTPException
 
 from agentic_librarian.enrichment import two_phase
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -53,12 +54,41 @@ def _require_queue_caller(authorization: str | None) -> None:
         raise HTTPException(status_code=403, detail="Caller is not the enrichment queue.")
 
 
+def _has_real_trope(work_id: UUID) -> bool:
+    """True if work_id has >=1 genuine narrative trope link (shared #111 predicate over
+    its linked trope names + its own genres/moods). False for zero links, or links that
+    are ALL fallback (re-encoded genre/mood) or junk."""
+    from agentic_librarian.db.models import Trope, Work, WorkTrope
+
+    with two_phase.db_manager.get_session() as session:
+        work = session.get(Work, work_id)
+        if work is None:
+            return False
+        names = (
+            session.query(Trope.name)
+            .join(WorkTrope, WorkTrope.trope_id == Trope.id)
+            .filter(WorkTrope.work_id == work_id)
+        ).all()
+        return any(is_fallback_trope_name(name, work.genres, work.moods) is False for (name,) in names)
+
+
 @router.post("/internal/enrich/{work_id}")
 def enrich(work_id: UUID, authorization: str | None = Header(None)):  # noqa: B008
     _require_queue_caller(authorization)
-    if not two_phase.enrich_deep(work_id):
+    result = two_phase.enrich_deep(work_id)
+    if result == "missing":
         # Non-retryable: the work no longer exists. 404 stops Cloud Tasks from retrying.
         raise HTTPException(status_code=404, detail="work not found")
+    if result == "empty":
+        if _has_real_trope(work_id):
+            # The work already has a real fingerprint from a prior pass; this empty pass
+            # added nothing new but isn't a failure — don't make Cloud Tasks retry forever.
+            return {"work_id": str(work_id), "status": "already_enriched"}
+        # No real trope AND this pass found nothing: retryable. Cloud Tasks retries with
+        # backoff; retry exhaustion is the poison-task end state — the requeue sweep
+        # (etl/enrichment_sweep.py, scripts/clean_catalog.py --requeue-unenriched) is the
+        # operator backstop for works that exhaust retries or were never queued at all.
+        raise HTTPException(status_code=503, detail={"work_id": str(work_id), "status": "empty_deep_pass"})
     return {"work_id": str(work_id), "status": "enriched"}
 
 

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -72,8 +72,23 @@ def _has_real_trope(work_id: UUID) -> bool:
         return any(is_fallback_trope_name(name, work.genres, work.moods) is False for (name,) in names)
 
 
+# Cloud Tasks' own retry-count header (set by the queue on every redelivery, 0 on the first
+# attempt) — https://cloud.google.com/tasks/docs/creating-http-target-tasks#handler. Cloud
+# Tasks' default maxAttempts is 100 with backoff maxing out around an hour between attempts, so
+# an unbounded empty-pass-503 loop on a genuinely poison book (bad title/author, scouts will
+# NEVER find a real trope for it) would otherwise cost ~100 PAID deep-LLM passes before anyone
+# notices. Giving up loudly at a bounded retry count is cheap insurance: the operator's
+# --requeue-unenriched sweep (etl/enrichment_sweep.py) is the documented backstop for works that
+# gave up here, so nothing is silently lost — it's just no longer an unbounded retry bill.
+GIVE_UP_AFTER_RETRIES = 8
+
+
 @router.post("/internal/enrich/{work_id}")
-def enrich(work_id: UUID, authorization: str | None = Header(None)):  # noqa: B008
+def enrich(
+    work_id: UUID,
+    authorization: str | None = Header(None),  # noqa: B008
+    x_cloudtasks_taskretrycount: str | None = Header(None),  # noqa: B008
+):
     _require_queue_caller(authorization)
     result = two_phase.enrich_deep(work_id)
     if result == "missing":
@@ -84,10 +99,20 @@ def enrich(work_id: UUID, authorization: str | None = Header(None)):  # noqa: B0
             # The work already has a real fingerprint from a prior pass; this empty pass
             # added nothing new but isn't a failure — don't make Cloud Tasks retry forever.
             return {"work_id": str(work_id), "status": "already_enriched"}
-        # No real trope AND this pass found nothing: retryable. Cloud Tasks retries with
-        # backoff; retry exhaustion is the poison-task end state — the requeue sweep
-        # (etl/enrichment_sweep.py, scripts/clean_catalog.py --requeue-unenriched) is the
-        # operator backstop for works that exhaust retries or were never queued at all.
+        try:
+            retry_count = int(x_cloudtasks_taskretrycount) if x_cloudtasks_taskretrycount is not None else 0
+        except ValueError:
+            retry_count = 0
+        if retry_count >= GIVE_UP_AFTER_RETRIES:
+            # Retry bound reached with still no real trope: this is the poison-task end state,
+            # not a transient failure. Return 200 (not 503) so Cloud Tasks STOPS retrying —
+            # the --requeue-unenriched sweep is the operator's backstop for these, not another
+            # 92 paid deep passes at ~hourly backoff.
+            logger.warning("empty deep pass gave up after %d retries (no real trope): work_id=%s", retry_count, work_id)
+            return {"work_id": str(work_id), "status": "empty_deep_pass_gave_up"}
+        # No real trope AND this pass found nothing, and we haven't hit the give-up bound yet:
+        # retryable. Cloud Tasks retries with backoff; the requeue sweep is also the backstop
+        # for works that exhaust retries or were never queued at all.
         raise HTTPException(status_code=503, detail={"work_id": str(work_id), "status": "empty_deep_pass"})
     return {"work_id": str(work_id), "status": "enriched"}
 

--- a/src/agentic_librarian/availability/service.py
+++ b/src/agentic_librarian/availability/service.py
@@ -116,7 +116,7 @@ def availability_for(session: Session, library: dict, title: str, author: str) -
     slug = library["slug"]
     now = datetime.now(UTC)
     row = session.get(AvailabilityCache, (_PROVIDER, slug, nt, na))
-    if row is not None and (now - row.fetched_at.replace(tzinfo=UTC)) < _ttl():
+    if row is not None and (now - row.fetched_at) < _ttl():
         return row.payload.get("formats", [])
 
     try:
@@ -148,7 +148,7 @@ def batch_availability(db_manager, libs: list[dict], items: list[tuple[str, str]
             for title, author in items:
                 nt, na = _normalize(title), _normalize(author)
                 row = session.get(AvailabilityCache, (_PROVIDER, lib["slug"], nt, na))
-                if row is not None and (now - row.fetched_at.replace(tzinfo=UTC)) < _ttl():
+                if row is not None and (now - row.fetched_at) < _ttl():
                     results[(lib["slug"], title, author)] = row.payload.get("formats", [])
                 else:
                     misses.append((lib, title, author))

--- a/src/agentic_librarian/db/get_or_create.py
+++ b/src/agentic_librarian/db/get_or_create.py
@@ -1,0 +1,64 @@
+"""Constraint-backed get-or-create (GH #95). The SELECT-then-INSERT races that used to
+create duplicates are now backstopped by unique constraints; this helper turns the
+IntegrityError loser into a clean re-query instead of a 500. SAVEPOINT (begin_nested)
+so the caller's outer transaction survives the rolled-back insert.
+
+Two helpers:
+
+- `get_or_create` — filters and re-queries with the SAME exact-match predicate
+  (`filter_by(**filters)`). Fine when the DB constraint matches the filter predicate
+  1:1 (editions on (work_id, format), reading_history, suggestions).
+
+- `insert_or_requery` — for sites whose DB constraint is NOT an exact-match predicate,
+  e.g. authors/narrators' `uq_*_name_lower` fires on `lower(name)` while an exact
+  `filter_by(name=name)` re-query would MISS a case-variant winner ("CasualFarmer" vs
+  "casualfarmer" collide at the DB but not under `==`). Callers keep their existing
+  case-insensitive first-query and pass a `requery` callable that performs the same
+  case-insensitive lookup for the recovery path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from sqlalchemy.exc import IntegrityError
+
+T = TypeVar("T")
+
+
+def get_or_create(session, model, defaults=None, **filters):
+    instance = session.query(model).filter_by(**filters).first()
+    if instance is not None:
+        return instance, False
+    params = dict(filters)
+    params.update(defaults or {})
+    try:
+        with session.begin_nested():
+            instance = model(**params)
+            session.add(instance)
+            session.flush()
+        return instance, True
+    except IntegrityError:
+        instance = session.query(model).filter_by(**filters).first()
+        if instance is None:  # constraint fired but filters don't match it (e.g. case-variant name)
+            raise
+        return instance, False
+
+
+def insert_or_requery(session, instance: T, requery: Callable[[], T | None]) -> tuple[T, bool]:
+    """Insert `instance` (already query-missed by the caller's own first lookup), wrapped
+    in the same begin_nested/IntegrityError-requery pattern as get_or_create — but recovery
+    uses the caller-supplied `requery` callable instead of an exact-match filter_by, since
+    the backing constraint may not be an exact-match predicate (case-insensitive unique
+    indexes on authors/narrators). Returns (instance, created)."""
+    try:
+        with session.begin_nested():
+            session.add(instance)
+            session.flush()
+        return instance, True
+    except IntegrityError:
+        existing = requery()
+        if existing is None:  # constraint fired but the requery genuinely finds nothing — not our race
+            raise
+        return existing, False

--- a/src/agentic_librarian/db/get_or_create.py
+++ b/src/agentic_librarian/db/get_or_create.py
@@ -28,6 +28,10 @@ T = TypeVar("T")
 
 
 def get_or_create(session, model, defaults=None, **filters):
+    if not filters:
+        # An empty filter_by() matches an arbitrary first row -- silent data corruption
+        # in an integrity helper.
+        raise ValueError("get_or_create requires at least one filter criterion")
     instance = session.query(model).filter_by(**filters).first()
     if instance is not None:
         return instance, False

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -2,7 +2,22 @@ from datetime import UTC, date, datetime
 from uuid import UUID, uuid4
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import ARRAY, Column, Date, DateTime, Float, ForeignKey, Integer, LargeBinary, String, Table, Text
+from sqlalchemy import (
+    ARRAY,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Table,
+    Text,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -36,14 +51,17 @@ class Author(Base):
     __tablename__ = "authors"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    # GH #95: uq_authors_name_lower — CREATE UNIQUE INDEX ... ON authors (lower(name)),
-    # NULLS NOT DISTINCT-free functional unique; expressible only as raw DDL, see the
-    # 48e3762d6c0c migration.
     name: Mapped[str] = mapped_column(String, nullable=False)
     bio: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     contributions: Mapped[list["WorkContributor"]] = relationship(back_populates="author")
     styles: Mapped[list["AuthorStyle"]] = relationship(back_populates="author", cascade="all, delete-orphan")
+
+    # GH #95/schema-drift: model parity with the 48e3762d6c0c migration's raw-DDL
+    # functional unique index (CREATE UNIQUE INDEX uq_authors_name_lower ON authors
+    # (lower(name))) — must match that DDL exactly (same name) or autogenerate drifts.
+    # Defined after `name` above so func.lower() closes over the real Column, not a string.
+    __table_args__ = (Index("uq_authors_name_lower", func.lower(name), unique=True),)
 
 
 class Work(Base):
@@ -71,11 +89,13 @@ class Narrator(Base):
     __tablename__ = "narrators"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    # GH #95: uq_narrators_name_lower — functional unique on lower(name), raw DDL in the
-    # 48e3762d6c0c migration (same shape as Author.name above).
     name: Mapped[str] = mapped_column(String, nullable=False)
 
     styles: Mapped[list["NarratorStyle"]] = relationship(back_populates="narrator", cascade="all, delete-orphan")
+
+    # GH #95/schema-drift: model parity with the 48e3762d6c0c migration's raw-DDL
+    # functional unique index (same shape as Author.name above) — name must match exactly.
+    __table_args__ = (Index("uq_narrators_name_lower", func.lower(name), unique=True),)
 
 
 class Style(Base):
@@ -159,8 +179,6 @@ class Edition(Base):
     # lookups on work_id alone; a separate single-column index would be redundant.
     work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False)
     isbn_13: Mapped[str | None] = mapped_column(String, nullable=True)
-    # GH #95: uq_editions_work_format — UNIQUE (work_id, format) NULLS NOT DISTINCT (raw
-    # DDL in the 48e3762d6c0c migration; not expressible via mapped_column/UniqueConstraint).
     format: Mapped[str | None] = mapped_column(String, nullable=True)
     page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     audio_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -170,6 +188,18 @@ class Edition(Base):
     narrators: Mapped[list["Narrator"]] = relationship(secondary=edition_narrators)
     reading_history: Mapped[list["ReadingHistory"]] = relationship(back_populates="edition")
 
+    # GH #95/schema-drift: model parity with the 48e3762d6c0c migration's raw-DDL
+    # UNIQUE (work_id, format) NULLS NOT DISTINCT index — name must match exactly.
+    __table_args__ = (
+        Index(
+            "uq_editions_work_format",
+            work_id,
+            format,
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
 
 class ReadingHistory(Base):
     __tablename__ = "reading_history"
@@ -178,23 +208,30 @@ class ReadingHistory(Base):
     edition_id: Mapped[UUID] = mapped_column(ForeignKey("editions.id"), nullable=False, index=True)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     date_started: Mapped[date | None] = mapped_column(Date, nullable=True)
-    # GH #95: uq_reading_history_user_edition_date — UNIQUE (user_id, edition_id,
-    # date_completed), raw DDL in the 48e3762d6c0c migration (kept here, not on user_id
-    # above, since the constraint is composite).
+    # Composite unique below (not on user_id above) since the constraint spans three columns.
     date_completed: Mapped[date] = mapped_column(Date, nullable=False)
     user_rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
     user_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     edition: Mapped["Edition"] = relationship(back_populates="reading_history")
 
+    # GH #95/schema-drift: model parity with the 48e3762d6c0c migration's raw-DDL
+    # UNIQUE (user_id, edition_id, date_completed) index — name must match exactly.
+    __table_args__ = (
+        Index(
+            "uq_reading_history_user_edition_date",
+            user_id,
+            edition_id,
+            date_completed,
+            unique=True,
+        ),
+    )
+
 
 class Suggestions(Base):
     __tablename__ = "suggestions"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    # GH #95: uq_suggestions_active — partial UNIQUE (user_id, work_id) WHERE
-    # status = 'Suggested', raw DDL in the 48e3762d6c0c migration (not expressible via
-    # mapped_column/UniqueConstraint).
     work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False, index=True)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     suggested_at: Mapped[datetime] = mapped_column(
@@ -206,6 +243,19 @@ class Suggestions(Base):
     conversation_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
 
     work: Mapped["Work"] = relationship(back_populates="suggestions")
+
+    # GH #95/schema-drift: model parity with the 48e3762d6c0c migration's raw-DDL
+    # partial UNIQUE (user_id, work_id) WHERE status = 'Suggested' index — name and
+    # predicate text must match exactly.
+    __table_args__ = (
+        Index(
+            "uq_suggestions_active",
+            user_id,
+            work_id,
+            unique=True,
+            postgresql_where=text("status = 'Suggested'"),
+        ),
+    )
 
 
 class Conversation(Base):

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -154,7 +154,10 @@ class Edition(Base):
     __tablename__ = "editions"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False, index=True)
+    # GH #109/final-review Minor 5: NO index=True here (no standalone ix_editions_work_id) — the
+    # leading column of uq_editions_work_format (work_id, format), just below, already serves
+    # lookups on work_id alone; a separate single-column index would be redundant.
+    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False)
     isbn_13: Mapped[str | None] = mapped_column(String, nullable=True)
     # GH #95: uq_editions_work_format — UNIQUE (work_id, format) NULLS NOT DISTINCT (raw
     # DDL in the 48e3762d6c0c migration; not expressible via mapped_column/UniqueConstraint).

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -16,7 +16,7 @@ class WorkContributor(Base):
     __tablename__ = "work_contributors"
 
     work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), primary_key=True)
-    author_id: Mapped[UUID] = mapped_column(ForeignKey("authors.id"), primary_key=True)
+    author_id: Mapped[UUID] = mapped_column(ForeignKey("authors.id"), primary_key=True, index=True)
     role: Mapped[str] = mapped_column(String, default="Primary", primary_key=True)
 
     work: Mapped["Work"] = relationship(back_populates="contributors")
@@ -28,7 +28,7 @@ edition_narrators = Table(
     "edition_narrators",
     Base.metadata,
     Column("edition_id", ForeignKey("editions.id"), primary_key=True),
-    Column("narrator_id", ForeignKey("narrators.id"), primary_key=True),
+    Column("narrator_id", ForeignKey("narrators.id"), primary_key=True, index=True),
 )
 
 
@@ -36,6 +36,9 @@ class Author(Base):
     __tablename__ = "authors"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    # GH #95: uq_authors_name_lower — CREATE UNIQUE INDEX ... ON authors (lower(name)),
+    # NULLS NOT DISTINCT-free functional unique; expressible only as raw DDL, see the
+    # 48e3762d6c0c migration.
     name: Mapped[str] = mapped_column(String, nullable=False)
     bio: Mapped[str | None] = mapped_column(Text, nullable=True)
 
@@ -53,6 +56,10 @@ class Work(Base):
     genres: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True)
     moods: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True)
 
+    # GH #97: stamped when a deep-enrichment pass completes (including confirmed-empty);
+    # NULL means never deep-enriched. See etl/enrichment_sweep.py's requeue predicate.
+    deep_enriched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     contributors: Mapped[list["WorkContributor"]] = relationship(back_populates="work", cascade="all, delete-orphan")
     editions: Mapped[list["Edition"]] = relationship(back_populates="work")
     tropes: Mapped[list["WorkTrope"]] = relationship(back_populates="work")
@@ -64,6 +71,8 @@ class Narrator(Base):
     __tablename__ = "narrators"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    # GH #95: uq_narrators_name_lower — functional unique on lower(name), raw DDL in the
+    # 48e3762d6c0c migration (same shape as Author.name above).
     name: Mapped[str] = mapped_column(String, nullable=False)
 
     styles: Mapped[list["NarratorStyle"]] = relationship(back_populates="narrator", cascade="all, delete-orphan")
@@ -89,7 +98,7 @@ class AuthorStyle(Base):
     __tablename__ = "author_styles"
 
     author_id: Mapped[UUID] = mapped_column(ForeignKey("authors.id"), primary_key=True)
-    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True)
+    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True, index=True)
     attribute_type: Mapped[str] = mapped_column(String, primary_key=True)  # 'pacing', 'tone', 'style', 'humor', etc.
 
     author: Mapped["Author"] = relationship(back_populates="styles")
@@ -100,7 +109,7 @@ class NarratorStyle(Base):
     __tablename__ = "narrator_styles"
 
     narrator_id: Mapped[UUID] = mapped_column(ForeignKey("narrators.id"), primary_key=True)
-    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True)
+    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True, index=True)
     attribute_type: Mapped[str] = mapped_column(String, primary_key=True)  # 'voice_differentiation', etc.
 
     narrator: Mapped["Narrator"] = relationship(back_populates="styles")
@@ -111,7 +120,7 @@ class WorkStyle(Base):
     __tablename__ = "work_styles"
 
     work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), primary_key=True)
-    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True)
+    style_id: Mapped[UUID] = mapped_column(ForeignKey("styles.id"), primary_key=True, index=True)
     attribute_type: Mapped[str] = mapped_column(String, primary_key=True)  # 'perspective', 'interiority', etc.
 
     work: Mapped["Work"] = relationship(back_populates="styles")
@@ -133,7 +142,7 @@ class WorkTrope(Base):
     __tablename__ = "work_tropes"
 
     work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), primary_key=True, nullable=False)
-    trope_id: Mapped[UUID] = mapped_column(ForeignKey("tropes.id"), primary_key=True, nullable=False)
+    trope_id: Mapped[UUID] = mapped_column(ForeignKey("tropes.id"), primary_key=True, nullable=False, index=True)
     relevance_score: Mapped[float] = mapped_column(Float, default=1.0, nullable=False)
     justification: Mapped[str | None] = mapped_column(Text, nullable=True)
 
@@ -145,8 +154,10 @@ class Edition(Base):
     __tablename__ = "editions"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False)
+    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False, index=True)
     isbn_13: Mapped[str | None] = mapped_column(String, nullable=True)
+    # GH #95: uq_editions_work_format — UNIQUE (work_id, format) NULLS NOT DISTINCT (raw
+    # DDL in the 48e3762d6c0c migration; not expressible via mapped_column/UniqueConstraint).
     format: Mapped[str | None] = mapped_column(String, nullable=True)
     page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     audio_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -161,9 +172,12 @@ class ReadingHistory(Base):
     __tablename__ = "reading_history"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    edition_id: Mapped[UUID] = mapped_column(ForeignKey("editions.id"), nullable=False)
+    edition_id: Mapped[UUID] = mapped_column(ForeignKey("editions.id"), nullable=False, index=True)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     date_started: Mapped[date | None] = mapped_column(Date, nullable=True)
+    # GH #95: uq_reading_history_user_edition_date — UNIQUE (user_id, edition_id,
+    # date_completed), raw DDL in the 48e3762d6c0c migration (kept here, not on user_id
+    # above, since the constraint is composite).
     date_completed: Mapped[date] = mapped_column(Date, nullable=False)
     user_rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
     user_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -175,9 +189,14 @@ class Suggestions(Base):
     __tablename__ = "suggestions"
 
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
-    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False)
+    # GH #95: uq_suggestions_active — partial UNIQUE (user_id, work_id) WHERE
+    # status = 'Suggested', raw DDL in the 48e3762d6c0c migration (not expressible via
+    # mapped_column/UniqueConstraint).
+    work_id: Mapped[UUID] = mapped_column(ForeignKey("works.id"), nullable=False, index=True)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
-    suggested_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    suggested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
     context: Mapped[str | None] = mapped_column(Text, nullable=True)
     justification: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String, default="Suggested", nullable=False)
@@ -196,9 +215,14 @@ class Conversation(Base):
     id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     title: Mapped[str | None] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
     )
 
     messages: Mapped[list["Message"]] = relationship(back_populates="conversation", cascade="all, delete-orphan")
@@ -213,7 +237,9 @@ class Message(Base):
     conversation_id: Mapped[UUID] = mapped_column(ForeignKey("conversations.id"), nullable=False, index=True)
     role: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
 
     conversation: Mapped["Conversation"] = relationship(back_populates="messages")
 
@@ -229,7 +255,9 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, nullable=False)  # lowercased; the invite key
     firebase_uid: Mapped[str | None] = mapped_column(String, unique=True, nullable=True)
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
 
 
 class Usage(Base):
@@ -246,9 +274,11 @@ class Usage(Base):
     input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     conversation_id: Mapped[UUID | None] = mapped_column(
-        PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True
+        PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True, index=True
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
 
 
 class UserCredential(Base):
@@ -262,9 +292,14 @@ class UserCredential(Base):
     vendor: Mapped[str] = mapped_column(String, primary_key=True)
     encrypted_key: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     kms_key_name: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
     )
 
 
@@ -280,7 +315,9 @@ class UserLibrary(Base):
     library_slug: Mapped[str] = mapped_column(String, primary_key=True)
     display_name: Mapped[str] = mapped_column(String, nullable=False)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
 
 
 class AvailabilityCache(Base):
@@ -296,7 +333,7 @@ class AvailabilityCache(Base):
     norm_author: Mapped[str] = mapped_column(String, primary_key=True)
     payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
     fetched_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False
+        DateTime(timezone=True), nullable=False
     )  # caller always supplies the fetch time; no default by design
 
 
@@ -311,7 +348,9 @@ class ImportJob(Base):
     source: Mapped[str] = mapped_column(String, nullable=False)  # 'goodreads' | 'generic'
     original_filename: Mapped[str | None] = mapped_column(String, nullable=True)
     total_rows: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
 
 
 class ImportRow(Base):
@@ -341,7 +380,12 @@ class ImportRow(Base):
         PG_UUID(as_uuid=True), nullable=True
     )  # resolved Work; soft reference, no FK by design (import_rows are a transient staging/audit log)
     error_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
     )

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -11,7 +11,10 @@ re-checks dedup before persisting (the #95 TOCTOU window is back to milliseconds
 of the scouts' full duration).
 
 This is a parallel surface to mcp/server.py's enrich_and_persist_work (the all-scouts
-discovery write tool, left untouched): same persist core, tiered scouts."""
+discovery write tool). enrich_and_persist_work now ROUTES THROUGH enrich_fast (not left
+untouched — corrected, final review Minor 6), so it is covered by enrich_fast's
+pg_advisory_xact_lock dedup guard the same as every other fast-pass caller: same persist
+core, tiered scouts."""
 
 from __future__ import annotations
 
@@ -180,15 +183,20 @@ def enrich_deep(work_id: UUID) -> str:
     call), then re-persist in a fresh session.
 
     Returns one of:
-      "missing" — no Work has that id, or it has no linked Author (non-retryable).
+      "missing" — no Work has that id, or it has no linked Author (non-retryable). Also
+                  returned (final-review Minor 7 honesty fix) if the write session's
+                  persist_enriched_work returns None — nothing was persisted and
+                  deep_enriched_at was never stamped, so "done" would be a lie; "missing" tells
+                  the caller (api/internal.py) this is non-retryable the same way an
+                  already-gone Work is, rather than falsely reporting success.
       "empty"   — the scouts yielded nothing to add this pass. A SHORT session stamps
                   work.deep_enriched_at = now() anyway (GH #97): the timestamp means "the
                   deep pass COMPLETED", including confirmed-empty — the caller (api/internal.py)
                   decides retryability from the work's real-trope state, not from this string
                   alone. An exception raised before this point propagates uncaught, leaving
                   deep_enriched_at unstamped so Cloud Tasks retries the whole pass.
-      "done"    — the scouts found something; the write session persists the row AND stamps
-                  deep_enriched_at on the SAME Work in the SAME session."""
+      "done"    — the scouts found something AND the write session actually persisted +
+                  stamped deep_enriched_at on the SAME Work in the SAME session."""
     with db_manager.get_session() as session:
         work = session.get(Work, work_id)
         if work is None:
@@ -213,7 +221,13 @@ def enrich_deep(work_id: UUID) -> str:
 
     with db_manager.get_session() as session:
         work = _persist_row(session, row)
-        if work is not None:
-            work.deep_enriched_at = datetime.now(UTC)
+        if work is None:
+            # Nothing was persisted (e.g. the scouted row had no usable contributor to attach
+            # to — persist_enriched_work's own "no work" case) and deep_enriched_at was never
+            # stamped. Reporting "done" here would be dishonest: the caller would treat a
+            # no-op as success. "missing" makes it non-retryable the same way an already-gone
+            # Work is (final-review Minor 7).
+            return "missing"
+        work.deep_enriched_at = datetime.now(UTC)
         session.flush()
     return "done"

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -16,6 +16,7 @@ discovery write tool, left untouched): same persist core, tiered scouts."""
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from uuid import UUID
 
 from sqlalchemy import func
@@ -172,28 +173,47 @@ def add_read_event(work_id: UUID, *, completed, rating: int | None, notes: str |
         return {"read_number": len(prior_reads) + 1, "already_logged": False}
 
 
-def enrich_deep(work_id: UUID) -> bool:
+def enrich_deep(work_id: UUID) -> str:
     """Deep pass (Cloud Tasks target): read the Work's identity in a short session, run
     the slow LLM scouts with NO session held (#94 — previously minutes idle-in-transaction
     at enrich-queue concurrency 4, where a late transient failure also re-paid every LLM
-    call), then re-persist in a fresh session. Returns False if no Work has that id."""
+    call), then re-persist in a fresh session.
+
+    Returns one of:
+      "missing" — no Work has that id, or it has no linked Author (non-retryable).
+      "empty"   — the scouts yielded nothing to add this pass. A SHORT session stamps
+                  work.deep_enriched_at = now() anyway (GH #97): the timestamp means "the
+                  deep pass COMPLETED", including confirmed-empty — the caller (api/internal.py)
+                  decides retryability from the work's real-trope state, not from this string
+                  alone. An exception raised before this point propagates uncaught, leaving
+                  deep_enriched_at unstamped so Cloud Tasks retries the whole pass.
+      "done"    — the scouts found something; the write session persists the row AND stamps
+                  deep_enriched_at on the SAME Work in the SAME session."""
     with db_manager.get_session() as session:
         work = session.get(Work, work_id)
         if work is None:
-            return False
+            return "missing"
         author = next((c.author.name for c in work.contributors if c.role == "Author"), None)
         if author is None:
-            return False
+            return "missing"
         title = work.title  # scalars captured before close (detached-instance rule)
         fmt = work.editions[0].format if work.editions else "ebook"
 
     row = _run_scouts(create_deep_scout_manager(), title=title, author=author, fmt=fmt)
     if row is None:
-        return True  # scouts found nothing to add; the task is done, not retryable
+        # scouts found nothing to add; the pass is done (not retryable on its own), but
+        # stamp completion so the requeue sweep doesn't treat this work as never-attempted.
+        with db_manager.get_session() as session:
+            w = session.get(Work, work_id)
+            if w is not None:
+                w.deep_enriched_at = datetime.now(UTC)
+        return "empty"
 
     _warm_embeddings(row)
 
     with db_manager.get_session() as session:
-        _persist_row(session, row)
+        work = _persist_row(session, row)
+        if work is not None:
+            work.deep_enriched_at = datetime.now(UTC)
         session.flush()
-    return True
+    return "done"

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -188,13 +188,16 @@ def enrich_deep(work_id: UUID) -> str:
                   persist_enriched_work returns None — nothing was persisted and
                   deep_enriched_at was never stamped, so "done" would be a lie; "missing" tells
                   the caller (api/internal.py) this is non-retryable the same way an
-                  already-gone Work is, rather than falsely reporting success.
-      "empty"   — the scouts yielded nothing to add this pass. A SHORT session stamps
-                  work.deep_enriched_at = now() anyway (GH #97): the timestamp means "the
-                  deep pass COMPLETED", including confirmed-empty — the caller (api/internal.py)
-                  decides retryability from the work's real-trope state, not from this string
-                  alone. An exception raised before this point propagates uncaught, leaving
-                  deep_enriched_at unstamped so Cloud Tasks retries the whole pass.
+                  already-gone Work is, rather than falsely reporting success. Also returned
+                  (PR #126 review) if the empty-path stamp session finds the Work gone —
+                  it was deleted while the slow scouts were running with no session held.
+      "empty"   — the scouts yielded nothing to add this pass, and the Work still exists. A
+                  SHORT session stamps work.deep_enriched_at = now() anyway (GH #97): the
+                  timestamp means "the deep pass COMPLETED", including confirmed-empty — the
+                  caller (api/internal.py) decides retryability from the work's real-trope
+                  state, not from this string alone. An exception raised before this point
+                  propagates uncaught, leaving deep_enriched_at unstamped so Cloud Tasks
+                  retries the whole pass.
       "done"    — the scouts found something AND the write session actually persisted +
                   stamped deep_enriched_at on the SAME Work in the SAME session."""
     with db_manager.get_session() as session:
@@ -213,8 +216,13 @@ def enrich_deep(work_id: UUID) -> str:
         # stamp completion so the requeue sweep doesn't treat this work as never-attempted.
         with db_manager.get_session() as session:
             w = session.get(Work, work_id)
-            if w is not None:
-                w.deep_enriched_at = datetime.now(UTC)
+            if w is None:
+                # The Work was deleted while the slow scouts were running. Falling through
+                # to "empty" would make the internal endpoint 503 and buy a pointless Cloud
+                # Tasks retry before the next pass 404s anyway -- report "missing" now, same
+                # honesty rule as the other non-retryable cases in this function.
+                return "missing"
+            w.deep_enriched_at = datetime.now(UTC)
         return "empty"
 
     _warm_embeddings(row)

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -19,8 +19,10 @@ import logging
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy import text as sa_text
 
 from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.models import Author, Edition, ReadingHistory, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl.persist import collect_embedding_texts, persist_enriched_work
@@ -123,6 +125,13 @@ def enrich_fast(title: str, author: str, fmt: str = "ebook") -> tuple[UUID, bool
     _warm_embeddings(row)
 
     with db_manager.get_session() as session:
+        if session.get_bind().dialect.name == "postgresql":
+            # GH #95: works can't carry a cross-table unique (title+author spans tables) —
+            # serialize concurrent same-book creators instead. xact-scoped: released on commit.
+            session.execute(
+                sa_text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+                {"k": f"{_normalize(title)}|{_normalize(author)}"},
+            )
         existing = _find_existing(session)  # dedup re-check (#94/#95)
         if existing:
             return existing.id, False
@@ -147,11 +156,9 @@ def add_read_event(work_id: UUID, *, completed, rating: int | None, notes: str |
         )
         if any(r.date_completed == completed for r in prior_reads):
             return {"read_number": len(prior_reads), "already_logged": True}
-        edition = session.query(Edition).filter_by(work_id=work_id, format=fmt).first()
-        if not edition:
-            edition = Edition(work_id=work_id, format=fmt)
-            session.add(edition)
-            session.flush()
+        # GH #95: uq_editions_work_format backstops this get-then-create against a
+        # concurrent add_read_event/persist race for the same (work_id, format).
+        edition, _created = get_or_create(session, Edition, work_id=work_id, format=fmt)
         session.add(
             ReadingHistory(
                 edition_id=edition.id,

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -19,7 +19,7 @@ import logging
 from uuid import UUID
 
 from sqlalchemy import func
-from sqlalchemy import text as sa_text
+from sqlalchemy import text as sa_text  # aliased: a loop variable in _warm_embeddings shadows 'text' (F402)
 
 from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.get_or_create import get_or_create

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -1,0 +1,645 @@
+"""Dedup planner + applier for Phase 6.3's THE USER GATE (Spec 2026-07-12): finds prod duplicate
+rows that would violate the incoming unique constraints (migration 48e3762d6c0c) and merges them.
+Session in, plan/summary out; the CLI is scripts/clean_catalog.py's --dedup-for-constraints mode.
+
+Structural distinguishers only, per the #69 lesson (memory: verify-backfill-distinguisher) — a
+backfill once nearly deleted real rows because it trusted a sometimes-populated column
+(work_tropes.justification) as a class label. Every class here groups on real relationships
+(FK link counts) or normalized values (lower(name), COALESCE(format, '')) — never on a column
+that is only sometimes populated.
+
+plan_dedup is read-only. apply_dedup takes the PLAN — not the session's current state — and
+touches only the exact ids the plan named ("apply what was shown"). If a planned row vanished
+between plan and apply (e.g. a concurrent write), it is skipped and counted under
+"skipped_stale", never re-derived.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from agentic_librarian.db.models import (
+    Author,
+    AuthorStyle,
+    Edition,
+    Narrator,
+    NarratorStyle,
+    ReadingHistory,
+    Suggestions,
+    Work,
+    WorkContributor,
+    edition_narrators,
+)
+from agentic_librarian.enrichment.two_phase import _normalize
+
+# --------------------------------------------------------------------------------------------
+# Plan dataclasses. Every entry carries the EXACT ids involved — apply_dedup never re-derives.
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class ContributorMergeGroup:
+    """One duplicate-name group for authors or narrators. repoint = (loser_id, [ids to
+    re-point onto the survivor]); delete = (loser_id, [ids to delete outright — PK collisions
+    with something the survivor already has])."""
+
+    survivor_id: UUID
+    survivor_name: str
+    loser_ids: list[UUID]
+    loser_names: list[str]
+    # work_contributors (authors) / edition_narrators (narrators): (loser_id, pk_tuple) to repoint
+    repoint_links: list[tuple[UUID, tuple]] = field(default_factory=list)
+    delete_links: list[tuple[UUID, tuple]] = field(default_factory=list)
+    # author_styles / narrator_styles
+    repoint_styles: list[tuple[UUID, tuple]] = field(default_factory=list)
+    delete_styles: list[tuple[UUID, tuple]] = field(default_factory=list)
+
+
+@dataclass
+class EditionMergeGroup:
+    survivor_id: UUID
+    work_id: UUID
+    fmt: str | None
+    loser_ids: list[UUID]
+    # reading_history ids to repoint onto survivor_id, and ids to delete (date-collision)
+    repoint_reading_history: list[UUID] = field(default_factory=list)
+    delete_reading_history: list[UUID] = field(default_factory=list)
+    # edition_narrators: (loser_edition_id, narrator_id) to repoint / delete
+    repoint_narrators: list[tuple[UUID, UUID]] = field(default_factory=list)
+    delete_narrators: list[tuple[UUID, UUID]] = field(default_factory=list)
+
+
+@dataclass
+class KeepDeleteGroup:
+    """Exact-duplicate rows (reading_history, suggestions): keep one id, delete the rest."""
+
+    survivor_id: UUID
+    loser_ids: list[UUID]
+    detail: str = ""
+
+
+@dataclass
+class WorkDupReport:
+    """REPORT ONLY — never applied. Normalized title+author collisions for the operator to
+    triage case by case (works carry no cross-table unique; see #95 decision 5)."""
+
+    work_ids: list[UUID]
+    titles: list[str]
+    norm_key: str
+
+
+@dataclass
+class DedupPlan:
+    duplicate_authors: list[ContributorMergeGroup] = field(default_factory=list)
+    duplicate_narrators: list[ContributorMergeGroup] = field(default_factory=list)
+    duplicate_editions: list[EditionMergeGroup] = field(default_factory=list)
+    duplicate_reading_history: list[KeepDeleteGroup] = field(default_factory=list)
+    duplicate_suggestions: list[KeepDeleteGroup] = field(default_factory=list)
+    orphan_authors: list[UUID] = field(default_factory=list)
+    duplicate_works_report_only: list[WorkDupReport] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "duplicate_authors": len(self.duplicate_authors),
+            "duplicate_narrators": len(self.duplicate_narrators),
+            "duplicate_editions": len(self.duplicate_editions),
+            "duplicate_reading_history": len(self.duplicate_reading_history),
+            "duplicate_suggestions": len(self.duplicate_suggestions),
+            "orphan_authors": len(self.orphan_authors),
+            "duplicate_works_report_only": len(self.duplicate_works_report_only),
+        }
+
+
+# --------------------------------------------------------------------------------------------
+# Survivor selection
+# --------------------------------------------------------------------------------------------
+
+
+def _pick_survivor_by_links(rows: list, link_counts: dict) -> object:
+    """Survivor = the row referenced by the MOST FK links; tie-break lowest str(id). This is a
+    structural choice (link count), not a sometimes-populated column — documented per the
+    class docstrings below. Author/Narrator have no created_at, so "oldest" is not available;
+    "most-linked" approximates "the one everything already points at" and minimizes repoints."""
+    return sorted(rows, key=lambda r: (-link_counts.get(r.id, 0), str(r.id)))[0]
+
+
+# --------------------------------------------------------------------------------------------
+# Class 1 & 2: duplicate_authors / duplicate_narrators
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
+    authors = session.query(Author).all()
+    groups: dict[str, list[Author]] = defaultdict(list)
+    for a in authors:
+        groups[a.name.lower()].append(a)
+
+    wc_counts = Counter(row.author_id for row in session.query(WorkContributor.author_id).all())
+    as_counts = Counter(row.author_id for row in session.query(AuthorStyle.author_id).all())
+    link_counts = Counter()
+    for aid, n in wc_counts.items():
+        link_counts[aid] += n
+    for aid, n in as_counts.items():
+        link_counts[aid] += n
+
+    out: list[ContributorMergeGroup] = []
+    for rows in groups.values():
+        if len(rows) < 2:
+            continue
+        survivor = _pick_survivor_by_links(rows, link_counts)
+        losers = [a for a in rows if a.id != survivor.id]
+        group = ContributorMergeGroup(
+            survivor_id=survivor.id,
+            survivor_name=survivor.name,
+            loser_ids=[loser.id for loser in losers],
+            loser_names=[loser.name for loser in losers],
+        )
+        survivor_wc_keys = {
+            (wc.work_id, wc.role) for wc in session.query(WorkContributor).filter_by(author_id=survivor.id).all()
+        }
+        survivor_style_keys = {
+            (st.style_id, st.attribute_type) for st in session.query(AuthorStyle).filter_by(author_id=survivor.id).all()
+        }
+        for loser in losers:
+            for wc in session.query(WorkContributor).filter_by(author_id=loser.id).all():
+                key = (wc.work_id, wc.role)
+                pk = (wc.work_id, wc.author_id, wc.role)
+                if key in survivor_wc_keys:
+                    group.delete_links.append((loser.id, pk))
+                else:
+                    group.repoint_links.append((loser.id, pk))
+                    survivor_wc_keys.add(key)
+            for st in session.query(AuthorStyle).filter_by(author_id=loser.id).all():
+                key = (st.style_id, st.attribute_type)
+                pk = (st.author_id, st.style_id, st.attribute_type)
+                if key in survivor_style_keys:
+                    group.delete_styles.append((loser.id, pk))
+                else:
+                    group.repoint_styles.append((loser.id, pk))
+                    survivor_style_keys.add(key)
+        out.append(group)
+    return out
+
+
+def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
+    narrators = session.query(Narrator).all()
+    groups: dict[str, list[Narrator]] = defaultdict(list)
+    for n in narrators:
+        groups[n.name.lower()].append(n)
+
+    en_counts = Counter(row.narrator_id for row in session.execute(select(edition_narrators.c.narrator_id)).all())
+    ns_counts = Counter(row.narrator_id for row in session.query(NarratorStyle.narrator_id).all())
+    link_counts = Counter()
+    for nid, n in en_counts.items():
+        link_counts[nid] += n
+    for nid, n in ns_counts.items():
+        link_counts[nid] += n
+
+    out: list[ContributorMergeGroup] = []
+    for rows in groups.values():
+        if len(rows) < 2:
+            continue
+        survivor = _pick_survivor_by_links(rows, link_counts)
+        losers = [n for n in rows if n.id != survivor.id]
+        group = ContributorMergeGroup(
+            survivor_id=survivor.id,
+            survivor_name=survivor.name,
+            loser_ids=[loser.id for loser in losers],
+            loser_names=[loser.name for loser in losers],
+        )
+        survivor_edition_ids = {
+            row.edition_id
+            for row in session.execute(
+                select(edition_narrators.c.edition_id).where(edition_narrators.c.narrator_id == survivor.id)
+            ).all()
+        }
+        survivor_style_keys = {
+            (st.style_id, st.attribute_type)
+            for st in session.query(NarratorStyle).filter_by(narrator_id=survivor.id).all()
+        }
+        for loser in losers:
+            loser_edition_ids = [
+                row.edition_id
+                for row in session.execute(
+                    select(edition_narrators.c.edition_id).where(edition_narrators.c.narrator_id == loser.id)
+                ).all()
+            ]
+            for eid in loser_edition_ids:
+                pk = (eid, loser.id)
+                if eid in survivor_edition_ids:
+                    group.delete_links.append((loser.id, pk))
+                else:
+                    group.repoint_links.append((loser.id, pk))
+                    survivor_edition_ids.add(eid)
+            for st in session.query(NarratorStyle).filter_by(narrator_id=loser.id).all():
+                key = (st.style_id, st.attribute_type)
+                pk = (st.narrator_id, st.style_id, st.attribute_type)
+                if key in survivor_style_keys:
+                    group.delete_styles.append((loser.id, pk))
+                else:
+                    group.repoint_styles.append((loser.id, pk))
+                    survivor_style_keys.add(key)
+        out.append(group)
+    return out
+
+
+def _apply_contributor_group(session: Session, group: ContributorMergeGroup, *, kind: str) -> dict[str, int]:
+    """kind: 'author' | 'narrator'. Applies exactly the ids in `group`; anything vanished since
+    planning is skipped and counted under skipped_stale."""
+    stats = {"merged": 0, "skipped_stale": 0}
+    survivor_id_present = session.get(Author if kind == "author" else Narrator, group.survivor_id) is not None
+    if not survivor_id_present:
+        stats["skipped_stale"] += 1
+        return stats
+
+    if kind == "author":
+        for _loser_id, pk in group.repoint_links:
+            work_id, author_id, role = pk
+            wc = session.get(WorkContributor, {"work_id": work_id, "author_id": author_id, "role": role})
+            if wc is None:
+                stats["skipped_stale"] += 1
+                continue
+            wc.author_id = group.survivor_id
+        for _loser_id, pk in group.delete_links:
+            work_id, author_id, role = pk
+            wc = session.get(WorkContributor, {"work_id": work_id, "author_id": author_id, "role": role})
+            if wc is None:
+                stats["skipped_stale"] += 1
+                continue
+            session.delete(wc)
+        session.flush()
+        for _loser_id, pk in group.repoint_styles:
+            author_id, style_id, attribute_type = pk
+            st = session.get(
+                AuthorStyle, {"author_id": author_id, "style_id": style_id, "attribute_type": attribute_type}
+            )
+            if st is None:
+                stats["skipped_stale"] += 1
+                continue
+            st.author_id = group.survivor_id
+        for _loser_id, pk in group.delete_styles:
+            author_id, style_id, attribute_type = pk
+            st = session.get(
+                AuthorStyle, {"author_id": author_id, "style_id": style_id, "attribute_type": attribute_type}
+            )
+            if st is None:
+                stats["skipped_stale"] += 1
+                continue
+            session.delete(st)
+        session.flush()
+    else:
+        for _loser_id, pk in group.repoint_links:
+            edition_id, narrator_id = pk
+            exists = session.execute(
+                select(edition_narrators.c.edition_id).where(
+                    edition_narrators.c.edition_id == edition_id,
+                    edition_narrators.c.narrator_id == narrator_id,
+                )
+            ).first()
+            if exists is None:
+                stats["skipped_stale"] += 1
+                continue
+            session.execute(
+                delete(edition_narrators).where(
+                    edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+                )
+            )
+            session.execute(edition_narrators.insert().values(edition_id=edition_id, narrator_id=group.survivor_id))
+        for _loser_id, pk in group.delete_links:
+            edition_id, narrator_id = pk
+            session.execute(
+                delete(edition_narrators).where(
+                    edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+                )
+            )
+        for _loser_id, pk in group.repoint_styles:
+            narrator_id, style_id, attribute_type = pk
+            st = session.get(
+                NarratorStyle, {"narrator_id": narrator_id, "style_id": style_id, "attribute_type": attribute_type}
+            )
+            if st is None:
+                stats["skipped_stale"] += 1
+                continue
+            st.narrator_id = group.survivor_id
+        for _loser_id, pk in group.delete_styles:
+            narrator_id, style_id, attribute_type = pk
+            st = session.get(
+                NarratorStyle, {"narrator_id": narrator_id, "style_id": style_id, "attribute_type": attribute_type}
+            )
+            if st is None:
+                stats["skipped_stale"] += 1
+                continue
+            session.delete(st)
+        session.flush()
+
+    model = Author if kind == "author" else Narrator
+    for loser_id in group.loser_ids:
+        row = session.get(model, loser_id)
+        if row is None:
+            stats["skipped_stale"] += 1
+            continue
+        session.delete(row)
+    session.flush()
+    stats["merged"] = 1
+    return stats
+
+
+# --------------------------------------------------------------------------------------------
+# Class 3: duplicate_editions
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_editions(session: Session) -> list[EditionMergeGroup]:
+    editions = session.query(Edition).all()
+    groups: dict[tuple[UUID, str], list[Edition]] = defaultdict(list)
+    for e in editions:
+        groups[(e.work_id, e.format or "")].append(e)
+
+    rh_counts = Counter(row.edition_id for row in session.query(ReadingHistory.edition_id).all())
+    en_counts = Counter(row.edition_id for row in session.execute(select(edition_narrators.c.edition_id)).all())
+    link_counts = Counter()
+    for eid, n in rh_counts.items():
+        link_counts[eid] += n
+    for eid, n in en_counts.items():
+        link_counts[eid] += n
+
+    out: list[EditionMergeGroup] = []
+    for (work_id, fmt), rows in groups.items():
+        if len(rows) < 2:
+            continue
+        survivor = _pick_survivor_by_links(rows, link_counts)
+        losers = [e for e in rows if e.id != survivor.id]
+        group = EditionMergeGroup(
+            survivor_id=survivor.id, work_id=work_id, fmt=fmt or None, loser_ids=[loser.id for loser in losers]
+        )
+
+        survivor_dates_by_user: dict[UUID, set] = defaultdict(set)
+        for rh in session.query(ReadingHistory).filter_by(edition_id=survivor.id).all():
+            survivor_dates_by_user[rh.user_id].add(rh.date_completed)
+
+        survivor_narrator_ids = {
+            row.narrator_id
+            for row in session.execute(
+                select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == survivor.id)
+            ).all()
+        }
+
+        for loser in losers:
+            for rh in session.query(ReadingHistory).filter_by(edition_id=loser.id).all():
+                if rh.date_completed in survivor_dates_by_user.get(rh.user_id, set()):
+                    group.delete_reading_history.append(rh.id)
+                else:
+                    group.repoint_reading_history.append(rh.id)
+                    survivor_dates_by_user[rh.user_id].add(rh.date_completed)
+            for row in session.execute(
+                select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == loser.id)
+            ).all():
+                nid = row.narrator_id
+                if nid in survivor_narrator_ids:
+                    group.delete_narrators.append((loser.id, nid))
+                else:
+                    group.repoint_narrators.append((loser.id, nid))
+                    survivor_narrator_ids.add(nid)
+        out.append(group)
+    return out
+
+
+def _apply_edition_group(session: Session, group: EditionMergeGroup) -> dict[str, int]:
+    stats = {"merged": 0, "skipped_stale": 0}
+    if session.get(Edition, group.survivor_id) is None:
+        stats["skipped_stale"] += 1
+        return stats
+
+    for rh_id in group.repoint_reading_history:
+        rh = session.get(ReadingHistory, rh_id)
+        if rh is None:
+            stats["skipped_stale"] += 1
+            continue
+        rh.edition_id = group.survivor_id
+    for rh_id in group.delete_reading_history:
+        rh = session.get(ReadingHistory, rh_id)
+        if rh is None:
+            stats["skipped_stale"] += 1
+            continue
+        session.delete(rh)
+    session.flush()
+
+    for edition_id, narrator_id in group.repoint_narrators:
+        exists = session.execute(
+            select(edition_narrators.c.edition_id).where(
+                edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+            )
+        ).first()
+        if exists is None:
+            stats["skipped_stale"] += 1
+            continue
+        session.execute(
+            delete(edition_narrators).where(
+                edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+            )
+        )
+        session.execute(edition_narrators.insert().values(edition_id=group.survivor_id, narrator_id=narrator_id))
+    for edition_id, narrator_id in group.delete_narrators:
+        session.execute(
+            delete(edition_narrators).where(
+                edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+            )
+        )
+    session.flush()
+
+    for loser_id in group.loser_ids:
+        e = session.get(Edition, loser_id)
+        if e is None:
+            stats["skipped_stale"] += 1
+            continue
+        session.delete(e)
+    session.flush()
+    stats["merged"] = 1
+    return stats
+
+
+# --------------------------------------------------------------------------------------------
+# Class 4: duplicate_reading_history (exact (user_id, edition_id, date_completed) groups)
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_reading_history(session: Session) -> list[KeepDeleteGroup]:
+    rows = session.query(ReadingHistory).all()
+    groups: dict[tuple, list[ReadingHistory]] = defaultdict(list)
+    for rh in rows:
+        groups[(rh.user_id, rh.edition_id, rh.date_completed)].append(rh)
+    out: list[KeepDeleteGroup] = []
+    for key, dup_rows in groups.items():
+        if len(dup_rows) < 2:
+            continue
+        survivor = min(dup_rows, key=lambda r: str(r.id))
+        losers = [r for r in dup_rows if r.id != survivor.id]
+        out.append(KeepDeleteGroup(survivor_id=survivor.id, loser_ids=[loser.id for loser in losers], detail=str(key)))
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Class 5: duplicate_suggestions (per (user_id, work_id) WHERE status='Suggested')
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_suggestions(session: Session) -> list[KeepDeleteGroup]:
+    rows = session.query(Suggestions).filter_by(status="Suggested").all()
+    groups: dict[tuple[UUID, UUID], list[Suggestions]] = defaultdict(list)
+    for s in rows:
+        groups[(s.user_id, s.work_id)].append(s)
+    out: list[KeepDeleteGroup] = []
+    for key, dup_rows in groups.items():
+        if len(dup_rows) < 2:
+            continue
+        survivor = min(dup_rows, key=lambda r: (r.suggested_at, str(r.id)))
+        losers = [s for s in dup_rows if s.id != survivor.id]
+        out.append(KeepDeleteGroup(survivor_id=survivor.id, loser_ids=[loser.id for loser in losers], detail=str(key)))
+    return out
+
+
+def _apply_keep_delete(session: Session, model, group: KeepDeleteGroup) -> dict[str, int]:
+    stats = {"deleted": 0, "skipped_stale": 0}
+    for loser_id in group.loser_ids:
+        row = session.get(model, loser_id)
+        if row is None:
+            stats["skipped_stale"] += 1
+            continue
+        session.delete(row)
+        stats["deleted"] += 1
+    session.flush()
+    return stats
+
+
+# --------------------------------------------------------------------------------------------
+# Class 6: orphan_authors (zero work_contributors AND zero author_styles)
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_orphan_authors(session: Session) -> list[UUID]:
+    """Computed against CURRENT state — NOT simulated against class-1 merges. An author
+    orphaned BY this run's own author-merge is caught only on a re-plan/re-apply; this is
+    deliberate (documented here and echoed in the CLI output), not an oversight: simulating
+    ahead of a not-yet-applied plan would make apply's ids depend on apply's own outcome,
+    breaking the "apply exactly what plan showed" discipline."""
+    linked_wc = {row.author_id for row in session.query(WorkContributor.author_id).all()}
+    linked_as = {row.author_id for row in session.query(AuthorStyle.author_id).all()}
+    linked = linked_wc | linked_as
+    return [a.id for a in session.query(Author).all() if a.id not in linked]
+
+
+def _apply_orphan_authors(session: Session, ids: list[UUID]) -> dict[str, int]:
+    stats = {"deleted": 0, "skipped_stale": 0}
+    for aid in ids:
+        a = session.get(Author, aid)
+        if a is None:
+            stats["skipped_stale"] += 1
+            continue
+        # re-verify structurally at apply time too — never delete a row that gained a link
+        # between plan and apply (still id-scoped to the plan; this is a safety re-check, not
+        # a re-derivation of WHICH ids are orphans)
+        has_wc = session.query(WorkContributor).filter_by(author_id=aid).first() is not None
+        has_as = session.query(AuthorStyle).filter_by(author_id=aid).first() is not None
+        if has_wc or has_as:
+            stats["skipped_stale"] += 1
+            continue
+        session.delete(a)
+        stats["deleted"] += 1
+    session.flush()
+    return stats
+
+
+# --------------------------------------------------------------------------------------------
+# Class 7: duplicate_works_report_only (normalized title+author; NEVER applied)
+# --------------------------------------------------------------------------------------------
+
+
+def _plan_duplicate_works(session: Session) -> list[WorkDupReport]:
+    rows = (
+        session.query(Work.id, Work.title, Author.name)
+        .join(WorkContributor, WorkContributor.work_id == Work.id)
+        .join(Author, Author.id == WorkContributor.author_id)
+        .filter(WorkContributor.role == "Author")
+        .all()
+    )
+    groups: dict[str, list[tuple[UUID, str]]] = defaultdict(list)
+    for work_id, title, author_name in rows:
+        key = f"{_normalize(title)}|{_normalize(author_name)}"
+        groups[key].append((work_id, title))
+    out: list[WorkDupReport] = []
+    for key, entries in groups.items():
+        seen_ids = {wid for wid, _ in entries}
+        if len(seen_ids) < 2:
+            continue
+        out.append(WorkDupReport(work_ids=[wid for wid, _ in entries], titles=[t for _, t in entries], norm_key=key))
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Top-level plan / apply
+# --------------------------------------------------------------------------------------------
+
+
+def plan_dedup(session: Session) -> DedupPlan:
+    """READ ONLY. Computes every class against the CURRENT db state. See _plan_orphan_authors
+    for why orphans are not simulated against not-yet-applied author merges."""
+    return DedupPlan(
+        duplicate_authors=_plan_authors(session),
+        duplicate_narrators=_plan_narrators(session),
+        duplicate_editions=_plan_editions(session),
+        duplicate_reading_history=_plan_reading_history(session),
+        duplicate_suggestions=_plan_suggestions(session),
+        orphan_authors=_plan_orphan_authors(session),
+        duplicate_works_report_only=_plan_duplicate_works(session),
+    )
+
+
+def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
+    """Applies EXACTLY plan's ids — no re-derivation. Order: authors, narrators, editions,
+    reading_history, suggestions, orphans. duplicate_works_report_only is NEVER applied.
+    Rows that vanished between plan and apply are skipped and counted under skipped_stale."""
+    result = {
+        "duplicate_authors": 0,
+        "duplicate_narrators": 0,
+        "duplicate_editions": 0,
+        "duplicate_reading_history": 0,
+        "duplicate_suggestions": 0,
+        "orphan_authors": 0,
+        "skipped_stale": 0,
+    }
+
+    for group in plan.duplicate_authors:
+        stats = _apply_contributor_group(session, group, kind="author")
+        result["duplicate_authors"] += stats["merged"]
+        result["skipped_stale"] += stats["skipped_stale"]
+
+    for group in plan.duplicate_narrators:
+        stats = _apply_contributor_group(session, group, kind="narrator")
+        result["duplicate_narrators"] += stats["merged"]
+        result["skipped_stale"] += stats["skipped_stale"]
+
+    for group in plan.duplicate_editions:
+        stats = _apply_edition_group(session, group)
+        result["duplicate_editions"] += stats["merged"]
+        result["skipped_stale"] += stats["skipped_stale"]
+
+    for group in plan.duplicate_reading_history:
+        stats = _apply_keep_delete(session, ReadingHistory, group)
+        result["duplicate_reading_history"] += stats["deleted"]
+        result["skipped_stale"] += stats["skipped_stale"]
+
+    for group in plan.duplicate_suggestions:
+        stats = _apply_keep_delete(session, Suggestions, group)
+        result["duplicate_suggestions"] += stats["deleted"]
+        result["skipped_stale"] += stats["skipped_stale"]
+
+    orphan_stats = _apply_orphan_authors(session, plan.orphan_authors)
+    result["orphan_authors"] += orphan_stats["deleted"]
+    result["skipped_stale"] += orphan_stats["skipped_stale"]
+
+    return result

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -307,8 +307,17 @@ def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
 
 def _apply_contributor_group(session: Session, group: ContributorMergeGroup, *, kind: str) -> dict[str, int]:
     """kind: 'author' | 'narrator'. Applies exactly the ids in `group`; anything vanished since
-    planning is skipped and counted under skipped_stale."""
-    stats = {"merged": 0, "skipped_stale": 0}
+    planning is skipped and counted under skipped_stale.
+
+    Belt-and-braces (adversarial pass, GH #95 #97 follow-up): mirrors _apply_edition_group's
+    unplanned-row re-verify. Author.styles / Narrator.styles cascade `all, delete-orphan` — a
+    bare `session.delete(loser)` would silently cascade-delete ANY style row still attached to
+    that loser at delete time, including one a concurrent write attached AFTER this group was
+    planned (this group's own repoint_styles/delete_styles is silent about it, same as the
+    edition case's silence about an unplanned narrator link). Before deleting each loser, check
+    for a style row that survives and was NOT named by this group's own plan for that loser id;
+    if found, refuse the delete and count it under skipped_unsafe instead."""
+    stats = {"merged": 0, "skipped_stale": 0, "skipped_unsafe": 0}
     survivor_id_present = session.get(Author if kind == "author" else Narrator, group.survivor_id) is not None
     if not survivor_id_present:
         stats["skipped_stale"] += 1
@@ -394,11 +403,29 @@ def _apply_contributor_group(session: Session, group: ContributorMergeGroup, *, 
             session.delete(st)
         session.flush()
 
+    # Planned style pks per loser, so the re-verify below can tell "planned, already handled
+    # above" apart from "unplanned, showed up since this group was planned".
+    planned_style_pks_by_loser: dict[UUID, set[tuple]] = defaultdict(set)
+    for loser_id, pk in group.repoint_styles:
+        planned_style_pks_by_loser[loser_id].add(pk)
+    for loser_id, pk in group.delete_styles:
+        planned_style_pks_by_loser[loser_id].add(pk)
+
     model = Author if kind == "author" else Narrator
+    style_model = AuthorStyle if kind == "author" else NarratorStyle
+    style_fk = "author_id" if kind == "author" else "narrator_id"
     for loser_id in group.loser_ids:
         row = session.get(model, loser_id)
         if row is None:
             stats["skipped_stale"] += 1
+            continue
+        remaining_style_pks = {
+            (getattr(st, style_fk), st.style_id, st.attribute_type)
+            for st in session.query(style_model).filter_by(**{style_fk: loser_id}).all()
+        }
+        unplanned = remaining_style_pks - planned_style_pks_by_loser.get(loser_id, set())
+        if unplanned:
+            stats["skipped_unsafe"] += 1
             continue
         session.delete(row)
     session.flush()
@@ -804,8 +831,8 @@ def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
     reading_history, suggestions, orphans. duplicate_works_report_only is NEVER applied.
     Rows that vanished between plan and apply are skipped and counted under skipped_stale.
     Rows that survived but weren't accounted for by the group's own plan (the
-    _apply_edition_group belt-and-braces re-verify — see its docstring) are counted separately
-    under skipped_unsafe, distinct from skipped_stale."""
+    _apply_edition_group / _apply_contributor_group belt-and-braces re-verify — see their
+    docstrings) are counted separately under skipped_unsafe, distinct from skipped_stale."""
     result = {
         "duplicate_authors": 0,
         "duplicate_narrators": 0,
@@ -821,11 +848,13 @@ def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
         stats = _apply_contributor_group(session, group, kind="author")
         result["duplicate_authors"] += stats["merged"]
         result["skipped_stale"] += stats["skipped_stale"]
+        result["skipped_unsafe"] += stats["skipped_unsafe"]
 
     for group in plan.duplicate_narrators:
         stats = _apply_contributor_group(session, group, kind="narrator")
         result["duplicate_narrators"] += stats["merged"]
         result["skipped_stale"] += stats["skipped_stale"]
+        result["skipped_unsafe"] += stats["skipped_unsafe"]
 
     for group in plan.duplicate_editions:
         stats = _apply_edition_group(session, group)

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -24,6 +24,16 @@ Every token in that id set is TAGGED with its operation (`merge:` / `repoint:` /
 `report:`, see plan_id_set's docstring) so an operation FLIP on the same underlying id between
 the reviewed dry-run and the fresh apply-time plan (e.g. a concurrent write turns a reviewed
 repoint into a delete) is visible as a new token, not hidden behind an unchanged bare id.
+
+INVARIANT (found live against prod, GH #95): this module runs against the PRE-migration schema
+— the gate precedes `alembic upgrade head` by design, so migration 48e3762d6c0c has NOT landed
+yet when plan_dedup/apply_dedup run. Never entity-load Work here (`session.query(Work)` /
+`session.get(Work, ...)`) — it must not reference post-migration columns (e.g.
+deep_enriched_at), which don't exist on prod's works table at this point and raise
+UndefinedColumn. The one Work reference in this module (_plan_duplicate_works) is already
+column-explicit (`session.query(Work.id, Work.title, Author.name)`) — keep any future Work
+query that shape. Author/Narrator/Edition/ReadingHistory/Suggestions entity loads are safe:
+this migration adds no columns to those tables.
 """
 
 from __future__ import annotations

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -155,7 +155,12 @@ def _pick_survivor_by_links(rows: list, link_counts: dict) -> object:
 
 
 def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
-    authors = session.query(Author).all()
+    # Minor 3 (final review): every group query is order_by'd on its pk so dry-run and an
+    # apply-time re-plan against unchanged data classify IDENTICALLY (which collision link goes
+    # to repoint vs delete depends on iteration order when two losers/links race for the same
+    # key) — without this, a Postgres row order that happens to differ between two plans over the
+    # same data can flip a classification and trip the apply-gate's drift-refuse spuriously.
+    authors = session.query(Author).order_by(Author.id).all()
     groups: dict[str, list[Author]] = defaultdict(list)
     for a in authors:
         groups[a.name.lower()].append(a)
@@ -173,7 +178,7 @@ def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
         if len(rows) < 2:
             continue
         survivor = _pick_survivor_by_links(rows, link_counts)
-        losers = [a for a in rows if a.id != survivor.id]
+        losers = sorted((a for a in rows if a.id != survivor.id), key=lambda a: str(a.id))
         group = ContributorMergeGroup(
             survivor_id=survivor.id,
             survivor_name=survivor.name,
@@ -181,13 +186,26 @@ def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
             loser_names=[loser.name for loser in losers],
         )
         survivor_wc_keys = {
-            (wc.work_id, wc.role) for wc in session.query(WorkContributor).filter_by(author_id=survivor.id).all()
+            (wc.work_id, wc.role)
+            for wc in session.query(WorkContributor)
+            .filter_by(author_id=survivor.id)
+            .order_by(WorkContributor.work_id, WorkContributor.role)
+            .all()
         }
         survivor_style_keys = {
-            (st.style_id, st.attribute_type) for st in session.query(AuthorStyle).filter_by(author_id=survivor.id).all()
+            (st.style_id, st.attribute_type)
+            for st in session.query(AuthorStyle)
+            .filter_by(author_id=survivor.id)
+            .order_by(AuthorStyle.style_id, AuthorStyle.attribute_type)
+            .all()
         }
         for loser in losers:
-            for wc in session.query(WorkContributor).filter_by(author_id=loser.id).all():
+            for wc in (
+                session.query(WorkContributor)
+                .filter_by(author_id=loser.id)
+                .order_by(WorkContributor.work_id, WorkContributor.role)
+                .all()
+            ):
                 key = (wc.work_id, wc.role)
                 pk = (wc.work_id, wc.author_id, wc.role)
                 if key in survivor_wc_keys:
@@ -195,7 +213,12 @@ def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
                 else:
                     group.repoint_links.append((loser.id, pk))
                     survivor_wc_keys.add(key)
-            for st in session.query(AuthorStyle).filter_by(author_id=loser.id).all():
+            for st in (
+                session.query(AuthorStyle)
+                .filter_by(author_id=loser.id)
+                .order_by(AuthorStyle.style_id, AuthorStyle.attribute_type)
+                .all()
+            ):
                 key = (st.style_id, st.attribute_type)
                 pk = (st.author_id, st.style_id, st.attribute_type)
                 if key in survivor_style_keys:
@@ -208,7 +231,8 @@ def _plan_authors(session: Session) -> list[ContributorMergeGroup]:
 
 
 def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
-    narrators = session.query(Narrator).all()
+    # Minor 3 (final review): order_by + sorted losers — see _plan_authors's comment.
+    narrators = session.query(Narrator).order_by(Narrator.id).all()
     groups: dict[str, list[Narrator]] = defaultdict(list)
     for n in narrators:
         groups[n.name.lower()].append(n)
@@ -226,7 +250,7 @@ def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
         if len(rows) < 2:
             continue
         survivor = _pick_survivor_by_links(rows, link_counts)
-        losers = [n for n in rows if n.id != survivor.id]
+        losers = sorted((n for n in rows if n.id != survivor.id), key=lambda n: str(n.id))
         group = ContributorMergeGroup(
             survivor_id=survivor.id,
             survivor_name=survivor.name,
@@ -236,18 +260,25 @@ def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
         survivor_edition_ids = {
             row.edition_id
             for row in session.execute(
-                select(edition_narrators.c.edition_id).where(edition_narrators.c.narrator_id == survivor.id)
+                select(edition_narrators.c.edition_id)
+                .where(edition_narrators.c.narrator_id == survivor.id)
+                .order_by(edition_narrators.c.edition_id)
             ).all()
         }
         survivor_style_keys = {
             (st.style_id, st.attribute_type)
-            for st in session.query(NarratorStyle).filter_by(narrator_id=survivor.id).all()
+            for st in session.query(NarratorStyle)
+            .filter_by(narrator_id=survivor.id)
+            .order_by(NarratorStyle.style_id, NarratorStyle.attribute_type)
+            .all()
         }
         for loser in losers:
             loser_edition_ids = [
                 row.edition_id
                 for row in session.execute(
-                    select(edition_narrators.c.edition_id).where(edition_narrators.c.narrator_id == loser.id)
+                    select(edition_narrators.c.edition_id)
+                    .where(edition_narrators.c.narrator_id == loser.id)
+                    .order_by(edition_narrators.c.edition_id)
                 ).all()
             ]
             for eid in loser_edition_ids:
@@ -257,7 +288,12 @@ def _plan_narrators(session: Session) -> list[ContributorMergeGroup]:
                 else:
                     group.repoint_links.append((loser.id, pk))
                     survivor_edition_ids.add(eid)
-            for st in session.query(NarratorStyle).filter_by(narrator_id=loser.id).all():
+            for st in (
+                session.query(NarratorStyle)
+                .filter_by(narrator_id=loser.id)
+                .order_by(NarratorStyle.style_id, NarratorStyle.attribute_type)
+                .all()
+            ):
                 key = (st.style_id, st.attribute_type)
                 pk = (st.narrator_id, st.style_id, st.attribute_type)
                 if key in survivor_style_keys:
@@ -376,7 +412,12 @@ def _apply_contributor_group(session: Session, group: ContributorMergeGroup, *, 
 
 
 def _plan_editions(session: Session) -> list[EditionMergeGroup]:
-    editions = session.query(Edition).all()
+    # Minor 3 (final review): order_by + sorted losers — see _plan_authors's comment. The
+    # per-loser ReadingHistory ordering here is the SAME lever behind the edition x
+    # reading_history intersection this plan defers (_defer_intersecting_groups): which row of
+    # an exact-duplicate date-collision pair gets repoint vs delete depends on this order, so
+    # dry-run and an apply-time re-plan must see the identical order every time.
+    editions = session.query(Edition).order_by(Edition.id).all()
     groups: dict[tuple[UUID, str], list[Edition]] = defaultdict(list)
     for e in editions:
         groups[(e.work_id, e.format or "")].append(e)
@@ -394,31 +435,35 @@ def _plan_editions(session: Session) -> list[EditionMergeGroup]:
         if len(rows) < 2:
             continue
         survivor = _pick_survivor_by_links(rows, link_counts)
-        losers = [e for e in rows if e.id != survivor.id]
+        losers = sorted((e for e in rows if e.id != survivor.id), key=lambda e: str(e.id))
         group = EditionMergeGroup(
             survivor_id=survivor.id, work_id=work_id, fmt=fmt or None, loser_ids=[loser.id for loser in losers]
         )
 
         survivor_dates_by_user: dict[UUID, set] = defaultdict(set)
-        for rh in session.query(ReadingHistory).filter_by(edition_id=survivor.id).all():
+        for rh in session.query(ReadingHistory).filter_by(edition_id=survivor.id).order_by(ReadingHistory.id).all():
             survivor_dates_by_user[rh.user_id].add(rh.date_completed)
 
         survivor_narrator_ids = {
             row.narrator_id
             for row in session.execute(
-                select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == survivor.id)
+                select(edition_narrators.c.narrator_id)
+                .where(edition_narrators.c.edition_id == survivor.id)
+                .order_by(edition_narrators.c.narrator_id)
             ).all()
         }
 
         for loser in losers:
-            for rh in session.query(ReadingHistory).filter_by(edition_id=loser.id).all():
+            for rh in session.query(ReadingHistory).filter_by(edition_id=loser.id).order_by(ReadingHistory.id).all():
                 if rh.date_completed in survivor_dates_by_user.get(rh.user_id, set()):
                     group.delete_reading_history.append(rh.id)
                 else:
                     group.repoint_reading_history.append(rh.id)
                     survivor_dates_by_user[rh.user_id].add(rh.date_completed)
             for row in session.execute(
-                select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == loser.id)
+                select(edition_narrators.c.narrator_id)
+                .where(edition_narrators.c.edition_id == loser.id)
+                .order_by(edition_narrators.c.narrator_id)
             ).all():
                 nid = row.narrator_id
                 if nid in survivor_narrator_ids:
@@ -504,7 +549,10 @@ def _apply_edition_group(session: Session, group: EditionMergeGroup) -> dict[str
 
 
 def _plan_reading_history(session: Session) -> list[KeepDeleteGroup]:
-    rows = session.query(ReadingHistory).all()
+    # Minor 3 (final review): order_by + sorted losers — see _plan_authors's comment. Survivor
+    # selection here is already order-independent (min by str(id)); ordering keeps loser_ids
+    # (and therefore the plan report / plan_id_set tokens) stable across re-plans too.
+    rows = session.query(ReadingHistory).order_by(ReadingHistory.id).all()
     groups: dict[tuple, list[ReadingHistory]] = defaultdict(list)
     for rh in rows:
         groups[(rh.user_id, rh.edition_id, rh.date_completed)].append(rh)
@@ -513,7 +561,7 @@ def _plan_reading_history(session: Session) -> list[KeepDeleteGroup]:
         if len(dup_rows) < 2:
             continue
         survivor = min(dup_rows, key=lambda r: str(r.id))
-        losers = [r for r in dup_rows if r.id != survivor.id]
+        losers = sorted((r for r in dup_rows if r.id != survivor.id), key=lambda r: str(r.id))
         out.append(KeepDeleteGroup(survivor_id=survivor.id, loser_ids=[loser.id for loser in losers], detail=str(key)))
     return out
 
@@ -524,7 +572,10 @@ def _plan_reading_history(session: Session) -> list[KeepDeleteGroup]:
 
 
 def _plan_suggestions(session: Session) -> list[KeepDeleteGroup]:
-    rows = session.query(Suggestions).filter_by(status="Suggested").all()
+    # Minor 3 (final review): order_by + sorted losers — see _plan_authors's comment. Survivor
+    # selection here is already order-independent (min by (suggested_at, str(id))); ordering
+    # keeps loser_ids stable across re-plans too.
+    rows = session.query(Suggestions).filter_by(status="Suggested").order_by(Suggestions.id).all()
     groups: dict[tuple[UUID, UUID], list[Suggestions]] = defaultdict(list)
     for s in rows:
         groups[(s.user_id, s.work_id)].append(s)
@@ -533,7 +584,7 @@ def _plan_suggestions(session: Session) -> list[KeepDeleteGroup]:
         if len(dup_rows) < 2:
             continue
         survivor = min(dup_rows, key=lambda r: (r.suggested_at, str(r.id)))
-        losers = [s for s in dup_rows if s.id != survivor.id]
+        losers = sorted((s for s in dup_rows if s.id != survivor.id), key=lambda s: str(s.id))
         out.append(KeepDeleteGroup(survivor_id=survivor.id, loser_ids=[loser.id for loser in losers], detail=str(key)))
     return out
 

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -19,6 +19,11 @@ gap would otherwise be applied without operator review, defeating the gate. plan
 plan into a per-class id set; plan_delta cross-checks a fresh plan's id set against the ids the
 operator actually reviewed (parsed back from the dry-run report) and returns what's new. See
 scripts/clean_catalog.py's --apply flow for how a non-empty delta refuses.
+
+Every token in that id set is TAGGED with its operation (`merge:` / `repoint:` / `delete:` /
+`report:`, see plan_id_set's docstring) so an operation FLIP on the same underlying id between
+the reviewed dry-run and the fresh apply-time plan (e.g. a concurrent write turns a reviewed
+repoint into a delete) is visible as a new token, not hidden behind an unchanged bare id.
 """
 
 from __future__ import annotations
@@ -674,60 +679,71 @@ PLAN_ID_SET_CLASSES = (
 
 
 def plan_id_set(plan: DedupPlan) -> dict[str, set[str]]:
-    """Every id the plan is 'about', per class, stringified — survivor ids included as part of
-    group identity (a group whose survivor changed IS a different plan, even if the loser set
-    is a subset of before), plus every loser/deleted-row/repointed-link identifier. Composite
-    identifiers (e.g. a repoint's (loser_id, pk) pair) are stringified as a single tuple-repr
-    token rather than decomposed, so a link moving between two otherwise-unchanged ids still
-    shows up as a new id in the delta. duplicate_works_report_only is included for a complete,
-    honest diff even though apply_dedup never touches it.
+    """Every id the plan is 'about', per class, stringified AND TAGGED with the operation it
+    belongs to — `merge:` for survivor+losers group identity, `repoint:` for a link/row being
+    re-pointed onto a survivor, `delete:` for a link/row/id being deleted outright, `report:`
+    for the never-applied duplicate_works_report_only class. The prefix is load-bearing, not
+    cosmetic: without it, the SAME id appearing under a different operation (e.g. a row X that
+    was `repoint:X` in the reviewed plan comes back as `delete:X` in the fresh plan — a
+    concurrent write flipped which case applied) would diff as "unchanged" under a bare id
+    comparison, because set-difference only sees the id, not what's about to happen to it. With
+    the tag riding along as part of the token, a flip removes the old tagged token and adds a
+    new one, so it surfaces as an addition in plan_delta and the existing refuse-on-addition
+    policy catches it.
+
+    Composite identifiers (e.g. a repoint's (loser_id, pk) pair) are stringified as
+    `<op>:<tuple-repr>` rather than decomposed, so a link moving between two otherwise-unchanged
+    ids still shows up as a new token in the delta. duplicate_works_report_only is included for
+    a complete, honest diff even though apply_dedup never touches it.
 
     This is the DB-free half of the apply gate (Spec 2026-07-12 follow-up to #95): the CLI
     parses this same shape back out of a previously-written report and calls plan_delta to
-    cross-check a fresh re-plan against what the operator actually reviewed."""
+    cross-check a fresh re-plan against what the operator actually reviewed. Tokens are opaque
+    strings on both the write and read side — the report writer/parser never interprets the
+    prefix, only carries it through unchanged."""
     out: dict[str, set[str]] = {name: set() for name in PLAN_ID_SET_CLASSES}
 
     for g in plan.duplicate_authors:
         s = out["duplicate_authors"]
-        s.add(str(g.survivor_id))
-        s.update(str(lid) for lid in g.loser_ids)
-        s.update(str(item) for item in g.repoint_links)
-        s.update(str(item) for item in g.delete_links)
-        s.update(str(item) for item in g.repoint_styles)
-        s.update(str(item) for item in g.delete_styles)
+        s.add(f"merge:{g.survivor_id}")
+        s.update(f"merge:{lid}" for lid in g.loser_ids)
+        s.update(f"repoint:{item}" for item in g.repoint_links)
+        s.update(f"delete:{item}" for item in g.delete_links)
+        s.update(f"repoint:{item}" for item in g.repoint_styles)
+        s.update(f"delete:{item}" for item in g.delete_styles)
 
     for g in plan.duplicate_narrators:
         s = out["duplicate_narrators"]
-        s.add(str(g.survivor_id))
-        s.update(str(lid) for lid in g.loser_ids)
-        s.update(str(item) for item in g.repoint_links)
-        s.update(str(item) for item in g.delete_links)
-        s.update(str(item) for item in g.repoint_styles)
-        s.update(str(item) for item in g.delete_styles)
+        s.add(f"merge:{g.survivor_id}")
+        s.update(f"merge:{lid}" for lid in g.loser_ids)
+        s.update(f"repoint:{item}" for item in g.repoint_links)
+        s.update(f"delete:{item}" for item in g.delete_links)
+        s.update(f"repoint:{item}" for item in g.repoint_styles)
+        s.update(f"delete:{item}" for item in g.delete_styles)
 
     for g in plan.duplicate_editions:
         s = out["duplicate_editions"]
-        s.add(str(g.survivor_id))
-        s.update(str(lid) for lid in g.loser_ids)
-        s.update(str(rh_id) for rh_id in g.repoint_reading_history)
-        s.update(str(rh_id) for rh_id in g.delete_reading_history)
-        s.update(str(item) for item in g.repoint_narrators)
-        s.update(str(item) for item in g.delete_narrators)
+        s.add(f"merge:{g.survivor_id}")
+        s.update(f"merge:{lid}" for lid in g.loser_ids)
+        s.update(f"repoint:{rh_id}" for rh_id in g.repoint_reading_history)
+        s.update(f"delete:{rh_id}" for rh_id in g.delete_reading_history)
+        s.update(f"repoint:{item}" for item in g.repoint_narrators)
+        s.update(f"delete:{item}" for item in g.delete_narrators)
 
     for g in plan.duplicate_reading_history:
         s = out["duplicate_reading_history"]
-        s.add(str(g.survivor_id))
-        s.update(str(lid) for lid in g.loser_ids)
+        s.add(f"merge:{g.survivor_id}")
+        s.update(f"delete:{lid}" for lid in g.loser_ids)
 
     for g in plan.duplicate_suggestions:
         s = out["duplicate_suggestions"]
-        s.add(str(g.survivor_id))
-        s.update(str(lid) for lid in g.loser_ids)
+        s.add(f"merge:{g.survivor_id}")
+        s.update(f"delete:{lid}" for lid in g.loser_ids)
 
-    out["orphan_authors"].update(str(aid) for aid in plan.orphan_authors)
+    out["orphan_authors"].update(f"delete:{aid}" for aid in plan.orphan_authors)
 
     for w in plan.duplicate_works_report_only:
-        out["duplicate_works_report_only"].update(str(wid) for wid in w.work_ids)
+        out["duplicate_works_report_only"].update(f"report:{wid}" for wid in w.work_ids)
 
     return out
 

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -12,6 +12,13 @@ plan_dedup is read-only. apply_dedup takes the PLAN — not the session's curren
 touches only the exact ids the plan named ("apply what was shown"). If a planned row vanished
 between plan and apply (e.g. a concurrent write), it is skipped and counted under
 "skipped_stale", never re-derived.
+
+plan_id_set / plan_delta (Spec 2026-07-12 follow-up to #95): --apply is a SEPARATE invocation
+from the reviewed dry-run and re-plans from scratch — new duplicates from live traffic in the
+gap would otherwise be applied without operator review, defeating the gate. plan_id_set turns a
+plan into a per-class id set; plan_delta cross-checks a fresh plan's id set against the ids the
+operator actually reviewed (parsed back from the dry-run report) and returns what's new. See
+scripts/clean_catalog.py's --apply flow for how a non-empty delta refuses.
 """
 
 from __future__ import annotations
@@ -643,3 +650,93 @@ def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
     result["skipped_stale"] += orphan_stats["skipped_stale"]
 
     return result
+
+
+# --------------------------------------------------------------------------------------------
+# Apply-gate cross-check (#95 follow-up, Spec 2026-07-12): --apply must re-plan from scratch
+# (live traffic may have created new duplicates since the operator's reviewed dry-run report),
+# so apply cross-checks the FRESH plan's id set against the REVIEWED report's id set and
+# refuses on any addition. plan_id_set/plan_delta are the pure (DB-free) half of that gate;
+# scripts/clean_catalog.py owns parsing the report file and the refuse/re-report flow.
+# --------------------------------------------------------------------------------------------
+
+# The per-class keys used by both plan_id_set and the report's "== PLAN IDS ==" section — one
+# source of truth so the report format and the gate's classes never drift apart.
+PLAN_ID_SET_CLASSES = (
+    "duplicate_authors",
+    "duplicate_narrators",
+    "duplicate_editions",
+    "duplicate_reading_history",
+    "duplicate_suggestions",
+    "orphan_authors",
+    "duplicate_works_report_only",
+)
+
+
+def plan_id_set(plan: DedupPlan) -> dict[str, set[str]]:
+    """Every id the plan is 'about', per class, stringified — survivor ids included as part of
+    group identity (a group whose survivor changed IS a different plan, even if the loser set
+    is a subset of before), plus every loser/deleted-row/repointed-link identifier. Composite
+    identifiers (e.g. a repoint's (loser_id, pk) pair) are stringified as a single tuple-repr
+    token rather than decomposed, so a link moving between two otherwise-unchanged ids still
+    shows up as a new id in the delta. duplicate_works_report_only is included for a complete,
+    honest diff even though apply_dedup never touches it.
+
+    This is the DB-free half of the apply gate (Spec 2026-07-12 follow-up to #95): the CLI
+    parses this same shape back out of a previously-written report and calls plan_delta to
+    cross-check a fresh re-plan against what the operator actually reviewed."""
+    out: dict[str, set[str]] = {name: set() for name in PLAN_ID_SET_CLASSES}
+
+    for g in plan.duplicate_authors:
+        s = out["duplicate_authors"]
+        s.add(str(g.survivor_id))
+        s.update(str(lid) for lid in g.loser_ids)
+        s.update(str(item) for item in g.repoint_links)
+        s.update(str(item) for item in g.delete_links)
+        s.update(str(item) for item in g.repoint_styles)
+        s.update(str(item) for item in g.delete_styles)
+
+    for g in plan.duplicate_narrators:
+        s = out["duplicate_narrators"]
+        s.add(str(g.survivor_id))
+        s.update(str(lid) for lid in g.loser_ids)
+        s.update(str(item) for item in g.repoint_links)
+        s.update(str(item) for item in g.delete_links)
+        s.update(str(item) for item in g.repoint_styles)
+        s.update(str(item) for item in g.delete_styles)
+
+    for g in plan.duplicate_editions:
+        s = out["duplicate_editions"]
+        s.add(str(g.survivor_id))
+        s.update(str(lid) for lid in g.loser_ids)
+        s.update(str(rh_id) for rh_id in g.repoint_reading_history)
+        s.update(str(rh_id) for rh_id in g.delete_reading_history)
+        s.update(str(item) for item in g.repoint_narrators)
+        s.update(str(item) for item in g.delete_narrators)
+
+    for g in plan.duplicate_reading_history:
+        s = out["duplicate_reading_history"]
+        s.add(str(g.survivor_id))
+        s.update(str(lid) for lid in g.loser_ids)
+
+    for g in plan.duplicate_suggestions:
+        s = out["duplicate_suggestions"]
+        s.add(str(g.survivor_id))
+        s.update(str(lid) for lid in g.loser_ids)
+
+    out["orphan_authors"].update(str(aid) for aid in plan.orphan_authors)
+
+    for w in plan.duplicate_works_report_only:
+        out["duplicate_works_report_only"].update(str(wid) for wid in w.work_ids)
+
+    return out
+
+
+def plan_delta(reviewed: dict[str, set[str]], fresh: DedupPlan) -> dict[str, set[str]]:
+    """Per-class ids present in the FRESH plan but NOT in the REVIEWED id set (from the
+    operator's approved report). Empty everywhere means fresh's id set is a subset of
+    reviewed's — i.e. nothing new appeared since the operator looked at the report, and it is
+    safe to apply the fresh plan (stale reviewed ids that vanished from fresh are fine; that's
+    ordinary `skipped_stale` territory at apply time, not a plan drift)."""
+    fresh_ids = plan_id_set(fresh)
+    return {name: fresh_ids.get(name, set()) - reviewed.get(name, set()) for name in PLAN_ID_SET_CLASSES}

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -114,6 +114,15 @@ class DedupPlan:
     duplicate_suggestions: list[KeepDeleteGroup] = field(default_factory=list)
     orphan_authors: list[UUID] = field(default_factory=list)
     duplicate_works_report_only: list[WorkDupReport] = field(default_factory=list)
+    # Final-review Critical (GH #95 follow-up): groups DROPPED from the classes above because
+    # they intersect another class's plan in a way that would compose into row loss if both
+    # applied from the SAME pre-apply snapshot (see _defer_intersecting_groups's docstring).
+    # Keyed by the class name the group was dropped FROM ("duplicate_editions" /
+    # "duplicate_reading_history"); each entry is {"reason": str, ...group-identifying fields}.
+    # EXPECTED on intersecting data, not an error — a subsequent dry-run/apply pass (the
+    # runbook's existing loop) re-plans after the intersecting class has already applied, so the
+    # intersection is gone and the deferred group applies cleanly on the next pass.
+    deferred_intersections: dict[str, list[dict]] = field(default_factory=dict)
 
     def summary(self) -> dict[str, int]:
         return {
@@ -422,7 +431,7 @@ def _plan_editions(session: Session) -> list[EditionMergeGroup]:
 
 
 def _apply_edition_group(session: Session, group: EditionMergeGroup) -> dict[str, int]:
-    stats = {"merged": 0, "skipped_stale": 0}
+    stats = {"merged": 0, "skipped_stale": 0, "skipped_unsafe": 0}
     if session.get(Edition, group.survivor_id) is None:
         stats["skipped_stale"] += 1
         return stats
@@ -468,6 +477,20 @@ def _apply_edition_group(session: Session, group: EditionMergeGroup) -> dict[str
         e = session.get(Edition, loser_id)
         if e is None:
             stats["skipped_stale"] += 1
+            continue
+        # Belt-and-braces (final-review Critical): by this point every edition_narrators row this
+        # GROUP's plan named for `loser_id` has already been repointed or deleted above. If any
+        # row for `loser_id` still exists now, it is UNPLANNED for this group — deleting the
+        # edition would cascade it away via Edition.narrators' `secondary=` relationship, exactly
+        # the narrator x edition composition loss the plan-time defer (see
+        # _defer_intersecting_groups) is meant to prevent. Mirrors the existing orphan-author
+        # re-verify-at-apply-time pattern: refuse and count separately from skipped_stale, since
+        # this isn't "the row vanished" — it's "an unaccounted-for row is still here."
+        unplanned = session.execute(
+            select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == loser_id)
+        ).first()
+        if unplanned is not None:
+            stats["skipped_unsafe"] += 1
             continue
         session.delete(e)
     session.flush()
@@ -593,28 +616,145 @@ def _plan_duplicate_works(session: Session) -> list[WorkDupReport]:
 
 
 # --------------------------------------------------------------------------------------------
+# Cross-class intersection deferral (final-review Critical, GH #95 follow-up)
+#
+# Two of the seven classes are computed independently but share rows in a way that makes their
+# COMPOSITION lossy when both are applied from the same plan snapshot:
+#
+# (a) narrator-merge x edition-merge: narrator-merge REWRITES an edition_narrators row's
+#     narrator_id (delete old pk, insert new) on whatever edition it happens to live on. If that
+#     edition is a LOSER in some edition-merge group, the edition group's plan (computed against
+#     the SAME pre-apply snapshot) still names the OLD (loser_edition_id, loser_narrator_id) pk
+#     in its own repoint_narrators/delete_narrators. By the time edition-merge applies, narrator-
+#     merge already ran (apply order: authors, narrators, editions, ...) and that old pk is gone
+#     -> edition-merge's repoint/delete for it goes skipped_stale, and the NEW row (same edition,
+#     survivor narrator) is never named by the edition group at all. Deleting the loser edition
+#     then cascades that unnamed row away via Edition.narrators' `secondary=` relationship — a
+#     link the reviewed plan promised to repoint is silently lost.
+#
+# (b) edition-merge x reading_history-dedup: edition-merge's OWN in-group collision logic can
+#     plan "repoint row R (first-seen for a user+date), delete row R2 (collides against R's
+#     date)" for an exact-duplicate reading_history pair living on the same loser edition. Class 4
+#     (duplicate_reading_history) independently groups the IDENTICAL pair by its own
+#     (user_id, edition_id, date_completed) key and may pick the opposite survivor. Applying both
+#     from the same snapshot: edition-merge deletes R2 directly, then class 4 (unaware R was
+#     already repointed elsewhere — it only does a stale `session.get` lookup, and repointing
+#     doesn't remove the row) deletes R too. Both copies of the user's read event are lost.
+#
+# The fix: compute the intersections at PLAN time and drop the affected groups from the classes
+# below, recording them under `deferred_intersections`. This is EXPECTED on intersecting data,
+# not an error — the runbook's existing dry-run/apply LOOP re-plans after the intersecting class
+# has already applied, so the intersection is gone and the deferred group applies cleanly on the
+# next pass (two-pass convergence, proven in test_dedup_backfill.py's intersection tests).
+# --------------------------------------------------------------------------------------------
+
+
+def _defer_intersecting_groups(
+    duplicate_narrators: list[ContributorMergeGroup],
+    duplicate_editions: list[EditionMergeGroup],
+    duplicate_reading_history: list[KeepDeleteGroup],
+) -> tuple[list[EditionMergeGroup], list[KeepDeleteGroup], dict[str, list[dict]]]:
+    """Returns (filtered_editions, filtered_reading_history, deferred_intersections). Never
+    mutates the inputs — builds fresh lists."""
+    deferred: dict[str, list[dict]] = {}
+
+    # (a) narrator ids touched by ANY narrator-merge group (survivor + losers) — a loser edition
+    # link involving any of these narrator ids may be REWRITTEN by narrator-merge before
+    # edition-merge applies.
+    narrator_ids_in_play: set[UUID] = set()
+    for g in duplicate_narrators:
+        narrator_ids_in_play.add(g.survivor_id)
+        narrator_ids_in_play.update(g.loser_ids)
+
+    filtered_editions: list[EditionMergeGroup] = []
+    for eg in duplicate_editions:
+        touched_narrator_ids = {nid for _eid, nid in eg.repoint_narrators} | {nid for _eid, nid in eg.delete_narrators}
+        if touched_narrator_ids & narrator_ids_in_play:
+            deferred.setdefault("duplicate_editions", []).append(
+                {
+                    "work_id": eg.work_id,
+                    "survivor_id": eg.survivor_id,
+                    "loser_ids": eg.loser_ids,
+                    "reason": (
+                        "narrator-merge touches a narrator id referenced by this edition group's "
+                        "narrator repoints/deletes — deferred to avoid the narrator x edition "
+                        "cascade-loss composition; re-plan after this apply pass."
+                    ),
+                }
+            )
+            continue
+        filtered_editions.append(eg)
+
+    # (b) reading_history ids this (already-filtered) set of edition groups will repoint/delete —
+    # a class-4 group sharing any of those ids would independently delete a row edition-merge
+    # already repointed/deleted from the SAME snapshot.
+    rh_ids_touched_by_editions: set[UUID] = set()
+    for eg in filtered_editions:
+        rh_ids_touched_by_editions.update(eg.repoint_reading_history)
+        rh_ids_touched_by_editions.update(eg.delete_reading_history)
+
+    filtered_reading_history: list[KeepDeleteGroup] = []
+    for rg in duplicate_reading_history:
+        group_ids = {rg.survivor_id, *rg.loser_ids}
+        if group_ids & rh_ids_touched_by_editions:
+            deferred.setdefault("duplicate_reading_history", []).append(
+                {
+                    "survivor_id": rg.survivor_id,
+                    "loser_ids": rg.loser_ids,
+                    "detail": rg.detail,
+                    "reason": (
+                        "an edition-merge group's own reading_history repoint/delete already "
+                        "covers a row in this group — deferred to avoid the edition x "
+                        "reading_history double-delete composition; re-plan after this apply pass."
+                    ),
+                }
+            )
+            continue
+        filtered_reading_history.append(rg)
+
+    return filtered_editions, filtered_reading_history, deferred
+
+
+# --------------------------------------------------------------------------------------------
 # Top-level plan / apply
 # --------------------------------------------------------------------------------------------
 
 
 def plan_dedup(session: Session) -> DedupPlan:
     """READ ONLY. Computes every class against the CURRENT db state. See _plan_orphan_authors
-    for why orphans are not simulated against not-yet-applied author merges."""
+    for why orphans are not simulated against not-yet-applied author merges.
+
+    See _defer_intersecting_groups for why duplicate_editions and duplicate_reading_history are
+    filtered against each other (and duplicate_narrators) before the plan is returned — two
+    deterministic lossy compositions (narrator x edition cascade; edition x reading_history
+    double-delete) are caught here and deferred rather than applied."""
+    duplicate_narrators = _plan_narrators(session)
+    duplicate_editions = _plan_editions(session)
+    duplicate_reading_history = _plan_reading_history(session)
+
+    duplicate_editions, duplicate_reading_history, deferred_intersections = _defer_intersecting_groups(
+        duplicate_narrators, duplicate_editions, duplicate_reading_history
+    )
+
     return DedupPlan(
         duplicate_authors=_plan_authors(session),
-        duplicate_narrators=_plan_narrators(session),
-        duplicate_editions=_plan_editions(session),
-        duplicate_reading_history=_plan_reading_history(session),
+        duplicate_narrators=duplicate_narrators,
+        duplicate_editions=duplicate_editions,
+        duplicate_reading_history=duplicate_reading_history,
         duplicate_suggestions=_plan_suggestions(session),
         orphan_authors=_plan_orphan_authors(session),
         duplicate_works_report_only=_plan_duplicate_works(session),
+        deferred_intersections=deferred_intersections,
     )
 
 
 def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
     """Applies EXACTLY plan's ids — no re-derivation. Order: authors, narrators, editions,
     reading_history, suggestions, orphans. duplicate_works_report_only is NEVER applied.
-    Rows that vanished between plan and apply are skipped and counted under skipped_stale."""
+    Rows that vanished between plan and apply are skipped and counted under skipped_stale.
+    Rows that survived but weren't accounted for by the group's own plan (the
+    _apply_edition_group belt-and-braces re-verify — see its docstring) are counted separately
+    under skipped_unsafe, distinct from skipped_stale."""
     result = {
         "duplicate_authors": 0,
         "duplicate_narrators": 0,
@@ -623,6 +763,7 @@ def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
         "duplicate_suggestions": 0,
         "orphan_authors": 0,
         "skipped_stale": 0,
+        "skipped_unsafe": 0,
     }
 
     for group in plan.duplicate_authors:
@@ -639,6 +780,7 @@ def apply_dedup(session: Session, plan: DedupPlan) -> dict[str, int]:
         stats = _apply_edition_group(session, group)
         result["duplicate_editions"] += stats["merged"]
         result["skipped_stale"] += stats["skipped_stale"]
+        result["skipped_unsafe"] += stats["skipped_unsafe"]
 
     for group in plan.duplicate_reading_history:
         stats = _apply_keep_delete(session, ReadingHistory, group)

--- a/src/agentic_librarian/etl/enrichment_sweep.py
+++ b/src/agentic_librarian/etl/enrichment_sweep.py
@@ -15,6 +15,7 @@ etl/trope_backfill.py's plan_fallback_prune."""
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
@@ -31,6 +32,12 @@ class RequeueCandidate:
     work_id: UUID
     title: str
     reason: RequeueReason
+    # Adversarial-pass finding (#95 #97 review): surfaced alongside each candidate so an
+    # operator re-reviewing a REPEAT sweep can see "already re-attempted after X" for a
+    # no_real_trope entry that keeps coming back — see plan_requeue's docstring and the
+    # runbook's step 6 repeat-cost warning. None for never_deep_enriched (that's the whole
+    # point of the class); set for no_real_trope (the prior stamp that didn't help).
+    deep_enriched_at: datetime | None = None
 
 
 def plan_requeue(session: Session) -> list[RequeueCandidate]:
@@ -59,5 +66,5 @@ def plan_requeue(session: Session) -> list[RequeueCandidate]:
         names = trope_names_by_work.get(work.id, [])
         has_real = any(is_fallback_trope_name(n, work.genres, work.moods) is False for n in names)
         if not has_real:
-            out.append(RequeueCandidate(work.id, work.title, "no_real_trope"))
+            out.append(RequeueCandidate(work.id, work.title, "no_real_trope", deep_enriched_at=work.deep_enriched_at))
     return out

--- a/src/agentic_librarian/etl/enrichment_sweep.py
+++ b/src/agentic_librarian/etl/enrichment_sweep.py
@@ -1,0 +1,63 @@
+"""Requeue-planner for the deep-enrichment poison-task backstop (GH #97).
+
+Two Cloud Tasks failure modes can leave a Work permanently under-enriched:
+  1. It was never queued at all (e.g. a fast-add whose enqueue_enrichment call silently
+     no-op'd because Cloud Tasks env wasn't configured, or failed — the 6.2b deferral).
+  2. Its deep pass exhausted Cloud Tasks retries while still "empty" (api/internal.py's
+     503 path, GH #97) — a poison task that never lands a real trope.
+
+plan_requeue(session) surfaces both classes so an operator can re-enqueue them via
+scripts/clean_catalog.py --requeue-unenriched. Read-only; session in, list out — the thin
+CLI (scripts/clean_catalog.py) does the printing/gating/enqueue, per the tag_backfill /
+trope_backfill house pattern. Join pattern for trope links borrowed from
+etl/trope_backfill.py's plan_fallback_prune."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
+
+RequeueReason = Literal["never_deep_enriched", "no_real_trope"]
+
+
+@dataclass
+class RequeueCandidate:
+    work_id: UUID
+    title: str
+    reason: RequeueReason
+
+
+def plan_requeue(session: Session) -> list[RequeueCandidate]:
+    """Works that need their deep-enrichment pass (re)queued:
+
+      - "never_deep_enriched": deep_enriched_at IS NULL — no deep pass has ever completed
+        (including a confirmed-empty one) for this work.
+      - "no_real_trope": deep_enriched_at IS SET, but every trope link this work has is
+        fallback/junk per the shared #111 predicate (or it has zero trope links at all) —
+        a poison task that exhausted Cloud Tasks retries without ever landing a genuine
+        narrative trope.
+
+    A work matching both conditions is impossible (no_real_trope requires deep_enriched_at
+    to be set), but if logic ever changes, never_deep_enriched wins and the work appears
+    exactly once. Read-only."""
+    rows = session.query(WorkTrope.work_id, Trope.name).join(Trope, Trope.id == WorkTrope.trope_id).all()
+    trope_names_by_work: dict[UUID, list[str]] = {}
+    for work_id, name in rows:
+        trope_names_by_work.setdefault(work_id, []).append(name)
+
+    out: list[RequeueCandidate] = []
+    for work in session.query(Work).all():
+        if work.deep_enriched_at is None:
+            out.append(RequeueCandidate(work.id, work.title, "never_deep_enriched"))
+            continue
+        names = trope_names_by_work.get(work.id, [])
+        has_real = any(is_fallback_trope_name(n, work.genres, work.moods) is False for n in names)
+        if not has_real:
+            out.append(RequeueCandidate(work.id, work.title, "no_real_trope"))
+    return out

--- a/src/agentic_librarian/etl/ingest.py
+++ b/src/agentic_librarian/etl/ingest.py
@@ -84,7 +84,13 @@ class HistoryIngestor:
             # 2. Work
             work = Work(title=row["Title"], contributors=contributors)
 
-            # 3. Edition
+            # 3. Edition. GH #95: this generator builds bare, unpersisted model instances —
+            # there is no session here to query/get_or_create against (the real ETL write
+            # path is enriched_metadata -> persist_enriched_work, which already goes through
+            # get_or_create/insert_or_requery). to_models() itself is exercised only by
+            # test_ingest.py, not by any live persistence call site, so there is nothing to
+            # guard: whoever eventually adds these objects to a session provides the
+            # constraint backstop via persist_enriched_work, not here.
             edition = Edition(
                 work=work,
                 format=row["format"],

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -11,6 +11,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.get_or_create import get_or_create, insert_or_requery
 from agentic_librarian.db.models import (
     Author,
     AuthorStyle,
@@ -174,9 +175,14 @@ def persist_enriched_work(
         # existing row instead of creating a duplicate Author (complements the dedup backfill).
         author = session.query(Author).filter(func.lower(Author.name) == name.lower()).first()
         if not author:
-            author = Author(name=name)
-            session.add(author)
-            session.flush()
+            # GH #95: uq_authors_name_lower fires on lower(name), which an exact filter_by
+            # would miss for a case-variant race winner — insert_or_requery's recovery path
+            # reuses this same case-insensitive lookup instead.
+            author, _created = insert_or_requery(
+                session,
+                Author(name=name),
+                lambda name=name: session.query(Author).filter(func.lower(Author.name) == name.lower()).first(),
+            )
 
         # Process Author Styles if role is Author
         if role == "Author" and author_style_data:
@@ -284,9 +290,14 @@ def persist_enriched_work(
         # Case-insensitive lookup so a casing variant reuses the existing Narrator row (see above).
         narrator = session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
         if not narrator:
-            narrator = Narrator(name=n_name)
-            session.add(narrator)
-            session.flush()
+            # GH #95: uq_narrators_name_lower — same case-insensitive requery pattern as Author above.
+            narrator, _created = insert_or_requery(
+                session,
+                Narrator(name=n_name),
+                lambda n_name=n_name: (
+                    session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
+                ),
+            )
 
         # Process Narrator Styles
         n_style_data = narrator_styles.get(n_name, {})
@@ -308,16 +319,27 @@ def persist_enriched_work(
         narrator_objs.append(narrator)
 
     if not edition:
-        edition = Edition(
-            work=work,
-            isbn_13=isbn_13,
-            format=row.get("format"),
-            page_count=page_count,
-            audio_minutes=audio_minutes,
-            publication_date=publication_date,
-            narrators=narrator_objs,
+        # GH #95: uq_editions_work_format backstops the SELECT-then-INSERT race above; a
+        # concurrent persist for the same (work_id, format) recovers via requery instead of
+        # a 500. narrators/other creation-only fields only apply on the winning insert — the
+        # loser's edition is re-queried as-is and updated by the existing-edition branch on
+        # its NEXT call (mirrors the pre-#95 eventual-consistency behavior).
+        # work_id= (not work=) so the not-yet-added Edition never lands in work.editions via
+        # the back_populates backref before session.add — that dangling membership is exactly
+        # what trips "Object of type <Edition> not in session" as an SAWarning-promoted error.
+        edition, _created = insert_or_requery(
+            session,
+            Edition(
+                work_id=work.id,
+                isbn_13=isbn_13,
+                format=row.get("format"),
+                page_count=page_count,
+                audio_minutes=audio_minutes,
+                publication_date=publication_date,
+                narrators=narrator_objs,
+            ),
+            lambda: session.query(Edition).filter_by(work_id=work.id, format=row.get("format")).first(),
         )
-        session.add(edition)
         session.flush()  # Ensure edition.id is populated for ReadingHistory check
     else:
         if not row.get("skip_enrichment"):
@@ -337,21 +359,17 @@ def persist_enriched_work(
 
     if date_completed:
         user_id = get_required_user_id()  # per-user: a friend re-reading my book is not a duplicate (ADR-048)
-        existing_history = (
-            session.query(ReadingHistory)
-            .filter_by(edition_id=edition.id, date_completed=date_completed, user_id=user_id)
-            .first()
+        # GH #95: uq_reading_history_user_edition_date backstops this guard against a
+        # concurrent same-read-event race; get_or_create's filters are an exact match for
+        # the constraint's columns, so no case-insensitive requery is needed here.
+        get_or_create(
+            session,
+            ReadingHistory,
+            edition_id=edition.id,
+            date_completed=date_completed,
+            user_id=user_id,
+            defaults={"user_rating": user_rating, "user_notes": user_notes},
         )
-
-        if not existing_history:
-            history_entry = ReadingHistory(
-                edition=edition,
-                user_id=user_id,
-                date_completed=date_completed,
-                user_rating=user_rating,
-                user_notes=user_notes,
-            )
-            session.add(history_entry)
 
     # 5. Tropes (Only if enriched). enriched_tropes/genres/moods were NaN-coerced to lists above,
     # so the truthy check and set() iteration below are safe even when pandas filled them with NaN.

--- a/src/agentic_librarian/imports/worker.py
+++ b/src/agentic_librarian/imports/worker.py
@@ -11,6 +11,7 @@ import logging
 from uuid import UUID
 
 from agentic_librarian.core.user_context import as_user
+from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.models import ImportRow, Suggestions
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
@@ -29,13 +30,19 @@ def set_db_manager(new_manager: DatabaseManager) -> None:
 
 def _upsert_suggestion(session, *, work_id: UUID, user_id: UUID, context: str) -> bool:
     """Get-or-create the user's wishlist suggestion. Returns True if created, False if it
-    already existed (re-import safe — mirrors add_read_event's idempotency)."""
-    existing = session.query(Suggestions).filter_by(work_id=work_id, user_id=user_id, status="Suggested").first()
-    if existing:
-        return False
-    session.add(Suggestions(work_id=work_id, user_id=user_id, status="Suggested", context=context))
-    session.flush()
-    return True
+    already existed (re-import safe — mirrors add_read_event's idempotency).
+
+    GH #95: uq_suggestions_active backstops this get-then-create against a concurrent
+    duplicate-suggestion race (partial unique on (user_id, work_id) WHERE status='Suggested')."""
+    _suggestion, created = get_or_create(
+        session,
+        Suggestions,
+        work_id=work_id,
+        user_id=user_id,
+        status="Suggested",
+        defaults={"context": context},
+    )
+    return created
 
 
 def _finish(row_id: UUID, *, status: str, outcome: str, work_id: UUID | None = None) -> None:

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import joinedload, selectinload
 from agentic_librarian.availability import service as availability_service
 from agentic_librarian.availability.links import build_links
 from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.models import (
     Author,
     AuthorStyle,
@@ -620,16 +621,23 @@ def log_suggestion(work_id: str, context: str, justification: str, conversation_
             # SEC-002 referent check: a suggestion must point at a real catalog work.
             if session.get(Work, uuid_obj) is None:
                 return f"Error: no work exists with id {work_id}."
-            suggestion = Suggestions(
+            # GH #95 (closes #88's root cause): dedup on the active-suggestion partial
+            # unique (user_id, work_id) WHERE status='Suggested' — get_or_create backstops
+            # the same race the old unconditional INSERT was vulnerable to.
+            _suggestion, created = get_or_create(
+                session,
+                Suggestions,
                 work_id=uuid_obj,
                 user_id=user_id,
-                context=(context or "")[:200],
-                justification=(justification or "")[:2000],
-                conversation_id=_parse_uuid(conversation_id),
                 status="Suggested",
+                defaults={
+                    "context": (context or "")[:200],
+                    "justification": (justification or "")[:2000],
+                    "conversation_id": _parse_uuid(conversation_id),
+                },
             )
-            session.add(suggestion)
-            session.flush()
+            if not created:
+                return f"Already an active suggestion for work {work_id} — not duplicated."
             return f"Logged suggestion for work {work_id}."
     except Exception as e:
         return f"Error logging suggestion: {str(e)}"

--- a/test/integration/constraint_helpers.py
+++ b/test/integration/constraint_helpers.py
@@ -36,3 +36,19 @@ def recreate_unique_indexes(conn: Connection, names: list[str]) -> None:
     for name in names:
         conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
         conn.execute(text(UNIQUE_INDEX_DDL[name]))
+
+
+def drop_work_deep_enriched_at(conn: Connection) -> None:
+    """Drop works.deep_enriched_at — mirrors the REAL pre-migration prod schema the gate tool
+    (scripts/clean_catalog.py --dedup-for-constraints, etl/dedup_backfill.py) runs against: the
+    gate is designed to run BEFORE `alembic upgrade head` lands migration 48e3762d6c0c, which is
+    what adds this column. Entity-loading Work while this column is absent from the test schema
+    but present on the SQLAlchemy model reproduces the live UndefinedColumn found against prod
+    (GH #95) instead of only ever testing against the POST-migration shape."""
+    conn.execute(text("ALTER TABLE works DROP COLUMN IF EXISTS deep_enriched_at"))
+
+
+def readd_work_deep_enriched_at(conn: Connection) -> None:
+    """Restore works.deep_enriched_at with the exact DDL from migration 48e3762d6c0c, so the
+    schema is unchanged for every other test in the run."""
+    conn.execute(text("ALTER TABLE works ADD COLUMN IF NOT EXISTS deep_enriched_at timestamptz"))

--- a/test/integration/constraint_helpers.py
+++ b/test/integration/constraint_helpers.py
@@ -1,0 +1,38 @@
+"""Shared helper for tests that must seed pre-constraint duplicate rows against the #95
+unique indexes (migration 48e3762d6c0c) — e.g. legacy dedup logic (contributor_dedup,
+dedup_backfill) that is only meaningful in the window BEFORE those constraints land on a
+real deploy. Drop the named indexes for the duration of a test, then recreate them with the
+exact DDL from the migration so the schema is unchanged for every other test in the run."""
+
+from sqlalchemy import Connection, text
+
+# Name -> exact CREATE-INDEX DDL from alembic/versions/48e3762d6c0c_phase6_3_schema_hardening.py
+# (UNIQUE_INDEXES). Keep in sync with the migration if it ever changes.
+UNIQUE_INDEX_DDL: dict[str, str] = {
+    "uq_authors_name_lower": "CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))",
+    "uq_narrators_name_lower": "CREATE UNIQUE INDEX uq_narrators_name_lower ON narrators (lower(name))",
+    "uq_editions_work_format": (
+        "CREATE UNIQUE INDEX uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT"
+    ),
+    "uq_reading_history_user_edition_date": (
+        "CREATE UNIQUE INDEX uq_reading_history_user_edition_date "
+        "ON reading_history (user_id, edition_id, date_completed)"
+    ),
+    "uq_suggestions_active": (
+        "CREATE UNIQUE INDEX uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'"
+    ),
+}
+
+
+def drop_unique_indexes(conn: Connection, names: list[str]) -> None:
+    """Drop the given #95 unique indexes (by name) so duplicate-seeding tests can insert
+    case/exact duplicate rows the live constraint would otherwise reject."""
+    for name in names:
+        conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
+
+
+def recreate_unique_indexes(conn: Connection, names: list[str]) -> None:
+    """Recreate the given #95 unique indexes with the exact DDL from migration 48e3762d6c0c."""
+    for name in names:
+        conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
+        conn.execute(text(UNIQUE_INDEX_DDL[name]))

--- a/test/integration/test_analysis_api.py
+++ b/test/integration/test_analysis_api.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import func
 
 from agentic_librarian.api import analysis as analysis_mod
 from agentic_librarian.api import auth
@@ -79,9 +80,15 @@ def _seed_read(
                     s.add(WorkStyle(work_id=work.id, style_id=st.id, attribute_type=attr))
         edition = Edition(work_id=work.id, format=fmt)
         if narrator:
-            n = Narrator(name=narrator)
-            s.add(n)
-            s.flush()
+            # uq_narrators_name_lower (GH #95): reuse an existing narrator by
+            # case-insensitive name instead of blindly inserting, so callers can pass
+            # the same narrator name across multiple _seed_read calls (e.g. to model
+            # one narrator across two books) without a UniqueViolation.
+            n = s.query(Narrator).filter(func.lower(Narrator.name) == narrator.lower()).one_or_none()
+            if n is None:
+                n = Narrator(name=narrator)
+                s.add(n)
+                s.flush()
             edition.narrators.append(n)
         s.add(edition)
         s.flush()

--- a/test/integration/test_constraint_backstops.py
+++ b/test/integration/test_constraint_backstops.py
@@ -1,0 +1,115 @@
+"""Integration tests exercising the real Task-1 constraints (48e3762d6c0c) against the
+Task-2 get_or_create/insert_or_requery adoption sites (GH #95; log_suggestion dedup
+closes #88's root cause). Sequential double-insert (not concurrent-thread races — the
+unit suite already proves the SAVEPOINT recovery mechanics; this file proves the real
+Postgres constraints actually fire and the adoption sites recover from them)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func
+
+from agentic_librarian.core.user_context import DEFAULT_USER_ID
+from agentic_librarian.db.get_or_create import get_or_create, insert_or_requery
+from agentic_librarian.db.models import Author, Edition, Suggestions, Work, WorkContributor
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.mcp.server import log_suggestion, set_db_manager
+
+pytestmark = pytest.mark.db_integration
+
+
+def _seed_work(manager, title="Constraint Test Work", author="Constraint Test Author"):
+    with manager.get_session() as s:
+        a = Author(name=author)
+        w = Work(title=title, contributors=[WorkContributor(author=a, role="Author")])
+        s.add_all([a, w])
+        s.flush()
+        s.commit()
+        return w.id
+
+
+def test_same_cased_author_double_insert_resolves_to_one_row(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s1:
+        s1.add(Author(name="Duplicate Author"))
+        s1.commit()
+
+    with manager.get_session() as s2:
+        author, created = insert_or_requery(
+            s2,
+            Author(name="Duplicate Author"),
+            lambda: s2.query(Author).filter(func.lower(Author.name) == "duplicate author").first(),
+        )
+        assert created is False
+        assert author.name == "Duplicate Author"
+
+    with manager.get_session() as s3:
+        assert s3.query(Author).filter(Author.name.ilike("duplicate author")).count() == 1
+
+
+def test_case_variant_author_double_insert_resolves_to_one_row(db_url):
+    """uq_authors_name_lower fires on lower(name) -- a case-variant second insert must be
+    caught by insert_or_requery's case-insensitive requery, not missed like an exact
+    filter_by(name=...) would miss it."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s1:
+        s1.add(Author(name="CasualFarmer"))
+        s1.commit()
+
+    with manager.get_session() as s2:
+        name = "casualfarmer"  # different case than the pre-existing row
+        author, created = insert_or_requery(
+            s2,
+            Author(name=name),
+            lambda: s2.query(Author).filter(func.lower(Author.name) == name.lower()).first(),
+        )
+        assert created is False
+        assert author.name == "CasualFarmer"  # the ORIGINAL row's casing, not a new row
+
+    with manager.get_session() as s3:
+        assert s3.query(Author).filter(Author.name.ilike("casualfarmer")).count() == 1
+
+
+def test_duplicate_active_suggestion_via_log_suggestion_resolves_to_one_row(db_url):
+    """GH #88 root cause: log_suggestion previously had zero dedup and would blindly
+    INSERT a second active suggestion for the same (user, work). uq_suggestions_active is
+    the partial unique backstop; log_suggestion must now dedup via get_or_create and
+    return the 'not duplicated' message on the second call."""
+    manager = DatabaseManager(db_url)
+    set_db_manager(manager)
+    work_id = _seed_work(manager)
+
+    first = log_suggestion(work_id=str(work_id), context="first rec", justification="reason one")
+    assert "Logged suggestion" in first
+
+    second = log_suggestion(work_id=str(work_id), context="second rec", justification="reason two")
+    assert "Already an active suggestion" in second
+    assert "not duplicated" in second
+
+    with manager.get_session() as s:
+        rows = s.query(Suggestions).filter_by(work_id=work_id, user_id=DEFAULT_USER_ID, status="Suggested").all()
+        assert len(rows) == 1
+        # The FIRST call's context/justification won -- the second call did not overwrite.
+        assert rows[0].context == "first rec"
+
+
+def test_duplicate_edition_via_get_or_create_resolves_to_one_row(db_url):
+    """uq_editions_work_format backstop: two sequential get_or_create calls for the same
+    (work_id, format) must resolve to a single Edition row (mirrors the ingest/persist/
+    add_read_event adoption sites)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager, title="Edition Constraint Work")
+
+    with manager.get_session() as s1:
+        edition1, created1 = get_or_create(s1, Edition, work_id=work_id, format="ebook")
+        assert created1 is True
+        s1.flush()
+        edition1_id = edition1.id  # capture the scalar before the session closes (detached-instance rule)
+
+    with manager.get_session() as s2:
+        edition2, created2 = get_or_create(s2, Edition, work_id=work_id, format="ebook")
+        assert created2 is False
+        assert edition2.id == edition1_id
+
+    with manager.get_session() as s3:
+        assert s3.query(Edition).filter_by(work_id=work_id, format="ebook").count() == 1

--- a/test/integration/test_contributor_dedup.py
+++ b/test/integration/test_contributor_dedup.py
@@ -1,10 +1,35 @@
 import pytest
+from sqlalchemy import create_engine
 
 from agentic_librarian.db.models import Author, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl import contributor_dedup as cd
+from test.integration.constraint_helpers import drop_unique_indexes, recreate_unique_indexes
 
 pytestmark = pytest.mark.db_integration
+
+# Migration 48e3762d6c0c (this branch) adds uq_narrators_name_lower — the legacy
+# contributor_dedup logic these tests pin is only meaningful in the pre-constraint prod
+# window (before that migration's dedup backfill + constraint land on a real deploy), and
+# test_apply_merges_dup_narrators seeds a case-only narrator dup ("Travis Baldree" vs
+# "travis baldree") that the live index now rejects. uq_authors_name_lower is untouched:
+# the author test's seed ("Casualfarmer" vs "Casualfarmer ") differs by trailing whitespace,
+# which lower() does not collapse, so it never violates that index.
+_CONTRIBUTOR_DEDUP_UNIQUE_INDEX_NAMES = ["uq_narrators_name_lower"]
+
+
+@pytest.fixture(autouse=True)
+def _pre_constraint_schema(db_url):
+    """Drop uq_narrators_name_lower for the duration of each test (the case-dup narrator
+    seed must be insertable), then restore it — mirroring the dry-run -> approve -> apply ->
+    `alembic upgrade head` sequence the legacy dedup logic actually ran under in prod."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        drop_unique_indexes(conn, _CONTRIBUTOR_DEDUP_UNIQUE_INDEX_NAMES)
+    yield
+    with engine.begin() as conn:
+        recreate_unique_indexes(conn, _CONTRIBUTOR_DEDUP_UNIQUE_INDEX_NAMES)
+    engine.dispose()
 
 
 def test_apply_merges_dup_authors_preserving_distinct_roles(db_url):

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -661,6 +661,68 @@ def test_apply_edition_group_refuses_when_loser_has_unplanned_narrator_link(db_u
         session.flush()
 
 
+# --------------------------------------------------------------------------------------------
+# Planner determinism (final-review Minor 3): every group query is order_by'd on its pk (and
+# losers are sorted) so dry-run and an apply-time re-plan against UNCHANGED data classify
+# collisions identically — otherwise a Postgres row-order difference between two plans over the
+# same rows could flip which loser link is "repoint" vs "delete", spuriously tripping the
+# apply-gate's drift-refuse (plan_delta sees a changed operation tag on an unchanged id).
+# --------------------------------------------------------------------------------------------
+
+
+def test_plan_dedup_is_deterministic_across_repeated_calls(db_url):
+    """Two consecutive plan_dedup calls against the SAME unchanged data must classify every
+    collision identically — same repoint/delete assignment, same loser order — not just the
+    same counts. Seeds two authors and two narrators, each with two losers that both carry a
+    link colliding with the survivor's, so classification depends on loser iteration order."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Repeat Survivor")  # most-linked -> survivor
+        a2 = Author(name="repeat survivor")  # loser 1
+        a3 = Author(name="REPEAT SURVIVOR")  # loser 2
+        w1 = Work(title="Determinism Work 1")
+        w2 = Work(title="Determinism Work 2")
+        w3 = Work(title="Determinism Work 3")
+        session.add_all([a1, a2, a3, w1, w2, w3])
+        session.flush()
+
+        # a1 (survivor) gets 3 links; a2 and a3 (losers) each get 1 link that collides with the
+        # SAME (work, role) key a1 already has — both should classify as delete_links regardless
+        # of which loser is processed first (this is what "deterministic" is actually testing:
+        # a REPEATABLE outcome across repeated plans, not merely "some" outcome).
+        session.add(WorkContributor(work_id=w1.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w3.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w1.id, author_id=a2.id, role="Author"))  # collides w1
+        session.add(WorkContributor(work_id=w1.id, author_id=a3.id, role="Author"))  # also collides w1
+        session.flush()
+
+        plan1 = db_.plan_dedup(session)
+        plan2 = db_.plan_dedup(session)
+
+        assert plan1.summary()["duplicate_authors"] == 1
+        assert plan2.summary()["duplicate_authors"] == 1
+        g1, g2 = plan1.duplicate_authors[0], plan2.duplicate_authors[0]
+
+        assert g1.survivor_id == g2.survivor_id == a1.id
+        # loser order must be identical (sorted losers, per Minor 3)
+        assert g1.loser_ids == g2.loser_ids
+        # classification must be identical: same links in delete_links, same in repoint_links,
+        # in the same order, across both plans
+        assert g1.delete_links == g2.delete_links
+        assert g1.repoint_links == g2.repoint_links
+        # both loser links collide with a1's existing w1 link -> both must be delete_links, not
+        # split across repoint/delete depending on processing order
+        assert len(g1.delete_links) == 2
+        assert len(g1.repoint_links) == 0
+
+        # cleanup: apply one of the (identical) plans so no case-duplicate authors remain for
+        # the module's autouse _pre_constraint_schema fixture to recreate uq_authors_name_lower
+        # against at teardown.
+        db_.apply_dedup(session, plan1)
+        session.flush()
+
+
 def test_orphan_authors_recomputed_after_merge_needs_replan(db_url):
     """An author orphaned BY a same-run merge is caught only on a re-run (documented honesty,
     not simulated ahead of time)."""

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -9,7 +9,7 @@ from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, delete
 
 from agentic_librarian.core.user_context import DEFAULT_USER_ID
 from agentic_librarian.db.models import (
@@ -402,6 +402,263 @@ def test_apply_skips_stale_plan_ids(db_url):
         result = db_.apply_dedup(session, plan)
         assert result["duplicate_reading_history"] == 0
         assert result["skipped_stale"] == 1
+
+
+# --------------------------------------------------------------------------------------------
+# Cross-class composition (final-review Critical, GH #95 follow-up): two deterministic lossy
+# compositions found in the applier's plan-time-vs-apply-time gap. (a) narrator-merge repoints a
+# link living on a LOSER edition, but edition-merge's plan (computed against the SAME pre-apply
+# snapshot) still names the OLD (loser_edition, loser_narrator) pk for repoint/delete — that pk is
+# gone by the time edition-merge applies (narrator-merge already rewrote it), so it goes
+# skipped_stale, and deleting the loser edition then CASCADES away the rewritten link via the
+# `Edition.narrators` secondary relationship — a link the plan promised to repoint is lost.
+# (b) edition-merge's OWN in-group collision logic can plan "repoint R (first-seen), delete R2
+# (date-collides with R)" for two exact-duplicate reading_history rows living on the same loser
+# edition — but class 4 (duplicate_reading_history) independently computed ITS OWN group over the
+# same (user_id, edition_id, date_completed) key, from the SAME pre-apply snapshot, and may pick
+# the opposite survivor (e.g. "keep R2, delete R"). Applying both classes then loses BOTH rows: R2
+# is deleted by edition-merge, and R survives edition-merge's repoint but is then deleted outright
+# by class 4 (which only checks `session.get` — repointing doesn't remove the row, so class 4's
+# stale-loser-id lookup still finds and deletes it).
+# --------------------------------------------------------------------------------------------
+
+
+def test_narrator_edition_intersection_is_deferred_not_applied(db_url):
+    """(a) Seed the narrator x edition intersection exactly: a narrator-merge group whose loser
+    narrator has a link on a loser edition that an edition-merge group's plan also touches. The
+    PLAN must defer the affected EDITION group (drop it from duplicate_editions, list it under
+    deferred_intersections) rather than applying a composition that would lose the repointed
+    link. Two-pass convergence (apply -> re-plan -> apply) must complete with the link intact."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        n1 = Narrator(name="Travis Baldree")  # most-linked -> survivor
+        n2 = Narrator(name="travis baldree")  # loser; linked only on the loser edition
+        w = Work(title="Intersection Test Work")
+        session.add_all([n1, n2, w])
+        session.flush()
+
+        e1 = Edition(work_id=w.id, format="audiobook")  # most-linked -> survivor
+        e2 = Edition(work_id=w.id, format="audiobook")  # exact (work_id, format) dup -> loser
+        session.add_all([e1, e2])
+        session.flush()
+
+        # e1 gets 2 reading_history links (survivor by link count)
+        session.add(ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1)))
+        session.add(ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 2, 1)))
+        # n1 gets 2 links total (e1 + a style) so it out-links n2's single link
+        session.execute(edition_narrators.insert().values(edition_id=e1.id, narrator_id=n1.id))
+        style = Style(name="Gravelly", category="Narrator")
+        session.add(style)
+        session.flush()
+        session.add(NarratorStyle(narrator_id=n1.id, style_id=style.id, attribute_type="voice_differentiation"))
+        # n2 (the narrator-merge LOSER) is linked only on e2 (the edition-merge LOSER) — this is
+        # the intersecting row: narrator-merge will repoint it (e2, n2) -> (e2, n1); edition-merge
+        # independently plans to repoint/delete the SAME (e2, n2) pk.
+        session.execute(edition_narrators.insert().values(edition_id=e2.id, narrator_id=n2.id))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+
+        # sanity: both groups exist as planned before the defer logic filters them
+        assert plan.summary()["duplicate_narrators"] == 1
+        narrator_group = plan.duplicate_narrators[0]
+        assert narrator_group.survivor_id == n1.id
+        assert narrator_group.loser_ids == [n2.id]
+        assert (n2.id, (e2.id, n2.id)) in narrator_group.repoint_links
+
+        # the intersecting EDITION group must be DEFERRED, not present in the apply-able plan
+        edition_work_ids = {g.work_id for g in plan.duplicate_editions}
+        assert w.id not in edition_work_ids, "intersecting edition group must be dropped from the plan"
+
+        assert "duplicate_editions" in plan.deferred_intersections
+        deferred = plan.deferred_intersections["duplicate_editions"]
+        assert len(deferred) == 1
+        assert deferred[0]["work_id"] == w.id
+        assert "reason" in deferred[0] and deferred[0]["reason"]
+
+        # apply pass 1: only the narrator merge (deferred edition group untouched)
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+        assert result["duplicate_narrators"] == 1
+        assert result["duplicate_editions"] == 0
+
+        # the repointed link survived (this is the row the bug used to cascade away)
+        e2_narrators = session.execute(
+            edition_narrators.select().where(edition_narrators.c.edition_id == e2.id)
+        ).fetchall()
+        assert [r.narrator_id for r in e2_narrators] == [n1.id]
+
+        # pass 2: re-plan now sees no narrator/edition intersection (narrators already merged) ->
+        # the edition group applies cleanly, converging within two dry-run/apply passes.
+        plan2 = db_.plan_dedup(session)
+        assert plan2.deferred_intersections.get("duplicate_editions", []) == []
+        assert any(g.work_id == w.id for g in plan2.duplicate_editions)
+        result2 = db_.apply_dedup(session, plan2)
+        session.flush()
+        assert result2["duplicate_editions"] == 1
+
+        # the repointed narrator link survived onto the final surviving edition too
+        assert session.query(Edition).filter_by(work_id=w.id).count() == 1
+        surviving_edition = session.query(Edition).filter_by(work_id=w.id).one()
+        surviving_narrators = {
+            r.narrator_id
+            for r in session.execute(
+                edition_narrators.select().where(edition_narrators.c.edition_id == surviving_edition.id)
+            ).fetchall()
+        }
+        assert n1.id in surviving_narrators  # the originally-repointed link, never lost
+
+        # fully converged
+        plan3 = db_.plan_dedup(session)
+        assert plan3.summary()["duplicate_narrators"] == 0
+        assert plan3.summary()["duplicate_editions"] == 0
+
+
+def test_edition_reading_history_intersection_is_deferred_not_applied(db_url):
+    """(b) Seed the edition x reading_history intersection: two exact-duplicate reading_history
+    rows on the SAME loser edition, with the same (user_id, date_completed) as each other, so
+    edition-merge's in-group collision logic plans "repoint one, delete the other" while class 4
+    independently plans its own keep/delete over the identical pair. The PLAN must defer the
+    affected duplicate_reading_history group; both rows (the user's read event) must survive
+    end-to-end across a two-pass apply."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="RH Intersection Work")
+        session.add(w)
+        session.flush()
+
+        e1 = Edition(work_id=w.id, format="ebook")  # survivor (most-linked)
+        e2 = Edition(work_id=w.id, format="ebook")  # loser
+        session.add_all([e1, e2])
+        session.flush()
+
+        # e1 gets THREE reading_history links so it out-links e2's pair below (survivor by count;
+        # e2 will carry 2 links from the duplicate pair seeded next, so e1 needs >2 to win).
+        session.add(ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1)))
+        session.add(ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 2, 1)))
+        session.add(ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 3, 1)))
+        session.flush()
+
+        # e2 (the loser) carries an EXACT reading_history duplicate pair: same user, same edition,
+        # same date_completed. Class 3 (edition-merge) will see: first row -> no survivor-date
+        # collision -> repoint; second row -> now collides (against the just-updated tracking set)
+        # -> delete. Class 4 (duplicate_reading_history) independently groups the identical pair
+        # by (user_id, edition_id, date_completed) and picks its OWN survivor (lowest str(id)).
+        rh_a = ReadingHistory(edition_id=e2.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 4, 1))
+        rh_b = ReadingHistory(edition_id=e2.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 4, 1))
+        session.add_all([rh_a, rh_b])
+        session.flush()
+        rh_ids = {rh_a.id, rh_b.id}
+
+        plan = db_.plan_dedup(session)
+
+        # sanity: both classes independently see this pair before the defer logic filters them
+        assert plan.summary()["duplicate_editions"] == 1
+        edition_group = plan.duplicate_editions[0]
+        assert set(edition_group.repoint_reading_history) | set(edition_group.delete_reading_history) == rh_ids
+
+        # the intersecting RH-dedup group must be DEFERRED, not present in the apply-able plan
+        rh_group_id_sets = [{g.survivor_id, *g.loser_ids} for g in plan.duplicate_reading_history]
+        assert not any(rh_ids <= s for s in rh_group_id_sets), "intersecting rh group must be dropped"
+
+        assert "duplicate_reading_history" in plan.deferred_intersections
+        deferred = plan.deferred_intersections["duplicate_reading_history"]
+        assert len(deferred) == 1
+        assert "reason" in deferred[0] and deferred[0]["reason"]
+
+        # apply pass 1: edition-merge applies (repoints/deletes within its own group); the
+        # intersecting class-4 group is deferred so it does NOT independently delete a row
+        # edition-merge already repointed.
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+        assert result["duplicate_editions"] == 1
+        assert result["duplicate_reading_history"] == 0
+
+        # exactly one of the pair survives (edition-merge's own repoint/delete-collision landed),
+        # and it is NOT double-deleted by a same-pass class-4 application.
+        surviving = session.query(ReadingHistory).filter(ReadingHistory.id.in_(rh_ids)).all()
+        assert len(surviving) == 1
+        assert session.query(Work).filter_by(id=w.id).one()
+        # the user's reading_history row count for this work is exactly 4: the 3 untouched e1
+        # rows plus the one survivor of the e2 pair (never 3 — that would mean both copies of the
+        # pair were lost, the bug this test guards against).
+        total_rh_for_work = session.query(ReadingHistory).join(Edition).filter(Edition.work_id == w.id).count()
+        assert total_rh_for_work == 4
+
+        # pass 2: re-plan now sees no edition/rh intersection (editions already merged) -> class 4
+        # either finds nothing left to do (the surviving row is unique) or converges cleanly.
+        plan2 = db_.plan_dedup(session)
+        assert plan2.deferred_intersections.get("duplicate_reading_history", []) == []
+        result2 = db_.apply_dedup(session, plan2)
+        session.flush()
+
+        # fully converged, and the row count is STILL 4 (no further loss on pass 2)
+        total_rh_for_work_final = session.query(ReadingHistory).join(Edition).filter(Edition.work_id == w.id).count()
+        assert total_rh_for_work_final == 4
+        plan3 = db_.plan_dedup(session)
+        assert plan3.summary()["duplicate_editions"] == 0
+        assert plan3.summary()["duplicate_reading_history"] == 0
+        assert result2 is not None  # apply_dedup on the converged plan is a valid no-op-ish call
+
+
+def test_apply_edition_group_refuses_when_loser_has_unplanned_narrator_link(db_url):
+    """Belt-and-braces (final-review Critical): _apply_edition_group must refuse to delete a
+    loser edition that still carries an edition_narrators row NOT named in the group's own
+    planned repoint_narrators/delete_narrators — mirroring the existing orphan-author
+    re-verify-at-apply-time pattern. Force-feed a hand-built EditionMergeGroup whose plan is
+    silent about a narrator link that exists on the loser edition at apply time (simulating a
+    plan/apply drift or a bug in the planner itself) and assert it is refused, not deleted."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="Unsafe Delete Work")
+        n = Narrator(name="Untracked Narrator")
+        session.add_all([w, n])
+        session.flush()
+
+        e1 = Edition(work_id=w.id, format="ebook")
+        e2 = Edition(work_id=w.id, format="ebook")
+        session.add_all([e1, e2])
+        session.flush()
+
+        # e2 (about to be force-fed as the loser) carries a narrator link the plan below is
+        # deliberately silent about — the unsafe state the belt-and-braces check must catch.
+        session.execute(edition_narrators.insert().values(edition_id=e2.id, narrator_id=n.id))
+        session.flush()
+
+        unsafe_group = db_.EditionMergeGroup(
+            survivor_id=e1.id,
+            work_id=w.id,
+            fmt="ebook",
+            loser_ids=[e2.id],
+            repoint_reading_history=[],
+            delete_reading_history=[],
+            repoint_narrators=[],  # silent about (e2, n) — the unsafe condition
+            delete_narrators=[],
+        )
+
+        stats = db_._apply_edition_group(session, unsafe_group)
+        session.flush()
+
+        # skipped_unsafe fires (distinct from skipped_stale — the row didn't vanish, it was
+        # unaccounted-for); the binding assertion is that the loser edition survives with its
+        # unplanned narrator link intact, not deleted out from under it.
+        assert stats.get("skipped_unsafe", 0) == 1
+        assert session.get(Edition, e2.id) is not None
+        e2_narrators = session.execute(
+            edition_narrators.select().where(edition_narrators.c.edition_id == e2.id)
+        ).fetchall()
+        assert [r.narrator_id for r in e2_narrators] == [n.id]
+
+        # Cleanup: the refused delete deliberately LEAVES a duplicate (work_id, format) pair in
+        # place (that's the point of the test — the belt-and-braces check refused it), which
+        # would violate uq_editions_work_format when the module's autouse _pre_constraint_schema
+        # fixture recreates it at teardown. Clear the narrator link (the plan's own silence about
+        # it was the test condition, now proven) and delete the loser edition directly so the
+        # schema is clean for the index recreate, mirroring the cleanup pattern used by
+        # test_apply_gate_refuses_on_new_duplicate_in_the_gap for the same reason.
+        session.execute(delete(edition_narrators).where(edition_narrators.c.edition_id == e2.id))
+        session.delete(session.get(Edition, e2.id))
+        session.flush()
 
 
 def test_orphan_authors_recomputed_after_merge_needs_replan(db_url):

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -7,9 +7,10 @@ touches only the ids it names (apply-what-was-shown)."""
 import importlib.util
 from datetime import date, timedelta
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine, delete
+from sqlalchemy import create_engine, delete, text
 
 from agentic_librarian.core.user_context import DEFAULT_USER_ID
 from agentic_librarian.db.models import (
@@ -27,7 +28,12 @@ from agentic_librarian.db.models import (
 )
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl import dedup_backfill as db_
-from test.integration.constraint_helpers import drop_unique_indexes, recreate_unique_indexes
+from test.integration.constraint_helpers import (
+    drop_unique_indexes,
+    drop_work_deep_enriched_at,
+    readd_work_deep_enriched_at,
+    recreate_unique_indexes,
+)
 
 # scripts/clean_catalog.py is not a package module (it's an operator CLI script) — load it the
 # same way test/unit/test_clean_catalog_cli.py does, so these tests exercise the REAL report
@@ -66,6 +72,22 @@ def _pre_constraint_schema(db_url):
     yield
     with engine.begin() as conn:
         recreate_unique_indexes(conn, _DEDUP_UNIQUE_INDEX_NAMES)
+    engine.dispose()
+
+
+@pytest.fixture
+def _drop_deep_enriched_at(db_url):
+    """Additionally drop works.deep_enriched_at — the REAL pre-migration prod schema (GH #95):
+    the gate runs BEFORE `alembic upgrade head` lands migration 48e3762d6c0c, which is what adds
+    this column. Only used by the one test below (not autouse) since every other test in this
+    module is indifferent to the column's presence — narrowing the blast radius of dropping a
+    column to the single test that exists to prove the tool tolerates its absence."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        drop_work_deep_enriched_at(conn)
+    yield
+    with engine.begin() as conn:
+        readd_work_deep_enriched_at(conn)
     engine.dispose()
 
 
@@ -981,3 +1003,67 @@ def test_apply_gate_reviewed_row_deleted_applies_with_skipped_stale(db_url):
         result = db_.apply_dedup(session, fresh_plan)
         assert result["duplicate_reading_history"] == 0
         assert session.query(ReadingHistory).count() == 1
+
+
+def test_plan_dedup_runs_against_pre_migration_schema_without_deep_enriched_at(db_url, _drop_deep_enriched_at):
+    """The REAL bug (found live against prod, GH #95): --dedup-for-constraints is designed to
+    run BEFORE `alembic upgrade head` lands migration 48e3762d6c0c — but the branch's Work model
+    already carries deep_enriched_at, so any full-entity `session.query(Work)` SELECTs a column
+    prod doesn't have yet and dies with UndefinedColumn. Under the dropped-column fixture (the
+    exact schema the tool meets in prod), seed one small duplicate-author class touching Work
+    rows and prove plan_dedup runs end-to-end and plans correctly with the column ABSENT."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Casualfarmer")
+        a2 = Author(name="casualfarmer")  # case dup, structural: lower(name) group
+        session.add_all([a1, a2])
+        session.flush()
+
+        # Seed the works via raw SQL, NOT the ORM: an ORM INSERT names every mapped column —
+        # including deep_enriched_at — and would itself die with UndefinedColumn under this
+        # fixture (proving the fixture faithfully mirrors prod, where rows simply already
+        # exist without the column).
+        w1_id, w2_id = uuid4(), uuid4()
+        session.execute(
+            text("INSERT INTO works (id, title) VALUES (:id1, :t1), (:id2, :t2)"),
+            {"id1": w1_id, "t1": "Beware of Chicken", "id2": w2_id, "t2": "Farming Life"},
+        )
+
+        # a1 gets 2 links (most-linked -> survivor); a2 gets 1 (clean repoint)
+        session.add(WorkContributor(work_id=w1_id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w2_id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w2_id, author_id=a2.id, role="Editor"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_authors"] == 1
+        group = plan.duplicate_authors[0]
+        assert group.survivor_id == a1.id
+        assert group.loser_ids == [a2.id]
+
+        result = db_.apply_dedup(session, plan)
+        assert result["duplicate_authors"] == 1
+        session.flush()
+
+        assert session.query(Author).count() == 1
+        editor_link = session.query(WorkContributor).filter_by(work_id=w2_id, role="Editor").one()
+        assert editor_link.author_id == a1.id
+
+        # re-plan converges to empty — proves the whole plan/apply round trip, not just plan,
+        # tolerates the column's absence
+        assert db_.plan_dedup(session).summary()["duplicate_authors"] == 0
+
+
+def test_dedup_dry_run_cli_runs_against_pre_migration_schema(db_url, _drop_deep_enriched_at, monkeypatch, tmp_path):
+    """The EXACT prod crash site (GH #95): the CLI's recency probe ran
+    `session.query(Work).count()` — SQLAlchemy renders that as count over a subquery selecting
+    EVERY mapped Work column, including deep_enriched_at, which the pre-migration prod schema
+    doesn't have -> UndefinedColumn before the dry-run ever reached the planner. Run the REAL
+    `--dedup-for-constraints --dry-run` through clean_catalog.main against the dropped-column
+    schema and assert it completes (rc 0)."""
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: db_url)
+    # _write_dedup_report / _newest_dedup_report use the cwd-relative data/reports — keep the
+    # test's report out of the repo tree.
+    monkeypatch.chdir(tmp_path)
+    rc = clean_catalog.main(["--dedup-for-constraints", "--dry-run"])
+    assert rc == 0

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -1,0 +1,431 @@
+"""Task 4 (Spec 2026-07-12 phase6-3): the gated pre-constraint dedup planner + applier.
+
+Structural distinguishers only (the #69 lesson) — every class groups on real relationships or
+normalized values, never a sometimes-populated column. apply_dedup takes the PLAN as input and
+touches only the ids it names (apply-what-was-shown)."""
+
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from agentic_librarian.core.user_context import DEFAULT_USER_ID
+from agentic_librarian.db.models import (
+    Author,
+    AuthorStyle,
+    Edition,
+    Narrator,
+    NarratorStyle,
+    ReadingHistory,
+    Style,
+    Suggestions,
+    Work,
+    WorkContributor,
+    edition_narrators,
+)
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import dedup_backfill as db_
+
+pytestmark = pytest.mark.db_integration
+
+# Migration 48e3762d6c0c (already on this branch) lands the #95 unique constraints these
+# planner tests are seeding duplicates AGAINST — but the real deploy sequence (spec: "Dedup
+# backfill (THE USER GATE)") runs the dedup backfill BEFORE those constraints land. To seed
+# realistic pre-constraint duplicate rows, drop just the 5 dedup-relevant indexes for this
+# module and recreate them afterward — the FK indexes/timestamptz/deep_enriched_at parts of
+# the same migration are irrelevant to duplicates and stay in place throughout.
+_DEDUP_UNIQUE_INDEXES = [
+    ("uq_authors_name_lower", "CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))"),
+    ("uq_narrators_name_lower", "CREATE UNIQUE INDEX uq_narrators_name_lower ON narrators (lower(name))"),
+    (
+        "uq_editions_work_format",
+        "CREATE UNIQUE INDEX uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT",
+    ),
+    (
+        "uq_reading_history_user_edition_date",
+        "CREATE UNIQUE INDEX uq_reading_history_user_edition_date "
+        "ON reading_history (user_id, edition_id, date_completed)",
+    ),
+    (
+        "uq_suggestions_active",
+        "CREATE UNIQUE INDEX uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _pre_constraint_schema(db_url):
+    """Drop the #95 unique indexes for the duration of each test (duplicates must be
+    insertable to test the planner that finds them), then restore them — mirroring the real
+    dry-run -> approve -> apply -> `alembic upgrade head` sequence."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        for name, _create_sql in _DEDUP_UNIQUE_INDEXES:
+            conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
+    yield
+    with engine.begin() as conn:
+        for name, create_sql in _DEDUP_UNIQUE_INDEXES:
+            conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
+            conn.execute(text(create_sql))
+    engine.dispose()
+
+
+def test_empty_db_plan_is_empty(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        plan = db_.plan_dedup(session)
+        assert plan.summary() == {
+            "duplicate_authors": 0,
+            "duplicate_narrators": 0,
+            "duplicate_editions": 0,
+            "duplicate_reading_history": 0,
+            "duplicate_suggestions": 0,
+            "orphan_authors": 0,
+            "duplicate_works_report_only": 0,
+        }
+
+
+def test_apply_on_empty_plan_is_noop(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        plan = db_.plan_dedup(session)
+        result = db_.apply_dedup(session, plan)
+        assert all(v == 0 for v in result.values())
+
+
+def test_duplicate_authors_repoint_and_collision_delete(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Casualfarmer")
+        a2 = Author(name="casualfarmer")  # case dup, structural: lower(name) group
+        w1 = Work(title="Beware of Chicken")
+        w2 = Work(title="Farming Life")
+        w3 = Work(title="A Practical Guide to Sorcery")
+        w4 = Work(title="Cursed Wife")
+        style = Style(name="Wry", category="Author")
+        session.add_all([a1, a2, w1, w2, w3, w4, style])
+        session.flush()
+
+        # a1 gets 4 links (most-linked -> survivor); a2 gets 3 (1 clean repoint + 1 collision + 1 style)
+        session.add(WorkContributor(work_id=w1.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w3.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w4.id, author_id=a1.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=a2.id, role="Editor"))
+        # collision case: a2 has the SAME (work, role) that a1 already has on w1 too
+        session.add(WorkContributor(work_id=w1.id, author_id=a2.id, role="Author"))
+        session.add(AuthorStyle(author_id=a2.id, style_id=style.id, attribute_type="tone"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_authors"] == 1
+        group = plan.duplicate_authors[0]
+        assert group.survivor_id == a1.id
+        assert group.loser_ids == [a2.id]
+
+        result = db_.apply_dedup(session, plan)
+        assert result["duplicate_authors"] == 1
+        session.flush()
+
+        assert session.query(Author).count() == 1
+        # the collision link (w1, Author) was deleted, not duplicated
+        roles_w1 = sorted(c.role for c in session.query(WorkContributor).filter_by(work_id=w1.id).all())
+        assert roles_w1 == ["Author"]
+        # the clean repoint (w2, Editor) landed on the survivor
+        roles_w2 = sorted(c.role for c in session.query(WorkContributor).filter_by(work_id=w2.id).all())
+        assert roles_w2 == ["Author", "Editor"]
+        editor_link = session.query(WorkContributor).filter_by(work_id=w2.id, role="Editor").one()
+        assert editor_link.author_id == a1.id
+        # author_styles repointed onto survivor
+        assert session.query(AuthorStyle).filter_by(author_id=a1.id, style_id=style.id).count() == 1
+
+        # re-plan converges to empty
+        assert db_.plan_dedup(session).summary()["duplicate_authors"] == 0
+
+
+def test_duplicate_narrators_repoint_edition_and_style(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        n1 = Narrator(name="Travis Baldree")
+        n2 = Narrator(name="travis baldree")
+        w = Work(title="Narr Test")
+        style = Style(name="Gravelly", category="Narrator")
+        session.add_all([n1, n2, w, style])
+        session.flush()
+
+        e1 = Edition(work_id=w.id, format="audiobook")
+        e2 = Edition(work_id=w.id, format="audiobook_abridged")
+        e3 = Edition(work_id=w.id, format="audiobook_full_cast")
+        session.add_all([e1, e2, e3])
+        session.flush()
+        # n1 linked on three editions (most-linked survivor)
+        session.execute(edition_narrators.insert().values(edition_id=e1.id, narrator_id=n1.id))
+        session.execute(edition_narrators.insert().values(edition_id=e2.id, narrator_id=n1.id))
+        session.execute(edition_narrators.insert().values(edition_id=e3.id, narrator_id=n1.id))
+        # n2 collides on e1 (same edition already has n1) and also carries a style link
+        session.execute(edition_narrators.insert().values(edition_id=e1.id, narrator_id=n2.id))
+        session.add(NarratorStyle(narrator_id=n2.id, style_id=style.id, attribute_type="voice_differentiation"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_narrators"] == 1
+        group = plan.duplicate_narrators[0]
+        assert group.survivor_id == n1.id
+        assert group.loser_ids == [n2.id]
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert result["duplicate_narrators"] == 1
+        assert session.query(Narrator).count() == 1
+        e1_narrators = session.execute(
+            edition_narrators.select().where(edition_narrators.c.edition_id == e1.id)
+        ).fetchall()
+        assert [r.narrator_id for r in e1_narrators] == [n1.id]  # collision deleted, not duplicated
+        assert session.query(NarratorStyle).filter_by(narrator_id=n1.id, style_id=style.id).count() == 1
+
+        assert db_.plan_dedup(session).summary()["duplicate_narrators"] == 0
+
+
+def test_duplicate_editions_repoint_reading_history_and_narrators(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="Dup Edition Work")
+        n = Narrator(name="Some Narrator")
+        session.add_all([w, n])
+        session.flush()
+
+        e1 = Edition(work_id=w.id, format="ebook")
+        e2 = Edition(work_id=w.id, format="ebook")  # exact (work_id, format) dup
+        session.add_all([e1, e2])
+        session.flush()
+        session.execute(edition_narrators.insert().values(edition_id=e1.id, narrator_id=n.id))
+        session.execute(edition_narrators.insert().values(edition_id=e2.id, narrator_id=n.id))  # collision
+
+        rh1 = ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1))
+        rh2 = ReadingHistory(edition_id=e2.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 2, 1))  # repoints
+        session.add_all([rh1, rh2])
+        session.flush()
+
+        # give e1 the extra link so it is "most-linked" (survivor)
+        rh3 = ReadingHistory(edition_id=e1.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 3, 1))
+        session.add(rh3)
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_editions"] == 1
+        group = plan.duplicate_editions[0]
+        assert group.survivor_id == e1.id
+        assert group.loser_ids == [e2.id]
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert result["duplicate_editions"] == 1
+        assert session.query(Edition).count() == 1
+        # rh2 repointed onto e1's surviving id
+        assert session.get(ReadingHistory, rh2.id).edition_id == e1.id
+        e1_narrators = session.execute(
+            edition_narrators.select().where(edition_narrators.c.edition_id == e1.id)
+        ).fetchall()
+        assert [r.narrator_id for r in e1_narrators] == [n.id]  # collision deleted, not duplicated
+
+        assert db_.plan_dedup(session).summary()["duplicate_editions"] == 0
+
+
+def test_duplicate_reading_history_exact_groups_keep_oldest(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="RH Dup Work")
+        session.add(w)
+        session.flush()
+        e = Edition(work_id=w.id, format="ebook")
+        session.add(e)
+        session.flush()
+
+        rh1 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 5, 1))
+        session.add(rh1)
+        session.flush()
+        rh2 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 5, 1))
+        session.add(rh2)
+        session.flush()
+
+        # ReadingHistory has no created_at; "keep oldest" uses the lowest-id structural
+        # proxy (same tie-break as contributor_dedup._pick_survivor), so the survivor is
+        # whichever of rh1/rh2 sorts first by str(id) — not necessarily insertion order.
+        expected_survivor, expected_loser = sorted([rh1, rh2], key=lambda r: str(r.id))
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_reading_history"] == 1
+        group = plan.duplicate_reading_history[0]
+        assert group.survivor_id == expected_survivor.id
+        assert group.loser_ids == [expected_loser.id]
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert result["duplicate_reading_history"] == 1
+        assert session.query(ReadingHistory).count() == 1
+        assert session.get(ReadingHistory, expected_survivor.id) is not None
+        assert session.get(ReadingHistory, expected_loser.id) is None
+
+        assert db_.plan_dedup(session).summary()["duplicate_reading_history"] == 0
+
+
+def test_duplicate_suggestions_keep_oldest_suggested(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="Suggestion Dup Work")
+        session.add(w)
+        session.flush()
+
+        now = __import__("datetime").datetime.now(__import__("datetime").UTC)
+        s1 = Suggestions(
+            work_id=w.id, user_id=DEFAULT_USER_ID, status="Suggested", suggested_at=now - timedelta(days=2)
+        )
+        session.add(s1)
+        session.flush()
+        s2 = Suggestions(work_id=w.id, user_id=DEFAULT_USER_ID, status="Suggested", suggested_at=now)
+        session.add(s2)
+        session.flush()
+        # a Rejected duplicate on the same (user, work) does NOT count (status filter is structural)
+        s3 = Suggestions(work_id=w.id, user_id=DEFAULT_USER_ID, status="Rejected", suggested_at=now)
+        session.add(s3)
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_suggestions"] == 1
+        group = plan.duplicate_suggestions[0]
+        assert group.survivor_id == s1.id
+        assert group.loser_ids == [s2.id]
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert result["duplicate_suggestions"] == 1
+        assert session.get(Suggestions, s1.id) is not None
+        assert session.get(Suggestions, s2.id) is None
+        assert session.get(Suggestions, s3.id) is not None  # untouched, different status
+
+        assert db_.plan_dedup(session).summary()["duplicate_suggestions"] == 0
+
+
+def test_orphan_authors_deleted(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        linked = Author(name="Linked Author")
+        orphan = Author(name="Orphan Author")
+        w = Work(title="Some Work")
+        session.add_all([linked, orphan, w])
+        session.flush()
+        session.add(WorkContributor(work_id=w.id, author_id=linked.id, role="Author"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["orphan_authors"] == 1
+        assert plan.orphan_authors == [orphan.id]
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert result["orphan_authors"] == 1
+        assert session.query(Author).count() == 1
+        assert session.get(Author, linked.id) is not None
+        assert session.get(Author, orphan.id) is None
+
+        assert db_.plan_dedup(session).summary()["orphan_authors"] == 0
+
+
+def test_orphan_author_with_style_link_not_orphaned(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a = Author(name="Styled Only")
+        style = Style(name="Wry", category="Author")
+        session.add_all([a, style])
+        session.flush()
+        session.add(AuthorStyle(author_id=a.id, style_id=style.id, attribute_type="tone"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["orphan_authors"] == 0
+
+
+def test_duplicate_works_report_only_never_applied(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a = Author(name="Ann Leckie")
+        w1 = Work(title="Ancillary Justice")
+        w2 = Work(title="  ancillary   justice  ")  # normalizes to the same title
+        session.add_all([a, w1, w2])
+        session.flush()
+        session.add(WorkContributor(work_id=w1.id, author_id=a.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=a.id, role="Author"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_works_report_only"] == 1
+
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+
+        assert "duplicate_works_report_only" not in result or result["duplicate_works_report_only"] == 0
+        assert session.query(Work).count() == 2  # never touched
+
+        # re-plan finds the same report-only group again (not converged, by design)
+        assert db_.plan_dedup(session).summary()["duplicate_works_report_only"] == 1
+
+
+def test_apply_skips_stale_plan_ids(db_url):
+    """apply_dedup applies EXACTLY the plan's ids; if a planned row vanished before apply,
+    it is skipped and counted, never re-derived."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="Stale Plan Work")
+        session.add(w)
+        session.flush()
+        e = Edition(work_id=w.id, format="ebook")
+        session.add(e)
+        session.flush()
+        rh1 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 6, 1))
+        session.add(rh1)
+        session.flush()
+        rh2 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 6, 1))
+        session.add(rh2)
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        assert plan.summary()["duplicate_reading_history"] == 1
+
+        # the loser row vanishes out from under the plan (simulating a concurrent change)
+        session.delete(session.get(ReadingHistory, plan.duplicate_reading_history[0].loser_ids[0]))
+        session.flush()
+
+        result = db_.apply_dedup(session, plan)
+        assert result["duplicate_reading_history"] == 0
+        assert result["skipped_stale"] == 1
+
+
+def test_orphan_authors_recomputed_after_merge_needs_replan(db_url):
+    """An author orphaned BY a same-run merge is caught only on a re-run (documented honesty,
+    not simulated ahead of time)."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Solo Writer")
+        a2 = Author(name="solo writer")
+        w = Work(title="Only Book")
+        session.add_all([a1, a2, w])
+        session.flush()
+        # only a2 (the loser, by fewer/equal links + tiebreak) is linked; a1 has zero links
+        # so after merge, if a1 becomes survivor, a2's link repoints and a1 is NOT orphaned —
+        # construct the reverse: a1 has the link, a2 has none, so a1 survives with the link.
+        session.add(WorkContributor(work_id=w.id, author_id=a1.id, role="Author"))
+        session.flush()
+
+        plan = db_.plan_dedup(session)
+        # a2 has zero links -> not "most-linked", but tie-break is lowest str(id); either way
+        # only one class fires in this single plan snapshot
+        assert plan.summary()["duplicate_authors"] == 1
+        result = db_.apply_dedup(session, plan)
+        session.flush()
+        assert result["duplicate_authors"] == 1
+        assert session.query(Author).count() == 1

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -495,7 +495,8 @@ def test_apply_gate_refuses_on_new_duplicate_in_the_gap(db_url):
 
         assert delta["duplicate_authors"] == set()  # unchanged class stays empty
         assert delta["duplicate_narrators"] != set()  # the new group shows up
-        assert {str(n1.id), str(n2.id)} <= delta["duplicate_narrators"]
+        # tokens are tagged with their operation (`merge:` for survivor+loser group identity)
+        assert {f"merge:{n1.id}", f"merge:{n2.id}"} <= delta["duplicate_narrators"]
 
         # the gate refuses: apply_dedup is never called against the fresh plan in this branch
         # (mirrors the CLI's `if any(delta.values()): return 1` before reaching apply_dedup)

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -4,7 +4,9 @@ Structural distinguishers only (the #69 lesson) — every class groups on real r
 normalized values, never a sometimes-populated column. apply_dedup takes the PLAN as input and
 touches only the ids it names (apply-what-was-shown)."""
 
+import importlib.util
 from datetime import date, timedelta
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
@@ -26,6 +28,15 @@ from agentic_librarian.db.models import (
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl import dedup_backfill as db_
 from test.integration.constraint_helpers import drop_unique_indexes, recreate_unique_indexes
+
+# scripts/clean_catalog.py is not a package module (it's an operator CLI script) — load it the
+# same way test/unit/test_clean_catalog_cli.py does, so these tests exercise the REAL report
+# write/parse round-trip (not a reimplementation of it).
+_spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(clean_catalog)
 
 pytestmark = pytest.mark.db_integration
 
@@ -417,3 +428,128 @@ def test_orphan_authors_recomputed_after_merge_needs_replan(db_url):
         session.flush()
         assert result["duplicate_authors"] == 1
         assert session.query(Author).count() == 1
+
+
+# --------------------------------------------------------------------------------------------
+# Apply gate cross-check (Spec 2026-07-12 follow-up to #95): --apply --yes is a SEPARATE
+# invocation from the reviewed dry-run and re-plans from scratch — these tests exercise the
+# real report write/parse round-trip (via the loaded scripts/clean_catalog.py module) against
+# a live DB, proving the gate actually catches live-traffic duplicates in the review gap.
+# --------------------------------------------------------------------------------------------
+
+
+def test_apply_gate_unchanged_db_applies_cleanly(db_url):
+    """(a) dry-run -> apply with an UNCHANGED db succeeds: the fresh re-plan's id set is
+    exactly what the reviewed report named, so the delta is empty everywhere."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Casualfarmer")
+        a2 = Author(name="casualfarmer")
+        w = Work(title="Beware of Chicken")
+        session.add_all([a1, a2, w])
+        session.flush()
+        session.add(WorkContributor(work_id=w.id, author_id=a1.id, role="Author"))
+        session.flush()
+
+        # the operator's reviewed dry-run
+        reviewed_plan = db_.plan_dedup(session)
+        report_path = clean_catalog._write_dedup_report(reviewed_plan)
+        reviewed_ids = clean_catalog._parse_plan_ids(report_path.read_text(encoding="utf-8"))
+
+        # --apply --yes, a later separate invocation: re-plans from scratch
+        fresh_plan = db_.plan_dedup(session)
+        delta = db_.plan_delta(reviewed_ids, fresh_plan)
+        assert all(len(v) == 0 for v in delta.values())
+
+        result = db_.apply_dedup(session, fresh_plan)
+        assert result["duplicate_authors"] == 1
+        assert session.query(Author).count() == 1
+
+
+def test_apply_gate_refuses_on_new_duplicate_in_the_gap(db_url):
+    """(b) dry-run -> seed a NEW duplicate group (simulating live traffic in the gap) -> the
+    fresh re-plan's delta against the reviewed report is non-empty for that class, and a fresh
+    report captures the new ids for re-review."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a1 = Author(name="Casualfarmer")
+        a2 = Author(name="casualfarmer")
+        w = Work(title="Beware of Chicken")
+        session.add_all([a1, a2, w])
+        session.flush()
+        session.add(WorkContributor(work_id=w.id, author_id=a1.id, role="Author"))
+        session.flush()
+
+        reviewed_plan = db_.plan_dedup(session)
+        report_path = clean_catalog._write_dedup_report(reviewed_plan)
+        reviewed_ids = clean_catalog._parse_plan_ids(report_path.read_text(encoding="utf-8"))
+
+        # live traffic: a brand-new duplicate-narrator group lands after the operator reviewed
+        n1 = Narrator(name="Travis Baldree")
+        n2 = Narrator(name="travis baldree")
+        session.add_all([n1, n2])
+        session.flush()
+
+        fresh_plan = db_.plan_dedup(session)
+        delta = db_.plan_delta(reviewed_ids, fresh_plan)
+
+        assert delta["duplicate_authors"] == set()  # unchanged class stays empty
+        assert delta["duplicate_narrators"] != set()  # the new group shows up
+        assert {str(n1.id), str(n2.id)} <= delta["duplicate_narrators"]
+
+        # the gate refuses: apply_dedup is never called against the fresh plan in this branch
+        # (mirrors the CLI's `if any(delta.values()): return 1` before reaching apply_dedup)
+        assert any(delta.values())
+
+        # a fresh report captures the new ids for re-review, and re-parsing IT shows no drift
+        # against itself (the operator's next reviewed report)
+        fresh_report_path = clean_catalog._write_dedup_report(fresh_plan)
+        re_reviewed_ids = clean_catalog._parse_plan_ids(fresh_report_path.read_text(encoding="utf-8"))
+        assert all(len(v) == 0 for v in db_.plan_delta(re_reviewed_ids, fresh_plan).values())
+
+        # This test deliberately never applies (the gate refused) — clean up the seeded
+        # duplicate rows so the module's autouse _pre_constraint_schema fixture can recreate
+        # the #95 unique indexes at teardown without a UniqueViolation.
+        db_.apply_dedup(session, fresh_plan)
+        session.flush()
+
+
+def test_apply_gate_reviewed_row_deleted_applies_with_skipped_stale(db_url):
+    """(c) dry-run -> a planned row is DELETED before apply -> the fresh re-plan no longer
+    contains it (fresh subset of reviewed, so the gate does not refuse) -> apply_dedup's own
+    stale-id handling (unchanged by this task) reports skipped_stale for it."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = Work(title="Stale Plan Work")
+        session.add(w)
+        session.flush()
+        e = Edition(work_id=w.id, format="ebook")
+        session.add(e)
+        session.flush()
+        rh1 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 6, 1))
+        rh2 = ReadingHistory(edition_id=e.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 6, 1))
+        session.add_all([rh1, rh2])
+        session.flush()
+
+        reviewed_plan = db_.plan_dedup(session)
+        assert reviewed_plan.summary()["duplicate_reading_history"] == 1
+        report_path = clean_catalog._write_dedup_report(reviewed_plan)
+        reviewed_ids = clean_catalog._parse_plan_ids(report_path.read_text(encoding="utf-8"))
+        loser_id = reviewed_plan.duplicate_reading_history[0].loser_ids[0]
+
+        # the planned loser row vanishes before apply (a concurrent change / cleanup)
+        session.delete(session.get(ReadingHistory, loser_id))
+        session.flush()
+
+        fresh_plan = db_.plan_dedup(session)
+        delta = db_.plan_delta(reviewed_ids, fresh_plan)
+        assert all(len(v) == 0 for v in delta.values())  # nothing NEW — a vanished id isn't a delta
+
+        # apply proceeds against the FRESH plan (per the gate's contract), which no longer
+        # names the vanished row at all — so apply_dedup has nothing stale to report here for
+        # THIS row (that path is exercised directly in test_apply_skips_stale_plan_ids, which
+        # applies the STALE plan rather than re-planning — this test proves the gate's own
+        # re-plan-then-apply flow doesn't choke on a vanished row either).
+        result = db_.apply_dedup(session, fresh_plan)
+        assert result["duplicate_reading_history"] == 0
+        assert session.query(ReadingHistory).count() == 1

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -661,6 +661,114 @@ def test_apply_edition_group_refuses_when_loser_has_unplanned_narrator_link(db_u
         session.flush()
 
 
+def test_apply_contributor_group_refuses_when_loser_author_has_unplanned_style(db_url):
+    """Adversarial-pass finding (GH #95 #97 follow-up): the contributor-delete path lacked the
+    skipped_unsafe guard the edition path has. Author.styles cascades `all, delete-orphan` — a
+    bare `session.delete(loser)` would silently cascade away ANY AuthorStyle row still attached
+    to that loser at delete time, including one a concurrent write attached AFTER this group was
+    planned (the group's own plan is silent about it, mirroring the edition-narrator case).
+    Force-feed a hand-built ContributorMergeGroup whose plan is silent about a style link that
+    exists on the loser author at apply time and assert the delete is refused, not applied."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = Author(name="Style Survivor")
+        loser = Author(name="style survivor")
+        style = Style(name="Untracked Pacing Style", category="Author")
+        session.add_all([survivor, loser, style])
+        session.flush()
+
+        # loser (about to be force-fed as the loser) carries a style link the plan below is
+        # deliberately silent about — the unsafe state the belt-and-braces check must catch.
+        session.add(AuthorStyle(author_id=loser.id, style_id=style.id, attribute_type="pacing"))
+        session.flush()
+
+        unsafe_group = db_.ContributorMergeGroup(
+            survivor_id=survivor.id,
+            survivor_name=survivor.name,
+            loser_ids=[loser.id],
+            loser_names=[loser.name],
+            repoint_links=[],
+            delete_links=[],
+            repoint_styles=[],  # silent about (loser, style) — the unsafe condition
+            delete_styles=[],
+        )
+
+        stats = db_._apply_contributor_group(session, unsafe_group, kind="author")
+        session.flush()
+
+        # skipped_unsafe fires (distinct from skipped_stale — the row didn't vanish, it was
+        # unaccounted-for); the binding assertion is that the loser author survives with its
+        # unplanned style link intact, not deleted out from under it.
+        # Note: stats["merged"] is unconditionally 1 here too — mirrors _apply_edition_group's
+        # existing convention (see test_apply_edition_group_refuses_when_loser_has_unplanned_
+        # narrator_link above, which likewise doesn't assert merged == 0); "merged" means "this
+        # group was processed", not "every planned row was applied". skipped_unsafe is the
+        # signal that actually distinguishes the refused delete.
+        assert stats.get("skipped_unsafe", 0) == 1
+        assert session.get(Author, loser.id) is not None
+        remaining = session.query(AuthorStyle).filter_by(author_id=loser.id, style_id=style.id).all()
+        assert len(remaining) == 1
+
+        # Cleanup: the refused delete deliberately LEAVES a duplicate lower(name) pair in place
+        # (that's the point of the test), which would violate uq_authors_name_lower when the
+        # module's autouse _pre_constraint_schema fixture recreates it at teardown. Clear the
+        # style link (its being unplanned was the test condition, now proven) and delete the
+        # loser author directly so the schema is clean for the index recreate, mirroring the
+        # edition test's cleanup above.
+        session.delete(
+            session.get(AuthorStyle, {"author_id": loser.id, "style_id": style.id, "attribute_type": "pacing"})
+        )
+        session.delete(session.get(Author, loser.id))
+        session.flush()
+
+
+def test_apply_contributor_group_refuses_when_loser_narrator_has_unplanned_style(db_url):
+    """Narrator-side mirror of the author test above — NarratorStyle also cascades
+    `all, delete-orphan` off Narrator.styles, so the same guard must apply on that branch of
+    _apply_contributor_group (kind="narrator"), which has its own separate code path."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = Narrator(name="Voice Survivor")
+        loser = Narrator(name="voice survivor")
+        style = Style(name="Untracked Voice Style", category="Narrator")
+        session.add_all([survivor, loser, style])
+        session.flush()
+
+        session.add(NarratorStyle(narrator_id=loser.id, style_id=style.id, attribute_type="voice_differentiation"))
+        session.flush()
+
+        unsafe_group = db_.ContributorMergeGroup(
+            survivor_id=survivor.id,
+            survivor_name=survivor.name,
+            loser_ids=[loser.id],
+            loser_names=[loser.name],
+            repoint_links=[],
+            delete_links=[],
+            repoint_styles=[],  # silent about (loser, style) — the unsafe condition
+            delete_styles=[],
+        )
+
+        stats = db_._apply_contributor_group(session, unsafe_group, kind="narrator")
+        session.flush()
+
+        # Note: stats["merged"] is unconditionally 1 — see the author test's comment above for
+        # why that's not the relevant signal here.
+        assert stats.get("skipped_unsafe", 0) == 1
+        assert session.get(Narrator, loser.id) is not None
+        remaining = session.query(NarratorStyle).filter_by(narrator_id=loser.id, style_id=style.id).all()
+        assert len(remaining) == 1
+
+        # Cleanup: same reasoning as the author test's cleanup above.
+        session.delete(
+            session.get(
+                NarratorStyle,
+                {"narrator_id": loser.id, "style_id": style.id, "attribute_type": "voice_differentiation"},
+            )
+        )
+        session.delete(session.get(Narrator, loser.id))
+        session.flush()
+
+
 # --------------------------------------------------------------------------------------------
 # Planner determinism (final-review Minor 3): every group query is order_by'd on its pk (and
 # losers are sorted) so dry-run and an apply-time re-plan against UNCHANGED data classify

--- a/test/integration/test_dedup_backfill.py
+++ b/test/integration/test_dedup_backfill.py
@@ -7,7 +7,7 @@ touches only the ids it names (apply-what-was-shown)."""
 from datetime import date, timedelta
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 
 from agentic_librarian.core.user_context import DEFAULT_USER_ID
 from agentic_librarian.db.models import (
@@ -25,6 +25,7 @@ from agentic_librarian.db.models import (
 )
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl import dedup_backfill as db_
+from test.integration.constraint_helpers import drop_unique_indexes, recreate_unique_indexes
 
 pytestmark = pytest.mark.db_integration
 
@@ -34,22 +35,12 @@ pytestmark = pytest.mark.db_integration
 # realistic pre-constraint duplicate rows, drop just the 5 dedup-relevant indexes for this
 # module and recreate them afterward — the FK indexes/timestamptz/deep_enriched_at parts of
 # the same migration are irrelevant to duplicates and stay in place throughout.
-_DEDUP_UNIQUE_INDEXES = [
-    ("uq_authors_name_lower", "CREATE UNIQUE INDEX uq_authors_name_lower ON authors (lower(name))"),
-    ("uq_narrators_name_lower", "CREATE UNIQUE INDEX uq_narrators_name_lower ON narrators (lower(name))"),
-    (
-        "uq_editions_work_format",
-        "CREATE UNIQUE INDEX uq_editions_work_format ON editions (work_id, format) NULLS NOT DISTINCT",
-    ),
-    (
-        "uq_reading_history_user_edition_date",
-        "CREATE UNIQUE INDEX uq_reading_history_user_edition_date "
-        "ON reading_history (user_id, edition_id, date_completed)",
-    ),
-    (
-        "uq_suggestions_active",
-        "CREATE UNIQUE INDEX uq_suggestions_active ON suggestions (user_id, work_id) WHERE status = 'Suggested'",
-    ),
+_DEDUP_UNIQUE_INDEX_NAMES = [
+    "uq_authors_name_lower",
+    "uq_narrators_name_lower",
+    "uq_editions_work_format",
+    "uq_reading_history_user_edition_date",
+    "uq_suggestions_active",
 ]
 
 
@@ -60,13 +51,10 @@ def _pre_constraint_schema(db_url):
     dry-run -> approve -> apply -> `alembic upgrade head` sequence."""
     engine = create_engine(db_url)
     with engine.begin() as conn:
-        for name, _create_sql in _DEDUP_UNIQUE_INDEXES:
-            conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
+        drop_unique_indexes(conn, _DEDUP_UNIQUE_INDEX_NAMES)
     yield
     with engine.begin() as conn:
-        for name, create_sql in _DEDUP_UNIQUE_INDEXES:
-            conn.execute(text(f"DROP INDEX IF EXISTS {name}"))
-            conn.execute(text(create_sql))
+        recreate_unique_indexes(conn, _DEDUP_UNIQUE_INDEX_NAMES)
     engine.dispose()
 
 

--- a/test/integration/test_enrichment_sweep.py
+++ b/test/integration/test_enrichment_sweep.py
@@ -1,0 +1,94 @@
+"""GH #97: plan_requeue surfaces works needing a (re)queued deep-enrichment pass."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl.enrichment_sweep import plan_requeue
+
+pytestmark = pytest.mark.db_integration
+
+
+def test_plan_requeue_classifies_three_works(db_url):
+    manager = DatabaseManager(db_url)
+
+    with manager.get_session() as s:
+        # 1. Stamped + real trope -> excluded entirely.
+        enriched = Work(title="Enriched Work", deep_enriched_at=datetime.now(UTC))
+        s.add(enriched)
+        s.flush()
+        real_trope = Trope(name="Found Family")
+        s.add(real_trope)
+        s.flush()
+        s.add(WorkTrope(work_id=enriched.id, trope_id=real_trope.id))
+
+        # 2. Never deep-enriched -> "never_deep_enriched".
+        unstamped = Work(title="Unstamped Work", deep_enriched_at=None)
+        s.add(unstamped)
+        s.flush()
+
+        # 3. Stamped, but every linked trope is a fallback (== one of its own genres) ->
+        # "no_real_trope".
+        fallback_work = Work(title="Fallback-Only Work", deep_enriched_at=datetime.now(UTC), genres=["Fantasy"])
+        s.add(fallback_work)
+        s.flush()
+        fallback_trope = Trope(name="Fantasy")
+        s.add(fallback_trope)
+        s.flush()
+        s.add(WorkTrope(work_id=fallback_work.id, trope_id=fallback_trope.id))
+
+        s.flush()
+        enriched_id, unstamped_id, fallback_id = enriched.id, unstamped.id, fallback_work.id
+
+    with manager.get_session() as s:
+        plan = plan_requeue(s)
+
+    by_id = {c.work_id: c for c in plan}
+    assert enriched_id not in by_id
+    assert by_id[unstamped_id].reason == "never_deep_enriched"
+    assert by_id[unstamped_id].title == "Unstamped Work"
+    assert by_id[fallback_id].reason == "no_real_trope"
+    assert by_id[fallback_id].title == "Fallback-Only Work"
+
+
+def test_plan_requeue_treats_zero_trope_links_as_no_real_trope(db_url):
+    """A stamped work with zero trope links at all (e.g. the #123 warm-failure case, where
+    every embedding was skipped) must also be flagged — no_real_trope isn't just
+    fallback-vs-real, it's "no genuine trope at all"."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s:
+        work = Work(title="No Tropes At All", deep_enriched_at=datetime.now(UTC))
+        s.add(work)
+        s.flush()
+        work_id = work.id
+
+    with manager.get_session() as s:
+        plan = plan_requeue(s)
+
+    by_id = {c.work_id: c for c in plan}
+    assert by_id[work_id].reason == "no_real_trope"
+
+
+def test_plan_requeue_never_deep_enriched_wins_over_no_real_trope(db_url):
+    """A work matching both conditions (unstamped AND fallback-only tropes) appears
+    exactly once, classified as never_deep_enriched."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s:
+        work = Work(title="Both Conditions", deep_enriched_at=None, genres=["Fantasy"])
+        s.add(work)
+        s.flush()
+        trope = Trope(name="Fantasy")
+        s.add(trope)
+        s.flush()
+        s.add(WorkTrope(work_id=work.id, trope_id=trope.id))
+        s.flush()
+        work_id = work.id
+
+    with manager.get_session() as s:
+        plan = plan_requeue(s)
+
+    matches = [c for c in plan if c.work_id == work_id]
+    assert len(matches) == 1
+    assert matches[0].reason == "never_deep_enriched"

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -126,6 +126,45 @@ def test_empty_deep_pass_on_work_with_real_trope_returns_200(client, db_url, mon
     assert resp.json() == {"work_id": str(work_id), "status": "already_enriched"}
 
 
+def test_empty_deep_pass_gives_up_after_8_retries_returns_200(client, db_url, monkeypatch):
+    """Important (final review): Cloud Tasks default maxAttempts=100 with ~hourly backoff would
+    otherwise mean ~100 PAID deep passes per poison book. Once Cloud Tasks' own
+    X-CloudTasks-TaskRetryCount header reports >=8 retries AND the work still has no real
+    trope, give up loudly with 200 (not 503) so Cloud Tasks stops retrying — the documented
+    backstop is the operator's --requeue-unenriched sweep, not unbounded paid retries."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager, with_real_trope=False)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "empty")
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}",
+        headers={"Authorization": "Bearer good", "X-CloudTasks-TaskRetryCount": "8"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "empty_deep_pass_gave_up"}
+
+
+def test_empty_deep_pass_still_retries_below_give_up_threshold(client, db_url, monkeypatch):
+    """The give-up threshold is >=8, not "any retry count present" — below it, the ordinary
+    retryable 503 path still fires so Cloud Tasks keeps retrying with backoff."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager, with_real_trope=False)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "empty")
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}",
+        headers={"Authorization": "Bearer good", "X-CloudTasks-TaskRetryCount": "3"},
+    )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": {"work_id": str(work_id), "status": "empty_deep_pass"}}
+
+
 def test_unverified_email_is_forbidden(client, monkeypatch):
     # Mutation guard: a token with the correct SA email but email_verified=False must still 403.
     # Deleting the `not claims.get("email_verified")` check would let this through.

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.db.models import Author, Edition, Work, WorkContributor
+from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
 
@@ -24,7 +24,7 @@ def client(db_url, monkeypatch):
     yield TestClient(api_main.app)
 
 
-def _seed_work(manager):
+def _seed_work(manager, *, with_real_trope=False):
     with manager.get_session() as s:
         work = Work(title="Dune")
         s.add(work)
@@ -34,6 +34,13 @@ def _seed_work(manager):
         s.flush()
         s.add(WorkContributor(work_id=work.id, author_id=a.id, role="Author"))
         s.add(Edition(work_id=work.id, format="ebook"))
+        if with_real_trope:
+            # "Found Family" cleans to something outside this work's (empty) genres/moods, so
+            # is_fallback_trope_name returns False — a genuine narrative trope.
+            trope = Trope(name="Found Family")
+            s.add(trope)
+            s.flush()
+            s.add(WorkTrope(work_id=work.id, trope_id=trope.id))
         s.flush()
         return work.id
 
@@ -45,10 +52,16 @@ def test_valid_queue_token_runs_deep_enrich(client, db_url, monkeypatch):
         internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
     )
     called = {}
-    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: called.setdefault("wid", wid) or True)
+
+    def _fake_enrich_deep(wid):
+        called["wid"] = wid
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
 
     resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
     assert str(called["wid"]) == str(work_id)
 
 
@@ -78,9 +91,39 @@ def test_unknown_work_returns_404(client, monkeypatch):
     monkeypatch.setattr(
         internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
     )
-    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: False)
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "missing")
     resp = client.post(f"/internal/enrich/{uuid4()}", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 404
+
+
+def test_empty_deep_pass_on_tropeless_work_returns_503(client, db_url, monkeypatch):
+    """GH #97: a work with no real trope after an empty deep pass is a retryable poison
+    task — Cloud Tasks must see a 5xx so it retries with backoff."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager, with_real_trope=False)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "empty")
+
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": {"work_id": str(work_id), "status": "empty_deep_pass"}}
+
+
+def test_empty_deep_pass_on_work_with_real_trope_returns_200(client, db_url, monkeypatch):
+    """GH #97: an empty pass on a work that already has a real trope from a prior pass is
+    NOT a failure — it just means this pass added nothing new. Don't retry forever."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager, with_real_trope=True)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "empty")
+
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "already_enriched"}
 
 
 def test_unverified_email_is_forbidden(client, monkeypatch):

--- a/test/integration/test_schema_hardening.py
+++ b/test/integration/test_schema_hardening.py
@@ -24,8 +24,10 @@ def test_fk_indexes_exist(db_url):
     from agentic_librarian.db.session import DatabaseManager
 
     insp = inspect(DatabaseManager(db_url).engine)
+    # Final-review Minor 5: editions.work_id is deliberately NOT in this list (and has no
+    # standalone ix_editions_work_id) — uq_editions_work_format's leading column (work_id,
+    # format) already serves lookups on work_id alone; see test_no_redundant_editions_work_id_index.
     for table, col in [
-        ("editions", "work_id"),
         ("reading_history", "edition_id"),
         ("work_tropes", "trope_id"),
         ("work_contributors", "author_id"),
@@ -38,6 +40,18 @@ def test_fk_indexes_exist(db_url):
     ]:
         names = {i["name"] for i in insp.get_indexes(table)}
         assert f"ix_{table}_{col}" in names, f"missing ix_{table}_{col}"
+
+
+def test_no_redundant_editions_work_id_index(db_url):
+    """Final-review Minor 5: uq_editions_work_format's leading column (work_id, format) already
+    serves lookups on work_id alone (standard btree behavior) — a separate ix_editions_work_id
+    would be redundant, so the migration deliberately does NOT create one."""
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    names = {i["name"] for i in insp.get_indexes("editions")}
+    assert "ix_editions_work_id" not in names
+    assert "uq_editions_work_format" in names  # the index that serves work_id lookups instead
 
 
 def test_timestamps_are_timestamptz(db_url):

--- a/test/integration/test_schema_hardening.py
+++ b/test/integration/test_schema_hardening.py
@@ -60,3 +60,50 @@ def test_works_deep_enriched_at(db_url):
     insp = inspect(DatabaseManager(db_url).engine)
     cols = {c["name"] for c in insp.get_columns("works")}
     assert "deep_enriched_at" in cols
+
+
+def test_deep_enriched_at_backfill_semantics(db_url):
+    """The migration's own `op.execute` backfill (works.deep_enriched_at = now() WHERE the
+    work has any work_tropes row) can't be exercised directly here: this suite's
+    `_create_test_database` fixture (test/conftest.py) runs `alembic upgrade head` against
+    an EMPTY database, so by the time this migration's upgrade() executes, `work_tropes` has
+    no rows for it to match — there's no way to seed a work+trope pair BEFORE the migration
+    runs within this test chain. What's actually verifiable post-migration is the semantics
+    contract the backfill establishes going forward: a work seeded WITH a trope link and no
+    explicit stamp behaves like a work the migration's backfill would have stamped (picked
+    up by plan_requeue only under "no_real_trope" if its tropes are all fallback, never under
+    "never_deep_enriched"), while a work with zero trope links and no stamp is
+    "never_deep_enriched" — exactly the reason class the runbook says the first sweep should
+    now report only real gaps for. See test/integration/test_enrichment_sweep.py for the
+    plan_requeue-level assertions of this contract, and the migration file's inline comment /
+    docs/runbooks/phase6-3-schema-rollout.md for the backfill itself."""
+    from datetime import UTC, datetime
+
+    from agentic_librarian.db.models import Trope, Work, WorkTrope
+    from agentic_librarian.db.session import DatabaseManager
+    from agentic_librarian.etl.enrichment_sweep import plan_requeue
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s:
+        # Simulates what the migration's backfill stamps: a work with a real trope link,
+        # deep_enriched_at set (as the backfill would set it).
+        stamped = Work(title="Backfill-Equivalent Work", deep_enriched_at=datetime.now(UTC))
+        s.add(stamped)
+        s.flush()
+        trope = Trope(name="Found Family")
+        s.add(trope)
+        s.flush()
+        s.add(WorkTrope(work_id=stamped.id, trope_id=trope.id))
+
+        # A work the backfill correctly leaves NULL: zero trope links.
+        never_touched = Work(title="No Trope Links At All", deep_enriched_at=None)
+        s.add(never_touched)
+        s.flush()
+        stamped_id, never_touched_id = stamped.id, never_touched.id
+
+    with manager.get_session() as s:
+        plan = plan_requeue(s)
+
+    by_id = {c.work_id: c for c in plan}
+    assert stamped_id not in by_id  # backfill-equivalent stamp + real trope -> excluded
+    assert by_id[never_touched_id].reason == "never_deep_enriched"

--- a/test/integration/test_schema_hardening.py
+++ b/test/integration/test_schema_hardening.py
@@ -1,0 +1,62 @@
+"""PR-D migration: constraints, indexes, timestamptz, deep_enriched_at (#95 #97 #108 #109)."""
+
+import pytest
+from sqlalchemy import inspect, text
+
+pytestmark = pytest.mark.db_integration
+
+
+def test_unique_indexes_exist(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    author_uniques = {i["name"] for i in insp.get_indexes("authors") if i.get("unique")}
+    assert "uq_authors_name_lower" in author_uniques
+    edition_uniques = {i["name"] for i in insp.get_indexes("editions") if i.get("unique")}
+    assert "uq_editions_work_format" in edition_uniques
+    rh = {i["name"] for i in insp.get_indexes("reading_history") if i.get("unique")}
+    assert "uq_reading_history_user_edition_date" in rh
+    sugg = {i["name"] for i in insp.get_indexes("suggestions") if i.get("unique")}
+    assert "uq_suggestions_active" in sugg
+
+
+def test_fk_indexes_exist(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    for table, col in [
+        ("editions", "work_id"),
+        ("reading_history", "edition_id"),
+        ("work_tropes", "trope_id"),
+        ("work_contributors", "author_id"),
+        ("suggestions", "work_id"),
+        ("author_styles", "style_id"),
+        ("work_styles", "style_id"),
+        ("usage", "conversation_id"),
+        ("narrator_styles", "style_id"),
+        ("edition_narrators", "narrator_id"),
+    ]:
+        names = {i["name"] for i in insp.get_indexes(table)}
+        assert f"ix_{table}_{col}" in names, f"missing ix_{table}_{col}"
+
+
+def test_timestamps_are_timestamptz(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    m = DatabaseManager(db_url)
+    with m.get_session() as s:
+        rows = s.execute(
+            text(
+                "SELECT table_name, column_name FROM information_schema.columns "
+                "WHERE data_type = 'timestamp without time zone' AND table_schema = 'public'"
+            )
+        ).all()
+    assert rows == [], f"still naive: {rows}"
+
+
+def test_works_deep_enriched_at(db_url):
+    from agentic_librarian.db.session import DatabaseManager
+
+    insp = inspect(DatabaseManager(db_url).engine)
+    cols = {c["name"] for c in insp.get_columns("works")}
+    assert "deep_enriched_at" in cols

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -80,6 +80,39 @@ def test_enrich_deep_updates_same_work_idempotently(db_url, monkeypatch):
         assert orphans == 0
 
 
+def test_enrich_deep_returns_missing_not_done_when_nothing_was_persisted(db_url, monkeypatch):
+    """Final-review Minor 7 (honesty): if the scouts return a row but persist_enriched_work
+    ends up with NOTHING to attach it to (raw_contributors empties out after the malformed-name
+    filter — e.g. the deep scout's only contributor entry has no usable name), nothing is
+    persisted and deep_enriched_at is never stamped. enrich_deep must report "missing", not lie
+    and say "done" — the caller (api/internal.py) maps "missing" to a non-retryable 404, while
+    "done" would tell Cloud Tasks (and the operator) a pass succeeded when it did nothing at
+    all."""
+    from agentic_librarian.enrichment import two_phase
+
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(two_phase, "db_manager", manager)
+    # A deep-scout result with contributors that all fail the malformed-name filter (persist.py's
+    # raw_contributors comprehension drops entries with no usable string name) — this is the
+    # concrete way persist_enriched_work returns None without touching the DB at all, standing in
+    # for "the work's identity vanished mid-pass and nothing could be attached."
+    deep = {
+        "enriched_tropes": [],
+        "narrator_names": [],
+        "contributors": [{"name": None, "role": "Author"}],
+    }
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+
+    work_id = _seed_work(manager, title="Vanishing Work", author="Some Author")
+
+    assert two_phase.enrich_deep(work_id) == "missing"
+
+    with manager.get_session() as s:
+        work = s.get(Work, work_id)
+        # nothing was persisted or stamped — the work is exactly as it was seeded
+        assert work.deep_enriched_at is None
+
+
 def test_enrich_deep_returns_false_for_unknown_work(db_url, monkeypatch):
     from uuid import uuid4
 

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -55,12 +55,15 @@ def test_enrich_deep_updates_same_work_idempotently(db_url, monkeypatch):
 
     work_id = _seed_work(manager, title="Dune", author="Frank Herbert")
 
-    assert two_phase.enrich_deep(work_id) is True
-    assert two_phase.enrich_deep(work_id) is True  # retry-safe (Cloud Tasks redelivery)
+    assert two_phase.enrich_deep(work_id) == "done"
+    assert two_phase.enrich_deep(work_id) == "done"  # retry-safe (Cloud Tasks redelivery)
 
     with manager.get_session() as s:
         links = s.query(WorkTrope).filter_by(work_id=work_id).all()
         assert len(links) == 1  # single trope link despite two runs
+        # GH #97: the write session stamps deep_enriched_at on a successful ("done") persist.
+        work = s.query(Work).filter_by(title="Dune").one()
+        assert work.deep_enriched_at is not None
 
         # GH #96: a co-author discovered by the deep pass must be LINKED on the existing work
         # (previously the WorkContributor dangled and SQLAlchemy 2.0 silently dropped it), and
@@ -84,7 +87,26 @@ def test_enrich_deep_returns_false_for_unknown_work(db_url, monkeypatch):
 
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(two_phase, "db_manager", manager)
-    assert two_phase.enrich_deep(uuid4()) is False
+    assert two_phase.enrich_deep(uuid4()) == "missing"
+
+
+def test_enrich_deep_empty_pass_still_stamps_deep_enriched_at(db_url, monkeypatch):
+    """GH #97: scouts-found-nothing is NOT a failure — it's a completed pass. The timestamp
+    means "the deep pass completed" (including confirmed-empty), so the requeue sweep doesn't
+    treat this work as never-attempted."""
+    from agentic_librarian.enrichment import two_phase
+
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(None))
+
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(two_phase, "db_manager", manager)
+    work_id = _seed_work(manager, title="Obscure Title", author="Obscure Author")
+
+    assert two_phase.enrich_deep(work_id) == "empty"
+
+    with manager.get_session() as s:
+        work = s.get(Work, work_id)
+        assert work.deep_enriched_at is not None
 
 
 def test_add_read_event_logs_and_dedups_rereads(db_url, monkeypatch):

--- a/test/unit/test_clean_catalog_cli.py
+++ b/test/unit/test_clean_catalog_cli.py
@@ -30,6 +30,11 @@ def test_apply_refused_without_yes(monkeypatch, capsys):
         def count(self):
             return 0
 
+        def scalar(self):
+            # the recency probe is column-explicit (func.count(...).scalar(), never an
+            # entity-load .count()) so it works on the pre-migration prod schema (GH #95)
+            return 0
+
     monkeypatch.setattr(
         clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
     )

--- a/test/unit/test_clean_catalog_prune_cli.py
+++ b/test/unit/test_clean_catalog_prune_cli.py
@@ -33,6 +33,11 @@ class _Sess:
     def count(self):
         return 0
 
+    def scalar(self):
+        # the recency probe is column-explicit (func.count(...).scalar(), never an
+        # entity-load .count()) so it works on the pre-migration prod schema (GH #95)
+        return 0
+
     def __iter__(self):
         return iter([])
 

--- a/test/unit/test_dedup_apply_gate.py
+++ b/test/unit/test_dedup_apply_gate.py
@@ -1,0 +1,266 @@
+"""DB-free unit tests for the dedup apply gate (Spec 2026-07-12 follow-up to #95):
+plan_id_set/plan_delta round-trip, and the report file's '== PLAN IDS ==' block parses back
+into the same shape it was written from. No Postgres needed — DedupPlan is a plain dataclass
+and the report format is pure text.
+
+Review finding this hardens: `--dedup-for-constraints --apply --yes` is a SEPARATE invocation
+from the reviewed dry-run and RE-PLANS from scratch, so a new duplicate group appearing in the
+gap (live traffic) would be applied without the operator ever reviewing it. plan_delta is the
+pure comparison at the heart of the fix."""
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+from agentic_librarian.etl import dedup_backfill as db_
+from agentic_librarian.etl.dedup_backfill import (
+    ContributorMergeGroup,
+    DedupPlan,
+    KeepDeleteGroup,
+)
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+def _uuid():
+    return uuid.uuid4()
+
+
+def _sample_plan() -> DedupPlan:
+    survivor = _uuid()
+    loser = _uuid()
+    rh_survivor = _uuid()
+    rh_loser = _uuid()
+    return DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor,
+                survivor_name="Ann Leckie",
+                loser_ids=[loser],
+                loser_names=["ann leckie"],
+            )
+        ],
+        duplicate_reading_history=[KeepDeleteGroup(survivor_id=rh_survivor, loser_ids=[rh_loser], detail="dup")],
+    )
+
+
+def test_plan_id_set_includes_survivor_and_loser_ids():
+    plan = _sample_plan()
+    ids = db_.plan_id_set(plan)
+
+    group = plan.duplicate_authors[0]
+    assert str(group.survivor_id) in ids["duplicate_authors"]
+    assert str(group.loser_ids[0]) in ids["duplicate_authors"]
+
+    rh_group = plan.duplicate_reading_history[0]
+    assert str(rh_group.survivor_id) in ids["duplicate_reading_history"]
+    assert str(rh_group.loser_ids[0]) in ids["duplicate_reading_history"]
+
+    # every declared class key is always present, even when empty
+    assert set(ids) == set(db_.PLAN_ID_SET_CLASSES)
+    assert ids["duplicate_narrators"] == set()
+
+
+def test_plan_delta_empty_when_fresh_is_subset_of_reviewed():
+    plan = _sample_plan()
+    reviewed = db_.plan_id_set(plan)
+
+    delta = db_.plan_delta(reviewed, plan)
+
+    assert all(len(v) == 0 for v in delta.values())
+
+
+def test_plan_delta_empty_when_reviewed_has_extra_stale_ids():
+    """Reviewed ids that vanished from the fresh plan (rows deleted/changed since review) do
+    NOT show up as a delta — plan_delta only reports NEW ids, never missing ones."""
+    plan = _sample_plan()
+    reviewed = db_.plan_id_set(plan)
+    reviewed["duplicate_authors"].add(str(uuid.uuid4()))  # an id that no longer appears
+
+    delta = db_.plan_delta(reviewed, plan)
+
+    assert all(len(v) == 0 for v in delta.values())
+
+
+def test_plan_delta_flags_new_group_id():
+    """A brand-new duplicate-author group (simulating live traffic in the review gap) shows up
+    as a delta for its class only."""
+    reviewed_plan = _sample_plan()
+    reviewed = db_.plan_id_set(reviewed_plan)
+
+    fresh_plan = _sample_plan()
+    fresh_plan.duplicate_authors = [*reviewed_plan.duplicate_authors, *_sample_plan().duplicate_authors]
+    fresh_plan.duplicate_reading_history = reviewed_plan.duplicate_reading_history
+
+    delta = db_.plan_delta(reviewed, fresh_plan)
+
+    assert delta["duplicate_authors"]  # the new group's survivor/loser ids
+    assert delta["duplicate_reading_history"] == set()
+
+
+def test_plan_delta_flags_new_loser_appended_to_existing_group():
+    """A group whose loser set grew (an extra live-traffic dup merged into an already-reviewed
+    group) is also caught — not just brand-new groups."""
+    survivor = _uuid()
+    reviewed_loser = _uuid()
+    new_loser = _uuid()
+    reviewed_plan = DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor, survivor_name="A", loser_ids=[reviewed_loser], loser_names=["a"]
+            )
+        ]
+    )
+    reviewed = db_.plan_id_set(reviewed_plan)
+
+    fresh_plan = DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor,
+                survivor_name="A",
+                loser_ids=[reviewed_loser, new_loser],
+                loser_names=["a", "a2"],
+            )
+        ]
+    )
+
+    delta = db_.plan_delta(reviewed, fresh_plan)
+
+    assert delta["duplicate_authors"] == {str(new_loser)}
+
+
+def test_report_plan_ids_block_round_trips(tmp_path, monkeypatch):
+    """_write_dedup_report's '== PLAN IDS ==' section parses back (via clean_catalog's
+    _parse_plan_ids) into the exact same per-class id set dedup_backfill.plan_id_set computed
+    from the plan it was written from."""
+    monkeypatch.chdir(tmp_path)
+    plan = _sample_plan()
+
+    report_path = clean_catalog._write_dedup_report(plan)
+    parsed = clean_catalog._parse_plan_ids(report_path.read_text(encoding="utf-8"))
+
+    assert parsed == db_.plan_id_set(plan)
+
+
+def test_parse_plan_ids_raises_on_missing_section():
+    import pytest
+
+    with pytest.raises(ValueError, match="PLAN IDS"):
+        clean_catalog._parse_plan_ids("some report with no machine-readable section\n")
+
+
+class _Sess:
+    """Minimal fake session — plan_dedup itself is monkeypatched below, so the fake session
+    only needs to satisfy main()'s top-of-loop recency probe (session.query(...).count())."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def query(self, *a, **k):
+        return self
+
+    def filter_by(self, *a, **k):
+        return self
+
+    def all(self):
+        return []
+
+    def count(self):
+        return 0
+
+
+def _patch_db(monkeypatch, plans):
+    """plans: a list consumed in order across successive main() calls / plan_dedup calls within
+    one call — main() calls plan_dedup exactly once per invocation, so pass one plan per call."""
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: "postgresql://u:p@prod-host/db")
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+    it = iter(plans)
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "plan_dedup", lambda session: next(it))
+
+
+def test_apply_succeeds_when_fresh_plan_matches_reviewed_report(monkeypatch, tmp_path, capsys):
+    """(a) dry-run -> apply with an unchanged DB succeeds — no new ids, apply proceeds."""
+    monkeypatch.chdir(tmp_path)
+    plan = _sample_plan()
+    _patch_db(monkeypatch, [plan, plan])  # one plan_dedup call for --dry-run, one for --apply
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "apply_dedup", lambda session, plan: {"duplicate_authors": 1})
+
+    rc_dry = clean_catalog.main(["--dedup-for-constraints", "--dry-run"])
+    assert rc_dry == 0
+
+    rc_apply = clean_catalog.main(["--dedup-for-constraints", "--apply", "--yes"])
+    out = capsys.readouterr().out
+    assert rc_apply == 0
+    assert "REFUSING" not in out
+    assert "applied:" in out
+
+
+def test_apply_refuses_when_fresh_plan_has_new_group(monkeypatch, tmp_path, capsys):
+    """(b) dry-run -> seed a NEW duplicate group (simulated via the re-plan returning an extra
+    group) -> apply REFUSES with the delta printed and a fresh report already on disk."""
+    monkeypatch.chdir(tmp_path)
+    reviewed_plan = _sample_plan()
+    fresh_plan = _sample_plan()
+    fresh_plan.duplicate_authors = [*reviewed_plan.duplicate_authors, *_sample_plan().duplicate_authors]
+    fresh_plan.duplicate_reading_history = reviewed_plan.duplicate_reading_history
+    _patch_db(monkeypatch, [reviewed_plan, fresh_plan])
+    apply_called = []
+    monkeypatch.setattr(
+        clean_catalog.dedup_backfill, "apply_dedup", lambda session, plan: apply_called.append(plan) or {}
+    )
+
+    rc_dry = clean_catalog.main(["--dedup-for-constraints", "--dry-run"])
+    assert rc_dry == 0
+    reports_before = sorted((tmp_path / "data" / "reports").glob("dedup-*.txt"))
+    assert len(reports_before) == 1
+
+    rc_apply = clean_catalog.main(["--dedup-for-constraints", "--apply", "--yes"])
+    out = capsys.readouterr().out
+
+    assert rc_apply == 1
+    assert "REFUSING --apply: plan changed since review" in out
+    assert "duplicate_authors" in out
+    assert apply_called == []  # apply_dedup never invoked
+    reports_after = sorted((tmp_path / "data" / "reports").glob("dedup-*.txt"))
+    assert len(reports_after) == 2  # the refusal's fresh plan was written as a new report too
+
+
+def test_apply_succeeds_with_skipped_stale_when_reviewed_row_vanished(monkeypatch, tmp_path, capsys):
+    """(c) dry-run -> a planned row is deleted before apply -> the FRESH re-plan simply no
+    longer contains it (fresh subset of reviewed) -> apply succeeds; apply_dedup's own
+    skipped_stale bookkeeping (tested at the dedup_backfill layer) is unaffected by this gate."""
+    monkeypatch.chdir(tmp_path)
+    reviewed_plan = _sample_plan()
+    fresh_plan = DedupPlan()  # the reviewed group's row vanished -> fresh has nothing for it
+    _patch_db(monkeypatch, [reviewed_plan, fresh_plan])
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "apply_dedup", lambda session, plan: {"skipped_stale": 0})
+
+    rc_dry = clean_catalog.main(["--dedup-for-constraints", "--dry-run"])
+    assert rc_dry == 0
+
+    rc_apply = clean_catalog.main(["--dedup-for-constraints", "--apply", "--yes"])
+    out = capsys.readouterr().out
+
+    assert rc_apply == 0
+    assert "REFUSING" not in out
+    assert "applied:" in out
+
+
+def test_apply_refuses_when_no_report_exists(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    _patch_db(monkeypatch, [_sample_plan()])
+
+    rc = clean_catalog.main(["--dedup-for-constraints", "--apply", "--yes"])
+    out = capsys.readouterr().out
+
+    assert rc == 1
+    assert "no dedup report found" in out

--- a/test/unit/test_dedup_apply_gate.py
+++ b/test/unit/test_dedup_apply_gate.py
@@ -52,17 +52,50 @@ def test_plan_id_set_includes_survivor_and_loser_ids():
     plan = _sample_plan()
     ids = db_.plan_id_set(plan)
 
+    # tokens are tagged with their operation (`merge:` for survivor+loser group identity) —
+    # see test_plan_id_set_tags_tokens_by_operation for the full tagging-scheme assertions.
     group = plan.duplicate_authors[0]
-    assert str(group.survivor_id) in ids["duplicate_authors"]
-    assert str(group.loser_ids[0]) in ids["duplicate_authors"]
+    assert f"merge:{group.survivor_id}" in ids["duplicate_authors"]
+    assert f"merge:{group.loser_ids[0]}" in ids["duplicate_authors"]
 
     rh_group = plan.duplicate_reading_history[0]
-    assert str(rh_group.survivor_id) in ids["duplicate_reading_history"]
-    assert str(rh_group.loser_ids[0]) in ids["duplicate_reading_history"]
+    assert f"merge:{rh_group.survivor_id}" in ids["duplicate_reading_history"]
+    assert f"delete:{rh_group.loser_ids[0]}" in ids["duplicate_reading_history"]
 
     # every declared class key is always present, even when empty
     assert set(ids) == set(db_.PLAN_ID_SET_CLASSES)
     assert ids["duplicate_narrators"] == set()
+
+
+def test_plan_id_set_tags_tokens_by_operation():
+    """Every token in plan_id_set is prefixed with the operation it belongs to (`merge:` for
+    survivor+losers group identity, `repoint:` for a link/row being re-pointed onto the
+    survivor, `delete:` for a link/row being deleted outright, `report:` for the never-applied
+    duplicate_works_report_only class). This is the mechanism the operation-flip regression
+    test (test_plan_delta_flags_operation_flip_on_same_id) depends on."""
+    survivor = _uuid()
+    loser = _uuid()
+    work_id = _uuid()
+    repoint_pk = (loser, (work_id, loser, "Author"))
+    plan = DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor,
+                survivor_name="Ann Leckie",
+                loser_ids=[loser],
+                loser_names=["ann leckie"],
+                repoint_links=[repoint_pk],
+            )
+        ],
+        orphan_authors=[_uuid()],
+    )
+    ids = db_.plan_id_set(plan)
+
+    assert f"merge:{survivor}" in ids["duplicate_authors"]
+    assert f"merge:{loser}" in ids["duplicate_authors"]
+    assert f"repoint:{repoint_pk}" in ids["duplicate_authors"]
+    assert all(tok.startswith(("merge:", "repoint:", "delete:")) for tok in ids["duplicate_authors"])
+    assert all(tok.startswith("delete:") for tok in ids["orphan_authors"])
 
 
 def test_plan_delta_empty_when_fresh_is_subset_of_reviewed():
@@ -130,7 +163,57 @@ def test_plan_delta_flags_new_loser_appended_to_existing_group():
 
     delta = db_.plan_delta(reviewed, fresh_plan)
 
-    assert delta["duplicate_authors"] == {str(new_loser)}
+    assert delta["duplicate_authors"] == {f"merge:{new_loser}"}
+
+
+def test_plan_delta_flags_operation_flip_on_same_id():
+    """THE core regression this task hardens: row X was reviewed as a REPOINT (its
+    work_contributors link would be moved onto the survivor), but a concurrent write between
+    the reviewed dry-run and the fresh apply-time re-plan means the fresh plan now treats X as
+    a DELETE instead (e.g. the survivor gained a link with the same (work_id, role) key in the
+    gap, so X's link now collides and must be deleted rather than repointed). The row id is
+    identical in both plans — only the OPERATION changed. An untagged id-set diff would see no
+    difference (X is "in both") and let the flip through unreviewed. With tagged tokens,
+    `repoint:X` is only in `reviewed` and `delete:X` is only in `fresh`, so plan_delta must be
+    non-empty (delete:X is a token fresh has that reviewed does not) and the apply gate refuses."""
+    survivor = _uuid()
+    loser = _uuid()
+    work_id = _uuid()
+    pk = (work_id, loser, "Author")
+    link_token = (loser, pk)
+
+    reviewed_plan = DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor,
+                survivor_name="Ann Leckie",
+                loser_ids=[loser],
+                loser_names=["ann leckie"],
+                repoint_links=[link_token],
+            )
+        ]
+    )
+    reviewed = db_.plan_id_set(reviewed_plan)
+
+    fresh_plan = DedupPlan(
+        duplicate_authors=[
+            ContributorMergeGroup(
+                survivor_id=survivor,
+                survivor_name="Ann Leckie",
+                loser_ids=[loser],
+                loser_names=["ann leckie"],
+                delete_links=[link_token],  # same (loser_id, pk) — different operation
+            )
+        ]
+    )
+
+    delta = db_.plan_delta(reviewed, fresh_plan)
+
+    assert delta["duplicate_authors"], "operation flip on the same id must surface as a delta"
+    assert f"delete:{link_token}" in delta["duplicate_authors"]
+    # the survivor/loser group identity itself didn't change, so it must NOT be part of the delta
+    assert f"merge:{survivor}" not in delta["duplicate_authors"]
+    assert f"merge:{loser}" not in delta["duplicate_authors"]
 
 
 def test_report_plan_ids_block_round_trips(tmp_path, monkeypatch):
@@ -151,6 +234,53 @@ def test_parse_plan_ids_raises_on_missing_section():
 
     with pytest.raises(ValueError, match="PLAN IDS"):
         clean_catalog._parse_plan_ids("some report with no machine-readable section\n")
+
+
+def test_parse_plan_ids_raises_on_missing_end_terminator():
+    """A truncated report (write got cut off, or someone hand-edited it) that has the start
+    marker but never reaches '== END PLAN IDS ==' must fail closed with a ValueError — not
+    silently parse whatever partial content came after the start marker as the full reviewed
+    set. Fail-closed here is an explicit tested contract, not an accident of subtraction
+    semantics: a truncated (too-small) reviewed set would otherwise make plan_delta look like
+    everything in the fresh plan is "new," or in the pathological case where the truncation
+    itself happens after some ids, other ids missing from the truncated file due to write
+    failure could silently vanish from the comparison instead of refusing outright."""
+    import pytest
+
+    text = "\n".join(
+        [
+            "Dedup plan report — truncated",
+            "== PLAN IDS ==",
+            "[duplicate_authors] 1",
+            "merge:11111111-1111-1111-1111-111111111111",
+            # no "== END PLAN IDS ==" — write was cut off
+        ]
+    )
+
+    with pytest.raises(ValueError, match="END PLAN IDS"):
+        clean_catalog._parse_plan_ids(text)
+
+
+def test_parse_plan_ids_raises_on_malformed_class_header():
+    """A line starting with '[' inside the PLAN IDS block that never closes with ']' (a
+    malformed/corrupted class header) must raise, not be silently absorbed as a plain id token
+    under whatever the previous class header was — that would hide real ids under the wrong
+    class (or under no class at all if none has been seen yet), corrupting the per-class diff
+    the apply gate depends on."""
+    import pytest
+
+    text = "\n".join(
+        [
+            "Dedup plan report — malformed",
+            "== PLAN IDS ==",
+            "[duplicate_authors",  # missing closing ']'
+            "merge:11111111-1111-1111-1111-111111111111",
+            "== END PLAN IDS ==",
+        ]
+    )
+
+    with pytest.raises(ValueError, match="malformed class-header"):
+        clean_catalog._parse_plan_ids(text)
 
 
 class _Sess:

--- a/test/unit/test_dedup_apply_gate.py
+++ b/test/unit/test_dedup_apply_gate.py
@@ -285,7 +285,9 @@ def test_parse_plan_ids_raises_on_malformed_class_header():
 
 class _Sess:
     """Minimal fake session — plan_dedup itself is monkeypatched below, so the fake session
-    only needs to satisfy main()'s top-of-loop recency probe (session.query(...).count())."""
+    only needs to satisfy main()'s top-of-loop recency probe (column-explicit
+    session.query(func.count(...)).scalar(), never an entity-load .count() — the probe must
+    work on the pre-migration prod schema, GH #95)."""
 
     def __enter__(self):
         return self
@@ -303,6 +305,9 @@ class _Sess:
         return []
 
     def count(self):
+        return 0
+
+    def scalar(self):
         return 0
 
 

--- a/test/unit/test_get_or_create.py
+++ b/test/unit/test_get_or_create.py
@@ -69,6 +69,13 @@ def test_returns_existing(session):
     assert session.query(Widget).count() == 1
 
 
+def test_empty_filters_raises(session):
+    """No filter criteria at all means filter_by() matches an arbitrary first row -- reject
+    it up front instead of silently returning/corrupting an unrelated row."""
+    with pytest.raises(ValueError, match="filter criterion"):
+        get_or_create(session, Widget)
+
+
 def test_creates_when_missing(session):
     """An empty table creates the row: (row, True)."""
     instance, created = get_or_create(session, Widget, name="beta")

--- a/test/unit/test_get_or_create.py
+++ b/test/unit/test_get_or_create.py
@@ -1,0 +1,206 @@
+"""Unit tests for the constraint-backed get_or_create/insert_or_requery helpers (GH #95).
+
+Uses a STANDALONE sqlite model defined here (never the app models on sqlite — they're
+pgvector/JSONB and won't create on sqlite). File-based sqlite (not :memory:) so a second
+connection can see rows committed by the first, letting test_integrity_race_recovers
+simulate a genuine concurrent-insert race.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from agentic_librarian.db.get_or_create import get_or_create, insert_or_requery
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class Widget(_Base):
+    """Tiny standalone model with a unique column, just for exercising the helpers."""
+
+    __tablename__ = "widgets"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String, unique=True, nullable=False)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "get_or_create_test.db"
+
+
+@pytest.fixture
+def engine(db_path):
+    eng = create_engine(f"sqlite:///{db_path}")
+    _Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def session_factory(engine):
+    return sessionmaker(bind=engine)
+
+
+@pytest.fixture
+def session(session_factory):
+    s = session_factory()
+    yield s
+    s.close()
+
+
+def test_returns_existing(session):
+    """A pre-inserted row is returned as-is: (row, False), no new insert."""
+    existing = Widget(name="alpha")
+    session.add(existing)
+    session.commit()
+
+    instance, created = get_or_create(session, Widget, name="alpha")
+
+    assert created is False
+    assert instance.id == existing.id
+    assert session.query(Widget).count() == 1
+
+
+def test_creates_when_missing(session):
+    """An empty table creates the row: (row, True)."""
+    instance, created = get_or_create(session, Widget, name="beta")
+
+    assert created is True
+    assert instance.name == "beta"
+    assert session.query(Widget).filter_by(name="beta").count() == 1
+
+
+def test_integrity_race_recovers(session_factory, engine):
+    """Simulate the classic SELECT-then-INSERT race: session A's initial SELECT misses
+    (row not yet there), a concurrent session B inserts and commits the same name, then
+    session A's INSERT hits the unique constraint. The helper must recover by re-querying
+    inside the except block -> (existing row from B, False) -- and the outer transaction on
+    session A must still be usable afterward (proves begin_nested's SAVEPOINT rollback did
+    not poison the outer transaction)."""
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+        # Pre-create the row that B will "concurrently" insert, but do it AFTER A's
+        # first-query miss and BEFORE A's flush, by monkeypatching Session.flush on A's
+        # session to insert-and-commit via B on first call.
+        original_flush = Session.flush
+        state = {"done": False}
+
+        def _racy_flush(self, *args, **kwargs):
+            if not state["done"]:
+                state["done"] = True
+                # Concurrent insert winner (session B) commits first.
+                session_b.add(Widget(name="gamma"))
+                session_b.commit()
+            return original_flush(self, *args, **kwargs)
+
+        session_a.flush = _racy_flush.__get__(session_a, Session)
+
+        instance, created = get_or_create(session_a, Widget, name="gamma")
+
+        assert created is False
+        assert instance.name == "gamma"
+
+        # Outer transaction on session_a must still be usable — begin_nested's SAVEPOINT
+        # rollback must not have poisoned it.
+        instance2, created2 = get_or_create(session_a, Widget, name="delta")
+        assert created2 is True
+        assert instance2.name == "delta"
+        session_a.commit()
+
+        assert session_a.query(Widget).filter_by(name="delta").count() == 1
+    finally:
+        session_a.close()
+        session_b.close()
+
+
+# --- insert_or_requery: for the case-insensitive authors/narrators sites ---
+
+
+def test_insert_or_requery_creates_when_missing(session):
+    requeried = {}
+
+    def requery():
+        requeried["called"] = True
+        return session.query(Widget).filter(Widget.name == "case-test").first()
+
+    instance = Widget(name="case-test")
+    result, created = insert_or_requery(session, instance, requery)
+
+    assert created is True
+    assert result.name == "case-test"
+    assert "called" not in requeried  # happy path never needs the requery lambda
+
+
+def test_insert_or_requery_recovers_via_case_insensitive_requery(session_factory, engine):
+    """The IntegrityError-recovery path must use the caller's requery callable (not an
+    exact-match filter_by), because a functional unique on lower(name) can be violated by
+    a DIFFERENT-CASE existing row that an exact filter_by(name=...) would miss entirely."""
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+        session_b.add(Widget(name="CasualFarmer"))
+        session_b.commit()
+
+        # session_a's app-level unique is only enforced at the DB via a plain UNIQUE column
+        # here (sqlite doesn't support functional lower() unique indexes the same way), so
+        # simulate the IntegrityError deterministically by attempting to insert a row whose
+        # name collides post-normalization — the requery callable does the case-insensitive
+        # lookup, mirroring func.lower(Author.name) == name.lower() in production.
+        new_instance = Widget(id=str(uuid.uuid4()), name="CasualFarmer")
+
+        def requery():
+            return session_a.query(Widget).filter(Widget.name.ilike("casualfarmer")).first()
+
+        result, created = insert_or_requery(session_a, new_instance, requery)
+
+        assert created is False
+        assert result.name == "CasualFarmer"
+        assert result.id != new_instance.id  # got session_b's winner back, not a duplicate
+
+        # Outer transaction still usable.
+        another = Widget(name="unrelated")
+        result2, created2 = insert_or_requery(
+            session_a, another, lambda: session_a.query(Widget).filter_by(name="unrelated").first()
+        )
+        assert created2 is True
+        session_a.commit()
+    finally:
+        session_a.close()
+        session_b.close()
+
+
+def test_insert_or_requery_reraises_when_requery_finds_nothing(session):
+    """If the constraint fired but the caller's requery genuinely finds nothing, that's not
+    the expected 'someone else won the race' case -- re-raise rather than silently return
+    None (mirrors get_or_create's own re-raise for an unrelated constraint violation)."""
+
+    class _BoomSession:
+        def add(self, *_a, **_k):
+            pass
+
+        def flush(self):
+            raise IntegrityError("stmt", "params", Exception("boom"))
+
+        def begin_nested(self):
+            import contextlib
+
+            @contextlib.contextmanager
+            def _cm():
+                yield
+
+            return _cm()
+
+    def requery():
+        return None
+
+    with pytest.raises(IntegrityError):
+        insert_or_requery(_BoomSession(), Widget(name="ghost"), requery)

--- a/test/unit/test_two_phase_fallback_flag.py
+++ b/test/unit/test_two_phase_fallback_flag.py
@@ -42,6 +42,14 @@ def test_enrich_fast_opts_out_of_fallback_tropes(monkeypatch):
         def flush(self):
             pass
 
+        def get_bind(self):
+            # GH #95: enrich_fast's advisory-lock guard checks dialect.name == "postgresql"
+            # before locking; this fake isn't postgres, so it takes the no-lock path.
+            return type("Bind", (), {"dialect": type("Dialect", (), {"name": "sqlite"})()})()
+
+        def execute(self, *a, **k):
+            pass
+
     monkeypatch.setattr(two_phase, "_run_scouts", fake_run_scouts)
     monkeypatch.setattr(two_phase, "_persist_row", fake_persist_row)
     monkeypatch.setattr(two_phase, "create_fast_scout_manager", lambda: None)

--- a/test/unit/test_two_phase_sessions.py
+++ b/test/unit/test_two_phase_sessions.py
@@ -75,3 +75,47 @@ def test_enrich_deep_runs_scouts_outside_any_session(monkeypatch):
     with patch.object(two_phase, "create_deep_scout_manager", return_value=MagicMock()):
         assert two_phase.enrich_deep(work_id=MagicMock()) == "empty"
     assert scout_seen["open_sessions_during_scout"] == 0
+
+
+def test_enrich_deep_empty_path_returns_missing_if_work_vanished(monkeypatch):
+    """PR #126 review: the empty-path stamp session re-fetches the Work after the scouts ran
+    with no session held. If the Work was deleted in the meantime, session.get returns None --
+    falling through to "empty" would make the internal endpoint 503 and buy a pointless Cloud
+    Tasks retry before the next pass 404s anyway. It must report "missing" instead, same
+    honesty rule as the other non-retryable cases."""
+
+    class FakeReadSession:
+        def __init__(self, work):
+            self._work = work
+
+        def __enter__(self):
+            m = MagicMock()
+            m.get.return_value = self._work
+            return m
+
+        def __exit__(self, *a):
+            return False
+
+    class FakeStampSession:
+        def __enter__(self):
+            m = MagicMock()
+            m.get.return_value = None  # work vanished mid-scouts
+            return m
+
+        def __exit__(self, *a):
+            return False
+
+    work = MagicMock()
+    work.title = "T"
+    work.contributors = [MagicMock(role="Author", author=MagicMock(name="A"))]
+    work.contributors[0].author.name = "A"
+    work.editions = []
+
+    sessions = [FakeReadSession(work), FakeStampSession()]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: None)
+
+    with patch.object(two_phase, "create_deep_scout_manager", return_value=MagicMock()):
+        assert two_phase.enrich_deep(work_id=MagicMock()) == "missing"

--- a/test/unit/test_two_phase_sessions.py
+++ b/test/unit/test_two_phase_sessions.py
@@ -73,5 +73,5 @@ def test_enrich_deep_runs_scouts_outside_any_session(monkeypatch):
 
     monkeypatch.setattr(two_phase, "_run_scouts", fake_run_scouts)
     with patch.object(two_phase, "create_deep_scout_manager", return_value=MagicMock()):
-        assert two_phase.enrich_deep(work_id=MagicMock()) is True
+        assert two_phase.enrich_deep(work_id=MagicMock()) == "empty"
     assert scout_seen["open_sessions_during_scout"] == 0


### PR DESCRIPTION
## ⚠️ DO NOT MERGE ON CI GREEN — operator sequence first

This PR's migration assumes prod data is already deduplicated. The sequence (scripted in `docs/runbooks/phase6-3-schema-rollout.md`):
1. pg_dump snapshot → 2. dedup dry-run (Claude runs) → 3. **operator reviews the report + approves** → 4. gated apply (drift-refusing; loop until clean) → 5. operator runs `alembic upgrade head` on prod → 6. **then** merge → deploy (ADR-058 guard passes).

## What

- **One migration** (`48e3762d6c0c`): 5 unique constraints (functional `lower(name)` ×2, editions `NULLS NOT DISTINCT`, reading_history triple, active-suggestions partial), 9 FK/composite indexes, all 13 naive DateTime columns → timestamptz, `works.deep_enriched_at` with a structural backfill (works with trope links are stamped, so the first #97 sweep is signal, not the whole catalog).
- **#95**: `db/get_or_create.py` (SAVEPOINT + IntegrityError re-query; a case-variant-aware sibling for the `lower(name)` constraints) behind every get-or-create — including `log_suggestion`, which finally gets dedup (**#88's root cause**); `pg_advisory_xact_lock` on normalized title+author serializes concurrent work creation.
- **#97**: `enrich_deep` returns `done/empty/missing` and stamps `deep_enriched_at`; the internal endpoint 503s retryably on an empty pass for a fingerprint-less work, **gives up at retry 8** (Cloud Tasks' default would have bought ~100 paid deep passes per poison book; queue also capped at 12 attempts); `clean_catalog --requeue-unenriched` is the reconciliation sweep.
- **The dedup gate** (`--dedup-for-constraints`): plan → full id report to `data/reports/` → apply **cross-checks the fresh plan against the reviewed report** (operation-tagged tokens — even a repoint→delete flip on the same row refuses), fail-closed parser, single-transaction apply, cross-class intersections deferred to the next pass (convergence proven with zero-row-loss tests), `skipped_unsafe` guards on cascade paths.
- Docs: rollout runbook, ADR-060, CLAUDE.md (the phase's verification mentality), key_facts.

## Review trail

5 task reviews → an adversarial gate review that **rejected once** (operation-flip hole → fixed → verified) → whole-branch final review that found a **Critical** (cross-class dedup compositions could silently delete user reading-history rows → intersection deferral + convergence tests) → an adversarial rollout pass (verdict: nothing blocks; runbook accuracy fixes applied). Every layer caught something the previous ones missed.

## After the sequence completes

Close #95 #97 #108 #109 (+#88 comment); Phase 6.3 done; 6.4 (cost guards) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUR4CLRn6yCUWV4Nubkhtb