### PR TITLE
feat(etl): fallback tropes exact-name only + gated pollution repair with drift refusal

### DIFF
--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -10,10 +10,14 @@
   python scripts/clean_catalog.py --dedup-for-constraints --dry-run
   python scripts/clean_catalog.py --dedup-for-constraints --apply --yes
   python scripts/clean_catalog.py --dedup-for-constraints --apply --yes --report data/reports/dedup-<ts>.txt
+  python scripts/clean_catalog.py --repair-fallbacks --dry-run
+  python scripts/clean_catalog.py --repair-fallbacks-apply --yes --report data/reports/fallback-repair-<ts>.txt
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost.
 --dedup-for-constraints --apply re-plans from scratch and cross-checks the fresh plan against
-the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if the plan drifted."""
+the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if the plan drifted.
+--repair-fallbacks-apply likewise re-plans fresh and refuses on any drift from --report (required,
+no default — GH #70)."""
 
 from __future__ import annotations
 
@@ -26,8 +30,9 @@ from sqlalchemy import func
 
 from agentic_librarian.db.models import Trope, Work
 from agentic_librarian.db.session import DatabaseManager, resolve_database_url
-from agentic_librarian.etl import contributor_dedup, dedup_backfill, enrichment_sweep, trope_backfill
+from agentic_librarian.etl import contributor_dedup, dedup_backfill, enrichment_sweep, fallback_repair, trope_backfill
 from agentic_librarian.etl.tag_backfill import is_prod_url
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
 
 
 def _write_dedup_report(plan) -> Path:
@@ -234,6 +239,32 @@ def main(argv: list[str] | None = None) -> int:
             "review) is fine and applies normally (ordinary skipped_stale)."
         ),
     )
+    ap.add_argument(
+        "--repair-fallbacks",
+        action="store_true",
+        help=(
+            "GH #70 (PR-D part 2): dry-run plan for the fallback-pollution repair — deletes "
+            "NULL-justified work_tropes links that are a deterministic recompute of the OLD "
+            "fallback writer's semantic redirect (see etl/fallback_repair.py's module "
+            "docstring for the distinguisher), restores exact-name slug fallbacks on works left "
+            "tropeless, clears falsely-backfilled deep_enriched_at stamps, and prunes orphaned "
+            "tropes. Writes data/reports/fallback-repair-<UTC timestamp>.txt for review — this "
+            "flag never applies; use --repair-fallbacks-apply for that."
+        ),
+    )
+    ap.add_argument(
+        "--repair-fallbacks-apply",
+        action="store_true",
+        help=(
+            "Apply the fallback-pollution repair (GH #70). A SEPARATE invocation from the "
+            "reviewed --repair-fallbacks dry-run: re-plans from scratch and REFUSES (exit 1) if "
+            "the fresh plan contains any token the operator never reviewed (op-tagged, so even "
+            "an operation flip on the same ids counts) — see etl/fallback_repair.py's "
+            "apply_fallback_repair. Requires --yes and --report (no default, unlike "
+            "--dedup-for-constraints — this is a distinct destructive operation and must name "
+            "its reviewed report explicitly)."
+        ),
+    )
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
@@ -242,9 +273,10 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help=(
-            "--dedup-for-constraints --apply only: path to the reviewed dry-run report to "
+            "--dedup-for-constraints --apply: path to the reviewed dry-run report to "
             "cross-check the fresh plan against (THE USER GATE). Defaults to the newest "
-            "data/reports/dedup-*.txt — the tool prints which one it used."
+            "data/reports/dedup-*.txt — the tool prints which one it used. "
+            "--repair-fallbacks-apply: same idea, but REQUIRED (no default)."
         ),
     )
     args = ap.parse_args(argv)
@@ -433,9 +465,71 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
 
+        if args.repair_fallbacks:
+            # #123: warm every cleaned genre/mood name's embedding BEFORE plan_fallback_repair
+            # runs any bogus_targets lookup against THIS session — see
+            # etl/fallback_repair.py's warm_fallback_repair_texts docstring.
+            for name in fallback_repair.warm_fallback_repair_texts(session):
+                get_cached_embedding(EMBED_MODEL, name)
+
+            plan = fallback_repair.plan_fallback_repair(session)
+            summary = plan.summary()
+            print("\n=== repair-fallbacks plan (THE USER GATE, GH #70) ===")
+            for key, count in summary.items():
+                print(f"  {key:32} {count}")
+
+            print("\n--- delete_links samples ---")
+            for d in plan.delete_links[:10]:
+                print(f"  work={d.work_id}  trope={d.trope_id}  ({d.trope_name!r})")
+            print("--- write_slugs samples ---")
+            for w in plan.write_slugs[:10]:
+                print(f"  work={w.work_id}  slug={w.trope_name!r}")
+            print("--- clear_stamps samples ---")
+            for c in plan.clear_stamps[:10]:
+                print(f"  work={c.work_id}")
+            print("--- prune_tropes samples ---")
+            for p in plan.prune_tropes[:10]:
+                print(f"  trope={p.trope_id}  ({p.trope_name!r})")
+
+            report_path = fallback_repair.write_report(plan)
+            print(f"\nfull plan (every token) written to {report_path} — review this before approving --apply.")
+            print(f"\napply with: --repair-fallbacks-apply --yes --report {report_path}")
+            return 0
+
+        if args.repair_fallbacks_apply:
+            if not args.yes:
+                print("\nREFUSING --repair-fallbacks-apply without --yes.")
+                return 2
+            if not is_prod_url(url):
+                print(f"\nREFUSING --repair-fallbacks-apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+                return 2
+            if args.report is None:
+                print(
+                    "\nREFUSING --repair-fallbacks-apply: --report is required (no default — "
+                    "name the reviewed --repair-fallbacks dry-run report explicitly)."
+                )
+                return 1
+
+            # #123: same warm-before-session discipline as the dry-run path — apply_fallback_repair
+            # re-plans fresh internally, so its bogus_targets lookups must find warmed cache hits.
+            for name in fallback_repair.warm_fallback_repair_texts(session):
+                get_cached_embedding(EMBED_MODEL, name)
+
+            try:
+                applied = fallback_repair.apply_fallback_repair(session, args.report)
+            except (OSError, ValueError) as exc:
+                print(f"\nREFUSING --repair-fallbacks-apply: {exc}")
+                return 1
+
+            print("\napplied:")
+            for key, count in applied.items():
+                print(f"  {key:32} {count}")
+            return 0
+
         print(
             "Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, "
-            "--requeue-unenriched, or --dedup-for-constraints."
+            "--requeue-unenriched, --dedup-for-constraints, --repair-fallbacks, or "
+            "--repair-fallbacks-apply."
         )
         return 1
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -213,9 +213,17 @@ def _warm_fallback_repair_embeddings(manager: DatabaseManager) -> None:
         get_cached_embedding(EMBED_MODEL, name)
 
 
-def _run_repair_fallbacks(manager: DatabaseManager) -> int:
+def _run_repair_fallbacks(manager: DatabaseManager, safe: str) -> int:
     """--repair-fallbacks: dry-run plan only, never applies. Warms BEFORE opening the work
-    session — see _warm_fallback_repair_embeddings."""
+    session — see _warm_fallback_repair_embeddings.
+
+    DB-target visibility (final whole-branch review fix): this mode branches out of main()
+    before the shared session block that prints `DB target: ...` for every other mode, so
+    without this line it silently never told the operator which database it planned
+    against. Print the exact same redacted `safe` string the shared block uses (built once in
+    main() from `url.split("@")[-1]`) — never re-derive it here, so the redaction stays in
+    exactly one place."""
+    print(f"DB target: …@{safe}")
     _warm_fallback_repair_embeddings(manager)
 
     with manager.get_session() as session:
@@ -238,7 +246,7 @@ def _run_repair_fallbacks(manager: DatabaseManager) -> int:
         for p in plan.prune_tropes[:10]:
             print(f"  trope={p.trope_id}  ({p.trope_name!r})")
 
-        report_path = fallback_repair.write_report(plan)
+        report_path = fallback_repair.write_report(plan, db_target=safe)
         print(f"\nfull plan (every token) written to {report_path} — review this before approving --apply.")
         print(f"\napply with: --repair-fallbacks-apply --yes --report {report_path}")
         return 0
@@ -247,7 +255,13 @@ def _run_repair_fallbacks(manager: DatabaseManager) -> int:
 def _run_repair_fallbacks_apply(manager: DatabaseManager, args, url: str, safe: str) -> int:
     """--repair-fallbacks-apply: guards first (no session needed for those), THEN warms in its
     own short session, THEN opens the work session that re-plans fresh and applies — see
-    _warm_fallback_repair_embeddings."""
+    _warm_fallback_repair_embeddings.
+
+    DB-target visibility (final whole-branch review fix): same rationale as
+    _run_repair_fallbacks — this mode also branches out of main() before the shared
+    `DB target: ...` print, so print it here too, before the --yes/prod-url/--report guards,
+    so the operator sees which DB was targeted even on an early refusal."""
+    print(f"DB target: …@{safe}")
     if not args.yes:
         print("\nREFUSING --repair-fallbacks-apply without --yes.")
         return 2
@@ -386,7 +400,7 @@ def main(argv: list[str] | None = None) -> int:
     # `with manager.get_session()` block every other mode shares, precisely so these two modes
     # never touch that shared session at all.
     if args.repair_fallbacks:
-        return _run_repair_fallbacks(manager)
+        return _run_repair_fallbacks(manager, safe)
     if args.repair_fallbacks_apply:
         return _run_repair_fallbacks_apply(manager, args, url, safe)
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -199,6 +199,100 @@ def _refuse(args, url, safe) -> int | None:
     return None
 
 
+def _warm_fallback_repair_embeddings(manager: DatabaseManager) -> None:
+    """Fix 2 (#123, honestly this time): a SHORT, DEDICATED session collects the cleaned
+    genre/mood names that would actually need an embedding lookup (warm_fallback_repair_texts
+    already excludes exact-name matches — Minor 7, see its docstring), and that session is
+    CLOSED before the warm loop below makes any embedding network call. Only once warming is
+    complete does the caller open the work session that runs plan/apply_fallback_repair — so no
+    embedding call is ever made while a work session sits open, honoring #123 in fact, not just
+    in a docstring's claim."""
+    with manager.get_session() as warm_session:
+        names = fallback_repair.warm_fallback_repair_texts(warm_session)
+    for name in names:
+        get_cached_embedding(EMBED_MODEL, name)
+
+
+def _run_repair_fallbacks(manager: DatabaseManager) -> int:
+    """--repair-fallbacks: dry-run plan only, never applies. Warms BEFORE opening the work
+    session — see _warm_fallback_repair_embeddings."""
+    _warm_fallback_repair_embeddings(manager)
+
+    with manager.get_session() as session:
+        plan = fallback_repair.plan_fallback_repair(session)
+        summary = plan.summary()
+        print("\n=== repair-fallbacks plan (THE USER GATE, GH #70) ===")
+        for key, count in summary.items():
+            print(f"  {key:32} {count}")
+
+        print("\n--- delete_links samples ---")
+        for d in plan.delete_links[:10]:
+            print(f"  work={d.work_id}  trope={d.trope_id}  ({d.trope_name!r})")
+        print("--- write_slugs samples ---")
+        for w in plan.write_slugs[:10]:
+            print(f"  work={w.work_id}  slug={w.trope_name!r}")
+        print("--- clear_stamps samples ---")
+        for c in plan.clear_stamps[:10]:
+            print(f"  work={c.work_id}")
+        print("--- prune_tropes samples ---")
+        for p in plan.prune_tropes[:10]:
+            print(f"  trope={p.trope_id}  ({p.trope_name!r})")
+
+        report_path = fallback_repair.write_report(plan)
+        print(f"\nfull plan (every token) written to {report_path} — review this before approving --apply.")
+        print(f"\napply with: --repair-fallbacks-apply --yes --report {report_path}")
+        return 0
+
+
+def _run_repair_fallbacks_apply(manager: DatabaseManager, args, url: str, safe: str) -> int:
+    """--repair-fallbacks-apply: guards first (no session needed for those), THEN warms in its
+    own short session, THEN opens the work session that re-plans fresh and applies — see
+    _warm_fallback_repair_embeddings."""
+    if not args.yes:
+        print("\nREFUSING --repair-fallbacks-apply without --yes.")
+        return 2
+    if not is_prod_url(url):
+        print(f"\nREFUSING --repair-fallbacks-apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+        return 2
+    if args.report is None:
+        print(
+            "\nREFUSING --repair-fallbacks-apply: --report is required (no default — "
+            "name the reviewed --repair-fallbacks dry-run report explicitly)."
+        )
+        return 1
+
+    # #123: same warm-before-session discipline as the dry-run path — apply_fallback_repair
+    # re-plans fresh internally, so its bogus_targets lookups must find warmed cache hits.
+    _warm_fallback_repair_embeddings(manager)
+
+    with manager.get_session() as session:
+        try:
+            applied = fallback_repair.apply_fallback_repair(session, args.report)
+        except fallback_repair.FallbackRepairDriftError as exc:
+            # Minor 5: mirrors clean_catalog.py's --dedup-for-constraints refusal — print the
+            # offending delta TOKENS (not just per-class counts) so the operator can see exactly
+            # which rows are new, plus the fresh report path already written for re-review.
+            print(f"\nREFUSING --repair-fallbacks-apply: {exc}")
+            print("New tokens present in the fresh plan but NOT in the reviewed report:")
+            for class_name in fallback_repair.PLAN_TOKEN_CLASSES:
+                new_tokens = sorted(exc.delta.get(class_name, set()))
+                if new_tokens:
+                    print(f"  [{class_name}] +{len(new_tokens)}: {new_tokens}")
+            print(
+                f"\nre-review {exc.fresh_report_path}, then re-run "
+                f"--repair-fallbacks-apply --yes --report {exc.fresh_report_path}"
+            )
+            return 1
+        except (OSError, ValueError) as exc:
+            print(f"\nREFUSING --repair-fallbacks-apply: {exc}")
+            return 1
+
+        print("\napplied:")
+        for key, count in applied.items():
+            print(f"  {key:32} {count}")
+        return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Dedup contributors / clean trope names.")
     ap.add_argument("--inventory", action="store_true")
@@ -284,6 +378,17 @@ def main(argv: list[str] | None = None) -> int:
     url = resolve_database_url()
     safe = url.split("@")[-1] if "@" in url else url  # never print credentials
     manager = DatabaseManager(url)
+
+    # Fix 2 (#123, honestly): --repair-fallbacks / --repair-fallbacks-apply run OUTSIDE the
+    # shared session block below — each warms its embeddings in its own short session (closed
+    # before any embedding network call) and then opens its OWN work session for plan/apply, so
+    # no embedding call is ever made while a work session is open. Handled here, before the
+    # `with manager.get_session()` block every other mode shares, precisely so these two modes
+    # never touch that shared session at all.
+    if args.repair_fallbacks:
+        return _run_repair_fallbacks(manager)
+    if args.repair_fallbacks_apply:
+        return _run_repair_fallbacks_apply(manager, args, url, safe)
 
     with manager.get_session() as session:
         print(f"DB target: …@{safe}")
@@ -463,67 +568,6 @@ def main(argv: list[str] | None = None) -> int:
                 "\nNext: operator runs `alembic upgrade head` on prod to land the #95 unique "
                 "constraints, then merge PR-D and deploy."
             )
-            return 0
-
-        if args.repair_fallbacks:
-            # #123: warm every cleaned genre/mood name's embedding BEFORE plan_fallback_repair
-            # runs any bogus_targets lookup against THIS session — see
-            # etl/fallback_repair.py's warm_fallback_repair_texts docstring.
-            for name in fallback_repair.warm_fallback_repair_texts(session):
-                get_cached_embedding(EMBED_MODEL, name)
-
-            plan = fallback_repair.plan_fallback_repair(session)
-            summary = plan.summary()
-            print("\n=== repair-fallbacks plan (THE USER GATE, GH #70) ===")
-            for key, count in summary.items():
-                print(f"  {key:32} {count}")
-
-            print("\n--- delete_links samples ---")
-            for d in plan.delete_links[:10]:
-                print(f"  work={d.work_id}  trope={d.trope_id}  ({d.trope_name!r})")
-            print("--- write_slugs samples ---")
-            for w in plan.write_slugs[:10]:
-                print(f"  work={w.work_id}  slug={w.trope_name!r}")
-            print("--- clear_stamps samples ---")
-            for c in plan.clear_stamps[:10]:
-                print(f"  work={c.work_id}")
-            print("--- prune_tropes samples ---")
-            for p in plan.prune_tropes[:10]:
-                print(f"  trope={p.trope_id}  ({p.trope_name!r})")
-
-            report_path = fallback_repair.write_report(plan)
-            print(f"\nfull plan (every token) written to {report_path} — review this before approving --apply.")
-            print(f"\napply with: --repair-fallbacks-apply --yes --report {report_path}")
-            return 0
-
-        if args.repair_fallbacks_apply:
-            if not args.yes:
-                print("\nREFUSING --repair-fallbacks-apply without --yes.")
-                return 2
-            if not is_prod_url(url):
-                print(f"\nREFUSING --repair-fallbacks-apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
-                return 2
-            if args.report is None:
-                print(
-                    "\nREFUSING --repair-fallbacks-apply: --report is required (no default — "
-                    "name the reviewed --repair-fallbacks dry-run report explicitly)."
-                )
-                return 1
-
-            # #123: same warm-before-session discipline as the dry-run path — apply_fallback_repair
-            # re-plans fresh internally, so its bogus_targets lookups must find warmed cache hits.
-            for name in fallback_repair.warm_fallback_repair_texts(session):
-                get_cached_embedding(EMBED_MODEL, name)
-
-            try:
-                applied = fallback_repair.apply_fallback_repair(session, args.report)
-            except (OSError, ValueError) as exc:
-                print(f"\nREFUSING --repair-fallbacks-apply: {exc}")
-                return 1
-
-            print("\napplied:")
-            for key, count in applied.items():
-                print(f"  {key:32} {count}")
             return 0
 
         print(

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -27,28 +27,52 @@ tags. It cannot be told apart from the actual pollution using only this work's d
 report is the human gate for this residual: the operator reviews every planned delete_link before
 approving --apply.
 
+A second, opposite-direction residual (fail-SAFE, name it honestly too): a pollution link whose
+old semantic target is no longer the nearest trope TODAY (e.g. the catalog grew a closer trope
+since the link was written, or the original nearest trope was itself since renamed/pruned) is
+invisible to bogus_targets' recompute — the current nearest-trope lookup simply won't reproduce
+that stale target, so the link is never proposed for deletion and stays. This under-deletes rather
+than over-deletes, so it is safe by construction, but it means a re-run of this tool is not
+guaranteed to converge on removing every historical pollution link in one pass; some residual
+junk can persist indefinitely without ever tripping the distinguisher again.
+
 Four action classes, one plan (mirrors etl/dedup_backfill.py's op-tagged token gate EXACTLY —
 see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmetic):
 
   1. delete_link(work_id, trope_id): NULL-justified link whose trope_id is in
      bogus_targets(work).
-  2. write_slug(work_id, trope_name): after (planned) deletions, the work would have NO real
-     trope left (no remaining/surviving link that is_fallback_trope_name(...) is False for) ->
-     plan the missing exact-name slug links for every name in clean_trope_name(tag),
-     tag in genres|moods, not already linked. Applied via D1's get_or_create_fallback_trope
-     (exact-name-only — never the semantic redirect that caused this mess).
-  3. clear_stamp(work_id): work has no real trope remaining (post-delete) AND
-     deep_enriched_at IS NOT NULL -> NULL it out. The 6.3 migration backfill stamped
-     deep_enriched_at on any work with >=1 trope row; a fallback-only work is a false positive
-     that must become visible to the #97 requeue sweep again.
+  2. write_slug(work_id, trope_name): DELETION-TRIGGERED ONLY (adjudicated fix, review pass 2)
+     — a work is eligible for write_slug ONLY IF this plan contains >=1 delete_link for that
+     work. Among eligible works, plan the missing exact-name slug links for every name in
+     clean_trope_name(tag), tag in genres|moods, not already linked, IF after the planned
+     deletions the work would have NO real trope left (no remaining/surviving link that
+     is_fallback_trope_name(...) is False for). Applied via D1's get_or_create_fallback_trope
+     (exact-name-only — never the semantic redirect that caused this mess). A work with ZERO
+     pre-existing trope links (never touched by the old fallback writer at all) is NEVER
+     eligible — writing slugs there would re-add fallback tropes the #67 prune deliberately
+     removed from fast-pass works. This module repairs works it strips, never works it didn't
+     touch.
+  3. clear_stamp(work_id): DELETION-TRIGGERED ONLY, same eligibility rule as write_slug (this
+     plan contains >=1 delete_link for that work). Among eligible works: work has no real trope
+     remaining (post-delete) AND deep_enriched_at IS NOT NULL -> NULL it out. The 6.3 migration
+     backfill stamped deep_enriched_at on any work with >=1 trope row; a fallback-only work
+     whose fallback links this plan is about to delete is a false positive that must become
+     visible to the #97 requeue sweep again. A work this plan does NOT delete anything from
+     keeps its stamp — clearing it would erase the sweep's legitimate repeat-cost signal for a
+     work that was correctly, honestly confirmed-empty.
   4. prune_trope(trope_id): a trope left with ZERO links after the PLANNED deletes (apply
      recomputes this at apply time — see apply_fallback_repair).
 
 Read-only during planning: bogus_targets NEVER creates a Trope. Per #123 (memory: warm
 embeddings before any session), every cleaned genre/mood name this plan might need to embed is
-warmed via get_cached_embedding BEFORE plan_fallback_repair opens/uses its session — see
-scripts/clean_catalog.py's --repair-fallbacks CLI wiring, which calls warm_fallback_repair_texts
-first.
+warmed via get_cached_embedding in a SHORT, SEPARATE, dedicated session that closes BEFORE the
+warm loop runs, which itself completes BEFORE the work session that opens plan_fallback_repair
+(or apply_fallback_repair) is opened — see scripts/clean_catalog.py's --repair-fallbacks /
+--repair-fallbacks-apply CLI wiring, which calls warm_fallback_repair_texts against its own
+short-lived session first, closes it, warms, and only then opens the work session. This is
+honest by construction, not just by convention: warm_fallback_repair_texts already excludes any
+name that exact-matches an existing Trope.name (Minor 7), since the planner never calls
+get_cached_embedding for those either — see warm_fallback_repair_texts's docstring.
 
 Apply is THE USER GATE (mirrors dedup_backfill/clean_catalog's --dedup-for-constraints exactly):
 apply_fallback_repair(session, reviewed_report_path) re-plans FRESH against current DB state,
@@ -148,14 +172,21 @@ def _cleaned_tag_names(genres: list[str] | None, moods: list[str] | None) -> lis
 
 
 def warm_fallback_repair_texts(session: Session) -> list[str]:
-    """Every cleaned genre/mood name across every work — the full set plan_fallback_repair's
-    bogus_targets scan might need to embed. Callers MUST warm these via get_cached_embedding
-    BEFORE opening/using the session that will call plan_fallback_repair (#123). Read-only:
-    only SELECTs Work.genres/moods, never touches Trope."""
+    """Every cleaned genre/mood name across every work that would actually need an embedding
+    lookup — the full set plan_fallback_repair's bogus_targets scan might call
+    get_cached_embedding for. Callers MUST warm these via get_cached_embedding BEFORE
+    opening/using the session that will call plan_fallback_repair (#123).
+
+    Minor 7 (combined with Fix 2): excludes any cleaned name that already exact-matches an
+    existing Trope.name — _nearest_trope_by_name returns None for those WITHOUT ever calling
+    get_cached_embedding (see its docstring), so warming them here would be wasted network
+    calls the planner will never make. Read-only: SELECTs Work.genres/moods and Trope.name
+    only, never mutates."""
+    all_trope_names = {name for (name,) in session.query(Trope.name).all()}
     names: set[str] = set()
     for genres, moods in session.query(Work.genres, Work.moods).all():
         names.update(_cleaned_tag_names(genres, moods))
-    return sorted(names)
+    return sorted(names - all_trope_names)
 
 
 # --------------------------------------------------------------------------------------------
@@ -175,7 +206,12 @@ def _nearest_trope_by_name(session: Session, all_tropes_by_name: dict[str, Trope
         session.query(Trope)
         .filter(Trope.embedding.isnot(None))
         .filter(Trope.embedding.cosine_distance(embedding) <= BOGUS_MATCH_THRESHOLD)
-        .order_by(Trope.embedding.cosine_distance(embedding))
+        # Fix 3 (deterministic tie-break, house rule from dedup_backfill's Minor-3 order_by
+        # discipline): Trope.id as the secondary sort key makes an exact-distance tie resolve
+        # identically every time, so a re-plan on unchanged data classifies the SAME nearest
+        # trope and can't spuriously trip the apply-gate's drift check on Postgres row-order
+        # nondeterminism alone.
+        .order_by(Trope.embedding.cosine_distance(embedding), Trope.id)
         .first()
     )
     return nearest
@@ -239,6 +275,18 @@ def _plan_from_data(
                 plan.delete_links.append(DeleteLink(work_id=wd.work_id, trope_id=trope_id, trope_name=name))
                 planned_deletes.add(trope_id)
                 deleted_link_count_by_trope[trope_id] += 1
+
+        # Fix 1 (adjudicated design change, review pass 2): write_slug/clear_stamp are
+        # DELETION-TRIGGERED ONLY — a work is eligible for either ONLY if this plan just
+        # planned >=1 delete_link for it. Without this gate, a work with ZERO pre-existing
+        # trope links (never touched by the old fallback writer) or a work whose tropelessness
+        # is legitimate and untouched by this run would also qualify by the old "no real trope
+        # survives" test alone — re-adding fallbacks the #67 prune deliberately removed from
+        # fast-pass works, and clearing a legitimately-stamped confirmed-empty work's
+        # deep_enriched_at (erasing the #97 sweep's repeat-cost signal). This module repairs
+        # works it strips, never works it didn't touch.
+        if not planned_deletes:
+            continue
 
         # A "real" trope survives if it's NOT planned for deletion AND is not itself a
         # fallback-name match for this work's own genres/moods (is_fallback_trope_name False).
@@ -426,37 +474,78 @@ def parse_report(report_text: str) -> dict[str, set[str]]:
 # --------------------------------------------------------------------------------------------
 
 
+class FallbackRepairDriftError(ValueError):
+    """Minor 5 (operator UX, mirrors dedup_backfill/clean_catalog's --dedup-for-constraints
+    refusal exactly): raised instead of a bare ValueError when apply_fallback_repair's fresh
+    re-plan drifted from the reviewed report. Carries the per-class delta TOKENS (not just
+    counts — an operator staring at "write_slugs: +1" has no way to find which row that is) and
+    the path of a FRESH report written from the drifted plan, ready for immediate re-review —
+    the operator doesn't have to re-run --repair-fallbacks by hand to see what changed."""
+
+    def __init__(self, delta: dict[str, set[str]], fresh_report_path: Path):
+        self.delta = delta
+        self.fresh_report_path = fresh_report_path
+        details = ", ".join(f"{name}: +{len(tokens)}" for name, tokens in delta.items() if tokens)
+        super().__init__(
+            f"REFUSING apply_fallback_repair: fresh plan drifted from the reviewed report ({details}). "
+            f"A fresh report was written to {fresh_report_path} — re-review it before re-applying."
+        )
+
+
 def apply_fallback_repair(session: Session, reviewed_report_path: Path) -> dict[str, int]:
     """--repair-fallbacks-apply is a SEPARATE invocation from the reviewed dry-run. Re-plans
     FRESH against current DB state, parses the reviewed report's token set (fail-closed — see
-    parse_report), and REFUSES (raises ValueError, no partial writes — nothing is flushed
-    before the drift check completes) if the fresh plan contains ANY token absent from the
-    reviewed set. fresh_tokens ⊆ reviewed_tokens is fine (reported under skipped_stale, not
+    parse_report), and REFUSES (raises FallbackRepairDriftError, no partial writes — nothing is
+    flushed before the drift check completes) if the fresh plan contains ANY token absent from
+    the reviewed set. fresh_tokens ⊆ reviewed_tokens is fine (reported under skipped_stale, not
     refused). Executes delete_link -> write_slug -> clear_stamp -> prune_trope in ONE
     transaction (session.flush() between phases so later phases see earlier ones; the caller
     owns commit/rollback via the session context manager, mirroring every other gated tool in
-    this package)."""
+    this package).
+
+    Minor 4 (skipped_stale semantics, matches dedup_backfill's convention — one TOTAL counter,
+    not split per-class): skipped_stale counts EVERY reviewed token that is no longer live by
+    the time it would be applied, from both directions —
+      (a) reviewed tokens already absent from the FRESH plan (the common case: some reviewed
+          rows were already applied, or the underlying data changed enough that this specific
+          row is no longer proposed at all — reviewed ⊃ fresh, i.e. plan shrinkage since
+          review), counted up front from reviewed_tokens - fresh_tokens, per class; PLUS
+      (b) fresh-plan rows that still vanish from the DB between the fresh re-plan above and this
+          row's own apply step (the sub-second race dedup_backfill's skipped_stale also covers),
+          counted by the per-row session.get() misses below.
+    Both are "the operator reviewed/approved this, but it wasn't there to apply" — same bucket,
+    same operator-facing meaning, mirroring dedup_backfill's apply_dedup docstring."""
     reviewed_tokens = parse_report(Path(reviewed_report_path).read_text(encoding="utf-8"))
 
     fresh_plan = plan_fallback_repair(session)
     delta = plan_delta(reviewed_tokens, fresh_plan)
     if any(delta.values()):
-        details = ", ".join(f"{name}: +{len(tokens)}" for name, tokens in delta.items() if tokens)
-        raise ValueError(
-            f"REFUSING apply_fallback_repair: fresh plan drifted from the reviewed report ({details}). "
-            "Re-review a fresh report before applying."
-        )
+        # Minor 5: write the drifted plan out as a fresh report (same shape --repair-fallbacks
+        # writes) so the operator has an immediately re-reviewable artifact, not just a count in
+        # an error message — mirrors clean_catalog.py's --dedup-for-constraints refusal, which
+        # reuses the fresh plan it already wrote rather than making the operator re-run dry-run.
+        fresh_report_path = write_report(fresh_plan)
+        raise FallbackRepairDriftError(delta, fresh_report_path)
 
     from agentic_librarian.scouts.trope_manager import TropeManager
 
     tm = TropeManager(session=session)
+
+    # Minor 4(a): reviewed tokens no longer present in the fresh plan — the shrinkage the
+    # operator's reviewed report promised but the fresh re-plan (computed above, already known
+    # to be a SUBSET check away from a refusal) doesn't contain. fresh ⊆ reviewed is exactly the
+    # non-refusing case reached here, so this is always >= 0 by construction.
+    fresh_tokens = plan_tokens(fresh_plan)
+    shrinkage = sum(
+        len(reviewed_tokens.get(name, set()) - fresh_tokens.get(name, set())) for name in PLAN_TOKEN_CLASSES
+    )
 
     result = {
         "delete_links": 0,
         "write_slugs": 0,
         "clear_stamps": 0,
         "prune_tropes": 0,
-        "skipped_stale": 0,
+        "skipped_stale": shrinkage,
     }
 
     for d in fresh_plan.delete_links:

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -36,6 +36,21 @@ than over-deletes, so it is safe by construction, but it means a re-run of this 
 guaranteed to converge on removing every historical pollution link in one pass; some residual
 junk can persist indefinitely without ever tripping the distinguisher again.
 
+A third residual, operational rather than algorithmic (final whole-branch review finding — name
+it honestly too): deploy the fixed writer (D1, TropeManager.get_or_create_fallback_trope) BEFORE
+running this repair, not after. If the OLD fallback writer is still serving traffic while
+--repair-fallbacks-apply runs (or in the gap between apply and deploy), it can mint a brand-new
+bogus semantic-redirect link mid-apply. Once this repair's write_slug phase has ALREADY created
+the exact-name slug trope for that same work's tag (the ordinary, correct write_slug outcome),
+`_nearest_trope_by_name`'s exact-name-match short-circuit (see its docstring) means every FUTURE
+re-plan treats that tag name as a legitimate slug and never calls bogus_targets/get_cached_
+embedding for it again — the new bogus link is permanently invisible to this tool's distinguisher
+from that point on. This is fail-safe in the same direction as the second residual above (under-
+delete, never over-delete: the bogus link just sits there, linked, forever) but it never
+converges away on its own, no matter how many times the repair is re-run. The only fix is
+ordering: land and deploy the fixed writer FIRST, confirm it is actually serving (not mid-rollout)
+THEN run --repair-fallbacks / --repair-fallbacks-apply.
+
 Four action classes, one plan (mirrors etl/dedup_backfill.py's op-tagged token gate EXACTLY —
 see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmetic):
 
@@ -390,10 +405,22 @@ def plan_delta(reviewed: dict[str, set[str]], fresh: FallbackRepairPlan) -> dict
 # --------------------------------------------------------------------------------------------
 
 
-def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None) -> Path:
+def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None, db_target: str | None = None) -> Path:
     """Every token in the plan, always written (dry-run AND apply) — this file is what the
     operator reviews before approving --repair-fallbacks-apply (THE USER GATE). Microsecond
-    timestamp resolution, same collision-avoidance reasoning as _write_dedup_report."""
+    timestamp resolution, same collision-avoidance reasoning as _write_dedup_report.
+
+    db_target (final whole-branch review fix — DB-target visibility): the same redacted
+    `safe` string scripts/clean_catalog.py prints as `DB target: ...` for every other mode,
+    passed through so the report FILE also records which database the plan was made against
+    — not just the operator's terminal. Written as a plain human-readable header line ABOVE
+    the '== PLAN TOKENS ==' block, never inside it: parse_report's fail-closed parser only
+    looks at lines between the start/end markers (see below), so this line is invisible to it
+    by construction and cannot be mistaken for a token — verified by
+    test_token_round_trip_format_parse_equal, which asserts a report carrying this header
+    line still round-trips to the exact same token set. Optional (defaults to None / omitted)
+    so existing callers that construct a report without a DB context (e.g. unit tests) are
+    unaffected."""
     reports_dir = reports_dir or Path("data/reports")
     reports_dir.mkdir(parents=True, exist_ok=True)
     now = datetime.now(UTC)
@@ -401,6 +428,9 @@ def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None) -> P
     path = reports_dir / f"fallback-repair-{ts}.txt"
 
     lines: list[str] = [f"Fallback-repair plan report — {ts}", "=" * 60, ""]
+    if db_target is not None:
+        lines.append(f"db target: {db_target}")
+        lines.append("")
 
     lines.append(f"delete_links: {len(plan.delete_links)} links (NULL-justified, recomputed-bogus)")
     for d in plan.delete_links:

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -1,0 +1,509 @@
+"""Gated fallback-pollution repair backfill (PR-D part 2, GH #70). Deletes prod's inherited
+damage from the OLD fallback writer, which called `standardize_trope`'s 0.85-cosine semantic
+match for genre/mood slug tags (e.g. mood tag "Dark" landing on the real trope "The Dark Night
+of the Soul" — 91 of 105 links on that one attractor). D1 (`TropeManager.get_or_create_fallback_
+trope`, scouts/trope_manager.py) fixed the writer going forward; this module repairs what
+already landed on prod.
+
+THE DISTINGUISHER (binding, read before touching this file): a link is bogus if it is
+NULL-justified AND its trope is a deterministic RECOMPUTE of what the OLD fallback writer would
+have produced from THIS WORK's genres/moods — i.e. `bogus_targets(work)` walks
+`clean_trope_name(tag)` for every tag in the work's genres∪moods, and for each cleaned name that
+does NOT already exist as an exact-name Trope, finds the nearest trope by cosine distance and
+marks it bogus if the distance is <= the redirect threshold `standardize_trope` used (0.15,
+i.e. 0.85 similarity — see BOGUS_MATCH_THRESHOLD below, which mirrors scouts/trope_manager.py's
+default `threshold=0.85` by DELIBERATE COUPLING, not coincidence: this module's whole point is
+to find what THAT redirect would have produced). This is a STRUCTURAL distinguisher (the #69
+lesson, memory verify-backfill-distinguisher) — NOT `justification IS NULL` alone. Justification
+is unreliable on its own (many real scout tropes are NULL-justified "semantic collapse"
+attractors, per trope_predicate.py's docstring); it is used here only as a NECESSARY co-condition
+(a justified link is NEVER touched, full stop) alongside the structural recompute.
+
+RESIDUAL (name it honestly): a real scout-supplied trope that happens to be NULL-justified AND
+whose name coincides with a recomputed semantic-fallback target for THAT SAME work's own
+genres/moods will be misclassified as bogus and deleted. This is a real, documented gap in the
+distinguisher — a NULL-justified attractor trope that is ALSO close to one of the work's own
+tags. It cannot be told apart from the actual pollution using only this work's data. The dry-run
+report is the human gate for this residual: the operator reviews every planned delete_link before
+approving --apply.
+
+Four action classes, one plan (mirrors etl/dedup_backfill.py's op-tagged token gate EXACTLY —
+see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmetic):
+
+  1. delete_link(work_id, trope_id): NULL-justified link whose trope_id is in
+     bogus_targets(work).
+  2. write_slug(work_id, trope_name): after (planned) deletions, the work would have NO real
+     trope left (no remaining/surviving link that is_fallback_trope_name(...) is False for) ->
+     plan the missing exact-name slug links for every name in clean_trope_name(tag),
+     tag in genres|moods, not already linked. Applied via D1's get_or_create_fallback_trope
+     (exact-name-only — never the semantic redirect that caused this mess).
+  3. clear_stamp(work_id): work has no real trope remaining (post-delete) AND
+     deep_enriched_at IS NOT NULL -> NULL it out. The 6.3 migration backfill stamped
+     deep_enriched_at on any work with >=1 trope row; a fallback-only work is a false positive
+     that must become visible to the #97 requeue sweep again.
+  4. prune_trope(trope_id): a trope left with ZERO links after the PLANNED deletes (apply
+     recomputes this at apply time — see apply_fallback_repair).
+
+Read-only during planning: bogus_targets NEVER creates a Trope. Per #123 (memory: warm
+embeddings before any session), every cleaned genre/mood name this plan might need to embed is
+warmed via get_cached_embedding BEFORE plan_fallback_repair opens/uses its session — see
+scripts/clean_catalog.py's --repair-fallbacks CLI wiring, which calls warm_fallback_repair_texts
+first.
+
+Apply is THE USER GATE (mirrors dedup_backfill/clean_catalog's --dedup-for-constraints exactly):
+apply_fallback_repair(session, reviewed_report_path) re-plans FRESH against current DB state,
+parses the reviewed report's token set (fail-closed — see parse_report), and REFUSES (raises,
+no partial writes) if the fresh plan's token set contains ANY token absent from the reviewed
+set. Op-tagged tokens make even an operation flip on the same ids (e.g. a row that was
+`delete_link:` in review becomes eligible for a DIFFERENT bogus_target by apply time) a new,
+visible token — see plan_tokens's docstring. fresh ⊆ reviewed is fine (skipped_stale is
+reported, not refused)."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.etl.tag_cleaning import clean_trope_name
+from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
+from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
+
+logger = logging.getLogger(__name__)
+
+# Mirrors scouts/trope_manager.py TropeManager.standardize_trope's default `threshold=0.85`
+# (cosine SIMILARITY) BY DELIBERATE COUPLING: this module exists to find exactly what that
+# redirect would have matched, so the two constants must move together. cosine DISTANCE is
+# (1 - similarity), hence 0.15 here.
+BOGUS_MATCH_THRESHOLD = 0.15
+
+
+# --------------------------------------------------------------------------------------------
+# Plan dataclasses
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class DeleteLink:
+    work_id: UUID
+    trope_id: UUID
+    trope_name: str
+
+
+@dataclass
+class WriteSlug:
+    work_id: UUID
+    trope_name: str
+
+
+@dataclass
+class ClearStamp:
+    work_id: UUID
+
+
+@dataclass
+class PruneTrope:
+    trope_id: UUID
+    trope_name: str
+
+
+@dataclass
+class FallbackRepairPlan:
+    delete_links: list[DeleteLink] = field(default_factory=list)
+    write_slugs: list[WriteSlug] = field(default_factory=list)
+    clear_stamps: list[ClearStamp] = field(default_factory=list)
+    prune_tropes: list[PruneTrope] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "delete_links": len(self.delete_links),
+            "write_slugs": len(self.write_slugs),
+            "clear_stamps": len(self.clear_stamps),
+            "prune_tropes": len(self.prune_tropes),
+        }
+
+
+# --------------------------------------------------------------------------------------------
+# Embedding warm-up (#123: no embed network calls inside a session)
+# --------------------------------------------------------------------------------------------
+
+
+def _cleaned_tag_names(genres: list[str] | None, moods: list[str] | None) -> list[str]:
+    """Every name clean_trope_name would produce for this work's genres|moods, de-duped,
+    order-stable. Pure — no I/O."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for tag in list(genres or []) + list(moods or []):
+        for name in clean_trope_name(tag):
+            if name not in seen:
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def warm_fallback_repair_texts(session: Session) -> list[str]:
+    """Every cleaned genre/mood name across every work — the full set plan_fallback_repair's
+    bogus_targets scan might need to embed. Callers MUST warm these via get_cached_embedding
+    BEFORE opening/using the session that will call plan_fallback_repair (#123). Read-only:
+    only SELECTs Work.genres/moods, never touches Trope."""
+    names: set[str] = set()
+    for genres, moods in session.query(Work.genres, Work.moods).all():
+        names.update(_cleaned_tag_names(genres, moods))
+    return sorted(names)
+
+
+# --------------------------------------------------------------------------------------------
+# bogus_targets: the structural distinguisher
+# --------------------------------------------------------------------------------------------
+
+
+def _nearest_trope_by_name(session: Session, all_tropes_by_name: dict[str, Trope], name: str) -> Trope | None:
+    """Exact-name match -> None (legitimate slug, never bogus — skip). Else the nearest trope
+    by cosine distance if within BOGUS_MATCH_THRESHOLD, else None (no bogus target for this
+    name). Read-only: never creates a Trope. Embeds `name` via the (already-warmed, per #123)
+    get_cached_embedding cache."""
+    if name in all_tropes_by_name:
+        return None  # an exact-name slug trope already exists for this tag -> legitimate
+    embedding = get_cached_embedding(EMBED_MODEL, name)
+    nearest = (
+        session.query(Trope)
+        .filter(Trope.embedding.isnot(None))
+        .filter(Trope.embedding.cosine_distance(embedding) <= BOGUS_MATCH_THRESHOLD)
+        .order_by(Trope.embedding.cosine_distance(embedding))
+        .first()
+    )
+    return nearest
+
+
+def bogus_targets(session: Session, work: Work, all_tropes_by_name: dict[str, Trope]) -> set[UUID]:
+    """The set of trope ids that are a bogus (deterministically re-derivable) semantic-redirect
+    target for THIS work's genres|moods. Read-only."""
+    out: set[UUID] = set()
+    for name in _cleaned_tag_names(work.genres, work.moods):
+        nearest = _nearest_trope_by_name(session, all_tropes_by_name, name)
+        if nearest is not None:
+            out.add(nearest.id)
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Plan
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class _WorkData:
+    """Pure input shape for _plan_from_data — a session-free snapshot of one work's identity,
+    genres/moods, and links. Split out from plan_fallback_repair so the classification core
+    (which action a link/work falls into) is unit-testable without faking SQLAlchemy's query
+    API or a live Postgres cosine_distance operator."""
+
+    work_id: UUID
+    genres: list[str] | None
+    moods: list[str] | None
+    deep_enriched_at: object | None  # only ever compared to None; type left loose for callers
+    # (trope_id, trope_name, justification) per link
+    links: list[tuple[UUID, str, str | None]]
+
+
+def _plan_from_data(
+    works_data: list[_WorkData],
+    all_tropes_by_id: dict[UUID, str],  # trope_id -> trope_name, every Trope in the DB
+    bogus_targets_by_work: dict[UUID, set[UUID]],  # work_id -> bogus_targets(work) result
+) -> FallbackRepairPlan:
+    """Pure classification core (no I/O): given every work's links + genres/moods and each
+    work's precomputed bogus_targets set, produce the four-class plan. See the module docstring
+    for the exact rules; this function is the single place they're encoded, exercised directly
+    by test/unit/test_fallback_repair.py and indirectly (via plan_fallback_repair) by the
+    db_integration suite."""
+    plan = FallbackRepairPlan()
+    deleted_link_count_by_trope: dict[UUID, int] = defaultdict(int)
+    total_link_count: dict[UUID, int] = defaultdict(int)
+
+    for wd in works_data:
+        for trope_id, _name, _justification in wd.links:
+            total_link_count[trope_id] += 1
+
+    for wd in works_data:
+        targets = bogus_targets_by_work.get(wd.work_id, set())
+
+        planned_deletes: set[UUID] = set()
+        for trope_id, name, justification in wd.links:
+            if justification is None and trope_id in targets:
+                plan.delete_links.append(DeleteLink(work_id=wd.work_id, trope_id=trope_id, trope_name=name))
+                planned_deletes.add(trope_id)
+                deleted_link_count_by_trope[trope_id] += 1
+
+        # A "real" trope survives if it's NOT planned for deletion AND is not itself a
+        # fallback-name match for this work's own genres/moods (is_fallback_trope_name False).
+        has_real_remaining = any(
+            trope_id not in planned_deletes and is_fallback_trope_name(name, wd.genres, wd.moods) is False
+            for trope_id, name, _justification in wd.links
+        )
+
+        if not has_real_remaining:
+            existing_names = {name for trope_id, name, _j in wd.links if trope_id not in planned_deletes}
+            for name in _cleaned_tag_names(wd.genres, wd.moods):
+                if name not in existing_names:
+                    plan.write_slugs.append(WriteSlug(work_id=wd.work_id, trope_name=name))
+            if wd.deep_enriched_at is not None:
+                plan.clear_stamps.append(ClearStamp(work_id=wd.work_id))
+
+    # prune_trope: a trope with ZERO links remaining after the planned deletes (recomputed
+    # against current total link counts minus planned deletes — apply recomputes fresh again).
+    for trope_id, deleted_count in deleted_link_count_by_trope.items():
+        if deleted_count >= total_link_count.get(trope_id, 0):
+            trope_name = all_tropes_by_id.get(trope_id)
+            if trope_name is not None:
+                plan.prune_tropes.append(PruneTrope(trope_id=trope_id, trope_name=trope_name))
+
+    return plan
+
+
+def plan_fallback_repair(session: Session) -> FallbackRepairPlan:
+    """READ ONLY. See the module docstring for the four action classes and the distinguisher.
+    Embeddings for any not-yet-embedded cleaned tag name are fetched via get_cached_embedding —
+    callers MUST have warmed these (warm_fallback_repair_texts) before opening this session
+    (#123)."""
+    all_tropes = session.query(Trope).order_by(Trope.id).all()
+    all_tropes_by_name = {t.name: t for t in all_tropes}
+    all_tropes_by_id = {t.id: t.name for t in all_tropes}
+
+    # work_id -> [(trope_id, name, justification), ...] for every link, ordered for determinism
+    # (mirrors dedup_backfill's Minor-3 order_by discipline — see _plan_authors's comment).
+    links_by_work: dict[UUID, list[tuple[UUID, str, str | None]]] = defaultdict(list)
+    for wt in (
+        session.query(WorkTrope.work_id, WorkTrope.trope_id, Trope.name, WorkTrope.justification)
+        .join(Trope, Trope.id == WorkTrope.trope_id)
+        .order_by(WorkTrope.work_id, WorkTrope.trope_id)
+        .all()
+    ):
+        work_id, trope_id, name, justification = wt
+        links_by_work[work_id].append((trope_id, name, justification))
+
+    works = session.query(Work).order_by(Work.id).all()
+
+    works_data = [
+        _WorkData(
+            work_id=work.id,
+            genres=work.genres,
+            moods=work.moods,
+            deep_enriched_at=work.deep_enriched_at,
+            links=links_by_work.get(work.id, []),
+        )
+        for work in works
+    ]
+    bogus_targets_by_work = {work.id: bogus_targets(session, work, all_tropes_by_name) for work in works}
+
+    return _plan_from_data(works_data, all_tropes_by_id, bogus_targets_by_work)
+
+
+# --------------------------------------------------------------------------------------------
+# Op-tagged tokens (mirrors etl/dedup_backfill.py's plan_id_set/plan_delta EXACTLY — see that
+# module's docstring for why the op-tag prefix is load-bearing, not cosmetic: it turns an
+# operation flip on the same underlying id into a NEW token, so plan_delta's refuse-on-addition
+# policy catches it instead of a bare-id diff seeing "unchanged").
+# --------------------------------------------------------------------------------------------
+
+PLAN_TOKEN_CLASSES = ("delete_links", "write_slugs", "clear_stamps", "prune_tropes")
+
+
+def plan_tokens(plan: FallbackRepairPlan) -> dict[str, set[str]]:
+    """Every action the plan is 'about', per class, as an opaque op-tagged token string.
+    Composite identifiers are stringified as `<op>:<tuple-repr>` (not decomposed), same
+    convention as dedup_backfill.plan_id_set."""
+    out: dict[str, set[str]] = {name: set() for name in PLAN_TOKEN_CLASSES}
+    out["delete_links"].update(f"delete_link:{(d.work_id, d.trope_id)}" for d in plan.delete_links)
+    out["write_slugs"].update(f"write_slug:{(w.work_id, w.trope_name)}" for w in plan.write_slugs)
+    out["clear_stamps"].update(f"clear_stamp:{c.work_id}" for c in plan.clear_stamps)
+    out["prune_tropes"].update(f"prune_trope:{p.trope_id}" for p in plan.prune_tropes)
+    return out
+
+
+def plan_delta(reviewed: dict[str, set[str]], fresh: FallbackRepairPlan) -> dict[str, set[str]]:
+    """Per-class tokens present in the FRESH plan but NOT in the REVIEWED token set. Empty
+    everywhere means fresh's tokens are a subset of reviewed's (safe to apply); any non-empty
+    class means something new (including an operation flip on the same ids) appeared since the
+    operator reviewed the report."""
+    fresh_tokens = plan_tokens(fresh)
+    return {name: fresh_tokens.get(name, set()) - reviewed.get(name, set()) for name in PLAN_TOKEN_CLASSES}
+
+
+# --------------------------------------------------------------------------------------------
+# Report: human-readable + machine-readable token block, fail-closed parser (mirrors
+# scripts/clean_catalog.py's _write_dedup_report / _parse_plan_ids EXACTLY, including the
+# explicit END marker and the same three fail-closed ValueError cases).
+# --------------------------------------------------------------------------------------------
+
+
+def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None) -> Path:
+    """Every token in the plan, always written (dry-run AND apply) — this file is what the
+    operator reviews before approving --repair-fallbacks-apply (THE USER GATE). Microsecond
+    timestamp resolution, same collision-avoidance reasoning as _write_dedup_report."""
+    reports_dir = reports_dir or Path("data/reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    ts = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
+    path = reports_dir / f"fallback-repair-{ts}.txt"
+
+    lines: list[str] = [f"Fallback-repair plan report — {ts}", "=" * 60, ""]
+
+    lines.append(f"delete_links: {len(plan.delete_links)} links (NULL-justified, recomputed-bogus)")
+    for d in plan.delete_links:
+        lines.append(f"  work_id={d.work_id}  trope_id={d.trope_id}  trope_name={d.trope_name!r}")
+    lines.append("")
+
+    lines.append(f"write_slugs: {len(plan.write_slugs)} exact-name slug links to restore")
+    for w in plan.write_slugs:
+        lines.append(f"  work_id={w.work_id}  trope_name={w.trope_name!r}")
+    lines.append("")
+
+    lines.append(f"clear_stamps: {len(plan.clear_stamps)} works' deep_enriched_at to NULL")
+    for c in plan.clear_stamps:
+        lines.append(f"  work_id={c.work_id}")
+    lines.append("")
+
+    lines.append(f"prune_tropes: {len(plan.prune_tropes)} tropes left with zero links")
+    for p in plan.prune_tropes:
+        lines.append(f"  trope_id={p.trope_id}  trope_name={p.trope_name!r}")
+    lines.append("")
+
+    lines.append("== PLAN TOKENS ==")
+    tokens = plan_tokens(plan)
+    for class_name in PLAN_TOKEN_CLASSES:
+        class_tokens = sorted(tokens.get(class_name, set()))
+        lines.append(f"[{class_name}] {len(class_tokens)}")
+        lines.extend(class_tokens)
+    lines.append("== END PLAN TOKENS ==")
+    lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def parse_report(report_text: str) -> dict[str, set[str]]:
+    """Parse the '== PLAN TOKENS ==' block back into the same per-class token-set shape
+    plan_tokens produces. Fail-closed (explicit, tested contract, mirrors
+    scripts/clean_catalog.py._parse_plan_ids): raises ValueError if the start marker is
+    missing, if the '== END PLAN TOKENS ==' terminator is missing (truncated report), or if a
+    line that looks like a class header (starts with '[') doesn't actually parse as one."""
+    lines = report_text.splitlines()
+    try:
+        start = lines.index("== PLAN TOKENS ==")
+    except ValueError as exc:
+        raise ValueError(
+            "report has no '== PLAN TOKENS ==' section — not a fallback-repair report, or an old-format one"
+        ) from exc
+
+    try:
+        end = lines.index("== END PLAN TOKENS ==", start + 1)
+    except ValueError as exc:
+        raise ValueError("report has no '== END PLAN TOKENS ==' terminator — truncated or corrupt report") from exc
+
+    out: dict[str, set[str]] = {name: set() for name in PLAN_TOKEN_CLASSES}
+    current: str | None = None
+    for line in lines[start + 1 : end]:
+        if line.startswith("["):
+            if "]" not in line:
+                raise ValueError(f"malformed class-header line in PLAN TOKENS block: {line!r}")
+            current = line[1 : line.index("]")]
+            if current not in out:
+                out[current] = set()
+            continue
+        if current is not None and line:
+            out[current].add(line)
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Apply — THE USER GATE
+# --------------------------------------------------------------------------------------------
+
+
+def apply_fallback_repair(session: Session, reviewed_report_path: Path) -> dict[str, int]:
+    """--repair-fallbacks-apply is a SEPARATE invocation from the reviewed dry-run. Re-plans
+    FRESH against current DB state, parses the reviewed report's token set (fail-closed — see
+    parse_report), and REFUSES (raises ValueError, no partial writes — nothing is flushed
+    before the drift check completes) if the fresh plan contains ANY token absent from the
+    reviewed set. fresh_tokens ⊆ reviewed_tokens is fine (reported under skipped_stale, not
+    refused). Executes delete_link -> write_slug -> clear_stamp -> prune_trope in ONE
+    transaction (session.flush() between phases so later phases see earlier ones; the caller
+    owns commit/rollback via the session context manager, mirroring every other gated tool in
+    this package)."""
+    reviewed_tokens = parse_report(Path(reviewed_report_path).read_text(encoding="utf-8"))
+
+    fresh_plan = plan_fallback_repair(session)
+    delta = plan_delta(reviewed_tokens, fresh_plan)
+    if any(delta.values()):
+        details = ", ".join(f"{name}: +{len(tokens)}" for name, tokens in delta.items() if tokens)
+        raise ValueError(
+            f"REFUSING apply_fallback_repair: fresh plan drifted from the reviewed report ({details}). "
+            "Re-review a fresh report before applying."
+        )
+
+    from agentic_librarian.scouts.trope_manager import TropeManager
+
+    tm = TropeManager(session=session)
+
+    result = {
+        "delete_links": 0,
+        "write_slugs": 0,
+        "clear_stamps": 0,
+        "prune_tropes": 0,
+        "skipped_stale": 0,
+    }
+
+    for d in fresh_plan.delete_links:
+        wt = session.get(WorkTrope, {"work_id": d.work_id, "trope_id": d.trope_id})
+        if wt is None:
+            result["skipped_stale"] += 1
+            continue
+        session.delete(wt)
+        result["delete_links"] += 1
+    session.flush()
+
+    for w in fresh_plan.write_slugs:
+        if session.get(Work, w.work_id) is None:
+            result["skipped_stale"] += 1
+            continue
+        trope = tm.get_or_create_fallback_trope(w.trope_name)
+        existing_link = session.get(WorkTrope, {"work_id": w.work_id, "trope_id": trope.id})
+        if existing_link is not None:
+            result["skipped_stale"] += 1
+            continue
+        session.add(WorkTrope(work_id=w.work_id, trope_id=trope.id))
+        result["write_slugs"] += 1
+    session.flush()
+
+    for c in fresh_plan.clear_stamps:
+        work = session.get(Work, c.work_id)
+        if work is None or work.deep_enriched_at is None:
+            result["skipped_stale"] += 1
+            continue
+        work.deep_enriched_at = None
+        result["clear_stamps"] += 1
+    session.flush()
+
+    for p in fresh_plan.prune_tropes:
+        trope = session.get(Trope, p.trope_id)
+        if trope is None:
+            result["skipped_stale"] += 1
+            continue
+        # Recompute at apply time (the module docstring's contract for class 4): only prune if
+        # STILL zero-linked now, after the deletes above actually ran — never trust the plan
+        # snapshot's count alone.
+        remaining = session.query(WorkTrope).filter_by(trope_id=p.trope_id).count()
+        if remaining > 0:
+            result["skipped_stale"] += 1
+            continue
+        session.delete(trope)
+        result["prune_tropes"] += 1
+    session.flush()
+
+    return result

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -418,8 +418,12 @@ def persist_enriched_work(
             if row.get("write_fallback_tropes", True) and not has_real_trope:
                 for tag in all_fallback_tags:
                     for name in clean_trope_name(tag):
+                        # #70: fallback tags map by EXACT cleaned name only — never
+                        # standardize_trope's 0.85 semantic match, which is how mood tags like
+                        # "Dark" landed on real tropes ("The Dark Night of the Soul") and
+                        # flattened every user's trope fingerprint.
                         standardized_trope = _safe_standardize(
-                            trope_manager.standardize_trope, name, label=f"trope {name!r}"
+                            trope_manager.get_or_create_fallback_trope, name, label=f"trope {name!r}"
                         )
                         if standardized_trope is None:
                             continue

--- a/src/agentic_librarian/scouts/trope_manager.py
+++ b/src/agentic_librarian/scouts/trope_manager.py
@@ -61,3 +61,21 @@ class TropeManager:
         self.session.flush()  # Ensure ID is populated for the caller
         # We don't commit here, let the caller handle it or use a flush
         return new_trope
+
+    def get_or_create_fallback_trope(self, name: str) -> Trope:
+        """Exact-name-only get-or-create for genre/mood fallback tags (#70): NEVER a semantic
+        match — the 0.85 redirect is how mood tags like 'Dark' polluted real tropes
+        ('The Dark Night of the Soul'). The slug trope still gets an embedding so
+        genre/mood-as-trope matching keeps working; it just cannot land on a real trope."""
+        # 1. Exact Name Match (do NOT update description — this is a slug tag, not a scout trope)
+        existing = self.session.query(Trope).filter(Trope.name == name).first()
+        if existing:
+            return existing
+
+        # 2. Create New — no semantic-similarity step, mirrors standardize_trope's creation
+        # branch's flush discipline so the caller gets a populated id.
+        embedding = self._get_embedding(name)
+        new_trope = Trope(name=name, embedding=embedding)
+        self.session.add(new_trope)
+        self.session.flush()
+        return new_trope

--- a/test/integration/test_fallback_repair.py
+++ b/test/integration/test_fallback_repair.py
@@ -1,0 +1,210 @@
+"""PR-D part 2 (GH #70): the gated fallback-pollution repair backfill, e2e-shaped per
+CLAUDE.md rule 6 — the plan/report/apply round-trip is driven through the REAL functions
+(plan_fallback_repair -> write_report -> parse_report -> apply_fallback_repair), mirroring
+test/integration/test_dedup_backfill.py's apply-gate tests and test_fallback_prune.py's seeding
+style. Embeddings are stubbed deterministically (monkeypatch fallback_repair.get_cached_embedding)
+so cosine-distance classification is exact and reproducible without a live Gemini call."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import fallback_repair as fr
+from agentic_librarian.scouts import trope_manager as trope_manager_module
+
+pytestmark = pytest.mark.db_integration
+
+# Deterministic embedding space for these tests: "Dark"-derived vectors are cosine-IDENTICAL to
+# "The Dark Night of the Soul"'s (attractor A); "Grim"-derived vectors are cosine-IDENTICAL to
+# "Trial by Shadow"'s (attractor B) — TWO DISTINCT attractor clusters, each with its own trigger
+# mood tag, so a nearest-trope lookup for one mood can never ambiguously tie against the OTHER
+# attractor (two tropes at the exact same distance from a query vector is not how the real
+# pollution incident looks — every attractor is its own semantic cluster; a same-distance tie
+# would make "nearest" a Postgres row-order accident rather than a real classification).
+# Everything else gets an orthogonal-ish vector so it never accidentally satisfies
+# BOGUS_MATCH_THRESHOLD.
+_ATTRACTOR_A_VEC = [1.0] + [0.0] * 1535
+_ATTRACTOR_B_VEC = [0.0, 0.0, 1.0] + [0.0] * 1533
+_OTHER_VEC = [0.0, 1.0] + [0.0] * 1534
+_ATTRACTOR_VEC = _ATTRACTOR_A_VEC  # back-compat alias for the single-attractor tests below
+
+
+def _fake_embed(model_name, text_):
+    if text_ == "Dark":
+        return _ATTRACTOR_A_VEC
+    if text_ == "Grim":
+        return _ATTRACTOR_B_VEC
+    return _OTHER_VEC
+
+
+@pytest.fixture(autouse=True)
+def _stub_embeddings(monkeypatch):
+    # plan_fallback_repair's bogus_targets scan calls get_cached_embedding via
+    # etl/fallback_repair.py's own module-level binding; apply_fallback_repair's write_slug
+    # phase separately constructs a REAL TropeManager (get_or_create_fallback_trope), which
+    # calls get_cached_embedding via ITS OWN module-level binding
+    # (scouts/trope_manager.py) — both import sites must be patched, since `from x import y`
+    # binds a local name in each importing module's namespace rather than a shared reference.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    monkeypatch.setattr(fr, "get_cached_embedding", _fake_embed)
+    monkeypatch.setattr(trope_manager_module, "get_cached_embedding", _fake_embed)
+
+
+def _link(session, work, trope, *, justification=None):
+    session.add(WorkTrope(work_id=work.id, trope_id=trope.id, justification=justification))
+
+
+def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+        # work 1: polluted — mood "Dark" was semantically redirected onto the real trope "The
+        # Dark Night of the Soul" (NULL-justified). No other trope on this work -> tropeless
+        # after the delete -> gets exact-name slugs + a cleared deep_enriched_at stamp.
+        work1 = Work(
+            title="Polluted Work",
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        # work 2: shares the SAME attractor trope, but via a real justified scout link — must
+        # survive untouched.
+        work2 = Work(title="Justified Work", genres=[], moods=[])
+        session.add_all([work1, work2])
+        session.flush()
+
+        attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
+        session.add(attractor)
+        session.flush()
+
+        _link(session, work1, attractor, justification=None)  # bogus: NULL-justified + derivable
+        _link(session, work2, attractor, justification="scout: framed as a spiritual crisis arc")
+        session.flush()
+
+        # --- dry-run plan ---
+        plan = fr.plan_fallback_repair(session)
+        assert len(plan.delete_links) == 1
+        assert plan.delete_links[0].work_id == work1.id
+        assert plan.delete_links[0].trope_id == attractor.id
+        assert {s.trope_name for s in plan.write_slugs if s.work_id == work1.id} == {"Thriller", "Dark"}
+        assert [c.work_id for c in plan.clear_stamps] == [work1.id]
+        assert [p.trope_id for p in plan.prune_tropes] == []  # attractor still has work2's link
+
+        report_path = fr.write_report(plan)
+        reviewed_tokens = fr.parse_report(report_path.read_text(encoding="utf-8"))
+
+        # --- apply ---
+        applied = fr.apply_fallback_repair(session, report_path)
+        session.flush()
+
+        assert applied["delete_links"] == 1
+        assert applied["write_slugs"] == 2
+        assert applied["clear_stamps"] == 1
+        assert applied["prune_tropes"] == 0  # work2's justified link keeps the attractor alive
+
+        # work1: attractor link gone, exact-name slugs present, stamp cleared
+        work1_links = {
+            session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=work1.id).all()
+        }
+        assert work1_links == {"Thriller", "Dark"}
+        assert session.get(Work, work1.id).deep_enriched_at is None
+
+        # work2: untouched
+        work2_links = session.query(WorkTrope).filter_by(work_id=work2.id).all()
+        assert len(work2_links) == 1
+        assert work2_links[0].trope_id == attractor.id
+        assert work2_links[0].justification is not None
+
+        # --- convergence: re-plan finds nothing left to do ---
+        converged = fr.plan_fallback_repair(session)
+        assert converged.summary() == {"delete_links": 0, "write_slugs": 0, "clear_stamps": 0, "prune_tropes": 0}
+
+        # sanity: the report's own tokens matched what got applied (round-trip already proven
+        # elsewhere; this just confirms the fixture wiring produced a non-empty reviewed set)
+        assert reviewed_tokens["delete_links"]
+
+
+def test_drift_gate_refuses_and_changes_nothing(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+        work1 = Work(title="Drift Work 1", genres=[], moods=["Dark"])
+        session.add(work1)
+        session.flush()
+
+        attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
+        session.add(attractor)
+        session.flush()
+        _link(session, work1, attractor, justification=None)
+        session.flush()
+
+        reviewed_plan = fr.plan_fallback_repair(session)
+        report_path = fr.write_report(reviewed_plan)
+
+        # live traffic in the gap: a NEW bogus NULL-justified link appears on a second work,
+        # sharing the same attractor.
+        work2 = Work(title="Drift Work 2", genres=[], moods=["Dark"])
+        session.add(work2)
+        session.flush()
+        _link(session, work2, attractor, justification=None)
+        session.flush()
+
+        # snapshot state before the refused apply, to assert NOTHING changed
+        work_tropes_before = {(wt.work_id, wt.trope_id, wt.justification) for wt in session.query(WorkTrope).all()}
+        works_stamps_before = {w.id: w.deep_enriched_at for w in session.query(Work).all()}
+        tropes_before = {t.id for t in session.query(Trope).all()}
+
+        with pytest.raises(ValueError, match="drifted"):
+            fr.apply_fallback_repair(session, report_path)
+        session.flush()
+
+        work_tropes_after = {(wt.work_id, wt.trope_id, wt.justification) for wt in session.query(WorkTrope).all()}
+        works_stamps_after = {w.id: w.deep_enriched_at for w in session.query(Work).all()}
+        tropes_after = {t.id for t in session.query(Trope).all()}
+
+        assert work_tropes_after == work_tropes_before
+        assert works_stamps_after == works_stamps_before
+        assert tropes_after == tropes_before
+
+
+def test_prune_trope_deleted_when_all_links_bogus_kept_when_justified_link_survives(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+        # attractor A: only ever bogus-linked -> pruned after apply
+        attractor_a = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_A_VEC)
+        # attractor B: bogus-linked on one work, justified-linked on another -> survives. Its own
+        # distinct trigger tag ("Grim") keeps it from tying against attractor A's nearest-lookup.
+        attractor_b = Trope(name="Trial by Shadow", embedding=_ATTRACTOR_B_VEC)
+        session.add_all([attractor_a, attractor_b])
+        session.flush()
+
+        work_a = Work(title="Prune Target Work", genres=[], moods=["Dark"])
+        work_b1 = Work(title="Kept Attractor Work 1", genres=[], moods=["Grim"])
+        work_b2 = Work(title="Kept Attractor Work 2", genres=[], moods=[])
+        session.add_all([work_a, work_b1, work_b2])
+        session.flush()
+
+        _link(session, work_a, attractor_a, justification=None)
+        _link(session, work_b1, attractor_b, justification=None)
+        _link(session, work_b2, attractor_b, justification="scout: real narrative arc")
+        session.flush()
+
+        plan = fr.plan_fallback_repair(session)
+        report_path = fr.write_report(plan)
+
+        applied = fr.apply_fallback_repair(session, report_path)
+        session.flush()
+
+        assert applied["prune_tropes"] == 1
+        assert session.get(Trope, attractor_a.id) is None  # pruned: zero links remained
+        assert session.get(Trope, attractor_b.id) is not None  # kept: work_b2's justified link
+        remaining_b_links = session.query(WorkTrope).filter_by(trope_id=attractor_b.id).all()
+        assert len(remaining_b_links) == 1
+        assert remaining_b_links[0].work_id == work_b2.id

--- a/test/integration/test_fallback_repair.py
+++ b/test/integration/test_fallback_repair.py
@@ -74,7 +74,17 @@ def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
         # work 2: shares the SAME attractor trope, but via a real justified scout link — must
         # survive untouched.
         work2 = Work(title="Justified Work", genres=[], moods=[])
-        session.add_all([work1, work2])
+        # work 3 (Fix 1, deletion-triggered eligibility): a seeded TROPELESS work with its own
+        # genres/moods AND a deep_enriched_at stamp — the #67-pruned-fast-pass shape. It has ZERO
+        # work_tropes links, so plan_fallback_repair must plan NO delete_link, NO write_slug, and
+        # NO clear_stamp for it: this run never touched it, so it must never touch it back.
+        work3 = Work(
+            title="Fast-Pass Tropeless Work",
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        session.add_all([work1, work2, work3])
         session.flush()
 
         attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
@@ -83,6 +93,7 @@ def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
 
         _link(session, work1, attractor, justification=None)  # bogus: NULL-justified + derivable
         _link(session, work2, attractor, justification="scout: framed as a spiritual crisis arc")
+        # work3 gets NO links at all — see above.
         session.flush()
 
         # --- dry-run plan ---
@@ -93,6 +104,13 @@ def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
         assert {s.trope_name for s in plan.write_slugs if s.work_id == work1.id} == {"Thriller", "Dark"}
         assert [c.work_id for c in plan.clear_stamps] == [work1.id]
         assert [p.trope_id for p in plan.prune_tropes] == []  # attractor still has work2's link
+
+        # work3: the plan must be entirely silent about it — no delete_link (nothing to delete),
+        # no write_slug (never eligible — zero delete_links planned for it), no clear_stamp
+        # (same eligibility gate; its stamp is left alone).
+        assert all(d.work_id != work3.id for d in plan.delete_links)
+        assert all(w.work_id != work3.id for w in plan.write_slugs)
+        assert all(c.work_id != work3.id for c in plan.clear_stamps)
 
         report_path = fr.write_report(plan)
         reviewed_tokens = fr.parse_report(report_path.read_text(encoding="utf-8"))
@@ -118,6 +136,12 @@ def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
         assert len(work2_links) == 1
         assert work2_links[0].trope_id == attractor.id
         assert work2_links[0].justification is not None
+
+        # work3: STILL zero links, stamp UNTOUCHED — apply must not have re-added fallback slugs
+        # or cleared its stamp, even though it superficially "has no real trope" too.
+        work3_links = session.query(WorkTrope).filter_by(work_id=work3.id).all()
+        assert work3_links == []
+        assert session.get(Work, work3.id).deep_enriched_at == datetime(2026, 6, 1, tzinfo=UTC)
 
         # --- convergence: re-plan finds nothing left to do ---
         converged = fr.plan_fallback_repair(session)
@@ -159,9 +183,17 @@ def test_drift_gate_refuses_and_changes_nothing(db_url):
         works_stamps_before = {w.id: w.deep_enriched_at for w in session.query(Work).all()}
         tropes_before = {t.id for t in session.query(Trope).all()}
 
-        with pytest.raises(ValueError, match="drifted"):
+        with pytest.raises(fr.FallbackRepairDriftError, match="drifted") as exc_info:
             fr.apply_fallback_repair(session, report_path)
         session.flush()
+
+        # Minor 5: the refusal carries the offending delta TOKENS (not just counts) and a fresh
+        # report path written from the drifted plan, ready for immediate re-review.
+        new_delete_token = f"delete_link:{(work2.id, attractor.id)}"
+        assert new_delete_token in exc_info.value.delta["delete_links"]
+        assert exc_info.value.fresh_report_path.exists()
+        fresh_reviewable = fr.parse_report(exc_info.value.fresh_report_path.read_text(encoding="utf-8"))
+        assert new_delete_token in fresh_reviewable["delete_links"]
 
         work_tropes_after = {(wt.work_id, wt.trope_id, wt.justification) for wt in session.query(WorkTrope).all()}
         works_stamps_after = {w.id: w.deep_enriched_at for w in session.query(Work).all()}
@@ -170,6 +202,52 @@ def test_drift_gate_refuses_and_changes_nothing(db_url):
         assert work_tropes_after == work_tropes_before
         assert works_stamps_after == works_stamps_before
         assert tropes_after == tropes_before
+
+
+def test_skipped_stale_reports_shrinkage_when_fresh_is_subset_of_reviewed(db_url):
+    """Minor 4: fresh ⊂ reviewed (some reviewed rows were already applied/vanished by the time
+    of this apply) is NOT a drift refusal — it applies cleanly, and skipped_stale reports the
+    exact shrinkage: the reviewed tokens no longer present in the fresh plan."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+        work1 = Work(title="Shrinkage Work 1", genres=[], moods=["Dark"])
+        work2 = Work(title="Shrinkage Work 2", genres=[], moods=["Dark"])
+        session.add_all([work1, work2])
+        session.flush()
+
+        attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
+        session.add(attractor)
+        session.flush()
+        _link(session, work1, attractor, justification=None)
+        _link(session, work2, attractor, justification=None)
+        session.flush()
+
+        # reviewed report sees BOTH bogus links AND (Fix 1: each work has >=1 delete_link, so
+        # both are write_slug-eligible) the exact-name "Dark" slug restore for each work.
+        reviewed_plan = fr.plan_fallback_repair(session)
+        assert len(reviewed_plan.delete_links) == 2
+        assert len(reviewed_plan.write_slugs) == 2
+        report_path = fr.write_report(reviewed_plan)
+
+        # work2's bogus link is removed out-of-band before apply runs (simulating "already
+        # applied by someone else" / "the row is simply gone by apply time") — the fresh re-plan
+        # sees only work1's delete_link (a SUBSET of what was reviewed): work2 now has ZERO
+        # links, so Fix 1's eligibility gate also drops its reviewed write_slug token — TWO
+        # reviewed tokens (delete_link + write_slug) vanish for the one out-of-band change.
+        stale_link = session.query(WorkTrope).filter_by(work_id=work2.id, trope_id=attractor.id).one()
+        session.delete(stale_link)
+        session.flush()
+
+        applied = fr.apply_fallback_repair(session, report_path)
+        session.flush()
+
+        assert applied["delete_links"] == 1  # only work1's link actually got deleted
+        assert applied["write_slugs"] == 1  # only work1's "Dark" slug actually got written
+        # skipped_stale must account for BOTH vanished work2 tokens (delete_link + write_slug) —
+        # the shrinkage Minor 4 asks to be reported, not silently dropped.
+        assert applied["skipped_stale"] == 2
 
 
 def test_prune_trope_deleted_when_all_links_bogus_kept_when_justified_link_survives(db_url):

--- a/test/integration/test_persist_contributor_guard.py
+++ b/test/integration/test_persist_contributor_guard.py
@@ -11,6 +11,9 @@ class _NullManager:
     def standardize_trope(self, *a, **k):
         return None
 
+    def get_or_create_fallback_trope(self, *a, **k):
+        return None
+
     def standardize_style(self, *a, **k):
         return None
 

--- a/test/integration/test_persist_fallback_flag.py
+++ b/test/integration/test_persist_fallback_flag.py
@@ -8,18 +8,25 @@ pytestmark = pytest.mark.db_integration
 
 
 class _PassthroughTrope:
-    """standardize_trope returns an exact-name Trope (no embedding) so names are assertable."""
+    """standardize_trope/get_or_create_fallback_trope both return an exact-name Trope (no
+    embedding) so names are assertable."""
 
     def __init__(self, session):
         self.session = session
 
-    def standardize_trope(self, name, *a, **k):
+    def _get_or_create(self, name):
         t = self.session.query(Trope).filter_by(name=name).first()
         if t is None:
             t = Trope(name=name)
             self.session.add(t)
             self.session.flush()
         return t
+
+    def standardize_trope(self, name, *a, **k):
+        return self._get_or_create(name)
+
+    def get_or_create_fallback_trope(self, name, *a, **k):
+        return self._get_or_create(name)
 
     def standardize_style(self, *a, **k):
         return None

--- a/test/integration/test_persist_tag_cleaning.py
+++ b/test/integration/test_persist_tag_cleaning.py
@@ -18,6 +18,9 @@ class _NullManager:
     def standardize_trope(self, *a, **k):
         return None
 
+    def get_or_create_fallback_trope(self, *a, **k):
+        return None
+
     def standardize_style(self, *a, **k):
         return None
 

--- a/test/integration/test_persist_trope_guard.py
+++ b/test/integration/test_persist_trope_guard.py
@@ -1,8 +1,13 @@
+from unittest.mock import patch
+
 import pytest
+from sqlalchemy import text
 
 from agentic_librarian.db.models import Trope, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl.persist import persist_enriched_work
+from agentic_librarian.scouts.style_manager import StyleManager
+from agentic_librarian.scouts.trope_manager import TropeManager
 
 pytestmark = pytest.mark.db_integration
 
@@ -10,18 +15,30 @@ UUID = "4c14c349-8d52-4893-aaf0-34f7e33bf275"
 
 
 class _PassthroughTrope:
-    """standardize_trope returns an exact-name Trope (no embedding) so we can assert names."""
+    """standardize_trope/get_or_create_fallback_trope both return an exact-name Trope (no
+    embedding) so we can assert names; each call is recorded so tests can assert which method
+    the fallback vs. enriched branches actually dispatch to (#70)."""
 
     def __init__(self, session):
         self.session = session
+        self.standardize_trope_calls: list[str] = []
+        self.fallback_calls: list[str] = []
 
-    def standardize_trope(self, name, *a, **k):
+    def _get_or_create(self, name):
         t = self.session.query(Trope).filter_by(name=name).first()
         if t is None:
             t = Trope(name=name)
             self.session.add(t)
             self.session.flush()
         return t
+
+    def standardize_trope(self, name, *a, **k):
+        self.standardize_trope_calls.append(name)
+        return self._get_or_create(name)
+
+    def get_or_create_fallback_trope(self, name, *a, **k):
+        self.fallback_calls.append(name)
+        return self._get_or_create(name)
 
     def standardize_style(self, *a, **k):
         return None
@@ -45,3 +62,89 @@ def test_fallback_tropes_are_cleaned(db_url):
             session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=work.id).all()
         }
         assert names == {"Science Fiction", "Fantasy"}  # cleaned + split, NOT the raw slug
+
+
+def test_fallback_branch_dispatches_to_get_or_create_fallback_trope_not_standardize(db_url):
+    """#70: the fallback (genre/mood) branch must call get_or_create_fallback_trope — never
+    standardize_trope, whose 0.85 semantic match is the pollution mechanism."""
+    manager = DatabaseManager(db_url)
+    row = {
+        "Title": "Fallback Dispatch Test",
+        "Author_1": "T. Author",
+        "format": "ebook",
+        "genres": [f"science-fiction-fantasy-{UUID}"],
+        "moods": [],
+    }
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        persist_enriched_work(session, row, tm, tm)
+        session.flush()
+        assert set(tm.fallback_calls) == {"Science Fiction", "Fantasy"}
+        assert tm.standardize_trope_calls == []
+
+
+def test_enriched_branch_still_dispatches_to_standardize_trope(db_url):
+    """The real (scout-supplied) trope branch is unaffected — it must keep using
+    standardize_trope's semantic matching, not the new exact-name-only method."""
+    manager = DatabaseManager(db_url)
+    row = {
+        "Title": "Enriched Dispatch Test",
+        "Author_1": "T. Author",
+        "format": "ebook",
+        "enriched_tropes": [{"trope_name": "Chosen One", "justification": "x"}],
+        "genres": [],
+        "moods": [],
+    }
+    with manager.get_session() as session:
+        tm = _PassthroughTrope(session)
+        persist_enriched_work(session, row, tm, tm)
+        session.flush()
+        assert tm.standardize_trope_calls == ["Chosen One"]
+        assert tm.fallback_calls == []
+
+
+def test_fallback_tag_never_lands_on_a_real_semantically_close_trope(db_url, monkeypatch):
+    """#70 end-to-end regression: seed a real trope "The Dark Night of the Soul" with an
+    embedding, then persist a work whose only mood is "Dark" (no enriched tropes,
+    write_fallback_tropes=True) using an embedding stub that makes "Dark" cosine-IDENTICAL to
+    that real trope. Before the fix, persist's fallback branch called standardize_trope, whose
+    0.85 semantic match would land "Dark" on "The Dark Night of the Soul". After the fix, the
+    work's link must go to a NEW trope named exactly "Dark"."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    manager = DatabaseManager(db_url)
+    real_trope_embedding = [0.42] * 1536
+
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        real_trope = Trope(name="The Dark Night of the Soul", embedding=real_trope_embedding)
+        session.add(real_trope)
+        session.flush()
+        real_trope_id = real_trope.id  # capture before the session closes (DetachedInstanceError)
+        session.commit()
+
+    with manager.get_session() as session:
+        tm = TropeManager(session=session)
+        sm = StyleManager(session=session)
+        row = {
+            "Title": "Dark Fallback Collision Test",
+            "Author_1": "T. Author",
+            "format": "ebook",
+            "genres": [],
+            "moods": ["Dark"],
+            "write_fallback_tropes": True,
+        }
+        # Every embed call (including the real trope's own re-embed, which never happens here
+        # since it's pre-seeded) returns the SAME vector as the real trope's, so a semantic
+        # (cosine) match would be a guaranteed hit if the fallback path used standardize_trope.
+        with patch.object(TropeManager, "_get_embedding", return_value=real_trope_embedding):
+            work = persist_enriched_work(session, row, tm, sm)
+            session.flush()
+
+        linked_names = {
+            session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=work.id).all()
+        }
+        assert linked_names == {"Dark"}
+        assert "The Dark Night of the Soul" not in linked_names
+
+        dark_trope = session.query(Trope).filter_by(name="Dark").one()
+        assert dark_trope.id != real_trope_id

--- a/test/unit/test_clean_catalog_repair_fallbacks_cli.py
+++ b/test/unit/test_clean_catalog_repair_fallbacks_cli.py
@@ -1,0 +1,107 @@
+"""CLI-level guard tests for --repair-fallbacks-apply (GH #70, PR-D part 2) — mirrors
+test_clean_catalog_prune_cli.py's structure. The planner/report/apply mechanics themselves are
+covered by test/unit/test_fallback_repair.py (pure) and test/integration/test_fallback_repair.py
+(db_integration); this file is about the CLI's own --yes / prod-url / --report guards."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def query(self, *a, **k):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def filter_by(self, *a, **k):
+        return self
+
+    def distinct(self):
+        return self
+
+    def all(self):
+        return []
+
+    def count(self):
+        return 0
+
+    def scalar(self):
+        return 0
+
+    def __iter__(self):
+        return iter([])
+
+
+def _patch_db(monkeypatch, *, url="postgresql://u:p@prod-host/db"):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: url)
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda db_url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+
+
+@pytest.mark.parametrize(
+    "argv, expected_rc, expected_message",
+    [
+        (
+            ["--repair-fallbacks-apply", "--report", "data/reports/fake.txt"],
+            2,
+            "REFUSING --repair-fallbacks-apply without --yes",
+        ),
+        (
+            ["--repair-fallbacks-apply", "--yes"],
+            1,
+            "REFUSING --repair-fallbacks-apply: --report is required",
+        ),
+    ],
+    ids=["missing_yes", "missing_report"],
+)
+def test_repair_fallbacks_apply_refused(monkeypatch, capsys, argv, expected_rc, expected_message):
+    _patch_db(monkeypatch)
+    rc = clean_catalog.main(argv)
+    assert rc == expected_rc
+    assert expected_message in capsys.readouterr().out
+
+
+def test_repair_fallbacks_apply_refused_on_non_prod_url(monkeypatch, capsys, tmp_path):
+    _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
+    report = tmp_path / "fallback-repair-fake.txt"
+    report.write_text("== PLAN TOKENS ==\n== END PLAN TOKENS ==\n", encoding="utf-8")
+    rc = clean_catalog.main(["--repair-fallbacks-apply", "--yes", "--report", str(report)])
+    assert rc == 2
+    assert "REFUSING --repair-fallbacks-apply: 'localhost/db' is not a live prod DB" in capsys.readouterr().out
+
+
+def test_repair_fallbacks_dry_run_never_applies(monkeypatch, capsys, tmp_path):
+    """--repair-fallbacks (no --apply variant exists for this flag) always writes a report and
+    returns 0 without needing --yes or a prod URL — it's read-only by construction. plan
+    construction itself does real SQLAlchemy query-building (order_by/join) — stub it, same as
+    test_clean_catalog_prune_cli.py stubs plan_fallback_prune; this test is only about the CLI's
+    report-write/return-0 wiring."""
+    _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
+    monkeypatch.setattr(clean_catalog.fallback_repair, "warm_fallback_repair_texts", lambda session: [])
+    monkeypatch.setattr(
+        clean_catalog.fallback_repair,
+        "plan_fallback_repair",
+        lambda session: clean_catalog.fallback_repair.FallbackRepairPlan(),
+    )
+    monkeypatch.chdir(tmp_path)
+    rc = clean_catalog.main(["--repair-fallbacks"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repair-fallbacks plan" in out
+    assert (tmp_path / "data" / "reports").exists()

--- a/test/unit/test_fallback_repair.py
+++ b/test/unit/test_fallback_repair.py
@@ -261,14 +261,30 @@ def _sample_plan() -> FallbackRepairPlan:
     )
 
 
-def test_token_round_trip_format_parse_equal(tmp_path):
+@pytest.mark.parametrize(
+    "db_target",
+    [None, "…@prod-host/shelfwright"],
+    ids=["no_db_target", "with_db_target_header"],
+)
+def test_token_round_trip_format_parse_equal(tmp_path, db_target):
+    """The optional `db target: ...` header (final whole-branch review fix, DB-target
+    visibility) is written ABOVE the '== PLAN TOKENS ==' block as a plain human-readable
+    line — parse_report's fail-closed parser only looks between the start/end markers, so
+    the header must never appear in (or otherwise corrupt) the parsed token set."""
     plan = _sample_plan()
     expected = plan_tokens(plan)
 
-    report_path = write_report(plan, reports_dir=tmp_path)
-    parsed = parse_report(report_path.read_text(encoding="utf-8"))
+    report_path = write_report(plan, reports_dir=tmp_path, db_target=db_target)
+    report_text = report_path.read_text(encoding="utf-8")
+    parsed = parse_report(report_text)
 
     assert parsed == expected
+    if db_target is not None:
+        assert f"db target: {db_target}" in report_text.splitlines()
+        # the header line must land before the token block, never inside it
+        header_line_idx = report_text.splitlines().index(f"db target: {db_target}")
+        token_start_idx = report_text.splitlines().index("== PLAN TOKENS ==")
+        assert header_line_idx < token_start_idx
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_fallback_repair.py
+++ b/test/unit/test_fallback_repair.py
@@ -81,6 +81,63 @@ def test_exact_name_slug_never_a_bogus_target_by_construction():
     assert plan.delete_links == []
 
 
+class TestDeletionTriggeredEligibility:
+    """Fix 1 (adjudicated design change, review pass 2): write_slug/clear_stamp are eligible
+    ONLY for a work that has >=1 delete_link planned. Without this gate a zero-link work or an
+    untouched legitimately-stamped work would also qualify by the old 'no real trope survives'
+    test alone."""
+
+    def test_zero_link_work_gets_no_write_slug_or_clear_stamp(self):
+        """A work with ZERO pre-existing trope links (never touched by the old fallback writer)
+        must not get write_slug/clear_stamp planned — that would re-add fallback tropes the #67
+        prune deliberately removed from fast-pass works."""
+        work = _work(
+            links=[],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {}, {work.work_id: set()})
+
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+
+    def test_linkless_and_stamped_work_untouched(self):
+        """A work with zero links but a deep_enriched_at stamp (a legitimately-stamped
+        confirmed-empty work the #97 sweep already knows about) must be left entirely alone —
+        no write_slug, no clear_stamp, no delete_link. Clearing its stamp would erase the
+        sweep's repeat-cost signal for a work this run never touched."""
+        work = _work(
+            links=[],
+            genres=[],
+            moods=[],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {}, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+
+    def test_work_with_only_justified_links_and_no_bogus_targets_untouched(self):
+        """A work with real (justified) links and no bogus targets plans no delete_link, so it
+        must not become eligible for write_slug/clear_stamp either, even though has_real_remaining
+        would still be True here anyway — this asserts the eligibility gate specifically, not
+        just the pre-existing has_real_remaining behavior."""
+        real_trope_id = uuid4()
+        work = _work(
+            links=[(real_trope_id, "Found Family", "scout")],
+            genres=["Thriller"],
+            moods=[],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {real_trope_id: "Found Family"}, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+
+
 class TestWriteSlugAndClearStamp:
     def test_write_slug_planned_when_no_real_trope_remains(self):
         bogus_trope_id = uuid4()

--- a/test/unit/test_fallback_repair.py
+++ b/test/unit/test_fallback_repair.py
@@ -1,0 +1,306 @@
+"""Pure-logic unit tests for etl/fallback_repair.py (PR-D part 2, GH #70): the classification
+core (_plan_from_data), op-tagged token round-trip, fail-closed report parsing, and the
+apply-gate's drift-refusal contract — all exercised WITHOUT a live Postgres session (that's the
+db_integration suite's job, test/integration/test_fallback_repair.py)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.etl.fallback_repair import (
+    ClearStamp,
+    DeleteLink,
+    FallbackRepairPlan,
+    PruneTrope,
+    WriteSlug,
+    _plan_from_data,
+    _WorkData,
+    parse_report,
+    plan_delta,
+    plan_tokens,
+    write_report,
+)
+
+# --------------------------------------------------------------------------------------------
+# Classification: bogus vs legitimate (_plan_from_data)
+# --------------------------------------------------------------------------------------------
+
+
+def _work(links, genres=None, moods=None, deep_enriched_at=None, work_id=None):
+    return _WorkData(
+        work_id=work_id or uuid4(),
+        genres=genres or [],
+        moods=moods or [],
+        deep_enriched_at=deep_enriched_at,
+        links=links,
+    )
+
+
+@pytest.mark.parametrize(
+    "case_name, justification, is_bogus_target, expect_delete",
+    [
+        ("null_justified_bogus_target_deleted", None, True, True),
+        ("justified_link_never_touched_even_if_bogus_target", "scout said so", True, False),
+        ("null_justified_not_a_bogus_target_never_touched", None, False, False),
+    ],
+)
+def test_delete_link_classification(case_name, justification, is_bogus_target, expect_delete):
+    """The distinguisher: NULL justification AND membership in bogus_targets(work) are BOTH
+    required. A justified link is never touched even when it happens to coincide with a
+    recomputed semantic-fallback target; a NULL-justified link whose trope is NOT derivable
+    from this work's tags (real scout NULL-justification, e.g. semantic-collapse attractors) is
+    never touched either."""
+    trope_id = uuid4()
+    work = _work(
+        links=[(trope_id, "The Dark Night of the Soul", justification)],
+        genres=["Fantasy"],
+        moods=["Dark"],
+    )
+    targets = {trope_id} if is_bogus_target else set()
+
+    plan = _plan_from_data([work], {trope_id: "The Dark Night of the Soul"}, {work.work_id: targets})
+
+    deleted_trope_ids = {d.trope_id for d in plan.delete_links}
+    assert (trope_id in deleted_trope_ids) is expect_delete
+
+
+def test_exact_name_slug_never_a_bogus_target_by_construction():
+    """bogus_targets (the session-touching half, tested in the db_integration suite) never adds
+    an exact-name-match trope to its result — this is enforced structurally by
+    _nearest_trope_by_name returning None on an exact match before any embedding/distance
+    lookup happens. Here we assert the classification core's contract: if bogus_targets_by_work
+    reports NO targets for a work (the exact-name-match outcome), no delete is planned even for
+    a NULL-justified link."""
+    trope_id = uuid4()
+    work = _work(links=[(trope_id, "Fantasy", None)], genres=["Fantasy"], moods=[])
+
+    plan = _plan_from_data([work], {trope_id: "Fantasy"}, {work.work_id: set()})
+
+    assert plan.delete_links == []
+
+
+class TestWriteSlugAndClearStamp:
+    def test_write_slug_planned_when_no_real_trope_remains(self):
+        bogus_trope_id = uuid4()
+        work = _work(
+            links=[(bogus_trope_id, "The Dark Night of the Soul", None)],
+            genres=["Thriller"],
+            moods=["Dark"],
+        )
+        plan = _plan_from_data([work], {bogus_trope_id: "The Dark Night of the Soul"}, {work.work_id: {bogus_trope_id}})
+
+        slug_names = {s.trope_name for s in plan.write_slugs if s.work_id == work.work_id}
+        assert slug_names == {"Thriller", "Dark"}
+
+    def test_no_write_slug_when_real_trope_survives(self):
+        real_trope_id = uuid4()
+        work = _work(
+            links=[(real_trope_id, "Found Family", "scout justification")],
+            genres=["Thriller"],
+            moods=["Dark"],
+        )
+        plan = _plan_from_data([work], {real_trope_id: "Found Family"}, {work.work_id: set()})
+
+        assert plan.write_slugs == []
+
+    def test_no_duplicate_slug_for_already_linked_exact_name(self):
+        """A work that already carries an exact-name 'Thriller' slug link (untouched, real=False
+        but not planned for deletion) must not get a second write_slug for the same name."""
+        bogus_trope_id = uuid4()
+        existing_slug_id = uuid4()
+        work = _work(
+            links=[
+                (bogus_trope_id, "The Dark Night of the Soul", None),
+                (existing_slug_id, "Thriller", None),  # exact-name slug already present
+            ],
+            genres=["Thriller"],
+            moods=["Dark"],
+        )
+        plan = _plan_from_data(
+            [work],
+            {bogus_trope_id: "The Dark Night of the Soul", existing_slug_id: "Thriller"},
+            {work.work_id: {bogus_trope_id}},
+        )
+
+        slug_names = {s.trope_name for s in plan.write_slugs}
+        assert slug_names == {"Dark"}
+
+    def test_clear_stamp_planned_when_no_real_trope_and_stamped(self):
+        bogus_trope_id = uuid4()
+        work = _work(
+            links=[(bogus_trope_id, "The Dark Night of the Soul", None)],
+            genres=[],
+            moods=["Dark"],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {bogus_trope_id: "The Dark Night of the Soul"}, {work.work_id: {bogus_trope_id}})
+
+        assert [c.work_id for c in plan.clear_stamps] == [work.work_id]
+
+    def test_no_clear_stamp_when_not_stamped(self):
+        bogus_trope_id = uuid4()
+        work = _work(
+            links=[(bogus_trope_id, "The Dark Night of the Soul", None)],
+            genres=[],
+            moods=["Dark"],
+            deep_enriched_at=None,
+        )
+        plan = _plan_from_data([work], {bogus_trope_id: "The Dark Night of the Soul"}, {work.work_id: {bogus_trope_id}})
+
+        assert plan.clear_stamps == []
+
+    def test_no_clear_stamp_when_real_trope_survives(self):
+        real_trope_id = uuid4()
+        work = _work(
+            links=[(real_trope_id, "Found Family", "scout")],
+            genres=[],
+            moods=[],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {real_trope_id: "Found Family"}, {work.work_id: set()})
+
+        assert plan.clear_stamps == []
+
+
+class TestPruneTrope:
+    def test_pruned_when_all_links_deleted(self):
+        trope_id = uuid4()
+        w1 = _work(links=[(trope_id, "The Dark Night of the Soul", None)], genres=[], moods=["Dark"])
+        w2 = _work(links=[(trope_id, "The Dark Night of the Soul", None)], genres=[], moods=["Dark"])
+        plan = _plan_from_data(
+            [w1, w2],
+            {trope_id: "The Dark Night of the Soul"},
+            {w1.work_id: {trope_id}, w2.work_id: {trope_id}},
+        )
+
+        assert [p.trope_id for p in plan.prune_tropes] == [trope_id]
+
+    def test_not_pruned_when_a_justified_link_survives(self):
+        trope_id = uuid4()
+        w1 = _work(links=[(trope_id, "The Dark Night of the Soul", None)], genres=[], moods=["Dark"])
+        w2 = _work(links=[(trope_id, "The Dark Night of the Soul", "scout justification")], genres=[], moods=[])
+        plan = _plan_from_data(
+            [w1, w2],
+            {trope_id: "The Dark Night of the Soul"},
+            {w1.work_id: {trope_id}, w2.work_id: set()},
+        )
+
+        assert plan.prune_tropes == []
+
+
+# --------------------------------------------------------------------------------------------
+# Op-tagged token round-trip (format -> parse -> equal; fail-closed parser)
+# --------------------------------------------------------------------------------------------
+
+
+def _sample_plan() -> FallbackRepairPlan:
+    return FallbackRepairPlan(
+        delete_links=[DeleteLink(work_id=uuid4(), trope_id=uuid4(), trope_name="The Dark Night of the Soul")],
+        write_slugs=[WriteSlug(work_id=uuid4(), trope_name="Dark")],
+        clear_stamps=[ClearStamp(work_id=uuid4())],
+        prune_tropes=[PruneTrope(trope_id=uuid4(), trope_name="The Dark Night of the Soul")],
+    )
+
+
+def test_token_round_trip_format_parse_equal(tmp_path):
+    plan = _sample_plan()
+    expected = plan_tokens(plan)
+
+    report_path = write_report(plan, reports_dir=tmp_path)
+    parsed = parse_report(report_path.read_text(encoding="utf-8"))
+
+    assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    "mutate, match",
+    [
+        (lambda lines: [line for line in lines if line != "== PLAN TOKENS =="], "PLAN TOKENS"),
+        (lambda lines: [line for line in lines if line != "== END PLAN TOKENS =="], "END PLAN TOKENS"),
+        (
+            lambda lines: [("[delete_links 3" if line.startswith("[delete_links") else line) for line in lines],
+            "malformed class-header",
+        ),
+    ],
+    ids=["missing_start_marker", "missing_end_marker", "malformed_header_line"],
+)
+def test_parse_report_fails_closed(tmp_path, mutate, match):
+    plan = _sample_plan()
+    report_path = write_report(plan, reports_dir=tmp_path)
+    lines = report_path.read_text(encoding="utf-8").splitlines()
+    corrupted = "\n".join(mutate(lines))
+
+    with pytest.raises(ValueError, match=match):
+        parse_report(corrupted)
+
+
+# --------------------------------------------------------------------------------------------
+# Drift refusal (plan_delta)
+# --------------------------------------------------------------------------------------------
+
+
+def test_plan_delta_identical_plans_is_empty():
+    plan = _sample_plan()
+    reviewed = plan_tokens(plan)
+
+    delta = plan_delta(reviewed, plan)
+
+    assert all(len(v) == 0 for v in delta.values())
+
+
+def test_plan_delta_extra_token_in_fresh_plan_is_flagged():
+    reviewed_plan = _sample_plan()
+    reviewed = plan_tokens(reviewed_plan)
+
+    fresh_plan = FallbackRepairPlan(
+        delete_links=list(reviewed_plan.delete_links),
+        write_slugs=[*reviewed_plan.write_slugs, WriteSlug(work_id=uuid4(), trope_name="Extra Slug")],
+        clear_stamps=list(reviewed_plan.clear_stamps),
+        prune_tropes=list(reviewed_plan.prune_tropes),
+    )
+
+    delta = plan_delta(reviewed, fresh_plan)
+
+    assert delta["write_slugs"] != set()
+    assert all(len(delta[k]) == 0 for k in delta if k != "write_slugs")
+
+
+def test_plan_delta_op_flip_on_same_row_is_flagged():
+    """The reviewed report named this (work_id, trope_id) as a delete_link; the fresh plan
+    (e.g. a concurrent write moved it) instead names it as prune_trope-relevant deletion — an
+    operation flip on the same underlying ids must NOT diff as 'unchanged' just because the raw
+    ids overlap. Simulated here by reviewing a delete_link for a pair and having the fresh plan
+    contain a DIFFERENT op-tagged token touching the same trope_id (prune_trope), which the
+    bare-id-unaware token scheme correctly treats as new."""
+    trope_id = uuid4()
+    work_id = uuid4()
+    reviewed_plan = FallbackRepairPlan(
+        delete_links=[DeleteLink(work_id=work_id, trope_id=trope_id, trope_name="The Dark Night of the Soul")]
+    )
+    reviewed = plan_tokens(reviewed_plan)
+
+    # Fresh plan: the delete_link is gone (e.g. already applied or link vanished) but a NEW
+    # prune_trope token for the same trope_id now appears — a flip in what's about to happen to
+    # this id that a bare-id comparison would miss entirely.
+    fresh_plan = FallbackRepairPlan(
+        prune_tropes=[PruneTrope(trope_id=trope_id, trope_name="The Dark Night of the Soul")]
+    )
+
+    delta = plan_delta(reviewed, fresh_plan)
+
+    assert delta["prune_tropes"] == {f"prune_trope:{trope_id}"}
+
+
+def test_plan_delta_fresh_subset_of_reviewed_is_empty():
+    """fresh ⊂ reviewed (some reviewed rows vanished/were already applied) is fine — no refusal,
+    handled as ordinary skipped_stale at apply time, not a drift."""
+    reviewed_plan = _sample_plan()
+    reviewed = plan_tokens(reviewed_plan)
+
+    fresh_plan = FallbackRepairPlan()  # everything vanished since review
+
+    delta = plan_delta(reviewed, fresh_plan)
+
+    assert all(len(v) == 0 for v in delta.values())

--- a/test/unit/test_trope_manager.py
+++ b/test/unit/test_trope_manager.py
@@ -97,3 +97,63 @@ def test_trope_manager_missing_api_key():
         pytest.raises(ValueError, match="Google API key not set for TropeManager."),
     ):
         TropeManager(session=MagicMock())
+
+
+@pytest.mark.parametrize(
+    "existing_tropes,expected_name",
+    [
+        # Case 1: exact-name hit returns the existing trope, no new row created.
+        ([Trope(name="Dark", embedding=[0.1, 0.2, 0.3])], "Dark"),
+    ],
+)
+def test_get_or_create_fallback_trope_exact_hit(trope_manager, existing_tropes, expected_name):
+    mock_query = trope_manager.session.query.return_value
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = existing_tropes[0]
+
+    result = trope_manager.get_or_create_fallback_trope("Dark")
+
+    assert result is existing_tropes[0]
+    assert result.name == expected_name
+    trope_manager.session.add.assert_not_called()
+
+
+def test_get_or_create_fallback_trope_miss_never_semantically_redirects(trope_manager, mock_genai_client):
+    """The anti-#70 assertion: even when a semantically-near trope exists (mocked here to
+    guarantee a would-be >=0.85 cosine match via find_similar_trope), get_or_create_fallback_trope
+    must NEVER return it — only an exact-name match may short-circuit creation."""
+    mock_response = MagicMock()
+    mock_response.embeddings = [MagicMock(values=[0.5] * 1536)]
+    mock_genai_client.models.embed_content.return_value = mock_response
+
+    near_trope = Trope(name="The Dark Night of the Soul", embedding=[0.5] * 1536)
+
+    # Exact-name lookup misses.
+    mock_query = trope_manager.session.query.return_value
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = None
+
+    # Even if find_similar_trope WOULD find a near match, get_or_create_fallback_trope must
+    # never call it — patch it to prove it's not consulted at all.
+    with patch.object(trope_manager, "find_similar_trope", return_value=near_trope) as mock_find_similar:
+        result = trope_manager.get_or_create_fallback_trope("Dark")
+
+    mock_find_similar.assert_not_called()
+    assert result is not near_trope
+    assert result.name == "Dark"
+    trope_manager.session.add.assert_called_once()
+    trope_manager.session.flush.assert_called_once()
+
+
+def test_get_or_create_fallback_trope_does_not_update_description(trope_manager):
+    """Unlike standardize_trope, the exact-name hit path never touches description (brief:
+    'do NOT update description')."""
+    existing = Trope(name="Cozy", embedding=[0.1, 0.2, 0.3], description=None)
+    mock_query = trope_manager.session.query.return_value
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = existing
+
+    result = trope_manager.get_or_create_fallback_trope("Cozy")
+
+    assert result is existing
+    assert existing.description is None


### PR DESCRIPTION
Closes #70 (PR-D of 4 — spec: `docs/superpowers/specs/2026-07-14-recommendation-quality-design.md`; rediagnosis evidence in the [#70 comment](https://github.com/jaydee829/shelfwright/issues/70#issuecomment-4969472837)). Independent of #134/#135/#136 by files; merge order doesn't matter for code, but see the operator sequence below.

## What

#70's dominant mechanism (prod-verified): the genre/mood fallback writer pushed tags like `Dark`/`Reflective`/`Romance` through `standardize_trope`'s 0.85 semantic match, landing them on real dramatic tropes (91 of "The Dark Night of the Soul"'s 105 links are this) and flattening every user's trope fingerprint. Two parts:

**1. Write path (`d7e7d83`):** fallback tags now get-or-create an **exact-name slug trope** (`TropeManager.get_or_create_fallback_trope`) — still embedded, so genre/mood-as-trope matching keeps working, but never redirected onto a real trope. Semantic standardization remains scout-tags-only. All 8 `standardize_trope`/`clean_trope_name` call sites swept and classified in review.

**2. Gated repair tool (`ee21df0` + review hardening):** `scripts/clean_catalog.py --repair-fallbacks` (dry-run report) / `--repair-fallbacks-apply --report <path>`. The distinguisher is a deterministic **recompute** of what the old writer would have produced from each work's genres∪moods (structural, per the #69 rule — never `justification IS NULL` alone). Four op-tagged action classes: `delete_link` (NULL-justified + semantically re-derivable), `write_slug` / `clear_stamp` (**deletion-triggered only** — works the tool didn't strip are never touched, so the #67 fast-pass prune isn't reversed and confirmed-empty stamps survive), `prune_trope` (zero links left). Apply re-plans fresh and **refuses on any drift** (op-flip = new token, fail-closed parser, END marker, refusal writes a fresh report and nothing else) in one transaction. Report records the DB target it was planned against.

## Operator sequence (binding, from the adversarial review)

1. **Merge + deploy this PR first, then run the repair.** A bogus link minted mid-apply by still-serving old writer code survives and becomes permanently invisible to re-runs (fail-safe under-delete, but it never converges away). Deploying first closes the window.
2. Dry-run → review the report (every `delete_link` is listed; the documented residual: a real scout link that is NULL-justified AND coincides with a recomputed fallback target gets classified bogus) → apply with that exact report. Expected shape from prod evidence: ~300-400 link deletes (Dark Night alone ~91), slug writes + stamp clears on the fallback-only works (e.g. *Lessons in Chemistry*).
3. `skipped_stale` note: one out-of-band-vanished link can retract **2** tokens (the delete + its coupled `write_slug`) — expected, not drift.
4. After apply: the #97 `--requeue-unenriched` sweep picks up the newly-unstamped works + the ~196 never-deep-enriched wishlist works (owner-approved policy; cost estimate to be presented before that run).

## Interaction with #134/#135/#136 (verified end-state)

Slug links are NULL-justified by design: PR-C's justified-only preference filter keeps them OUT of taste profiles, while PR-A's retrieval (no justification filter) still finds works through them. Works stay retrievable; profiles stay clean.

## Tests

TDD throughout; 28 unit tests (classification table incl. the real-scout-NULL-justification protection, token round-trip, fail-closed parser, drift/op-flip refusal, deletion-trigger gating) + 4 e2e-shaped db_integration tests (full dry-run→apply→convergence round-trip, drift-gate-refuses-and-changes-NOTHING, prune classes, tropeless-work non-touch) — **executed against real local Postgres**, not just collected. Full unit suite green modulo the 5 known env-dependent failures (stash-verified).

Follow-up filed from review: #137 (pre-existing concurrent trope-create race silently drops links in the import path; the repair apply path fails loud and is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
