### PR TITLE
fix(recommendations): rank candidates into the pool, honor negative targets, never re-suggest

### DIFF
--- a/docs/superpowers/specs/2026-07-14-recommendation-quality-design.md
+++ b/docs/superpowers/specs/2026-07-14-recommendation-quality-design.md
@@ -1,0 +1,177 @@
+# Recommendation Quality — bad recs (#125) + trope pollution (#70) (Design)
+
+**Date:** 2026-07-14 · **Issues:** #125 #70 · **Spec status:** self-approved per ground
+rules (user authorized design 2026-07-14: "start designing and speccing the fixes, only
+come to me with big questions").
+
+## Goal
+
+A user who says "less fantasy, more thriller or romantasy" must get recommendations that
+track that request. Today they get the admin's sci-fi back. Fix the three layers that
+produce this: retrieval that ignores relevance and feedback (PR-A), a prompt that mandates
+recs and never seeks feedback (PR-B), a taste profile computed from polluted frequency
+(PR-C), and the pollution source itself plus data repair (PR-D).
+
+## Verified findings (prod investigation 2026-07-14, user-approved read-only queries)
+
+The full #125 session was reconstructed from `suggestions` + `messages` for the affected
+user (125 history rows, all trope-tagged; thriller/romantasy reader — Katee Robert, Lisa
+Unger, Alice Feeney, Ruth Ware, Riley Sager, Lucy Foley).
+
+1. **No admin hardcoding.** Identity is fail-closed (`user_context.py`), `DEFAULT_USER_ID`
+   reaches only CLI + Dagster. All per-user tools filter correctly. The "admin taste"
+   effect is catalog composition + the defects below.
+2. **The taste profile is an attractor echo.** Every rec round's justification cites
+   "The Dark Night of the Soul, Found Family, and Mysterious Origins" — even her
+   climate-fiction request got funneled through them. `get_user_trope_preferences` ranks
+   by raw frequency; her computed top-5 are all attractors; her real signal (Crime
+   Thrillers, Warrior Romance, Unreliable Narrator, Gothic) sits at ranks 8–18.
+3. **#70's dominant mechanism is FALLBACK-TAG pollution, not scout-trope collapse.**
+   The genre/mood fallback writer (`persist.py:418-430`) pushes mood tags through
+   `standardize_trope`, whose 0.85 semantic match lands them on real dramatic tropes:
+   `Dark`→The Dark Night of the Soul, `Reflective`→Mirror/Shadow Self,
+   `Romance`→Warrior Romance, `Challenging`→Myth-Busting Quest. Evidence: on her works,
+   84 have mood `Dark`, 76 have Dark Night links, 74 are the NULL-justification overlap.
+   Catalog-wide NULL-justification share of top attractors: Dark Night 91/105,
+   Fantasy Kitchen Sink 76/77, Mysterious Origins 79/88, Pioneer/Frontier 66/75,
+   Myth-Busting 66/88. **Found Family is the exception: 239/239 justified (real scout
+   output — a genuine preference signal).** Raising the 0.85 threshold is NOT the fix and
+   re-running enrichment is NOT required for repair (see PR-D).
+4. **Specimen:** *Lessons in Chemistry* has ZERO real scout tropes — its whole
+   "fingerprint" is semantically-warped mood/genre fallbacks (incl. junk trope
+   `Comics Graphic Novels`), yet it is stamped `deep_enriched_at` because the 6.3
+   migration backfill stamped any work with ≥1 trope row. "Stamped but fallback-only" is
+   exactly the #97 requeue sweep's detection class.
+5. **Candidate pools are selected arbitrarily.** `search_internal_database`
+   (`mcp/server.py:122-124`, styles 137-151) joins works to the top-5 nearest tropes with
+   `.limit(n)` and NO ordering — pool membership is arbitrary DB order among all works
+   sharing those tropes; ranking happens only within the arbitrary pool. Attractor
+   targets (works sharing Dark Night: 71 Fantasy, 40 SF, 36 Thriller…) therefore retrieve
+   essentially anything — hence *We Are Legion* for a thriller/romantasy request.
+6. **Feedback is structurally discarded.** No negative-target path exists (Analyst
+   captures `session_constraints`, tools accept only positive targets).
+   `get_unacted_suggestions` re-injects prior suggestions into every fresh candidate set
+   (unread-first ordering floats them up) — Starsight was re-presented after the user
+   deflected; the duplicate `log_suggestion` was absorbed by `uq_suggestions_active`.
+7. **The retrievable thriller supply is thin.** 201/800 works have zero tropes (196 never
+   deep-enriched — largely wishlist/to-read imports, incl. 4 of 8 Ruth Ware titles);
+   zero-trope works are invisible to trope retrieval. Her read thrillers are correctly
+   excluded (<2y re-read rule). User decision 2026-07-14: **enrich wishlist works** to
+   build the catalog and reduce in-conversation Explorer dependence.
+8. **Bonus:** *We Are Legion* exists as TWO work rows (`14c8f3b5…`, `7fc21c9e…` —
+   punctuation variant defeated title dedup), each 1 edition, different trope sets. Added
+   to the dup-works triage list (report-only class; works-merge tooling still doesn't
+   exist).
+
+## Delivery shape: four PRs
+
+Sequenced so each ships value alone; A+B+C fix the live experience, D fixes the data.
+
+### PR-A `fix/rec-retrieval-correctness` — retrieval ranking, negative targets, no re-suggest (#125)
+
+1. **Rank into the pool, not after it.** Rewrite the candidate selection in
+   `search_internal_database`: works are scored by
+   `min(trope.embedding <-> query_vec) * f(relevance_score)` across their trope links
+   (and analogously for styles) and ORDER BY that score BEFORE `LIMIT`. Keep a top-K
+   trope prefilter for index use but widen it (top-5 tropes is a second collapse point);
+   ranking must happen at every stage that limits. pgvector SQL is pg-only: compile-assert
+   locally (`postgresql.dialect()`), execute in `db_integration` (CLAUDE.md rule 4).
+2. **Negative targets.** Add `exclude_tropes: list[str]` / `exclude_styles: list[str]`
+   to `search_internal_database`, `get_recommendation_candidates`, `curate_candidates`.
+   Embed each exclusion; a candidate whose best trope/style match to any negative vector
+   is closer than its best positive match is dropped; near-misses are demoted below all
+   clean candidates. Thread the Analyst's `session_constraints` into these params in both
+   backends (ADK + Claude; `candidates.py` is the shared seam).
+3. **No re-suggesting.** Fresh candidate sets EXCLUDE works with an active `Suggested`
+   suggestion for the current user: `curate_candidates` stops unioning
+   `get_unacted_suggestions`, and the catalog search filters them out.
+   `get_unacted_suggestions` remains available as an explicit tool ("what did you already
+   suggest me?"), no longer an implicit candidate source.
+4. Tests: parametrized unit tests on the pure seams (curate_candidates with faked rows);
+   compiled-SQL assertions for the ranked pool query; db_integration tests that execute
+   ranked retrieval + exclusion + no-resuggest against real pgvector.
+
+### PR-B `feat/librarian-conversational-charter` — prompt overhaul (#125)
+
+Rewrite `LIBRARIAN_INSTRUCTION` (and the ADK orchestrator instruction inline in
+`services.py` — the prompts.py docstring's parity rule) around the user's expanded
+charter (2026-07-14):
+
+- **Overarching goal:** find recommendations the user will like that match the soft
+  preferences expressed across the conversation — not "produce 3 recs per turn."
+- Recommendations are conditional: conversational turns (feedback, chat, questions) get
+  conversational replies; a fresh rec set only when the user is asking for one.
+- Clarifying questions are encouraged (drop "at most one" phrasing; keep them purposeful).
+- **After recommending, seek feedback; ACT on that feedback** in all subsequent recs
+  (feed deflections into exclude_* targets; never re-suggest deflected titles — pairs
+  with PR-A's structural guarantee).
+- The Librarian is authorized to run **multiple rounds** with analyst/critic/explorer
+  until the set makes sense in the broader conversation context (bounded by judgment,
+  not a fixed pipeline).
+- `CRITIC_INSTRUCTION` gains the exclusion contract (apply negative targets as hard
+  filters, not soft penalties).
+
+Honest verification note: prompt changes are validated structurally in tests (the
+instructions mention the new tool params; parity between backends) plus an operator chat
+smoke on prod — LLM behavior itself is not unit-testable (rule 10).
+
+### PR-C `fix/preference-signal-quality` — `get_user_trope_preferences` (#125/#70 bridge)
+
+Two changes, both non-destructive (aggregation-only — no data touched):
+
+1. **Aggregate over justified links only** (`work_tropes.justification IS NOT NULL`).
+   In current prod this removes the fallback pollution from the profile (the top
+   attractors are 75–99% NULL-justification) while keeping real signals (Found Family
+   239/239 justified). Known limitation, stated honestly: legacy scout links with NULL
+   justification are under-counted until PR-D repairs the data; acceptable for a
+   preference ranking (not deletion — the #69 lesson applies to destructive ops).
+2. **Lift over raw frequency.** Score = smoothed
+   `(user_links/user_works) / (catalog_links/catalog_works)`; return top-N by lift,
+   tie-broken by raw count. This preserves the user's concern case — a genuine
+   Found Family lover over-indexes vs the catalog baseline and keeps it — while
+   deflating tropes that are merely ubiquitous. With few users the catalog baseline is
+   admin-skewed; lift is still ordinal-correct for that exact reason (admin-common tropes
+   get deflated for everyone else). Revisit baseline choice when user count grows.
+
+### PR-D `fix/fallback-trope-pollution` — write path + gated repair + sweep (#70)
+
+1. **Write path:** fallback genre/mood tags NEVER go through semantic standardization.
+   New `get_or_create_fallback_trope` (exact cleaned-name match, create slug trope if
+   missing) replaces `standardize_trope` in persist's fallback branch. Genre-as-trope
+   rows keep existing (the work-representation constraint: they are how genres/moods
+   reach matching) — they just can't land on real tropes anymore. `standardize_trope`
+   itself (real scout tags) keeps 0.85; no threshold change (finding 3).
+2. **Gated repair backfill** (destructive → dry-run report → USER approval → apply,
+   clean_catalog plan/apply house pattern): for every NULL-justification link, recompute
+   what the OLD fallback writer would have produced from the work's genres∪moods
+   (clean → embed → nearest trope ≥0.85) — a deterministic, structural distinguisher
+   (recompute-and-match, not a sometimes-populated column; #69 rule satisfied). Delete
+   exactly the recomputed matches; leave legitimate exact-name slug fallbacks and all
+   justified links untouched. Plan persists full id list; apply refuses on any drift.
+   **This is why no paid re-enrichment is needed for repair** (user Q1 answered).
+3. **`deep_enriched_at` honesty:** clear the stamp on works whose remaining tropes are
+   all fallback-shaped after repair (the migration backfill's false positives, finding 4)
+   so the #97 sweep sees them.
+4. **Enrichment sweep (ops, user-approved policy):** after repair, run the #97
+   `--requeue-unenriched` flow over the ~196 never-deep-enriched works + the newly
+   unstamped ones. Paid bulk operation: present the count + cost estimate before firing
+   (ties into Phase 6.4 #100 cost-guard decisions). Expected effect: wishlist thrillers
+   become retrievable, reducing Explorer dependence in conversation.
+
+## Sequencing & interactions
+
+A → B → C are independent of D and ship the visible fix (the #125 session replayed
+against A+B+C would have honored "less fantasy, more thriller or romantasy"). D makes the
+data honest; after D, PR-C's justified-only filter becomes redundant but harmless (all
+surviving links carry real provenance or are exact-name slugs excluded by lift anyway).
+The sweep runs last so re-enriched works land on the fixed write path.
+
+## Out of scope
+
+- Works-merge tooling for the dup pair (triage list, with the 6.3 trio).
+- Work-level representation refactor (work embeddings; memory
+  `work-representation-embedding-gap`) — the durable fix for genre/mood matching, still
+  deferred.
+- Semantic over-collapse among REAL scout tropes (the original #70 framing): mild in
+  current data (Found Family is legitimately common); reassess from the post-repair
+  distribution before spending on it.

--- a/src/agentic_librarian/agents/backends/claude_tools.py
+++ b/src/agentic_librarian/agents/backends/claude_tools.py
@@ -37,8 +37,17 @@ _TOOL_SCHEMAS: list[tuple[str, str, dict[str, Any], Any]] = [
     ),
     (
         "search_internal_database",
-        "Vector search the catalog by tropes/styles.",
-        _schema({"target_tropes": _STR_ARRAY, "target_styles": _STR_ARRAY, "limit": _INT}, required=["target_tropes"]),
+        "Vector search the catalog by tropes/styles; exclude_* are negative targets (session constraints).",
+        _schema(
+            {
+                "target_tropes": _STR_ARRAY,
+                "target_styles": _STR_ARRAY,
+                "limit": _INT,
+                "exclude_tropes": _STR_ARRAY,
+                "exclude_styles": _STR_ARRAY,
+            },
+            required=["target_tropes"],
+        ),
         mcp_server.search_internal_database,
     ),
     (
@@ -49,8 +58,17 @@ _TOOL_SCHEMAS: list[tuple[str, str, dict[str, Any], Any]] = [
     ),
     (
         "get_recommendation_candidates",
-        "Read-status-aware, novelty-balanced catalog candidates (unread-first; has_unread flag).",
-        _schema({"target_tropes": _STR_ARRAY, "target_styles": _STR_ARRAY, "limit": _INT}, required=["target_tropes"]),
+        "Read-status-aware catalog candidates (unread-first; has_unread flag); pass session constraints as exclude_tropes/exclude_styles.",
+        _schema(
+            {
+                "target_tropes": _STR_ARRAY,
+                "target_styles": _STR_ARRAY,
+                "limit": _INT,
+                "exclude_tropes": _STR_ARRAY,
+                "exclude_styles": _STR_ARRAY,
+            },
+            required=["target_tropes"],
+        ),
         mcp_server.get_recommendation_candidates,
     ),
     (

--- a/src/agentic_librarian/agents/candidates.py
+++ b/src/agentic_librarian/agents/candidates.py
@@ -49,7 +49,12 @@ def extract_candidate_ids(state: dict) -> list[str]:
     constraints = targets.get("session_constraints") or []
     if not tropes and not styles:
         return []
-    rows = search_internal_database(target_tropes=tropes, target_styles=styles, exclude_tropes=constraints or None)
+    rows = search_internal_database(
+        target_tropes=tropes,
+        target_styles=styles,
+        exclude_tropes=constraints or None,
+        exclude_styles=constraints or None,
+    )
     suggested = get_active_suggestion_work_ids()
     seen: list[str] = []
     for r in rows:

--- a/src/agentic_librarian/agents/candidates.py
+++ b/src/agentic_librarian/agents/candidates.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 import json
 import re
 
-from agentic_librarian.mcp.server import get_read_status, get_unacted_suggestions, search_internal_database
+from agentic_librarian.mcp.server import (
+    get_active_suggestion_work_ids,
+    get_read_status,
+    search_internal_database,
+)
 
 
 def coerce_schema_value(value) -> dict:
@@ -36,46 +40,60 @@ def coerce_schema_value(value) -> dict:
 
 
 def extract_candidate_ids(state: dict) -> list[str]:
-    """Gather internal DB candidates from the Analyst's targets, de-duplicated, order preserved."""
+    """Gather internal DB candidates from the Analyst's targets, de-duplicated, order preserved.
+    The Analyst's session_constraints become negative retrieval targets (#125: 'less fantasy'
+    must exclude structurally), and actively-suggested works never re-enter a fresh set."""
     targets = coerce_schema_value(state.get("targets"))
     tropes = targets.get("tropes") or []
     styles = targets.get("styles") or []
+    constraints = targets.get("session_constraints") or []
     if not tropes and not styles:
         return []
-    rows = search_internal_database(target_tropes=tropes, target_styles=styles)
-    rows += get_unacted_suggestions(target_tropes=tropes, target_styles=styles)
+    rows = search_internal_database(target_tropes=tropes, target_styles=styles, exclude_tropes=constraints or None)
+    suggested = get_active_suggestion_work_ids()
     seen: list[str] = []
     for r in rows:
         wid = r.get("id")
-        if wid and wid not in seen:
+        if wid and wid not in seen and wid not in suggested:
             seen.append(wid)
     return seen
 
 
 def _candidate_view(r: dict) -> dict:
-    """Normalize a row from either source into a common candidate shape.
-    search_internal_database -> id/title/authors/genres/description;
-    get_unacted_suggestions -> id/title/justification (no authors/genres)."""
+    """Normalize a search row into the common candidate shape."""
     return {
         "id": r.get("id"),
         "title": r.get("title"),
         "authors": r.get("authors") or [],
         "genres": r.get("genres") or [],
-        "description": r.get("description") or r.get("justification") or "",
+        "description": r.get("description") or "",
     }
 
 
-def curate_candidates(target_tropes: list[str], target_styles: list[str] | None = None, limit: int = 10) -> dict:
-    """Deterministic, read-status-aware candidate set for recommendations (spec A1/A3).
-    Unions internal vector matches + prior unacted (unread) suggestions, annotates each with
-    read status, DROPS books finished <2y ago, orders unread-first, and reports has_unread so
-    the caller can fall back to the Explorer for a fresh discovery."""
-    rows = search_internal_database(target_tropes=target_tropes, target_styles=target_styles, limit=limit)
-    rows += get_unacted_suggestions(target_tropes=target_tropes, target_styles=target_styles, limit=limit)
+def curate_candidates(
+    target_tropes: list[str],
+    target_styles: list[str] | None = None,
+    limit: int = 10,
+    exclude_tropes: list[str] | None = None,
+    exclude_styles: list[str] | None = None,
+) -> dict:
+    """Deterministic, read-status-aware candidate set for recommendations (spec A1/A3 + #125).
+    Vector-searches the catalog (relevance-ranked, negative targets honored), DROPS books
+    finished <2y ago AND books already pitched with an unresolved suggestion (never re-offer
+    what the user hasn't reacted to), orders unread-first, and reports has_unread so the
+    caller can fall back to the Explorer for a fresh discovery."""
+    rows = search_internal_database(
+        target_tropes=target_tropes,
+        target_styles=target_styles,
+        limit=limit,
+        exclude_tropes=exclude_tropes,
+        exclude_styles=exclude_styles,
+    )
+    suggested = get_active_suggestion_work_ids()
     by_id: dict[str, dict] = {}
     for r in rows:
         wid = r.get("id")
-        if wid and wid not in by_id:
+        if wid and wid not in by_id and wid not in suggested:
             by_id[wid] = r
     if not by_id:
         return {"candidates": [], "has_unread": False, "unread_count": 0, "reread_count": 0}

--- a/src/agentic_librarian/agents/prompts.py
+++ b/src/agentic_librarian/agents/prompts.py
@@ -87,7 +87,8 @@ DELEGATION STRATEGY (internal-first — the user's enriched catalog is the prima
 1. Delegate to the 'analyst' agent to turn user vibes into structured trope/style targets and
    session constraints.
 2. Use 'get_recommendation_candidates' with target vibes to get read-status-tagged, novelty-
-   balanced candidates plus a has_unread flag (it wraps get_unacted_suggestions + the catalog search).
+   balanced candidates plus a has_unread flag (the catalog search; it excludes books already
+   suggested and awaiting the user's reaction).
 3. Delegate to the 'critic' agent to search the internal catalog and rank candidates.
 4. Delegate to the 'explorer' agent ONLY when: internal candidates are too few or poorly
    matched; OR the strong internal matches have already been suggested or read; OR the user

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -140,8 +140,8 @@ class LibrarianAgent(LlmAgent):
             DELEGATION STRATEGY (internal-first — the user's enriched catalog is the primary source):
             1. Call the 'Analyst' to turn user vibes into structured targets and session constraints.
             2. Call 'get_recommendation_candidates' with target vibes to get read-status-tagged,
-               novelty-balanced candidates plus a has_unread flag (it wraps get_unacted_suggestions
-               + the catalog search).
+               novelty-balanced candidates plus a has_unread flag (the catalog search; it excludes
+               books already suggested and awaiting the user's reaction).
             3. Call the 'Critic' to search the internal catalog and rank candidates.
             4. Call the 'Explorer' ONLY when: internal candidates are too few or poorly matched;
                OR the strong internal matches have already been suggested or read; OR the user

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -103,12 +103,15 @@ _EXCLUDE_DEMOTE_DISTANCE = 0.35  # candidates this close to a negative rank belo
 
 def _trope_rank_select(query_vector, trope_ids, pool_limit: int, exclude_work_ids=None):
     """Works ranked by their best-matching trope: cosine distance to the query vector,
-    penalized for low link relevance (relevance 1.0 → ×1, relevance 0.0 → ×2)."""
+    penalized for low link relevance (relevance 1.0 → ×1, relevance 0.0 → ×2).
+    embedding IS NOT NULL everywhere a distance is aggregated: an unembedded trope can't
+    be semantically near anything, and a NULL distance surviving into min() would put a
+    Python None into the score maps (relevance_score itself is NOT NULL by schema)."""
     score = func.min(Trope.embedding.cosine_distance(query_vector) * (2.0 - WorkTrope.relevance_score)).label("score")
     stmt = (
         select(WorkTrope.work_id, score)
         .join(Trope, Trope.id == WorkTrope.trope_id)
-        .where(WorkTrope.trope_id.in_(trope_ids))
+        .where(WorkTrope.trope_id.in_(trope_ids), Trope.embedding.isnot(None))
     )
     if exclude_work_ids:
         stmt = stmt.where(WorkTrope.work_id.notin_(exclude_work_ids))
@@ -120,7 +123,7 @@ def _work_style_rank_select(query_vector, style_ids, pool_limit: int, exclude_wo
     stmt = (
         select(WorkStyle.work_id, score)
         .join(Style, Style.id == WorkStyle.style_id)
-        .where(WorkStyle.style_id.in_(style_ids))
+        .where(WorkStyle.style_id.in_(style_ids), Style.embedding.isnot(None))
     )
     if exclude_work_ids:
         stmt = stmt.where(WorkStyle.work_id.notin_(exclude_work_ids))
@@ -134,7 +137,7 @@ def _author_style_rank_select(query_vector, style_ids, pool_limit: int, exclude_
         .join(Author, Author.id == WorkContributor.author_id)
         .join(AuthorStyle, AuthorStyle.author_id == Author.id)
         .join(Style, Style.id == AuthorStyle.style_id)
-        .where(AuthorStyle.style_id.in_(style_ids))
+        .where(AuthorStyle.style_id.in_(style_ids), Style.embedding.isnot(None))
     )
     if exclude_work_ids:
         stmt = stmt.where(WorkContributor.work_id.notin_(exclude_work_ids))
@@ -147,7 +150,7 @@ def _neg_trope_distance_select(query_vector, work_ids):
     return (
         select(WorkTrope.work_id, func.min(Trope.embedding.cosine_distance(query_vector)))
         .join(Trope, Trope.id == WorkTrope.trope_id)
-        .where(WorkTrope.work_id.in_(work_ids))
+        .where(WorkTrope.work_id.in_(work_ids), Trope.embedding.isnot(None))
         .group_by(WorkTrope.work_id)
     )
 
@@ -156,7 +159,7 @@ def _neg_style_distance_selects(query_vector, work_ids):
     work_arm = (
         select(WorkStyle.work_id, func.min(Style.embedding.cosine_distance(query_vector)))
         .join(Style, Style.id == WorkStyle.style_id)
-        .where(WorkStyle.work_id.in_(work_ids))
+        .where(WorkStyle.work_id.in_(work_ids), Style.embedding.isnot(None))
         .group_by(WorkStyle.work_id)
     )
     author_arm = (
@@ -164,7 +167,7 @@ def _neg_style_distance_selects(query_vector, work_ids):
         .join(Author, Author.id == WorkContributor.author_id)
         .join(AuthorStyle, AuthorStyle.author_id == Author.id)
         .join(Style, Style.id == AuthorStyle.style_id)
-        .where(WorkContributor.work_id.in_(work_ids))
+        .where(WorkContributor.work_id.in_(work_ids), Style.embedding.isnot(None))
         .group_by(WorkContributor.work_id)
     )
     return work_arm, author_arm
@@ -256,6 +259,7 @@ def search_internal_database(
             trope_ids = [
                 t.id
                 for t in session.query(Trope)
+                .filter(Trope.embedding.isnot(None))
                 .order_by(Trope.embedding.cosine_distance(avg_vector))
                 .limit(_POOL_NEAREST_TAGS)
                 .all()
@@ -271,6 +275,7 @@ def search_internal_database(
             style_ids = [
                 s.id
                 for s in session.query(Style)
+                .filter(Style.embedding.isnot(None))
                 .order_by(Style.embedding.cosine_distance(avg_style_vector))
                 .limit(_POOL_NEAREST_TAGS)
                 .all()

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -98,46 +98,47 @@ def get_server_status() -> str:
 _POOL_NEAREST_TAGS = 20  # nearest tropes/styles feeding the pool (5 was a second collapse point)
 _POOL_OVERFETCH = 3  # each arm over-fetches limit*3; exclusion/merge trims back to limit
 _EXCLUDE_DEMOTE_DISTANCE = 0.35  # candidates this close to a negative rank below all clean ones
+# untuned heuristic knob — real embedding-distance distributions should tune it (follow-up)
 
 
-def _trope_rank_select(query_vector, trope_ids, pool_limit: int):
+def _trope_rank_select(query_vector, trope_ids, pool_limit: int, exclude_work_ids=None):
     """Works ranked by their best-matching trope: cosine distance to the query vector,
     penalized for low link relevance (relevance 1.0 → ×1, relevance 0.0 → ×2)."""
     score = func.min(Trope.embedding.cosine_distance(query_vector) * (2.0 - WorkTrope.relevance_score)).label("score")
-    return (
+    stmt = (
         select(WorkTrope.work_id, score)
         .join(Trope, Trope.id == WorkTrope.trope_id)
         .where(WorkTrope.trope_id.in_(trope_ids))
-        .group_by(WorkTrope.work_id)
-        .order_by(score)
-        .limit(pool_limit)
     )
+    if exclude_work_ids:
+        stmt = stmt.where(WorkTrope.work_id.notin_(exclude_work_ids))
+    return stmt.group_by(WorkTrope.work_id).order_by(score).limit(pool_limit)
 
 
-def _work_style_rank_select(query_vector, style_ids, pool_limit: int):
+def _work_style_rank_select(query_vector, style_ids, pool_limit: int, exclude_work_ids=None):
     score = func.min(Style.embedding.cosine_distance(query_vector)).label("score")
-    return (
+    stmt = (
         select(WorkStyle.work_id, score)
         .join(Style, Style.id == WorkStyle.style_id)
         .where(WorkStyle.style_id.in_(style_ids))
-        .group_by(WorkStyle.work_id)
-        .order_by(score)
-        .limit(pool_limit)
     )
+    if exclude_work_ids:
+        stmt = stmt.where(WorkStyle.work_id.notin_(exclude_work_ids))
+    return stmt.group_by(WorkStyle.work_id).order_by(score).limit(pool_limit)
 
 
-def _author_style_rank_select(query_vector, style_ids, pool_limit: int):
+def _author_style_rank_select(query_vector, style_ids, pool_limit: int, exclude_work_ids=None):
     score = func.min(Style.embedding.cosine_distance(query_vector)).label("score")
-    return (
+    stmt = (
         select(WorkContributor.work_id, score)
         .join(Author, Author.id == WorkContributor.author_id)
         .join(AuthorStyle, AuthorStyle.author_id == Author.id)
         .join(Style, Style.id == AuthorStyle.style_id)
         .where(AuthorStyle.style_id.in_(style_ids))
-        .group_by(WorkContributor.work_id)
-        .order_by(score)
-        .limit(pool_limit)
     )
+    if exclude_work_ids:
+        stmt = stmt.where(WorkContributor.work_id.notin_(exclude_work_ids))
+    return stmt.group_by(WorkContributor.work_id).order_by(score).limit(pool_limit)
 
 
 def _neg_trope_distance_select(query_vector, work_ids):
@@ -182,7 +183,11 @@ def _merge_min(*score_maps: dict) -> dict:
 def _apply_exclusions(pos_scores: dict, neg_scores: dict) -> list:
     """Order candidates by positive score. DROP any at least as close to a negative
     target as to the positives (ties go to the exclusion — user feedback wins); DEMOTE
-    near-misses (within _EXCLUDE_DEMOTE_DISTANCE of a negative) below all clean ones."""
+    near-misses (within _EXCLUDE_DEMOTE_DISTANCE of a negative) below all clean ones.
+    pos_scores carry the relevance penalty while neg distances are raw — deliberate
+    asymmetry: weak positive evidence earns less protection from a user's exclusion.
+    A candidate with no links in an exclusion's space has no measured distance and is
+    kept un-demoted (fail-open by design — no evidence to measure)."""
     kept, demoted = [], []
     for wid in sorted(pos_scores, key=pos_scores.get):
         neg = neg_scores.get(wid)
@@ -221,7 +226,11 @@ def search_internal_database(
     exclude_tropes/exclude_styles are NEGATIVE targets (session constraints like
     "less fantasy", "nothing gory"): candidates closer to a negative than to the
     positive targets are dropped; near-misses rank below all clean candidates.
+    Results never include works already pitched and awaiting the user's reaction.
     """
+    limit = max(int(limit), 0)
+    if limit == 0:
+        return []
     _warm_embeddings([*(target_tropes or []), *(target_styles or []), *(exclude_tropes or []), *(exclude_styles or [])])
 
     with db_manager.get_session() as session:
@@ -229,6 +238,16 @@ def search_internal_database(
         sm = StyleManager(session=session)
         pool_limit = max(limit, 1) * _POOL_OVERFETCH
         pos_scores: dict[UUID, float] = {}
+
+        # Works with an active 'Suggested' suggestion for this user are excluded at the
+        # ranking source: a deflected title must not be retrievable by Critic-direct search,
+        # and it must not consume a result slot ahead of the limit (#125 follow-up).
+        suggested = [
+            row[0]
+            for row in session.query(Suggestions.work_id)
+            .filter(Suggestions.status == "Suggested", Suggestions.user_id == get_required_user_id())
+            .all()
+        ]
 
         # 1. Trope arm — ranked into the pool.
         if target_tropes:
@@ -242,7 +261,7 @@ def search_internal_database(
                 .all()
             ]
             if trope_ids:
-                rows = session.execute(_trope_rank_select(avg_vector, trope_ids, pool_limit)).all()
+                rows = session.execute(_trope_rank_select(avg_vector, trope_ids, pool_limit, suggested)).all()
                 pos_scores = _merge_min(pos_scores, dict(rows))
 
         # 2. Style arm (work styles + primary-author styles) — ranked into the pool.
@@ -257,8 +276,8 @@ def search_internal_database(
                 .all()
             ]
             for stmt in (
-                _work_style_rank_select(avg_style_vector, style_ids, pool_limit),
-                _author_style_rank_select(avg_style_vector, style_ids, pool_limit),
+                _work_style_rank_select(avg_style_vector, style_ids, pool_limit, suggested),
+                _author_style_rank_select(avg_style_vector, style_ids, pool_limit, suggested),
             ):
                 if style_ids:
                     pos_scores = _merge_min(pos_scores, dict(session.execute(stmt).all()))

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -87,98 +87,203 @@ def get_server_status() -> str:
         return f"Librarian MCP Server error: {str(e)}"
 
 
+# --- Candidate-pool ranking & exclusion (#125) --------------------------------------
+# The pool that reaches the Critic must be relevance-ranked at every stage that limits:
+# the old code joined works to the nearest tropes with an unordered `.limit()`, making
+# pool membership arbitrary among every work sharing those tropes (how a thriller
+# request retrieved We Are Legion). Negative targets make "less fantasy" a structural
+# exclusion instead of a polite request. The pgvector statements are pg-only:
+# compile-inspected in test_search_ranking.py, executed in test_internal_retrieval.py.
+
+_POOL_NEAREST_TAGS = 20  # nearest tropes/styles feeding the pool (5 was a second collapse point)
+_POOL_OVERFETCH = 3  # each arm over-fetches limit*3; exclusion/merge trims back to limit
+_EXCLUDE_DEMOTE_DISTANCE = 0.35  # candidates this close to a negative rank below all clean ones
+
+
+def _trope_rank_select(query_vector, trope_ids, pool_limit: int):
+    """Works ranked by their best-matching trope: cosine distance to the query vector,
+    penalized for low link relevance (relevance 1.0 → ×1, relevance 0.0 → ×2)."""
+    score = func.min(Trope.embedding.cosine_distance(query_vector) * (2.0 - WorkTrope.relevance_score)).label("score")
+    return (
+        select(WorkTrope.work_id, score)
+        .join(Trope, Trope.id == WorkTrope.trope_id)
+        .where(WorkTrope.trope_id.in_(trope_ids))
+        .group_by(WorkTrope.work_id)
+        .order_by(score)
+        .limit(pool_limit)
+    )
+
+
+def _work_style_rank_select(query_vector, style_ids, pool_limit: int):
+    score = func.min(Style.embedding.cosine_distance(query_vector)).label("score")
+    return (
+        select(WorkStyle.work_id, score)
+        .join(Style, Style.id == WorkStyle.style_id)
+        .where(WorkStyle.style_id.in_(style_ids))
+        .group_by(WorkStyle.work_id)
+        .order_by(score)
+        .limit(pool_limit)
+    )
+
+
+def _author_style_rank_select(query_vector, style_ids, pool_limit: int):
+    score = func.min(Style.embedding.cosine_distance(query_vector)).label("score")
+    return (
+        select(WorkContributor.work_id, score)
+        .join(Author, Author.id == WorkContributor.author_id)
+        .join(AuthorStyle, AuthorStyle.author_id == Author.id)
+        .join(Style, Style.id == AuthorStyle.style_id)
+        .where(AuthorStyle.style_id.in_(style_ids))
+        .group_by(WorkContributor.work_id)
+        .order_by(score)
+        .limit(pool_limit)
+    )
+
+
+def _neg_trope_distance_select(query_vector, work_ids):
+    """Best (min) distance from each candidate's tropes to one negative target. Measured
+    for EVERY candidate — no LIMIT; an exclusion check must never truncate."""
+    return (
+        select(WorkTrope.work_id, func.min(Trope.embedding.cosine_distance(query_vector)))
+        .join(Trope, Trope.id == WorkTrope.trope_id)
+        .where(WorkTrope.work_id.in_(work_ids))
+        .group_by(WorkTrope.work_id)
+    )
+
+
+def _neg_style_distance_selects(query_vector, work_ids):
+    work_arm = (
+        select(WorkStyle.work_id, func.min(Style.embedding.cosine_distance(query_vector)))
+        .join(Style, Style.id == WorkStyle.style_id)
+        .where(WorkStyle.work_id.in_(work_ids))
+        .group_by(WorkStyle.work_id)
+    )
+    author_arm = (
+        select(WorkContributor.work_id, func.min(Style.embedding.cosine_distance(query_vector)))
+        .join(Author, Author.id == WorkContributor.author_id)
+        .join(AuthorStyle, AuthorStyle.author_id == Author.id)
+        .join(Style, Style.id == AuthorStyle.style_id)
+        .where(WorkContributor.work_id.in_(work_ids))
+        .group_by(WorkContributor.work_id)
+    )
+    return work_arm, author_arm
+
+
+def _merge_min(*score_maps: dict) -> dict:
+    """Union score maps keeping the best (lowest) score per key."""
+    merged: dict = {}
+    for scores in score_maps:
+        for key, value in scores.items():
+            if key not in merged or value < merged[key]:
+                merged[key] = value
+    return merged
+
+
+def _apply_exclusions(pos_scores: dict, neg_scores: dict) -> list:
+    """Order candidates by positive score. DROP any at least as close to a negative
+    target as to the positives (ties go to the exclusion — user feedback wins); DEMOTE
+    near-misses (within _EXCLUDE_DEMOTE_DISTANCE of a negative) below all clean ones."""
+    kept, demoted = [], []
+    for wid in sorted(pos_scores, key=pos_scores.get):
+        neg = neg_scores.get(wid)
+        if neg is None:
+            kept.append(wid)
+        elif neg <= pos_scores[wid]:
+            continue
+        elif neg <= _EXCLUDE_DEMOTE_DISTANCE:
+            demoted.append(wid)
+        else:
+            kept.append(wid)
+    return kept + demoted
+
+
+def _warm_embeddings(texts: list[str]) -> None:
+    """GH #123: warm the embedding LRU before the session opens so in-session
+    _get_embedding calls are cache hits, not network round-trips held under a pooled
+    connection (the pool's 5+2 sizing depends on no embed calls inside sessions)."""
+    for text in texts:
+        try:
+            get_cached_embedding(EMBED_MODEL, text)
+        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call retries
+            logger.warning("embed warm failed for %r — retrying in-session", text)
+
+
 @mcp.tool()
-def search_internal_database(target_tropes: list[str], target_styles: list[str] = None, limit: int = 10) -> list[dict]:
+def search_internal_database(
+    target_tropes: list[str],
+    target_styles: list[str] = None,
+    limit: int = 10,
+    exclude_tropes: list[str] = None,
+    exclude_styles: list[str] = None,
+) -> list[dict]:
     """
-    Performs a pgvector similarity search across tropes and literary styles.
+    pgvector similarity search across tropes and literary styles, relevance-ranked.
+    exclude_tropes/exclude_styles are NEGATIVE targets (session constraints like
+    "less fantasy", "nothing gory"): candidates closer to a negative than to the
+    positive targets are dropped; near-misses rank below all clean candidates.
     """
-    # GH #123: warm the embedding LRU before the session opens so the in-session
-    # _get_embedding calls below are cache hits, not network round-trips held under a
-    # pooled connection (the pool's 5+2 sizing depends on no embed calls inside sessions).
-    for t in target_tropes or []:
-        try:
-            get_cached_embedding(EMBED_MODEL, t)
-        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
-            logger.warning("embed warm failed for trope %r — retrying in-session", t)
-    for s in target_styles or []:
-        try:
-            get_cached_embedding(EMBED_MODEL, s)
-        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
-            logger.warning("embed warm failed for style %r — retrying in-session", s)
+    _warm_embeddings([*(target_tropes or []), *(target_styles or []), *(exclude_tropes or []), *(exclude_styles or [])])
 
     with db_manager.get_session() as session:
         tm = TropeManager(session=session)
         sm = StyleManager(session=session)
+        pool_limit = max(limit, 1) * _POOL_OVERFETCH
+        pos_scores: dict[UUID, float] = {}
 
-        candidate_work_ids = set()
-        avg_vector = None
-
-        # 1. Trope Search
+        # 1. Trope arm — ranked into the pool.
         if target_tropes:
             embeddings = [tm._get_embedding(t) for t in target_tropes]
             avg_vector = np.mean(embeddings, axis=0).tolist()
-            similar_tropes = session.query(Trope).order_by(Trope.embedding.cosine_distance(avg_vector)).limit(5).all()
-            trope_ids = [t.id for t in similar_tropes]
-            trope_works = (
-                session.query(Work.id).join(WorkTrope).filter(WorkTrope.trope_id.in_(trope_ids)).limit(limit).all()
-            )
-            candidate_work_ids.update([w[0] for w in trope_works])
+            trope_ids = [
+                t.id
+                for t in session.query(Trope)
+                .order_by(Trope.embedding.cosine_distance(avg_vector))
+                .limit(_POOL_NEAREST_TAGS)
+                .all()
+            ]
+            if trope_ids:
+                rows = session.execute(_trope_rank_select(avg_vector, trope_ids, pool_limit)).all()
+                pos_scores = _merge_min(pos_scores, dict(rows))
 
-        # 2. Style Search
+        # 2. Style arm (work styles + primary-author styles) — ranked into the pool.
         if target_styles:
             s_embeddings = [sm._get_embedding(s) for s in target_styles]
             avg_style_vector = np.mean(s_embeddings, axis=0).tolist()
-            similar_styles = (
-                session.query(Style).order_by(Style.embedding.cosine_distance(avg_style_vector)).limit(5).all()
-            )
-            style_ids = [s.id for s in similar_styles]
-
-            # Check Author, Work, and Narrator styles
-            author_works = (
-                session.query(Work.id)
-                .join(WorkContributor)
-                .join(Author)
-                .join(AuthorStyle)
-                .filter(AuthorStyle.style_id.in_(style_ids))
-                .limit(limit)
+            style_ids = [
+                s.id
+                for s in session.query(Style)
+                .order_by(Style.embedding.cosine_distance(avg_style_vector))
+                .limit(_POOL_NEAREST_TAGS)
                 .all()
-            )
-            work_styles = (
-                session.query(Work.id).join(WorkStyle).filter(WorkStyle.style_id.in_(style_ids)).limit(limit).all()
-            )
+            ]
+            for stmt in (
+                _work_style_rank_select(avg_style_vector, style_ids, pool_limit),
+                _author_style_rank_select(avg_style_vector, style_ids, pool_limit),
+            ):
+                if style_ids:
+                    pos_scores = _merge_min(pos_scores, dict(session.execute(stmt).all()))
 
-            candidate_work_ids.update([w[0] for w in author_works])
-            candidate_work_ids.update([w[0] for w in work_styles])
-
-        # 3. Final Work Retrieval, ordered by semantic relevance.
-        if not candidate_work_ids:
+        if not pos_scores:
             return []
 
-        # Order candidates by their closest matching trope to the query vector (cosine
-        # distance). Candidates that arrived via style-only matching (no matching trope)
-        # are appended afterward in a stable order. Without this, the set + IN filter
-        # returns rows in arbitrary DB order.
-        ordered_ids: list[UUID] = []
-        if target_tropes and avg_vector is not None:
-            ranked = (
-                session.query(Work.id)
-                .join(WorkTrope, WorkTrope.work_id == Work.id)
-                .join(Trope, Trope.id == WorkTrope.trope_id)
-                .filter(Work.id.in_(list(candidate_work_ids)))
-                .group_by(Work.id)
-                .order_by(func.min(Trope.embedding.cosine_distance(avg_vector)))
-                .limit(limit)
-                .all()
+        # 3. Negative targets: best distance from each candidate to each exclusion.
+        candidate_ids = list(pos_scores)
+        neg_scores: dict[UUID, float] = {}
+        for text in exclude_tropes or []:
+            vec = tm._get_embedding(text)
+            neg_scores = _merge_min(
+                neg_scores, dict(session.execute(_neg_trope_distance_select(vec, candidate_ids)).all())
             )
-            ordered_ids = [w[0] for w in ranked]
-        # sorted() so the style-only leftovers have a deterministic order (set iteration
-        # order is process-randomized).
-        for wid in sorted(candidate_work_ids):
-            if wid not in ordered_ids:
-                ordered_ids.append(wid)
-        ordered_ids = ordered_ids[:limit]
+        for text in exclude_styles or []:
+            vec = sm._get_embedding(text)
+            for stmt in _neg_style_distance_selects(vec, candidate_ids):
+                neg_scores = _merge_min(neg_scores, dict(session.execute(stmt).all()))
 
-        # Eager load contributors/authors, then restore the ranked order.
+        ordered_ids = _apply_exclusions(pos_scores, neg_scores)[:limit]
+        if not ordered_ids:
+            return []
+
+        # 4. Final retrieval; restore the ranked order.
         works = (
             session.query(Work)
             .options(joinedload(Work.contributors).joinedload(WorkContributor.author))
@@ -186,8 +291,6 @@ def search_internal_database(target_tropes: list[str], target_styles: list[str] 
             .all()
         )
         works_by_id = {w.id: w for w in works}
-        ordered_works = [works_by_id[wid] for wid in ordered_ids if wid in works_by_id]
-
         return [
             {
                 "id": str(w.id),
@@ -196,7 +299,8 @@ def search_internal_database(target_tropes: list[str], target_styles: list[str] 
                 "genres": w.genres,
                 "description": w.description,
             }
-            for w in ordered_works
+            for wid in ordered_ids
+            if (w := works_by_id.get(wid)) is not None
         ]
 
 
@@ -207,18 +311,9 @@ def get_unacted_suggestions(target_tropes: list[str], target_styles: list[str] =
     ranked by similarity to current target vibes.
     """
     user_id = get_required_user_id()
-    # GH #123: warm before the session opens (see search_internal_database above) — a no-op
-    # cache-hit in-session either way if there turn out to be no suggestions to rank.
-    for t in target_tropes or []:
-        try:
-            get_cached_embedding(EMBED_MODEL, t)
-        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
-            logger.warning("embed warm failed for trope %r — retrying in-session", t)
-    for s in target_styles or []:
-        try:
-            get_cached_embedding(EMBED_MODEL, s)
-        except Exception:  # noqa: BLE001 - warming is best-effort; the in-session call below retries
-            logger.warning("embed warm failed for style %r — retrying in-session", s)
+    # GH #123: warm before the session opens — a no-op cache-hit in-session either way
+    # if there turn out to be no suggestions to rank.
+    _warm_embeddings([*(target_tropes or []), *(target_styles or [])])
 
     with db_manager.get_session() as session:
         # 1. Get all unacted suggestions with Eager Loading (Fixes N+1)
@@ -304,6 +399,22 @@ def get_unacted_suggestions(target_tropes: list[str], target_styles: list[str] =
             }
             for s in ranked[:limit]
         ]
+
+
+def get_active_suggestion_work_ids() -> set[str]:
+    """Work ids with an ACTIVE ('Suggested') suggestion for the current user. Fresh
+    candidate sets exclude these (#125): a pitched-but-unacted book must not be
+    re-offered on the next request; resolving the suggestion (Accepted / Dismissed /
+    Already Read) frees the work again. A curation-layer helper (candidates.py), not
+    an MCP tool — the LLM never needs it directly."""
+    user_id = get_required_user_id()
+    with db_manager.get_session() as session:
+        rows = (
+            session.query(Suggestions.work_id)
+            .filter(Suggestions.status == "Suggested", Suggestions.user_id == user_id)
+            .all()
+        )
+        return {str(wid) for (wid,) in rows}
 
 
 def reread_eligibility(date_completed: date) -> tuple[bool, float]:
@@ -444,16 +555,25 @@ def get_read_status(work_ids: list[str]) -> dict:
 
 @mcp.tool()
 def get_recommendation_candidates(
-    target_tropes: list[str], target_styles: list[str] | None = None, limit: int = 10
+    target_tropes: list[str],
+    target_styles: list[str] | None = None,
+    limit: int = 10,
+    exclude_tropes: list[str] | None = None,
+    exclude_styles: list[str] | None = None,
 ) -> dict:
     """Read-status-aware, novelty-balanced candidates for a recommendation. Returns
     {"candidates":[{id,title,authors,genres,description,read_status,last_read,rating}],
     "has_unread","unread_count","reread_count"}. candidates is unread-first and excludes books
-    finished <2y ago. If has_unread is false, delegate to the Explorer for a fresh discovery.
+    finished <2y ago, plus books already pitched and awaiting the user's reaction.
+    ALWAYS pass the user's session constraints ("less fantasy", "nothing gory") as
+    exclude_tropes/exclude_styles — matching candidates are structurally dropped.
+    If has_unread is false, delegate to the Explorer for a fresh discovery.
     This is the Critic's primary catalog tool."""
     from agentic_librarian.agents.candidates import curate_candidates
 
-    return curate_candidates(target_tropes, target_styles, limit=limit)
+    return curate_candidates(
+        target_tropes, target_styles, limit=limit, exclude_tropes=exclude_tropes, exclude_styles=exclude_styles
+    )
 
 
 _READING_STATUSES = ("read",)

--- a/test/integration/test_internal_retrieval.py
+++ b/test/integration/test_internal_retrieval.py
@@ -156,6 +156,38 @@ def test_recommendation_candidates_exclude_actively_suggested_work(db_url, monke
 
 
 @pytest.mark.db_integration
+def test_search_internal_database_excludes_actively_suggested_work(db_url, monkeypatch):
+    """#125 follow-up: search_internal_database itself must exclude works with an active
+    'Suggested' suggestion for the current user — Critic-direct search can't retrieve a
+    deflected title, and a suggested work stops consuming a result slot ahead of the limit.
+    Once the suggestion is resolved (Dismissed), the work becomes a candidate again."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    test_db_manager = DatabaseManager(db_url)
+    set_db_manager(test_db_manager)
+
+    with test_db_manager.get_session() as session:
+        work = _seed_work(session, "A Courtship", "Romance Author", ROMANCE)
+        session.add(Suggestions(work=work, user_id=DEFAULT_USER_ID, status="Suggested", justification="prior"))
+        session.commit()
+        work_id = work.id
+
+    def fake_embedding(self, text):
+        return FIXTURE[text]
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        results = search_internal_database(target_tropes=["enemies to lovers"])
+    assert all(r["title"] != "A Courtship" for r in results), results
+
+    with test_db_manager.get_session() as session:
+        row = session.query(Suggestions).filter(Suggestions.work_id == work_id).one()
+        row.status = "Dismissed"
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        results = search_internal_database(target_tropes=["enemies to lovers"])
+    assert any(r["title"] == "A Courtship" for r in results), results
+
+
+@pytest.mark.db_integration
 def test_user_trope_preferences_ranked_by_frequency(db_url):
     test_db_manager = DatabaseManager(db_url)
     set_db_manager(test_db_manager)

--- a/test/integration/test_internal_retrieval.py
+++ b/test/integration/test_internal_retrieval.py
@@ -74,6 +74,88 @@ def test_search_ranks_semantically_near_work_first(db_url, monkeypatch):
 
 
 @pytest.mark.db_integration
+def test_search_pool_selection_is_ranked_at_limit_one(db_url, monkeypatch):
+    """#125 regression: the candidate POOL itself must be relevance-ranked. The old code
+    joined works to the nearest tropes with an unordered LIMIT, so at limit=1 the pool was
+    whatever the heap returned first (the grimdark work, seeded first) and the ranking pass
+    never saw the romance work at all."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    test_db_manager = DatabaseManager(db_url)
+    set_db_manager(test_db_manager)
+
+    with test_db_manager.get_session() as session:
+        _seed_work(session, "The Long War", "Grimdark Author", GRIMDARK)
+        _seed_work(session, "A Courtship", "Romance Author", ROMANCE)
+        session.commit()
+
+    def fake_embedding(self, text):
+        return FIXTURE[text]
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        results = search_internal_database(target_tropes=["enemies to lovers"], limit=1)
+
+    assert [r["title"] for r in results] == ["A Courtship"]
+
+
+@pytest.mark.db_integration
+def test_search_drops_candidates_matching_negative_targets(db_url, monkeypatch):
+    """#125: 'less fantasy, more thriller' must structurally exclude, not politely request.
+    A work whose tropes sit closer to an exclude target than to the positive target is
+    dropped from the results entirely."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    test_db_manager = DatabaseManager(db_url)
+    set_db_manager(test_db_manager)
+
+    with test_db_manager.get_session() as session:
+        _seed_work(session, "The Long War", "Grimdark Author", GRIMDARK)
+        _seed_work(session, "A Courtship", "Romance Author", ROMANCE)
+        session.commit()
+
+    def fake_embedding(self, text):
+        return FIXTURE[text]
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        results = search_internal_database(target_tropes=["enemies to lovers"], exclude_tropes=["grimdark war"])
+
+    titles = [r["title"] for r in results]
+    assert "A Courtship" in titles
+    assert "The Long War" not in titles
+
+
+@pytest.mark.db_integration
+def test_recommendation_candidates_exclude_actively_suggested_work(db_url, monkeypatch):
+    """#125: a work with an active 'Suggested' row must not re-enter fresh candidate sets
+    (Starsight was re-pitched after the user deflected it); once the suggestion is
+    resolved (Dismissed), the work becomes a candidate again."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    test_db_manager = DatabaseManager(db_url)
+    set_db_manager(test_db_manager)
+
+    with test_db_manager.get_session() as session:
+        work = _seed_work(session, "A Courtship", "Romance Author", ROMANCE)
+        session.add(Suggestions(work=work, user_id=DEFAULT_USER_ID, status="Suggested", justification="prior"))
+        session.commit()
+        work_id = work.id
+
+    from agentic_librarian.mcp.server import get_recommendation_candidates
+
+    def fake_embedding(self, text):
+        return FIXTURE[text]
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        out = get_recommendation_candidates(target_tropes=["enemies to lovers"])
+    assert all(c["title"] != "A Courtship" for c in out["candidates"]), out
+
+    with test_db_manager.get_session() as session:
+        row = session.query(Suggestions).filter(Suggestions.work_id == work_id).one()
+        row.status = "Dismissed"
+
+    with patch("agentic_librarian.mcp.server.TropeManager._get_embedding", fake_embedding):
+        out = get_recommendation_candidates(target_tropes=["enemies to lovers"])
+    assert any(c["title"] == "A Courtship" for c in out["candidates"]), out
+
+
+@pytest.mark.db_integration
 def test_user_trope_preferences_ranked_by_frequency(db_url):
     test_db_manager = DatabaseManager(db_url)
     set_db_manager(test_db_manager)

--- a/test/unit/test_curate_candidates.py
+++ b/test/unit/test_curate_candidates.py
@@ -6,8 +6,7 @@ from agentic_librarian.agents import candidates
 def _patch(monkeypatch, internal, status, suggested=frozenset()):
     monkeypatch.setattr(candidates, "search_internal_database", lambda **kw: internal)
     monkeypatch.setattr(candidates, "get_read_status", lambda ids: status)
-    # raising=False: the helper doesn't exist yet on the first RED run (TDD).
-    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set(suggested), raising=False)
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set(suggested))
 
 
 def test_curate_orders_unread_first_and_drops_recent_reads(monkeypatch):
@@ -142,6 +141,7 @@ def test_extract_candidate_ids_passes_session_constraints_as_exclusions(monkeypa
     assert seen.get("target_tropes") == ["heist"]
     assert seen.get("target_styles") == ["witty"]
     assert seen.get("exclude_tropes") == ["high fantasy", "gore"]
+    assert seen.get("exclude_styles") == ["high fantasy", "gore"]
 
 
 def test_extract_candidate_ids_excludes_actively_suggested(monkeypatch):

--- a/test/unit/test_curate_candidates.py
+++ b/test/unit/test_curate_candidates.py
@@ -1,10 +1,13 @@
+import pytest
+
 from agentic_librarian.agents import candidates
 
 
-def _patch(monkeypatch, internal, unacted, status):
+def _patch(monkeypatch, internal, status, suggested=frozenset()):
     monkeypatch.setattr(candidates, "search_internal_database", lambda **kw: internal)
-    monkeypatch.setattr(candidates, "get_unacted_suggestions", lambda **kw: unacted)
     monkeypatch.setattr(candidates, "get_read_status", lambda ids: status)
+    # raising=False: the helper doesn't exist yet on the first RED run (TDD).
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set(suggested), raising=False)
 
 
 def test_curate_orders_unread_first_and_drops_recent_reads(monkeypatch):
@@ -18,7 +21,7 @@ def test_curate_orders_unread_first_and_drops_recent_reads(monkeypatch):
         "w-recent": {"status": "Read", "last_read": "2025-12-01", "is_re_read_candidate": False, "rating": None},
         "w-new": {"status": "Unread", "last_read": None, "is_re_read_candidate": True, "rating": None},
     }
-    _patch(monkeypatch, internal, [], status)
+    _patch(monkeypatch, internal, status)
 
     out = candidates.curate_candidates(["cozy"], ["lyrical"])
 
@@ -35,19 +38,131 @@ def test_curate_orders_unread_first_and_drops_recent_reads(monkeypatch):
 def test_curate_reports_no_unread_when_all_reads_eligible(monkeypatch):
     internal = [{"id": "w1", "title": "T", "authors": [], "genres": [], "description": ""}]
     status = {"w1": {"status": "Read", "last_read": "2018-01-01", "is_re_read_candidate": True, "rating": None}}
-    _patch(monkeypatch, internal, [], status)
+    _patch(monkeypatch, internal, status)
 
     out = candidates.curate_candidates(["x"], None)
     assert out["has_unread"] is False
     assert [c["id"] for c in out["candidates"]] == ["w1"]
 
 
-def test_curate_falls_back_to_unacted_when_search_empty(monkeypatch):
-    unacted = [{"id": "s1", "title": "Prior Pick", "justification": "you might like this"}]
-    status = {"s1": {"status": "Unread", "last_read": None, "is_re_read_candidate": True, "rating": None}}
-    _patch(monkeypatch, [], unacted, status)
+def test_curate_excludes_actively_suggested_works(monkeypatch):
+    """Fresh candidate sets must not re-offer works the Librarian already suggested and the
+    user never acted on (#125: Starsight was re-presented after the user deflected it)."""
+    internal = [
+        {"id": "w-pitched", "title": "Already Pitched", "authors": [], "genres": [], "description": ""},
+        {"id": "w-new", "title": "Fresh", "authors": [], "genres": [], "description": ""},
+    ]
+    status = {
+        "w-pitched": {"status": "Unread", "last_read": None, "is_re_read_candidate": True, "rating": None},
+        "w-new": {"status": "Unread", "last_read": None, "is_re_read_candidate": True, "rating": None},
+    }
+    _patch(monkeypatch, internal, status, suggested={"w-pitched"})
 
-    out = candidates.curate_candidates([], [])
-    assert out["has_unread"] is True
-    assert out["candidates"][0]["title"] == "Prior Pick"
-    assert out["candidates"][0]["description"] == "you might like this"  # justification -> description
+    out = candidates.curate_candidates(["x"])
+    assert [c["id"] for c in out["candidates"]] == ["w-new"]
+
+
+def test_curate_does_not_reinject_prior_suggestions(monkeypatch):
+    """curate no longer unions get_unacted_suggestions into fresh candidate sets (#125:
+    the union floated deflected suggestions back to the top on every new request)."""
+    called = []
+    monkeypatch.setattr(
+        candidates,
+        "search_internal_database",
+        lambda **kw: [{"id": "w1", "title": "T", "authors": [], "genres": [], "description": ""}],
+    )
+    monkeypatch.setattr(
+        candidates,
+        "get_unacted_suggestions",
+        lambda **kw: called.append(kw) or [{"id": "s1", "title": "Prior Pick", "justification": "j"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        candidates,
+        "get_read_status",
+        lambda ids: {
+            i: {"status": "Unread", "last_read": None, "is_re_read_candidate": True, "rating": None} for i in ids
+        },
+    )
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set())
+
+    out = candidates.curate_candidates(["x"])
+    assert [c["id"] for c in out["candidates"]] == ["w1"]
+    assert called == []  # never consulted for fresh candidates
+
+
+def test_curate_returns_empty_when_search_finds_nothing(monkeypatch):
+    """With the unacted union removed, an empty search means an empty candidate set —
+    has_unread False signals the caller to delegate to the Explorer."""
+    _patch(monkeypatch, [], {})
+    out = candidates.curate_candidates(["x"], [])
+    assert out == {"candidates": [], "has_unread": False, "unread_count": 0, "reread_count": 0}
+
+
+@pytest.mark.parametrize(
+    ("exclude_tropes", "exclude_styles"),
+    [
+        (["gore"], None),
+        (None, ["grimdark prose"]),
+        (["gore", "body horror"], ["grimdark prose"]),
+    ],
+)
+def test_curate_forwards_exclusions_to_search(monkeypatch, exclude_tropes, exclude_styles):
+    seen = {}
+
+    def fake_search(**kw):
+        seen.update(kw)
+        return []
+
+    monkeypatch.setattr(candidates, "search_internal_database", fake_search)
+    monkeypatch.setattr(candidates, "get_read_status", lambda ids: {})
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set())
+
+    candidates.curate_candidates(["x"], None, exclude_tropes=exclude_tropes, exclude_styles=exclude_styles)
+    assert seen.get("exclude_tropes") == exclude_tropes
+    assert seen.get("exclude_styles") == exclude_styles
+
+
+def test_extract_candidate_ids_passes_session_constraints_as_exclusions(monkeypatch):
+    """The Analyst's session_constraints ('less fantasy') must structurally reach retrieval
+    as negative targets, not just live in the prompt (#125)."""
+    seen = {}
+
+    def fake_search(**kw):
+        seen.update(kw)
+        return [{"id": "w1"}, {"id": "w2"}]
+
+    monkeypatch.setattr(candidates, "search_internal_database", fake_search)
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set())
+
+    state = {"targets": {"tropes": ["heist"], "styles": ["witty"], "session_constraints": ["high fantasy", "gore"]}}
+    ids = candidates.extract_candidate_ids(state)
+
+    assert ids == ["w1", "w2"]
+    assert seen.get("target_tropes") == ["heist"]
+    assert seen.get("target_styles") == ["witty"]
+    assert seen.get("exclude_tropes") == ["high fantasy", "gore"]
+
+
+def test_extract_candidate_ids_excludes_actively_suggested(monkeypatch):
+    monkeypatch.setattr(candidates, "search_internal_database", lambda **kw: [{"id": "w-pitched"}, {"id": "w-new"}])
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: {"w-pitched"})
+
+    state = {"targets": {"tropes": ["heist"], "styles": [], "session_constraints": []}}
+    assert candidates.extract_candidate_ids(state) == ["w-new"]
+
+
+def test_extract_candidate_ids_does_not_reinject_prior_suggestions(monkeypatch):
+    called = []
+    monkeypatch.setattr(candidates, "search_internal_database", lambda **kw: [{"id": "w1"}])
+    monkeypatch.setattr(
+        candidates,
+        "get_unacted_suggestions",
+        lambda **kw: called.append(kw) or [{"id": "s1"}],
+        raising=False,
+    )
+    monkeypatch.setattr(candidates, "get_active_suggestion_work_ids", lambda: set())
+
+    state = {"targets": {"tropes": ["heist"], "styles": [], "session_constraints": []}}
+    assert candidates.extract_candidate_ids(state) == ["w1"]
+    assert called == []

--- a/test/unit/test_mcp_tools.py
+++ b/test/unit/test_mcp_tools.py
@@ -76,21 +76,33 @@ def test_search_internal_database_mock(mock_db_manager, mock_trope_manager, mock
     mock_query.distinct.return_value = mock_query
     mock_query.options.return_value = mock_query  # Support .options()
 
-    # Now set the 'all' results based on the context
-    # This is tricky with simple mocks. Let's simplify:
-    # Just ensure candidate_work_ids gets something.
+    # session.query(...).all() calls, in order: trope prefilter, style prefilter,
+    # final Work retrieval (#125 rewrite — the ranked pool itself now comes from
+    # session.execute(<select>).all(), mocked separately below).
     mock_query.all.side_effect = [
-        [mock_trope],  # search_internal_database (tropes similarity)
-        [(mock_works[0].id,)],  # search_internal_database (trope_works)
-        [mock_style],  # search_internal_database (styles similarity)
-        [(mock_works[1].id,)],  # search_internal_database (author_works)
-        [],  # search_internal_database (work_styles)
-        mock_works,  # search_internal_database (Final Works retrieval)
+        [mock_trope],  # nearest-tag trope prefilter
+        [mock_style],  # nearest-tag style prefilter
+        mock_works,  # final Work retrieval
     ]
 
+    # session.execute(<select>).all() calls, in order: trope-rank, work-style-rank,
+    # author-style-rank — each returns (work_id, score) rows.
+    mock_execute_results = [
+        [(mock_works[0].id, 0.1)],  # trope-rank
+        [(mock_works[1].id, 0.2)],  # work-style-rank
+        [],  # author-style-rank
+    ]
+    session.execute.side_effect = [MagicMock(all=MagicMock(return_value=rows)) for rows in mock_execute_results]
+
     results = search_internal_database(target_tropes=["fantasy"], target_styles=["grimdark"])
-    assert len(results) > 0
-    assert results[0]["title"] in [b["title"] for b in standard_books]
+    assert len(results) == 2
+    assert results[0]["id"] == str(mock_works[0].id)  # lower (better) score ranks first
+    assert results[1]["id"] == str(mock_works[1].id)
+    for row, work in zip(results, [mock_works[0], mock_works[1]], strict=True):
+        assert row["title"] == work.title
+        assert row["authors"] == [c.author.name for c in work.contributors]
+        assert row["genres"] == work.genres
+        assert row["description"] == work.description
 
 
 def test_get_unacted_suggestions_mock(mock_db_manager, mock_trope_manager, mock_style_manager):

--- a/test/unit/test_mcp_tools.py
+++ b/test/unit/test_mcp_tools.py
@@ -76,10 +76,11 @@ def test_search_internal_database_mock(mock_db_manager, mock_trope_manager, mock
     mock_query.distinct.return_value = mock_query
     mock_query.options.return_value = mock_query  # Support .options()
 
-    # session.query(...).all() calls, in order: trope prefilter, style prefilter,
-    # final Work retrieval (#125 rewrite — the ranked pool itself now comes from
-    # session.execute(<select>).all(), mocked separately below).
+    # session.query(...).all() calls, in order: active-suggestion exclusion set, trope
+    # prefilter, style prefilter, final Work retrieval (#125 rewrite — the ranked pool
+    # itself now comes from session.execute(<select>).all(), mocked separately below).
     mock_query.all.side_effect = [
+        [],  # active-suggestion exclusion set (none suggested)
         [mock_trope],  # nearest-tag trope prefilter
         [mock_style],  # nearest-tag style prefilter
         mock_works,  # final Work retrieval

--- a/test/unit/test_pipeline_agents.py
+++ b/test/unit/test_pipeline_agents.py
@@ -35,9 +35,10 @@ def test_extract_candidate_ids_calls_search(monkeypatch):
     state = {"targets": {"tropes": ["heist"], "styles": []}}
     with (
         patch(
-            "agentic_librarian.agents.candidates.search_internal_database", return_value=[{"id": "w1"}, {"id": "w2"}]
+            "agentic_librarian.agents.candidates.search_internal_database",
+            return_value=[{"id": "w1"}, {"id": "w2"}, {"id": "w1"}],
         ),
-        patch("agentic_librarian.agents.candidates.get_unacted_suggestions", return_value=[{"id": "w2"}]),
+        patch("agentic_librarian.agents.candidates.get_active_suggestion_work_ids", return_value=set()),
     ):
         ids = extract_candidate_ids(state)
     assert ids == ["w1", "w2"]  # de-duplicated, order preserved

--- a/test/unit/test_prompts.py
+++ b/test/unit/test_prompts.py
@@ -34,7 +34,10 @@ def test_librarian_instruction_delegates_to_the_mesh():
     assert "log_suggestion" in text
     assert "update_suggestion_status" in text
     assert "update_reading_status" in text
-    assert "get_unacted_suggestions" in text
+    # get_recommendation_candidates is the catalog search; it no longer wraps
+    # get_unacted_suggestions (#125 follow-up — a stale tool description was corrected).
+    assert "get_recommendation_candidates" in text
+    assert "excludes books already" in text and "awaiting the user's reaction" in text
 
 
 def test_explorer_has_a_search_budget_and_keeps_its_contract():

--- a/test/unit/test_search_ranking.py
+++ b/test/unit/test_search_ranking.py
@@ -68,6 +68,25 @@ def test_neg_trope_distance_select_returns_min_distance_per_work():
     assert "LIMIT" not in sql  # measures every candidate; never truncates
 
 
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        server._trope_rank_select(VEC, IDS, pool_limit=30),
+        server._work_style_rank_select(VEC, IDS, pool_limit=30),
+        server._author_style_rank_select(VEC, IDS, pool_limit=30),
+        server._neg_trope_distance_select(VEC, IDS),
+        *server._neg_style_distance_selects(VEC, IDS),
+    ],
+    ids=["trope_rank", "work_style_rank", "author_style_rank", "neg_trope", "neg_work_style", "neg_author_style"],
+)
+def test_every_distance_aggregate_excludes_null_embeddings(stmt):
+    """A NULL embedding must never reach a distance aggregate: SQL min() over all-NULL
+    distances yields NULL, which lands a Python None in the score maps and TypeErrors the
+    sort. relevance_score is NOT NULL by schema; embeddings are the one nullable input."""
+    sql = _compiled(stmt)
+    assert "embedding IS NOT NULL" in sql
+
+
 def test_merge_min_keeps_best_score_per_work():
     merged = server._merge_min({"a": 0.5, "b": 0.2}, {"a": 0.3, "c": 0.9})
     assert merged == {"a": 0.3, "b": 0.2, "c": 0.9}

--- a/test/unit/test_search_ranking.py
+++ b/test/unit/test_search_ranking.py
@@ -43,6 +43,24 @@ def test_author_style_rank_select_reaches_works_through_contributors():
     assert sql.index("ORDER BY") < sql.index("LIMIT")
 
 
+@pytest.mark.parametrize(
+    "builder",
+    [server._trope_rank_select, server._work_style_rank_select, server._author_style_rank_select],
+)
+def test_rank_select_excludes_work_ids_when_given(builder):
+    sql = _compiled(builder(VEC, IDS, pool_limit=30, exclude_work_ids=IDS))
+    assert "NOT IN" in sql
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [server._trope_rank_select, server._work_style_rank_select, server._author_style_rank_select],
+)
+def test_rank_select_omits_exclusion_by_default(builder):
+    sql = _compiled(builder(VEC, IDS, pool_limit=30))
+    assert "NOT IN" not in sql
+
+
 def test_neg_trope_distance_select_returns_min_distance_per_work():
     sql = _compiled(server._neg_trope_distance_select(VEC, IDS))
     assert "min" in sql.lower() and "<=>" in sql
@@ -60,7 +78,9 @@ def test_merge_min_keeps_best_score_per_work():
     [
         # No negatives: pure positive-score order.
         ({"a": 0.2, "b": 0.1}, {}, ["b", "a"]),
-        # Closer to a negative than to any positive target: dropped.
+        # Closer to a negative than to any positive target: dropped. pos_scores carry the
+        # relevance penalty while neg distances are raw — deliberate asymmetry: weak positive
+        # evidence earns less protection from a user's exclusion.
         ({"a": 0.2, "b": 0.1}, {"a": 0.05}, ["b"]),
         # Near a negative (within the demote margin) but still closer to the positive:
         # kept, demoted below every clean candidate despite a better positive score.

--- a/test/unit/test_search_ranking.py
+++ b/test/unit/test_search_ranking.py
@@ -1,0 +1,77 @@
+"""Unit tests for the ranked candidate-pool selection in search_internal_database (#125).
+
+The pool-selection SQL is pgvector-only, so per CLAUDE.md rule 4 the statements are
+compile-inspected against the postgresql dialect here; test_internal_retrieval.py executes
+them for real under the db_integration marker. The drop/demote exclusion logic is pure
+Python and tested directly."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from agentic_librarian.mcp import server
+
+VEC = [0.1] * 1536
+IDS = ["11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"]
+
+
+def _compiled(stmt) -> str:
+    return str(stmt.compile(dialect=postgresql.dialect()))
+
+
+def test_trope_rank_select_orders_by_score_before_limiting():
+    sql = _compiled(server._trope_rank_select(VEC, IDS, pool_limit=30))
+    assert "GROUP BY work_tropes.work_id" in sql
+    assert "<=>" in sql  # pgvector cosine distance
+    assert "relevance_score" in sql  # low-relevance links are penalized in the pool score
+    assert "ORDER BY" in sql and "LIMIT" in sql
+    assert sql.index("ORDER BY") < sql.index("LIMIT")  # ranked INTO the pool, not after it
+
+
+def test_work_style_rank_select_orders_by_score_before_limiting():
+    sql = _compiled(server._work_style_rank_select(VEC, IDS, pool_limit=30))
+    assert "GROUP BY work_styles.work_id" in sql
+    assert "<=>" in sql
+    assert sql.index("ORDER BY") < sql.index("LIMIT")
+
+
+def test_author_style_rank_select_reaches_works_through_contributors():
+    sql = _compiled(server._author_style_rank_select(VEC, IDS, pool_limit=30))
+    assert "work_contributors" in sql and "author_styles" in sql
+    assert "GROUP BY work_contributors.work_id" in sql
+    assert sql.index("ORDER BY") < sql.index("LIMIT")
+
+
+def test_neg_trope_distance_select_returns_min_distance_per_work():
+    sql = _compiled(server._neg_trope_distance_select(VEC, IDS))
+    assert "min" in sql.lower() and "<=>" in sql
+    assert "GROUP BY work_tropes.work_id" in sql
+    assert "LIMIT" not in sql  # measures every candidate; never truncates
+
+
+def test_merge_min_keeps_best_score_per_work():
+    merged = server._merge_min({"a": 0.5, "b": 0.2}, {"a": 0.3, "c": 0.9})
+    assert merged == {"a": 0.3, "b": 0.2, "c": 0.9}
+
+
+@pytest.mark.parametrize(
+    ("pos", "neg", "expected"),
+    [
+        # No negatives: pure positive-score order.
+        ({"a": 0.2, "b": 0.1}, {}, ["b", "a"]),
+        # Closer to a negative than to any positive target: dropped.
+        ({"a": 0.2, "b": 0.1}, {"a": 0.05}, ["b"]),
+        # Near a negative (within the demote margin) but still closer to the positive:
+        # kept, demoted below every clean candidate despite a better positive score.
+        ({"a": 0.10, "b": 0.40}, {"a": 0.30}, ["b", "a"]),
+        # Far from all negatives: untouched ordering.
+        ({"a": 0.2, "b": 0.1}, {"a": 0.9, "b": 0.8}, ["b", "a"]),
+        # Equal distances resolve as a drop (ties go to the exclusion — feedback wins).
+        ({"a": 0.3}, {"a": 0.3}, []),
+        # Mixed: c dropped, a demoted, b clean.
+        ({"a": 0.10, "b": 0.15, "c": 0.20}, {"a": 0.30, "c": 0.10}, ["b", "a"]),
+    ],
+)
+def test_apply_exclusions_drop_demote_keep(pos, neg, expected):
+    assert server._apply_exclusions(pos, neg) == expected


### PR DESCRIPTION
Part of #125 (PR-A of 4 — see `docs/superpowers/specs/2026-07-14-recommendation-quality-design.md`, prod evidence in the [#125 root-cause comment](https://github.com/jaydee829/shelfwright/issues/125#issuecomment-4969234725)).

## What

Three retrieval-correctness fixes so recommendations track what the user actually asked for:

1. **Candidates are ranked INTO the pool, not after it.** `search_internal_database` previously joined works to the top-5 nearest tropes with an unordered `LIMIT`, so pool membership was arbitrary among every work sharing those tropes — how a thriller/romantasy request retrieved *We Are Legion*. Pool selection now orders by `min(cosine_distance × (2 − relevance_score))` before every limit, the nearest-tag prefilter is widened 5 → 20, and style-arm candidates are scored the same way (no more unranked leftovers).
2. **Negative targets.** New `exclude_tropes` / `exclude_styles` params on `search_internal_database` / `get_recommendation_candidates` / `curate_candidates`: a candidate closer to a negative target than to the positives is dropped (ties go to the exclusion — feedback wins); near-misses are demoted below all clean candidates. The Analyst's `session_constraints` now reach retrieval structurally (both exclusion spaces) in the shared `candidates.py` seam used by both backends.
3. **Never re-suggest.** Works with an active `Suggested` row are filtered inside the catalog search (pre-limit, so they don't consume result slots and Critic-direct search can't resurface them) AND at the curation layer; `curate_candidates` / `extract_candidate_ids` stop unioning `get_unacted_suggestions` into fresh candidate sets (it remains available as an explicit tool).

Also corrects the now-false "wraps get_unacted_suggestions" tool description in both orchestrator prompts (the full prompt overhaul is PR-B).

## Tests

- New `test/unit/test_search_ranking.py`: compiled-SQL assertions (postgresql dialect) that every pool statement orders before limiting + the NOT IN suggestion filter; parametrized drop/demote/keep exclusion cases.
- `test/unit/test_curate_candidates.py` rewritten for the new contract (no-resuggest, no unacted-union, exclusion forwarding, session-constraint threading).
- 4 new `db_integration` tests in `test/integration/test_internal_retrieval.py`: pool ranking at `limit=1` (fails on the old code), negative-target drop, active-suggestion exclusion at both the search and curation layers with Dismissed-frees-it round-trips.
- Full unit suite: 598 passed; the only failures are the 5 known env-dependent ones (verified pre-existing via `git stash` re-run).

⚠️ **Merge gate:** first CI run is the first real execution of the new/changed `db_integration` tests (no local Postgres) — per house rule, treat CI green as the gate, not a formality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
