### PR TITLE
feat(etl): repair resets works with zero justified links

### DIFF
--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -245,6 +245,9 @@ def _run_repair_fallbacks(manager: DatabaseManager, safe: str) -> int:
         print("--- prune_tropes samples ---")
         for p in plan.prune_tropes[:10]:
             print(f"  trope={p.trope_id}  ({p.trope_name!r})")
+        print("--- reset (no-evidence) works samples ---")
+        for r in plan.reset_works[:10]:
+            print(f"  work={r.work_id}  title={r.title!r}")
 
         report_path = fallback_repair.write_report(plan, db_target=safe)
         print(f"\nfull plan (every token) written to {report_path} — review this before approving --apply.")

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -51,6 +51,31 @@ converges away on its own, no matter how many times the repair is re-run. The on
 ordering: land and deploy the fixed writer FIRST, confirm it is actually serving (not mid-rollout)
 THEN run --repair-fallbacks / --repair-fallbacks-apply.
 
+RESET-NO-EVIDENCE (#70 follow-up, owner-approved 2026-07-14): a work whose EVERY trope link is
+NULL-justified has no deep-scout evidence at all. The per-link structural distinguisher above
+(bogus_targets) only catches links that are a deterministic recompute of THIS work's own
+genres/moods — a non-derivable junk residue link (e.g. a stray "Comics Graphic Novels" tag that
+isn't a semantic match for anything on the work) survives it, reads as a "real" trope to
+has_real_remaining, and therefore permanently blocks write_slug/clear_stamp — leaving the work
+stamped, junk-fingerprinted, and invisible to the #97 requeue sweep forever (25 such works found
+on prod, e.g. Lessons in Chemistry, several Rivers of London/Expanse volumes). The fix is a
+SECOND, work-level trigger, deliberately NOT the #69 trap (classifying an individual link as
+real-vs-fallback by justification alone, which the #69 lesson forbids because many real scout
+tropes ARE NULL-justified "semantic collapse" attractors — trope_predicate.py's docstring):
+the signal here is not per-link but "this work has NO evidence-bearing link at all" — checked
+catalog-wide, every deep-scout link that DOES carry justification does so reliably (6247/6247),
+so a work with >=1 link and ZERO justified links is a work the deep scout never actually
+vouched for anything on. When that holds, EVERY one of the work's (necessarily NULL-just) links
+is planned for deletion regardless of bogus_targets membership, and the pre-existing
+deletion-triggered write_slug/clear_stamp classes below fire for it unchanged (a delete is a
+delete — same token format whichever trigger planned it). The trigger structurally cannot touch
+#67's zero-link works (it requires >=1 link) or a work with even one justified link (the
+justified-link co-condition on the ORIGINAL per-link trigger already protects those; this new
+trigger adds its own explicit "zero justified links" gate on top). The affected work list is
+always in the dry-run report (see write_report's 'reset (no-evidence) works' section) for the
+operator to review before approving --apply, and the operation is recoverable: the #97 sweep
+re-enriches any work whose stamp this clears.
+
 Four action classes, one plan (mirrors etl/dedup_backfill.py's op-tagged token gate EXACTLY —
 see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmetic):
 
@@ -153,11 +178,23 @@ class PruneTrope:
 
 
 @dataclass
+class ResetWork:
+    """One work caught by the zero-justified-links reset trigger (#70 follow-up): informational
+    only, for write_report's human-readable section — NOT part of the op-tagged token block (a
+    reset work's links are already individually represented as delete_link tokens; this is a
+    derived, report-only view grouping them by work for the operator)."""
+
+    work_id: UUID
+    title: str
+
+
+@dataclass
 class FallbackRepairPlan:
     delete_links: list[DeleteLink] = field(default_factory=list)
     write_slugs: list[WriteSlug] = field(default_factory=list)
     clear_stamps: list[ClearStamp] = field(default_factory=list)
     prune_tropes: list[PruneTrope] = field(default_factory=list)
+    reset_works: list[ResetWork] = field(default_factory=list)
 
     def summary(self) -> dict[str, int]:
         return {
@@ -165,6 +202,7 @@ class FallbackRepairPlan:
             "write_slugs": len(self.write_slugs),
             "clear_stamps": len(self.clear_stamps),
             "prune_tropes": len(self.prune_tropes),
+            "reset_works": len(self.reset_works),
         }
 
 
@@ -261,6 +299,7 @@ class _WorkData:
     deep_enriched_at: object | None  # only ever compared to None; type left loose for callers
     # (trope_id, trope_name, justification) per link
     links: list[tuple[UUID, str, str | None]]
+    title: str = ""
 
 
 def _plan_from_data(
@@ -284,12 +323,52 @@ def _plan_from_data(
     for wd in works_data:
         targets = bogus_targets_by_work.get(wd.work_id, set())
 
+        # Reset-no-evidence trigger (#70 follow-up, owner-approved 2026-07-14): a work with
+        # >=1 link and ZERO justified links has no deep-scout evidence at all — not even one
+        # link the original per-link structural distinguisher can vouch for. Catalog-wide,
+        # every REAL deep-scout link carries justification (6247/6247, see module docstring),
+        # so "no justified link survives on this work" is itself a reliable, work-level signal
+        # that everything on it is old-writer pollution — including non-derivable junk residue
+        # (e.g. a "Comics Graphic Novels" link) that bogus_targets' per-link recompute cannot
+        # touch because it isn't a semantic redirect of THIS work's own tags. This is
+        # deliberately NOT the #69 trap (classifying a link real-vs-fallback by justification
+        # alone): the signal here is "zero evidence anywhere on the work," not "this particular
+        # link lacks justification." A work that has already tripped this rule is planned for
+        # full deletion regardless of bogus_targets membership; a work with even one justified
+        # link NEVER trips it (existing semantic-recompute trigger still applies to its
+        # NULL-just links only). The zero-link guard (`wd.links` empty -> loop body below never
+        # runs) keeps #67's fast-pass tropeless works untouched, same as always.
+        #
+        # CONVERGENCE (found via db_integration test, not in the original design note — a real
+        # re-plan-after-apply gap, not a hypothetical): write_slug ALWAYS writes its exact-name
+        # slug links with justification=None (get_or_create_fallback_trope never sets one), so a
+        # work this trigger just reset would, on the VERY NEXT re-plan, still have zero justified
+        # links — its brand-new legitimate slugs would look exactly like "no evidence" again and
+        # get deleted-and-rewritten forever. A legitimate exact-name fallback slug
+        # (is_fallback_trope_name(...) is True for this work's own genres/moods) is NOT missing
+        # evidence — it doesn't need justification, it's structurally self-evident from the
+        # work's own tags. So it is excluded from BOTH the "any evidence?" scan below AND from
+        # what gets force-deleted when the trigger does fire elsewhere on the same work: this
+        # matches has_real_remaining's existing fallback-name carve-out just below, applied one
+        # step earlier so the trigger itself converges instead of only its aftermath.
+        non_slug_links = [
+            (trope_id, name, justification)
+            for trope_id, name, justification in wd.links
+            if is_fallback_trope_name(name, wd.genres, wd.moods) is not True
+        ]
+        has_any_justified_link = any(justification is not None for _tid, _name, justification in non_slug_links)
+        reset_no_evidence = bool(non_slug_links) and not has_any_justified_link
+
         planned_deletes: set[UUID] = set()
         for trope_id, name, justification in wd.links:
-            if justification is None and trope_id in targets:
+            is_slug = is_fallback_trope_name(name, wd.genres, wd.moods) is True
+            if (reset_no_evidence and not is_slug) or (justification is None and trope_id in targets):
                 plan.delete_links.append(DeleteLink(work_id=wd.work_id, trope_id=trope_id, trope_name=name))
                 planned_deletes.add(trope_id)
                 deleted_link_count_by_trope[trope_id] += 1
+
+        if reset_no_evidence:
+            plan.reset_works.append(ResetWork(work_id=wd.work_id, title=wd.title))
 
         # Fix 1 (adjudicated design change, review pass 2): write_slug/clear_stamp are
         # DELETION-TRIGGERED ONLY — a work is eligible for either ONLY if this plan just
@@ -359,6 +438,7 @@ def plan_fallback_repair(session: Session) -> FallbackRepairPlan:
             moods=work.moods,
             deep_enriched_at=work.deep_enriched_at,
             links=links_by_work.get(work.id, []),
+            title=work.title,
         )
         for work in works
     ]
@@ -450,6 +530,19 @@ def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None, db_t
     lines.append(f"prune_tropes: {len(plan.prune_tropes)} tropes left with zero links")
     for p in plan.prune_tropes:
         lines.append(f"  trope_id={p.trope_id}  trope_name={p.trope_name!r}")
+    lines.append("")
+
+    # Informational only (#70 follow-up) — NOT part of the token block: every reset work's
+    # links are already individually represented as delete_link tokens above/below, this is
+    # just a human-readable grouping so the operator can see, at a glance, which works are
+    # getting a FULL reset (every link gone, exact-name slugs written, stamp cleared) rather
+    # than a partial per-link cleanup. Placed ABOVE '== PLAN TOKENS ==' like every other
+    # human-readable section — parse_report's fail-closed parser only looks between the
+    # start/end markers, so this section is invisible to it by construction (verified by
+    # test_token_round_trip_format_parse_equal's extension for this section).
+    lines.append(f"reset (no-evidence) works: {len(plan.reset_works)} works with zero justified links")
+    for r in plan.reset_works:
+        lines.append(f"  work_id={r.work_id}  title={r.title!r}")
     lines.append("")
 
     lines.append("== PLAN TOKENS ==")

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -65,16 +65,38 @@ tropes ARE NULL-justified "semantic collapse" attractors — trope_predicate.py'
 the signal here is not per-link but "this work has NO evidence-bearing link at all" — checked
 catalog-wide, every deep-scout link that DOES carry justification does so reliably (6247/6247),
 so a work with >=1 link and ZERO justified links is a work the deep scout never actually
-vouched for anything on. When that holds, EVERY one of the work's (necessarily NULL-just) links
-is planned for deletion regardless of bogus_targets membership, and the pre-existing
-deletion-triggered write_slug/clear_stamp classes below fire for it unchanged (a delete is a
-delete — same token format whichever trigger planned it). The trigger structurally cannot touch
-#67's zero-link works (it requires >=1 link) or a work with even one justified link (the
-justified-link co-condition on the ORIGINAL per-link trigger already protects those; this new
-trigger adds its own explicit "zero justified links" gate on top). The affected work list is
-always in the dry-run report (see write_report's 'reset (no-evidence) works' section) for the
-operator to review before approving --apply, and the operation is recoverable: the #97 sweep
-re-enriches any work whose stamp this clears.
+vouched for anything on. When that holds, EVERY one of the work's (necessarily NULL-just)
+NON-SLUG links is planned for deletion regardless of bogus_targets membership, and the
+pre-existing deletion-triggered write_slug/clear_stamp classes below fire for it unchanged (a
+delete is a delete — same token format whichever trigger planned it). The trigger structurally
+cannot touch #67's zero-link works (it requires >=1 link) or a work with even one justified
+link — a work with ANY justified link (slug-named or not) NEVER trips this trigger, full stop:
+the evidence scan considers EVERY link on the work, not just its non-slug ones (Fix 1,
+adjudicated review pass 3 — an earlier draft of this trigger scoped the evidence scan itself to
+non-slug links only, which meant a work with one justified slug link and other NULL-justified
+non-slug links could still trip the reset and force-delete links a real justified link should
+have protected; corrected). The slug carve-out (_is_slug_link, Fix 2 — matched against exactly
+what write_slug writes, `_cleaned_tag_names`, not the shared trope_predicate.is_fallback_trope_
+name, which only ever checks against a work's RAW uncleaned tags and misses COMBO_MAP splits)
+applies ONLY to (i) the "is there at least one non-slug link to force-delete" non-emptiness
+check and (ii) which links are actually force-deleted — never to the evidence scan. The
+affected work list is always in the dry-run report (see write_report's 'reset (no-evidence)
+works' section) for the operator to review before approving --apply, and the operation is
+recoverable: the #97 sweep re-enriches any work whose stamp this clears.
+
+STAMP-ONLY CLASS (Fix 3, adjudicated review pass 3): a stamped work with >=1 link, ZERO
+justified links anywhere, and where EVERY link is slug-named (_is_slug_link) is a DIFFERENT
+shape than the reset-no-evidence trigger above — its fallback representation is already
+correct (there is no non-slug link to force-delete, so the (i) non-emptiness check above is
+False and reset_no_evidence does not fire), but the work is still carrying the 6.3 migration
+backfill's stale deep_enriched_at stamp (that backfill stamped ANY work with >=1 trope row, without regard
+to whether those rows were fallback slugs). For this shape, plan clear_stamp ONLY — no
+delete_link, no write_slug (there is nothing to delete or restore). This is an ADDITIONAL
+clear_stamp trigger, independent of the deletion-triggered eligibility gate (Fix 1, review pass
+2) that gates every other write_slug/clear_stamp: there are no deletes to gate on here by
+design. #67's zero-link works remain untouched (this trigger also requires >=1 link). These
+works appear in the dry-run report's 'reset (no-evidence) works' section too, marked
+'stamp-only' (see write_report).
 
 Four action classes, one plan (mirrors etl/dedup_backfill.py's op-tagged token gate EXACTLY —
 see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmetic):
@@ -86,7 +108,7 @@ see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmet
      work. Among eligible works, plan the missing exact-name slug links for every name in
      clean_trope_name(tag), tag in genres|moods, not already linked, IF after the planned
      deletions the work would have NO real trope left (no remaining/surviving link that
-     is_fallback_trope_name(...) is False for). Applied via D1's get_or_create_fallback_trope
+     _is_slug_link(...) is False for — see Fix 2, review pass 3). Applied via D1's get_or_create_fallback_trope
      (exact-name-only — never the semantic redirect that caused this mess). A work with ZERO
      pre-existing trope links (never touched by the old fallback writer at all) is NEVER
      eligible — writing slugs there would re-add fallback tropes the #67 prune deliberately
@@ -99,7 +121,10 @@ see plan_id_set's docstring there for why the op-tag is load-bearing, not cosmet
      whose fallback links this plan is about to delete is a false positive that must become
      visible to the #97 requeue sweep again. A work this plan does NOT delete anything from
      keeps its stamp — clearing it would erase the sweep's legitimate repeat-cost signal for a
-     work that was correctly, honestly confirmed-empty.
+     work that was correctly, honestly confirmed-empty. PLUS a second, independent trigger (Fix
+     3, review pass 3 — see STAMP-ONLY CLASS below): a stamped work with >=1 link, zero justified
+     links, and EVERY link slug-named plans clear_stamp with NO delete_link at all (nothing to
+     delete — the fallback representation is already correct, only the stale stamp is wrong).
   4. prune_trope(trope_id): a trope left with ZERO links after the PLANNED deletes (apply
      recomputes this at apply time — see apply_fallback_repair).
 
@@ -136,7 +161,6 @@ from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import Trope, Work, WorkTrope
 from agentic_librarian.etl.tag_cleaning import clean_trope_name
-from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
 
 logger = logging.getLogger(__name__)
@@ -179,13 +203,20 @@ class PruneTrope:
 
 @dataclass
 class ResetWork:
-    """One work caught by the zero-justified-links reset trigger (#70 follow-up): informational
-    only, for write_report's human-readable section — NOT part of the op-tagged token block (a
-    reset work's links are already individually represented as delete_link tokens; this is a
-    derived, report-only view grouping them by work for the operator)."""
+    """One work caught by the zero-justified-links reset trigger (#70 follow-up) OR the Fix 3
+    stamp-only class (review pass 3): informational only, for write_report's human-readable
+    section — NOT part of the op-tagged token block (a full-reset work's links are already
+    individually represented as delete_link tokens, and a stamp-only work's clear_stamp is
+    already represented as a clear_stamp token; this is a derived, report-only view grouping
+    them by work for the operator).
+
+    stamp_only=True marks the Fix 3 shape (>=1 link, zero justified links, ALL links slug-named
+    — nothing to delete or restore, only the stale migration-backfill stamp to clear);
+    stamp_only=False (default) is the original full reset (>=1 non-slug link force-deleted)."""
 
     work_id: UUID
     title: str
+    stamp_only: bool = False
 
 
 @dataclass
@@ -222,6 +253,30 @@ def _cleaned_tag_names(genres: list[str] | None, moods: list[str] | None) -> lis
                 seen.add(name)
                 names.append(name)
     return names
+
+
+def _is_slug_link(name: str, genres: list[str] | None, moods: list[str] | None) -> bool:
+    """Fix 2 (adjudicated, review pass 3): a link is slug-named iff its trope name
+    (case-insensitive) is a member of `_cleaned_tag_names(genres, moods)` — EXACTLY the set
+    write_slug writes (via get_or_create_fallback_trope, one call per cleaned name). This
+    replaces trope_predicate.is_fallback_trope_name for this module's internal slug carve-out
+    (that shared predicate stays as-is for its other callers — persist.py/enrichment_sweep.py/
+    trope_backfill.py/api/internal.py — this is a LOCAL redefinition, not a change to the shared
+    function).
+
+    Why the shared predicate is wrong for this purpose: is_fallback_trope_name checks the
+    cleaned NAME against the work's RAW, uncleaned genres|moods (lowercased) — so it never
+    accounts for COMBO_MAP splits. A raw genre tag "Science Fiction Fantasy" cleans (via
+    clean_trope_name/_cleaned_tag_names) to ["Science Fiction", "Fantasy"], and write_slug
+    writes exactly those two exact-name links — but is_fallback_trope_name("Science Fiction",
+    genres=["Science Fiction Fantasy"], moods=[]) is False, because "science fiction" is not a
+    literal member of the raw genre set. Without this fix, a freshly-written combo slug is
+    misclassified as a 'real' trope on the very next re-plan: has_real_remaining sees it as
+    real-remaining evidence (blocking write_slug/clear_stamp forever) and the reset-no-evidence
+    scan below counts it as non-slug 'evidence' too, both wrong for a link this tool itself just
+    wrote as a plain exact-name slug. Matching against write_slug's own output set closes that
+    gap by construction: whatever write_slug writes is always classified as a slug."""
+    return name.lower() in {n.lower() for n in _cleaned_tag_names(genres, moods)}
 
 
 def warm_fallback_repair_texts(session: Session) -> list[str]:
@@ -323,45 +378,56 @@ def _plan_from_data(
     for wd in works_data:
         targets = bogus_targets_by_work.get(wd.work_id, set())
 
-        # Reset-no-evidence trigger (#70 follow-up, owner-approved 2026-07-14): a work with
-        # >=1 link and ZERO justified links has no deep-scout evidence at all — not even one
-        # link the original per-link structural distinguisher can vouch for. Catalog-wide,
-        # every REAL deep-scout link carries justification (6247/6247, see module docstring),
-        # so "no justified link survives on this work" is itself a reliable, work-level signal
-        # that everything on it is old-writer pollution — including non-derivable junk residue
-        # (e.g. a "Comics Graphic Novels" link) that bogus_targets' per-link recompute cannot
-        # touch because it isn't a semantic redirect of THIS work's own tags. This is
-        # deliberately NOT the #69 trap (classifying a link real-vs-fallback by justification
-        # alone): the signal here is "zero evidence anywhere on the work," not "this particular
-        # link lacks justification." A work that has already tripped this rule is planned for
-        # full deletion regardless of bogus_targets membership; a work with even one justified
-        # link NEVER trips it (existing semantic-recompute trigger still applies to its
-        # NULL-just links only). The zero-link guard (`wd.links` empty -> loop body below never
-        # runs) keeps #67's fast-pass tropeless works untouched, same as always.
+        # Reset-no-evidence trigger (#70 follow-up, owner-approved 2026-07-14; evidence scan
+        # corrected in review pass 3 — Fix 1): a work with >=1 link and ZERO justified links
+        # ANYWHERE ON THE WORK has no deep-scout evidence at all — not even one link the
+        # original per-link structural distinguisher can vouch for. Catalog-wide, every REAL
+        # deep-scout link carries justification (6247/6247, see module docstring), so "no
+        # justified link survives on this work" is itself a reliable, work-level signal that
+        # everything on it is old-writer pollution — including non-derivable junk residue (e.g.
+        # a "Comics Graphic Novels" link) that bogus_targets' per-link recompute cannot touch
+        # because it isn't a semantic redirect of THIS work's own tags. This is deliberately NOT
+        # the #69 trap (classifying a link real-vs-fallback by justification alone): the signal
+        # here is "zero evidence anywhere on the work," not "this particular link lacks
+        # justification." The zero-link guard (`wd.links` empty -> loop body below never runs)
+        # keeps #67's fast-pass tropeless works untouched, same as always.
         #
+        # Fix 1 (adjudicated, review pass 3 — CORRECTS the original design note above, which was
+        # wrong): the evidence scan (has_any_justified_link) MUST consider EVERY link of the
+        # work, including slug-named ones — a justified slug-named link (e.g. a "Thriller" exact-
+        # name link the scout happened to also justify) IS evidence and must block the reset
+        # trigger entirely, full stop. The slug exclusion (_is_slug_link, Fix 2) applies ONLY to
+        # (a) the "does a non-slug link exist" non-emptiness check below, and (b) which links get
+        # force-deleted when the trigger DOES fire. It must never be applied inside the
+        # evidence scan itself — that was the bug: scoping has_any_justified_link to non-slug
+        # links only meant a justified slug link was silently excluded from "is there evidence,"
+        # so a work with ONE justified slug link and other NULL-justified non-slug links could
+        # still trip the reset trigger and force-delete links a real justified link should have
+        # protected.
+        non_slug_links = [
+            (trope_id, name, justification)
+            for trope_id, name, justification in wd.links
+            if not _is_slug_link(name, wd.genres, wd.moods)
+        ]
+        has_any_justified_link = any(justification is not None for _tid, _name, justification in wd.links)
+        reset_no_evidence = bool(non_slug_links) and not has_any_justified_link
+
         # CONVERGENCE (found via db_integration test, not in the original design note — a real
         # re-plan-after-apply gap, not a hypothetical): write_slug ALWAYS writes its exact-name
         # slug links with justification=None (get_or_create_fallback_trope never sets one), so a
         # work this trigger just reset would, on the VERY NEXT re-plan, still have zero justified
         # links — its brand-new legitimate slugs would look exactly like "no evidence" again and
-        # get deleted-and-rewritten forever. A legitimate exact-name fallback slug
-        # (is_fallback_trope_name(...) is True for this work's own genres/moods) is NOT missing
-        # evidence — it doesn't need justification, it's structurally self-evident from the
-        # work's own tags. So it is excluded from BOTH the "any evidence?" scan below AND from
-        # what gets force-deleted when the trigger does fire elsewhere on the same work: this
-        # matches has_real_remaining's existing fallback-name carve-out just below, applied one
-        # step earlier so the trigger itself converges instead of only its aftermath.
-        non_slug_links = [
-            (trope_id, name, justification)
-            for trope_id, name, justification in wd.links
-            if is_fallback_trope_name(name, wd.genres, wd.moods) is not True
-        ]
-        has_any_justified_link = any(justification is not None for _tid, _name, justification in non_slug_links)
-        reset_no_evidence = bool(non_slug_links) and not has_any_justified_link
+        # get deleted-and-rewritten forever. A legitimate exact-name fallback slug (_is_slug_link
+        # True for this work's own genres/moods, Fix 2) is NOT missing evidence — it doesn't need
+        # justification, it's structurally self-evident from the work's own tags. So it is
+        # excluded from the "does a non-slug link exist" non-emptiness check above AND from what
+        # gets force-deleted when the trigger fires (below): this matches has_real_remaining's
+        # existing fallback-name carve-out just below, applied one step earlier so the trigger
+        # itself converges instead of only its aftermath.
 
         planned_deletes: set[UUID] = set()
         for trope_id, name, justification in wd.links:
-            is_slug = is_fallback_trope_name(name, wd.genres, wd.moods) is True
+            is_slug = _is_slug_link(name, wd.genres, wd.moods)
             if (reset_no_evidence and not is_slug) or (justification is None and trope_id in targets):
                 plan.delete_links.append(DeleteLink(work_id=wd.work_id, trope_id=trope_id, trope_name=name))
                 planned_deletes.add(trope_id)
@@ -369,6 +435,31 @@ def _plan_from_data(
 
         if reset_no_evidence:
             plan.reset_works.append(ResetWork(work_id=wd.work_id, title=wd.title))
+
+        # Fix 3 (adjudicated, review pass 3): a stamped work with >=1 link, ZERO justified links
+        # anywhere, and ALL links slug-named (per Fix 2's _is_slug_link) is a migration-backfill
+        # false positive whose fallback representation is ALREADY CORRECT — reset_no_evidence
+        # does NOT fire for this shape (bool(non_slug_links) is False: there is no non-slug link
+        # to force-delete), so there is nothing to delete and nothing to write; the only
+        # actionable state is the stale deep_enriched_at stamp left by the 6.3 migration backfill
+        # (which stamped any work with >=1 trope row, without regard to whether those rows were
+        # fallback slugs). This is an ADDITIONAL clear_stamp trigger, independent of planned
+        # deletes (the deletion-triggered eligibility gate just below intentionally does not
+        # cover this case — there are no deletes to gate on). #67's zero-link works remain
+        # untouched: this trigger requires `wd.links` non-empty (all_slug_links below is
+        # vacuously True on an empty list, but the `bool(wd.links)` guard keeps a zero-link work
+        # out of this branch entirely, same rail as the reset-no-evidence trigger above).
+        all_slug_links = bool(wd.links) and all(_is_slug_link(name, wd.genres, wd.moods) for _tid, name, _j in wd.links)
+        stamp_only = (
+            bool(wd.links)
+            and not has_any_justified_link
+            and all_slug_links
+            and not planned_deletes
+            and wd.deep_enriched_at is not None
+        )
+        if stamp_only:
+            plan.clear_stamps.append(ClearStamp(work_id=wd.work_id))
+            plan.reset_works.append(ResetWork(work_id=wd.work_id, title=wd.title, stamp_only=True))
 
         # Fix 1 (adjudicated design change, review pass 2): write_slug/clear_stamp are
         # DELETION-TRIGGERED ONLY — a work is eligible for either ONLY if this plan just
@@ -378,14 +469,15 @@ def _plan_from_data(
         # survives" test alone — re-adding fallbacks the #67 prune deliberately removed from
         # fast-pass works, and clearing a legitimately-stamped confirmed-empty work's
         # deep_enriched_at (erasing the #97 sweep's repeat-cost signal). This module repairs
-        # works it strips, never works it didn't touch.
+        # works it strips, never works it didn't touch. (Fix 3's stamp_only trigger above is the
+        # sole, deliberate exception — it plans clear_stamp WITHOUT any delete_link, by design.)
         if not planned_deletes:
             continue
 
         # A "real" trope survives if it's NOT planned for deletion AND is not itself a
-        # fallback-name match for this work's own genres/moods (is_fallback_trope_name False).
+        # slug-name match for this work's own genres/moods (Fix 2: _is_slug_link False).
         has_real_remaining = any(
-            trope_id not in planned_deletes and is_fallback_trope_name(name, wd.genres, wd.moods) is False
+            trope_id not in planned_deletes and not _is_slug_link(name, wd.genres, wd.moods)
             for trope_id, name, _justification in wd.links
         )
 
@@ -532,17 +624,21 @@ def write_report(plan: FallbackRepairPlan, reports_dir: Path | None = None, db_t
         lines.append(f"  trope_id={p.trope_id}  trope_name={p.trope_name!r}")
     lines.append("")
 
-    # Informational only (#70 follow-up) — NOT part of the token block: every reset work's
-    # links are already individually represented as delete_link tokens above/below, this is
-    # just a human-readable grouping so the operator can see, at a glance, which works are
-    # getting a FULL reset (every link gone, exact-name slugs written, stamp cleared) rather
-    # than a partial per-link cleanup. Placed ABOVE '== PLAN TOKENS ==' like every other
-    # human-readable section — parse_report's fail-closed parser only looks between the
+    # Informational only (#70 follow-up; stamp-only marking added Fix 3, review pass 3) — NOT
+    # part of the token block: a full-reset work's links are already individually represented as
+    # delete_link tokens above/below, and a stamp-only work's clear_stamp is already represented
+    # as a clear_stamp token above; this is just a human-readable grouping so the operator can
+    # see, at a glance, which works are getting a FULL reset (every non-slug link gone, exact-
+    # name slugs written, stamp cleared) rather than a partial per-link cleanup, and which are
+    # merely 'stamp-only' (already-correct fallback representation, only the stale migration
+    # stamp cleared — no delete, no slug write). Placed ABOVE '== PLAN TOKENS ==' like every
+    # other human-readable section — parse_report's fail-closed parser only looks between the
     # start/end markers, so this section is invisible to it by construction (verified by
     # test_token_round_trip_format_parse_equal's extension for this section).
     lines.append(f"reset (no-evidence) works: {len(plan.reset_works)} works with zero justified links")
     for r in plan.reset_works:
-        lines.append(f"  work_id={r.work_id}  title={r.title!r}")
+        marker = "  [stamp-only]" if r.stamp_only else ""
+        lines.append(f"  work_id={r.work_id}  title={r.title!r}{marker}")
     lines.append("")
 
     lines.append("== PLAN TOKENS ==")

--- a/src/agentic_librarian/etl/fallback_repair.py
+++ b/src/agentic_librarian/etl/fallback_repair.py
@@ -255,14 +255,19 @@ def _cleaned_tag_names(genres: list[str] | None, moods: list[str] | None) -> lis
     return names
 
 
-def _is_slug_link(name: str, genres: list[str] | None, moods: list[str] | None) -> bool:
+def _is_slug_link(name: str, work_slugs: set[str]) -> bool:
     """Fix 2 (adjudicated, review pass 3): a link is slug-named iff its trope name
-    (case-insensitive) is a member of `_cleaned_tag_names(genres, moods)` — EXACTLY the set
+    (case-insensitive) is a member of `work_slugs` — the lowercased
+    `_cleaned_tag_names(genres, moods)` set for the work in question, EXACTLY the set
     write_slug writes (via get_or_create_fallback_trope, one call per cleaned name). This
     replaces trope_predicate.is_fallback_trope_name for this module's internal slug carve-out
     (that shared predicate stays as-is for its other callers — persist.py/enrichment_sweep.py/
     trope_backfill.py/api/internal.py — this is a LOCAL redefinition, not a change to the shared
     function).
+
+    Perf (Gemini review adoption): callers precompute `work_slugs` ONCE per work (there are up
+    to four call sites per work in `_plan_from_data`'s per-work loop) rather than recomputing
+    `_cleaned_tag_names` — and re-lowercasing every name in it — on every call.
 
     Why the shared predicate is wrong for this purpose: is_fallback_trope_name checks the
     cleaned NAME against the work's RAW, uncleaned genres|moods (lowercased) — so it never
@@ -276,7 +281,7 @@ def _is_slug_link(name: str, genres: list[str] | None, moods: list[str] | None) 
     scan below counts it as non-slug 'evidence' too, both wrong for a link this tool itself just
     wrote as a plain exact-name slug. Matching against write_slug's own output set closes that
     gap by construction: whatever write_slug writes is always classified as a slug."""
-    return name.lower() in {n.lower() for n in _cleaned_tag_names(genres, moods)}
+    return name.lower() in work_slugs
 
 
 def warm_fallback_repair_texts(session: Session) -> list[str]:
@@ -302,35 +307,62 @@ def warm_fallback_repair_texts(session: Session) -> list[str]:
 # --------------------------------------------------------------------------------------------
 
 
-def _nearest_trope_by_name(session: Session, all_tropes_by_name: dict[str, Trope], name: str) -> Trope | None:
+def _nearest_trope_by_name(
+    session: Session,
+    all_tropes_by_name: dict[str, Trope],
+    name: str,
+    cache: dict[str, Trope | None] | None = None,
+) -> Trope | None:
     """Exact-name match -> None (legitimate slug, never bogus — skip). Else the nearest trope
     by cosine distance if within BOGUS_MATCH_THRESHOLD, else None (no bogus target for this
     name). Read-only: never creates a Trope. Embeds `name` via the (already-warmed, per #123)
-    get_cached_embedding cache."""
+    get_cached_embedding cache.
+
+    Perf (profiled against prod — this was the dominant cost of a repair-plan run: thousands of
+    pgvector round-trips for ~200 unique cleaned tag names, since the same handful of names
+    recur across many works' genres/moods): this lookup is purely a function of `name` (and the
+    DB state captured by `all_tropes_by_name`/the Trope table) within one plan run, so callers
+    MAY pass a `cache` dict to memoize it — one query per unique name per plan, instead of one
+    per (work, name) pair. `cache` is scoped to a single plan_fallback_repair invocation and
+    created fresh by that caller; see plan_fallback_repair for why a module-global cache (e.g.
+    functools.lru_cache) is forbidden here instead."""
+    if cache is not None and name in cache:
+        return cache[name]
     if name in all_tropes_by_name:
-        return None  # an exact-name slug trope already exists for this tag -> legitimate
-    embedding = get_cached_embedding(EMBED_MODEL, name)
-    nearest = (
-        session.query(Trope)
-        .filter(Trope.embedding.isnot(None))
-        .filter(Trope.embedding.cosine_distance(embedding) <= BOGUS_MATCH_THRESHOLD)
-        # Fix 3 (deterministic tie-break, house rule from dedup_backfill's Minor-3 order_by
-        # discipline): Trope.id as the secondary sort key makes an exact-distance tie resolve
-        # identically every time, so a re-plan on unchanged data classifies the SAME nearest
-        # trope and can't spuriously trip the apply-gate's drift check on Postgres row-order
-        # nondeterminism alone.
-        .order_by(Trope.embedding.cosine_distance(embedding), Trope.id)
-        .first()
-    )
-    return nearest
+        result = None  # an exact-name slug trope already exists for this tag -> legitimate
+    else:
+        embedding = get_cached_embedding(EMBED_MODEL, name)
+        result = (
+            session.query(Trope)
+            .filter(Trope.embedding.isnot(None))
+            .filter(Trope.embedding.cosine_distance(embedding) <= BOGUS_MATCH_THRESHOLD)
+            # Fix 3 (deterministic tie-break, house rule from dedup_backfill's Minor-3 order_by
+            # discipline): Trope.id as the secondary sort key makes an exact-distance tie
+            # resolve identically every time, so a re-plan on unchanged data classifies the SAME
+            # nearest trope and can't spuriously trip the apply-gate's drift check on Postgres
+            # row-order nondeterminism alone.
+            .order_by(Trope.embedding.cosine_distance(embedding), Trope.id)
+            .first()
+        )
+    if cache is not None:
+        cache[name] = result
+    return result
 
 
-def bogus_targets(session: Session, work: Work, all_tropes_by_name: dict[str, Trope]) -> set[UUID]:
+def bogus_targets(
+    session: Session,
+    work: Work,
+    all_tropes_by_name: dict[str, Trope],
+    nearest_trope_cache: dict[str, Trope | None] | None = None,
+) -> set[UUID]:
     """The set of trope ids that are a bogus (deterministically re-derivable) semantic-redirect
-    target for THIS work's genres|moods. Read-only."""
+    target for THIS work's genres|moods. Read-only.
+
+    `nearest_trope_cache`, if given, is forwarded to `_nearest_trope_by_name` unchanged — see
+    plan_fallback_repair for the plan-scoped memoization this supports."""
     out: set[UUID] = set()
     for name in _cleaned_tag_names(work.genres, work.moods):
-        nearest = _nearest_trope_by_name(session, all_tropes_by_name, name)
+        nearest = _nearest_trope_by_name(session, all_tropes_by_name, name, cache=nearest_trope_cache)
         if nearest is not None:
             out.add(nearest.id)
     return out
@@ -377,6 +409,10 @@ def _plan_from_data(
 
     for wd in works_data:
         targets = bogus_targets_by_work.get(wd.work_id, set())
+        # Gemini review adoption: compute this work's slug-name set ONCE and reuse it at every
+        # _is_slug_link call site below (there are four), instead of recomputing
+        # _cleaned_tag_names (and re-lowercasing it) per call.
+        work_slugs = {n.lower() for n in _cleaned_tag_names(wd.genres, wd.moods)}
 
         # Reset-no-evidence trigger (#70 follow-up, owner-approved 2026-07-14; evidence scan
         # corrected in review pass 3 — Fix 1): a work with >=1 link and ZERO justified links
@@ -407,7 +443,7 @@ def _plan_from_data(
         non_slug_links = [
             (trope_id, name, justification)
             for trope_id, name, justification in wd.links
-            if not _is_slug_link(name, wd.genres, wd.moods)
+            if not _is_slug_link(name, work_slugs)
         ]
         has_any_justified_link = any(justification is not None for _tid, _name, justification in wd.links)
         reset_no_evidence = bool(non_slug_links) and not has_any_justified_link
@@ -427,7 +463,7 @@ def _plan_from_data(
 
         planned_deletes: set[UUID] = set()
         for trope_id, name, justification in wd.links:
-            is_slug = _is_slug_link(name, wd.genres, wd.moods)
+            is_slug = _is_slug_link(name, work_slugs)
             if (reset_no_evidence and not is_slug) or (justification is None and trope_id in targets):
                 plan.delete_links.append(DeleteLink(work_id=wd.work_id, trope_id=trope_id, trope_name=name))
                 planned_deletes.add(trope_id)
@@ -449,7 +485,7 @@ def _plan_from_data(
         # untouched: this trigger requires `wd.links` non-empty (all_slug_links below is
         # vacuously True on an empty list, but the `bool(wd.links)` guard keeps a zero-link work
         # out of this branch entirely, same rail as the reset-no-evidence trigger above).
-        all_slug_links = bool(wd.links) and all(_is_slug_link(name, wd.genres, wd.moods) for _tid, name, _j in wd.links)
+        all_slug_links = bool(wd.links) and all(_is_slug_link(name, work_slugs) for _tid, name, _j in wd.links)
         stamp_only = (
             bool(wd.links)
             and not has_any_justified_link
@@ -477,7 +513,7 @@ def _plan_from_data(
         # A "real" trope survives if it's NOT planned for deletion AND is not itself a
         # slug-name match for this work's own genres/moods (Fix 2: _is_slug_link False).
         has_real_remaining = any(
-            trope_id not in planned_deletes and not _is_slug_link(name, wd.genres, wd.moods)
+            trope_id not in planned_deletes and not _is_slug_link(name, work_slugs)
             for trope_id, name, _justification in wd.links
         )
 
@@ -534,7 +570,27 @@ def plan_fallback_repair(session: Session) -> FallbackRepairPlan:
         )
         for work in works
     ]
-    bogus_targets_by_work = {work.id: bogus_targets(session, work, all_tropes_by_name) for work in works}
+    # Perf (profiled against prod, adopted alongside the per-work slug-set fix): memoize
+    # _nearest_trope_by_name PER INVOCATION of this function — it is purely a function of `name`
+    # within one plan run, and the same handful of cleaned tag names (~200 unique) recur across
+    # many hundreds of works, so without this cache every work re-issues a pgvector round-trip
+    # for names already resolved by an earlier work in the same run. The cache is created fresh
+    # here, lives only as long as this call, and is thrown away when it returns.
+    #
+    # Deliberately NOT a module-global cache (e.g. functools.lru_cache on
+    # _nearest_trope_by_name): this module's whole contract is that plan_fallback_repair always
+    # reflects the CURRENT DB state (see the module docstring's "Apply is THE USER GATE" section
+    # — apply_fallback_repair re-plans FRESH specifically so drift since review is detected). A
+    # process-lifetime cache would silently serve a stale nearest-trope result across separate
+    # plan runs — e.g. a trope created or deleted between a dry-run and the apply re-plan, or
+    # between two operator invocations in the same process — corrupting exactly the re-plan-
+    # fresh guarantee the drift gate depends on. Scoping the cache to one call sidesteps that
+    # entirely: it can never outlive the DB state it was computed against.
+    nearest_trope_cache: dict[str, Trope | None] = {}
+    bogus_targets_by_work = {
+        work.id: bogus_targets(session, work, all_tropes_by_name, nearest_trope_cache=nearest_trope_cache)
+        for work in works
+    }
 
     return _plan_from_data(works_data, all_tropes_by_id, bogus_targets_by_work)
 

--- a/test/integration/test_fallback_repair.py
+++ b/test/integration/test_fallback_repair.py
@@ -145,7 +145,13 @@ def test_full_round_trip_delete_write_slug_clear_stamp_prune(db_url):
 
         # --- convergence: re-plan finds nothing left to do ---
         converged = fr.plan_fallback_repair(session)
-        assert converged.summary() == {"delete_links": 0, "write_slugs": 0, "clear_stamps": 0, "prune_tropes": 0}
+        assert converged.summary() == {
+            "delete_links": 0,
+            "write_slugs": 0,
+            "clear_stamps": 0,
+            "prune_tropes": 0,
+            "reset_works": 0,
+        }
 
         # sanity: the report's own tokens matched what got applied (round-trip already proven
         # elsewhere; this just confirms the fixture wiring produced a non-empty reviewed set)
@@ -286,3 +292,86 @@ def test_prune_trope_deleted_when_all_links_bogus_kept_when_justified_link_survi
         remaining_b_links = session.query(WorkTrope).filter_by(trope_id=attractor_b.id).all()
         assert len(remaining_b_links) == 1
         assert remaining_b_links[0].work_id == work_b2.id
+
+
+def test_reset_no_evidence_full_reset_including_non_derivable_junk_link(db_url):
+    """#70 follow-up (owner-approved 2026-07-14): the Lessons-analog shape — a stamped work
+    with genres/moods and TWO NULL-justified links, one cosine-derivable from its own mood
+    tag (the ORIGINAL per-link distinguisher would catch this alone) and one junk trope FAR
+    from every tag (non-derivable — the original distinguisher structurally cannot touch it,
+    which is exactly the residue that used to survive forever and block write_slug/clear_stamp).
+    Because the work has ZERO justified links, the new reset-no-evidence trigger plans BOTH
+    links for deletion regardless of derivability. Post-apply: both links gone, exact-name
+    slug links exist for the work's genres/moods, the stamp is cleared, the now-linkless junk
+    trope is pruned, and a fresh re-plan converges to empty."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+        # derivable: "Dark" mood cosine-redirects onto this attractor (same distinguisher as
+        # every other test in this module).
+        attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
+        # non-derivable junk: an orthogonal embedding, nowhere near any of the work's own
+        # genres/moods (via _fake_embed's _OTHER_VEC) — bogus_targets' recompute can never
+        # produce this trope for this work, so ONLY the new work-level trigger can catch it.
+        junk = Trope(name="Comics Graphic Novels", embedding=_OTHER_VEC)
+        session.add_all([attractor, junk])
+        session.flush()
+
+        work = Work(
+            title="Lessons in Chemistry",
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        session.add(work)
+        session.flush()
+
+        _link(session, work, attractor, justification=None)  # derivable, NULL-justified
+        _link(session, work, junk, justification=None)  # non-derivable, NULL-justified
+        session.flush()
+
+        # --- dry-run plan ---
+        plan = fr.plan_fallback_repair(session)
+        deleted_trope_ids = {d.trope_id for d in plan.delete_links if d.work_id == work.id}
+        assert deleted_trope_ids == {attractor.id, junk.id}
+        assert {s.trope_name for s in plan.write_slugs if s.work_id == work.id} == {"Thriller", "Dark"}
+        assert [c.work_id for c in plan.clear_stamps] == [work.id]
+        reset_work_ids = {r.work_id for r in plan.reset_works}
+        assert reset_work_ids == {work.id}
+
+        report_path = fr.write_report(plan)
+
+        # --- apply ---
+        applied = fr.apply_fallback_repair(session, report_path)
+        session.flush()
+
+        assert applied["delete_links"] == 2
+        assert applied["write_slugs"] == 2
+        assert applied["clear_stamps"] == 1
+        # both the attractor and the junk trope are left with zero links anywhere (this
+        # fixture's work was their only link) -> both pruned.
+        assert applied["prune_tropes"] == 2
+
+        # both original links gone, exact-name slugs present, stamp cleared
+        work_links = {
+            session.get(Trope, wt.trope_id).name for wt in session.query(WorkTrope).filter_by(work_id=work.id).all()
+        }
+        assert work_links == {"Thriller", "Dark"}
+        assert session.get(Work, work.id).deep_enriched_at is None
+
+        # both original tropes pruned (neither had any other link); the newly-written
+        # exact-name "Dark"/"Thriller" slug tropes are DIFFERENT tropes than the attractor
+        # they used to be redirected onto.
+        assert session.get(Trope, junk.id) is None
+        assert session.get(Trope, attractor.id) is None
+
+        # --- convergence: re-plan finds nothing left to do ---
+        converged = fr.plan_fallback_repair(session)
+        assert converged.summary() == {
+            "delete_links": 0,
+            "write_slugs": 0,
+            "clear_stamps": 0,
+            "prune_tropes": 0,
+            "reset_works": 0,
+        }

--- a/test/integration/test_fallback_repair.py
+++ b/test/integration/test_fallback_repair.py
@@ -24,11 +24,14 @@ pytestmark = pytest.mark.db_integration
 # attractor (two tropes at the exact same distance from a query vector is not how the real
 # pollution incident looks — every attractor is its own semantic cluster; a same-distance tie
 # would make "nearest" a Postgres row-order accident rather than a real classification).
-# Everything else gets an orthogonal-ish vector so it never accidentally satisfies
-# BOGUS_MATCH_THRESHOLD.
+# Everything else (every cleaned tag name the fixtures use that ISN'T "Dark"/"Grim"/"Junk Basis",
+# e.g. "Thriller", "Found Family") gets _OTHER_VEC so it never accidentally satisfies
+# BOGUS_MATCH_THRESHOLD. _JUNK_BASIS_VEC is its OWN fourth orthogonal dimension (Fix 4,
+# adjudicated review pass 3) — see its own comment below for why it must NOT reuse _OTHER_VEC.
 _ATTRACTOR_A_VEC = [1.0] + [0.0] * 1535
 _ATTRACTOR_B_VEC = [0.0, 0.0, 1.0] + [0.0] * 1533
 _OTHER_VEC = [0.0, 1.0] + [0.0] * 1534
+_JUNK_BASIS_VEC = [0.0, 0.0, 0.0, 1.0] + [0.0] * 1532
 _ATTRACTOR_VEC = _ATTRACTOR_A_VEC  # back-compat alias for the single-attractor tests below
 
 
@@ -37,6 +40,8 @@ def _fake_embed(model_name, text_):
         return _ATTRACTOR_A_VEC
     if text_ == "Grim":
         return _ATTRACTOR_B_VEC
+    if text_ == "Junk Basis":
+        return _JUNK_BASIS_VEC
     return _OTHER_VEC
 
 
@@ -303,7 +308,21 @@ def test_reset_no_evidence_full_reset_including_non_derivable_junk_link(db_url):
     Because the work has ZERO justified links, the new reset-no-evidence trigger plans BOTH
     links for deletion regardless of derivability. Post-apply: both links gone, exact-name
     slug links exist for the work's genres/moods, the stamp is cleared, the now-linkless junk
-    trope is pruned, and a fresh re-plan converges to empty."""
+    trope is pruned, and a fresh re-plan converges to empty.
+
+    Fix 4 (Important, adjudicated review pass 3): the junk trope gets its OWN basis vector
+    (_JUNK_BASIS_VEC, a fourth orthogonal dimension) rather than reusing _OTHER_VEC — the
+    catch-all _fake_embed returns for every cleaned tag name that isn't "Dark"/"Grim". Reusing
+    _OTHER_VEC was a fixture bug: this work's OWN "Thriller" genre ALSO embeds to _OTHER_VEC
+    (it's not "Dark" or "Grim" either), so a junk trope embedded at _OTHER_VEC sits at cosine
+    distance 0 from "Thriller"'s embedding — well within BOGUS_MATCH_THRESHOLD — making it a
+    bogus_targets member via the ORIGINAL per-link distinguisher alone. That means the junk
+    link's delete would have been explained by the pre-existing NULL-justified+bogus_targets
+    rule, not by the NEW reset-no-evidence trigger this test exists to exercise — the fixture
+    was not actually testing what its own docstring/comments claimed. With its own basis vector,
+    the junk trope is not the nearest match for ANY of this work's cleaned tag names, so it is
+    provably absent from bogus_targets(work) (asserted below via _nearest_trope_by_name), and
+    its deletion is attributable ONLY to the reset-no-evidence trigger."""
     manager = DatabaseManager(db_url)
     with manager.get_session() as session:
         session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
@@ -311,12 +330,23 @@ def test_reset_no_evidence_full_reset_including_non_derivable_junk_link(db_url):
         # derivable: "Dark" mood cosine-redirects onto this attractor (same distinguisher as
         # every other test in this module).
         attractor = Trope(name="The Dark Night of the Soul", embedding=_ATTRACTOR_VEC)
-        # non-derivable junk: an orthogonal embedding, nowhere near any of the work's own
-        # genres/moods (via _fake_embed's _OTHER_VEC) — bogus_targets' recompute can never
-        # produce this trope for this work, so ONLY the new work-level trigger can catch it.
-        junk = Trope(name="Comics Graphic Novels", embedding=_OTHER_VEC)
+        # non-derivable junk: its OWN orthogonal basis vector (_JUNK_BASIS_VEC), distinct from
+        # _OTHER_VEC (the catch-all vector this work's OWN "Thriller" genre also embeds to —
+        # see the Fix 4 docstring note above for why reusing it would have made the junk trope
+        # a bogus_targets member via the ORIGINAL distinguisher, defeating the point of this
+        # fixture). bogus_targets' recompute can never produce this trope for this work, so
+        # ONLY the new work-level trigger can catch it.
+        junk = Trope(name="Comics Graphic Novels", embedding=_JUNK_BASIS_VEC)
         session.add_all([attractor, junk])
         session.flush()
+
+        # Fix 4: prove the junk trope is genuinely non-derivable BEFORE the plan runs — for
+        # every cleaned tag name this work actually carries, the nearest trope within
+        # BOGUS_MATCH_THRESHOLD must never be the junk trope (or None, if nothing is within
+        # threshold at all).
+        for tag_name in ("Thriller", "Dark"):
+            nearest = fr._nearest_trope_by_name(session, {"The Dark Night of the Soul": attractor}, tag_name)
+            assert nearest is None or nearest.id != junk.id
 
         work = Work(
             title="Lessons in Chemistry",

--- a/test/unit/test_fallback_repair.py
+++ b/test/unit/test_fallback_repair.py
@@ -191,7 +191,15 @@ class TestWriteSlugAndClearStamp:
         The exact-name slug link is given a justification here (a justified genre-derived link
         is a perfectly ordinary shape) so this work has >=1 justified link and stays out of the
         reset-no-evidence trigger's reach (see TestResetNoEvidence) — isolating the ORIGINAL
-        per-link bogus_targets distinguisher, which is what this test is about."""
+        per-link bogus_targets distinguisher, which is what this test is about. This claim is
+        only true because of Fix 1 (review pass 3): the evidence scan considers EVERY link on
+        the work, including this justified SLUG-named one — an earlier, buggy draft scoped the
+        evidence scan to non-slug links only, under which this same justified "Thriller" link
+        would have been silently excluded from "is there evidence," and the work's other
+        NULL-justified non-slug link ("The Dark Night of the Soul") would have wrongly tripped
+        the reset-no-evidence trigger instead of being governed by the per-link distinguisher
+        this test isolates (see test_reset_no_evidence_trigger_scan_covers_all_links, which
+        pins the corrected behavior directly)."""
         bogus_trope_id = uuid4()
         existing_slug_id = uuid4()
         work = _work(
@@ -337,6 +345,40 @@ class TestResetNoEvidence:
         assert plan.write_slugs == []
         assert plan.clear_stamps == []
 
+    def test_reset_no_evidence_trigger_scan_covers_all_links(self):
+        """Fix 1 (Critical, adjudicated review pass 3): the evidence scan must consider EVERY
+        link of the work, including slug-named ones — a justified slug-named link IS evidence
+        and must block the reset trigger entirely. Here the work has one JUSTIFIED slug-named
+        link ("Thriller", justification set, name is a member of the work's own genres — an
+        entirely ordinary justified genre-derived slug link) plus one NULL-justified,
+        non-derivable, non-slug link ("Some Junk", not a bogus_targets member and not a
+        slug). An earlier, buggy draft scoped the evidence scan to non-slug links only, under
+        which the justified slug link would have been silently excluded from 'is there
+        evidence' and this work would have wrongly tripped the reset trigger, force-deleting
+        the junk link and reporting the work as reset. The corrected scan sees the justified
+        slug link as evidence -> the trigger must NOT fire at all: no delete_link (the junk
+        link is neither a bogus_targets member nor a slug so the ORIGINAL per-link trigger
+        also leaves it alone), no write_slug, no clear_stamp, and reset_works stays empty."""
+        thriller_slug_id = uuid4()
+        junk_id = uuid4()
+        work = _work(
+            links=[
+                (thriller_slug_id, "Thriller", "scout: genre-derived, confirmed"),
+                (junk_id, "Some Junk", None),
+            ],
+            genres=["Thriller"],
+            moods=[],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        all_tropes_by_id = {thriller_slug_id: "Thriller", junk_id: "Some Junk"}
+        # junk_id is NOT a bogus_targets member (non-derivable from this work's own tags).
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+        assert plan.reset_works == []
+
     def test_already_reset_work_converges_to_nothing_on_replan(self):
         """Convergence (found via the db_integration round-trip, not in the original design
         note): write_slug ALWAYS writes its exact-name slug links with justification=None, so
@@ -364,6 +406,93 @@ class TestResetNoEvidence:
         assert plan.write_slugs == []
         assert plan.clear_stamps == []
         assert plan.reset_works == []
+
+    def test_already_reset_work_with_combo_map_genre_converges_to_nothing_on_replan(self):
+        """Fix 2 (Important, adjudicated review pass 3): the slug carve-out must be keyed to
+        write_slug's EXACT output — _cleaned_tag_names(genres, moods) — not the shared
+        trope_predicate.is_fallback_trope_name (which checks a cleaned name against the work's
+        RAW, uncleaned genres|moods and therefore never accounts for COMBO_MAP splits). Raw
+        genre tag "Science Fiction Fantasy" is a COMBO_MAP entry that cleans to two exact-name
+        slugs, ["Science Fiction", "Fantasy"] (tag_maps.COMBO_MAP["science fiction fantasy"]) —
+        exactly what write_slug would have written as this work's post-reset shape. Simulates
+        that post-apply state directly (both links present, NULL-justified, as write_slug
+        always writes them, deep_enriched_at already cleared): re-plan must plan NOTHING for
+        this work — no delete, no re-trigger of the reset, no duplicate slug. Under the OLD
+        is_fallback_trope_name-based carve-out, neither "Science Fiction" nor "Fantasy" would
+        match the raw genre string "Science Fiction Fantasy" as a set member, so both would be
+        misclassified as non-slug 'real' tropes: has_real_remaining would see them as
+        real-remaining evidence (permanently blocking write_slug/clear_stamp), and — because
+        they're also NULL-justified — the reset-no-evidence scan would count them as non-slug
+        'evidence' too, wrongly re-triggering a full reset on this already-correctly-shaped
+        work forever."""
+        sci_fi_slug_id = uuid4()
+        fantasy_slug_id = uuid4()
+        work = _work(
+            links=[
+                (sci_fi_slug_id, "Science Fiction", None),
+                (fantasy_slug_id, "Fantasy", None),
+            ],
+            genres=["Science Fiction Fantasy"],
+            moods=[],
+            deep_enriched_at=None,  # already cleared by the prior reset's clear_stamp
+        )
+        all_tropes_by_id = {sci_fi_slug_id: "Science Fiction", fantasy_slug_id: "Fantasy"}
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+        assert plan.reset_works == []
+
+
+class TestStampOnlyClass:
+    """Fix 3 (Important, adjudicated review pass 3): a stamped work with >=1 link, ZERO
+    justified links anywhere, and ALL links slug-named (per Fix 2's _is_slug_link) is a
+    migration-backfill false positive whose fallback representation is already correct — plan
+    clear_stamp ONLY (no deletes, no slug writes). This traces case (a) from the review
+    directly: a work whose only links are the exact-name "Thriller"/"Dark" slugs write_slug
+    would have written, all NULL-justified, with a deep_enriched_at stamp still set (the 6.3
+    migration backfill stamped ANY work with >=1 trope row, without regard to whether those
+    rows were fallback slugs)."""
+
+    @pytest.mark.parametrize(
+        "deep_enriched_at, expect_clear_stamp, expect_reset_work",
+        [
+            ("2026-01-01T00:00:00Z", True, True),
+            (None, False, False),
+        ],
+        ids=["stamped_clears_stamp_only", "unstamped_plans_nothing"],
+    )
+    def test_slug_only_zero_justified_work(self, deep_enriched_at, expect_clear_stamp, expect_reset_work):
+        thriller_slug_id = uuid4()
+        dark_slug_id = uuid4()
+        work = _work(
+            links=[
+                (thriller_slug_id, "Thriller", None),
+                (dark_slug_id, "Dark", None),
+            ],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at=deep_enriched_at,
+        )
+        all_tropes_by_id = {thriller_slug_id: "Thriller", dark_slug_id: "Dark"}
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: set()})
+
+        # never any deletes or slug writes for this shape, stamped or not
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+
+        assert ([c.work_id for c in plan.clear_stamps] == [work.work_id]) is expect_clear_stamp
+        if not expect_clear_stamp:
+            assert plan.clear_stamps == []
+
+        reset_work_ids = {r.work_id for r in plan.reset_works}
+        assert (work.work_id in reset_work_ids) is expect_reset_work
+        if expect_reset_work:
+            (reset_entry,) = [r for r in plan.reset_works if r.work_id == work.work_id]
+            assert reset_entry.stamp_only is True
+        else:
+            assert plan.reset_works == []
 
 
 class TestPruneTrope:

--- a/test/unit/test_fallback_repair.py
+++ b/test/unit/test_fallback_repair.py
@@ -14,6 +14,7 @@ from agentic_librarian.etl.fallback_repair import (
     DeleteLink,
     FallbackRepairPlan,
     PruneTrope,
+    ResetWork,
     WriteSlug,
     _plan_from_data,
     _WorkData,
@@ -51,16 +52,28 @@ def test_delete_link_classification(case_name, justification, is_bogus_target, e
     required. A justified link is never touched even when it happens to coincide with a
     recomputed semantic-fallback target; a NULL-justified link whose trope is NOT derivable
     from this work's tags (real scout NULL-justification, e.g. semantic-collapse attractors) is
-    never touched either."""
+    never touched either.
+
+    A second, always-justified link is included on every work here so the work always has
+    >=1 justified link — this isolates the ORIGINAL per-link distinguisher under test from the
+    newer reset-no-evidence trigger (TestResetNoEvidence), which fires on a *different*
+    condition (zero justified links anywhere on the work) and would otherwise override the
+    'never_touched' cases below regardless of bogus_targets membership."""
     trope_id = uuid4()
+    anchor_id = uuid4()
     work = _work(
-        links=[(trope_id, "The Dark Night of the Soul", justification)],
+        links=[
+            (trope_id, "The Dark Night of the Soul", justification),
+            (anchor_id, "Found Family", "scout justification"),
+        ],
         genres=["Fantasy"],
         moods=["Dark"],
     )
     targets = {trope_id} if is_bogus_target else set()
 
-    plan = _plan_from_data([work], {trope_id: "The Dark Night of the Soul"}, {work.work_id: targets})
+    plan = _plan_from_data(
+        [work], {trope_id: "The Dark Night of the Soul", anchor_id: "Found Family"}, {work.work_id: targets}
+    )
 
     deleted_trope_ids = {d.trope_id for d in plan.delete_links}
     assert (trope_id in deleted_trope_ids) is expect_delete
@@ -72,11 +85,20 @@ def test_exact_name_slug_never_a_bogus_target_by_construction():
     _nearest_trope_by_name returning None on an exact match before any embedding/distance
     lookup happens. Here we assert the classification core's contract: if bogus_targets_by_work
     reports NO targets for a work (the exact-name-match outcome), no delete is planned even for
-    a NULL-justified link."""
-    trope_id = uuid4()
-    work = _work(links=[(trope_id, "Fantasy", None)], genres=["Fantasy"], moods=[])
+    a NULL-justified link.
 
-    plan = _plan_from_data([work], {trope_id: "Fantasy"}, {work.work_id: set()})
+    A second, always-justified link keeps this work out of the reset-no-evidence trigger's
+    reach (see test_delete_link_classification's docstring for why), isolating the
+    bogus-targets-membership behavior under test here."""
+    trope_id = uuid4()
+    anchor_id = uuid4()
+    work = _work(
+        links=[(trope_id, "Fantasy", None), (anchor_id, "Found Family", "scout justification")],
+        genres=["Fantasy"],
+        moods=[],
+    )
+
+    plan = _plan_from_data([work], {trope_id: "Fantasy", anchor_id: "Found Family"}, {work.work_id: set()})
 
     assert plan.delete_links == []
 
@@ -164,13 +186,18 @@ class TestWriteSlugAndClearStamp:
 
     def test_no_duplicate_slug_for_already_linked_exact_name(self):
         """A work that already carries an exact-name 'Thriller' slug link (untouched, real=False
-        but not planned for deletion) must not get a second write_slug for the same name."""
+        but not planned for deletion) must not get a second write_slug for the same name.
+
+        The exact-name slug link is given a justification here (a justified genre-derived link
+        is a perfectly ordinary shape) so this work has >=1 justified link and stays out of the
+        reset-no-evidence trigger's reach (see TestResetNoEvidence) — isolating the ORIGINAL
+        per-link bogus_targets distinguisher, which is what this test is about."""
         bogus_trope_id = uuid4()
         existing_slug_id = uuid4()
         work = _work(
             links=[
                 (bogus_trope_id, "The Dark Night of the Soul", None),
-                (existing_slug_id, "Thriller", None),  # exact-name slug already present
+                (existing_slug_id, "Thriller", "scout justification"),  # exact-name slug already present
             ],
             genres=["Thriller"],
             moods=["Dark"],
@@ -221,6 +248,124 @@ class TestWriteSlugAndClearStamp:
         assert plan.clear_stamps == []
 
 
+class TestResetNoEvidence:
+    """GH #70 follow-up: a work whose EVERY trope link is NULL-justified has no deep-scout
+    evidence at all. Non-derivable junk residue (a link that is NOT a bogus_targets member)
+    used to survive the original distinguisher, read as a real trope to has_real_remaining,
+    and permanently block write_slug/clear_stamp. New trigger: >=1 link AND zero
+    justified links -> ALL links planned for deletion, regardless of bogus_targets
+    membership. Existing rules (justified-link gate, zero-link works untouched) must be
+    unaffected."""
+
+    def test_zero_justified_work_all_links_deleted_including_non_derivable(self):
+        """3 NULL-justified links, only 1 of which is a bogus_targets member (semantically
+        derivable) -> ALL 3 are planned for deletion by the new trigger, and slugs/stamp
+        clearing follow from the existing deletion-triggered classes."""
+        derivable_id = uuid4()
+        junk_id_1 = uuid4()
+        junk_id_2 = uuid4()
+        work = _work(
+            links=[
+                (derivable_id, "The Dark Night of the Soul", None),
+                (junk_id_1, "Comics Graphic Novels", None),
+                (junk_id_2, "Some Other Junk", None),
+            ],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        all_tropes_by_id = {
+            derivable_id: "The Dark Night of the Soul",
+            junk_id_1: "Comics Graphic Novels",
+            junk_id_2: "Some Other Junk",
+        }
+        # only derivable_id is a bogus_targets member; the two junk tropes are NOT derivable
+        # from this work's genres/moods at all.
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: {derivable_id}})
+
+        deleted_trope_ids = {d.trope_id for d in plan.delete_links if d.work_id == work.work_id}
+        assert deleted_trope_ids == {derivable_id, junk_id_1, junk_id_2}
+
+        slug_names = {s.trope_name for s in plan.write_slugs if s.work_id == work.work_id}
+        assert slug_names == {"Thriller", "Dark"}
+        assert [c.work_id for c in plan.clear_stamps] == [work.work_id]
+
+    def test_at_least_one_justified_link_never_triggers_full_reset(self):
+        """1 justified + 2 NULL-just links (1 of the NULL-just links derivable, 1 not) ->
+        the new trigger must NOT fire (there IS a justified link); only the original
+        semantic-recompute trigger applies, so only the derivable NULL-just link is deleted.
+        The justified link survives, so no slug/stamp actions follow."""
+        justified_id = uuid4()
+        derivable_id = uuid4()
+        junk_id = uuid4()
+        work = _work(
+            links=[
+                (justified_id, "Found Family", "scout justification"),
+                (derivable_id, "The Dark Night of the Soul", None),
+                (junk_id, "Comics Graphic Novels", None),
+            ],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        all_tropes_by_id = {
+            justified_id: "Found Family",
+            derivable_id: "The Dark Night of the Soul",
+            junk_id: "Comics Graphic Novels",
+        }
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: {derivable_id}})
+
+        deleted_trope_ids = {d.trope_id for d in plan.delete_links if d.work_id == work.work_id}
+        assert deleted_trope_ids == {derivable_id}
+
+        # the justified link survives -> no write_slug/clear_stamp for this work
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+
+    def test_zero_link_work_never_triggers_reset(self):
+        """A work with ZERO links must never trigger the new reset (the trigger explicitly
+        requires >=1 link) — the #67 fast-pass tropeless works stay invisible."""
+        work = _work(
+            links=[],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at="2026-01-01T00:00:00Z",
+        )
+        plan = _plan_from_data([work], {}, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+
+    def test_already_reset_work_converges_to_nothing_on_replan(self):
+        """Convergence (found via the db_integration round-trip, not in the original design
+        note): write_slug ALWAYS writes its exact-name slug links with justification=None, so
+        a work that was JUST reset would, without the fallback-name carve-out, still have zero
+        justified links on the very next re-plan and get its brand-new legitimate slugs
+        deleted-and-rewritten forever. Simulates that post-apply state directly: a work whose
+        ONLY links are exact-name genre/mood slugs (NULL-justified, as write_slug always writes
+        them) must plan NOTHING — not a delete, not a re-trigger of the reset, not a duplicate
+        slug."""
+        thriller_slug_id = uuid4()
+        dark_slug_id = uuid4()
+        work = _work(
+            links=[
+                (thriller_slug_id, "Thriller", None),
+                (dark_slug_id, "Dark", None),
+            ],
+            genres=["Thriller"],
+            moods=["Dark"],
+            deep_enriched_at=None,  # already cleared by the prior reset's clear_stamp
+        )
+        all_tropes_by_id = {thriller_slug_id: "Thriller", dark_slug_id: "Dark"}
+        plan = _plan_from_data([work], all_tropes_by_id, {work.work_id: set()})
+
+        assert plan.delete_links == []
+        assert plan.write_slugs == []
+        assert plan.clear_stamps == []
+        assert plan.reset_works == []
+
+
 class TestPruneTrope:
     def test_pruned_when_all_links_deleted(self):
         trope_id = uuid4()
@@ -258,6 +403,7 @@ def _sample_plan() -> FallbackRepairPlan:
         write_slugs=[WriteSlug(work_id=uuid4(), trope_name="Dark")],
         clear_stamps=[ClearStamp(work_id=uuid4())],
         prune_tropes=[PruneTrope(trope_id=uuid4(), trope_name="The Dark Night of the Soul")],
+        reset_works=[ResetWork(work_id=uuid4(), title="Lessons in Chemistry")],
     )
 
 
@@ -270,7 +416,12 @@ def test_token_round_trip_format_parse_equal(tmp_path, db_target):
     """The optional `db target: ...` header (final whole-branch review fix, DB-target
     visibility) is written ABOVE the '== PLAN TOKENS ==' block as a plain human-readable
     line — parse_report's fail-closed parser only looks between the start/end markers, so
-    the header must never appear in (or otherwise corrupt) the parsed token set."""
+    the header must never appear in (or otherwise corrupt) the parsed token set.
+
+    _sample_plan() also carries a reset_works entry (#70 follow-up) — the report's
+    'reset (no-evidence) works' section is informational only (ABOVE/OUTSIDE the token
+    block, like the db-target header), so its presence must not affect the parsed token set
+    either."""
     plan = _sample_plan()
     expected = plan_tokens(plan)
 
@@ -285,6 +436,12 @@ def test_token_round_trip_format_parse_equal(tmp_path, db_target):
         header_line_idx = report_text.splitlines().index(f"db target: {db_target}")
         token_start_idx = report_text.splitlines().index("== PLAN TOKENS ==")
         assert header_line_idx < token_start_idx
+
+    report_lines = report_text.splitlines()
+    reset_section_idx = next(i for i, line in enumerate(report_lines) if line.startswith("reset (no-evidence) works"))
+    token_start_idx = report_lines.index("== PLAN TOKENS ==")
+    assert reset_section_idx < token_start_idx
+    assert f"  work_id={plan.reset_works[0].work_id}  title='Lessons in Chemistry'" in report_lines
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up to #138 (part of #70). Found at the apply gate: 25 prod works (incl. *Lessons in Chemistry* — and *Ghost Story* + *Empire in Black and Gold*, two of the #125 session's bad recommendations) have ZERO justified links — no deep-scout evidence ever landed. The #138 repair deletes their re-derivable links, but non-derivable junk residue survives, reads as a "real" trope, and permanently blocks slug restoration, stamp clearing, and the #97 sweep.

## What

One new delete trigger + one stamp-only trigger, both riding the existing gate unchanged:

- **reset:** a work with ≥1 link, zero justified links anywhere, and at least one non-slug link gets ALL its links planned for deletion; the existing deletion-triggered `write_slug`/`clear_stamp` classes then fire naturally. A single justified link anywhere blocks the trigger entirely (review-hardened: the evidence scan covers ALL links).
- **stamp-only:** a stamped work whose links are all legitimate exact-name slugs (zero justified) just gets its stamp cleared — its fallback representation is already correct; the sweep re-enriches it.
- Slug identity = case-insensitive membership in `_cleaned_tag_names(genres∪moods)` — exactly `write_slug`'s output — so combo/alias genres can't cause delete-and-rewrite churn on re-plans (review-caught).
- On the #69 rule: the signal is not per-link real-vs-fallback classification but "no evidence-bearing link on the whole work" (all 6,247 justified links in prod came from real scout runs); zero-link works are untouchable by construction; the reset work list appears in the dry-run report for operator review; the operation is recoverable (the sweep rebuilds fingerprints).

Token format, parser, and drift gate byte-identical — a stale pre-extension report simply drift-refuses against the richer fresh plan.

## Tests

36 unit (incl. the review's Critical counterexample as a pinned case, combo-genre convergence, stamp-only both ways) + 5 db_integration executed against real local Postgres (Lessons-analog e2e with a provably non-derivable junk vector). Full unit suite green modulo known env-dependent failures (stash-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
