### PR TITLE
fix(api): real tropes outrank slug fallbacks in history and catalog displays

### DIFF
--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -127,10 +127,16 @@ def db_health_check(user: AuthenticatedUser = Depends(get_current_user)):  # noq
         return JSONResponse(status_code=503, content={"status": "error", "detail": str(e)})
 
 
+def _ranked_tropes(work_tropes):
+    """Real scout tropes (justified) outrank genre/mood slug fallbacks (justification is
+    NULL, default relevance 1.0) — otherwise slugs crowd every display list (#70)."""
+    return sorted(work_tropes, key=lambda wt: (wt.justification is None, -wt.relevance_score, wt.trope.name))
+
+
 def _history_item(h) -> dict:
     """Serialize one ReadingHistory row to the /history payload shape (shared by GET + PATCH)."""
     work = h.edition.work
-    top = sorted(work.tropes, key=lambda wt: wt.relevance_score, reverse=True)[:3]
+    top = _ranked_tropes(work.tropes)[:3]
     return {
         "id": str(h.id),
         "title": work.title,
@@ -289,7 +295,7 @@ def get_works(
                 "publication_year": w.original_publication_year,
                 "genres": w.genres or [],
                 "moods": w.moods or [],
-                "tropes": [wt.trope.name for wt in w.tropes],
+                "tropes": [wt.trope.name for wt in _ranked_tropes(w.tropes)],
                 "styles": [{"attribute": ws.attribute_type, "name": ws.style.name} for ws in w.styles],
             }
             for w in works

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -129,8 +129,10 @@ def db_health_check(user: AuthenticatedUser = Depends(get_current_user)):  # noq
 
 def _ranked_tropes(work_tropes):
     """Real scout tropes (justified) outrank genre/mood slug fallbacks (justification is
-    NULL, default relevance 1.0) — otherwise slugs crowd every display list (#70)."""
-    return sorted(work_tropes, key=lambda wt: (wt.justification is None, -wt.relevance_score, wt.trope.name))
+    NULL, default relevance 1.0) — otherwise slugs crowd every display list (#70).
+    The sort touches wt.trope.name for EVERY link: callers must eager-load
+    WorkTrope.trope (both current call sites do) or this becomes an N+1."""
+    return sorted(work_tropes, key=lambda wt: (wt.justification is None, -wt.relevance_score, wt.trope.name.lower()))
 
 
 def _history_item(h) -> dict:

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -122,6 +122,44 @@ def test_history_includes_genre_and_top_three_tropes(two_user_client, db_url):
     assert row["tropes"] == ["Antihero", "Found Family", "Heist"]  # top 3, score desc; "Low Score" dropped
 
 
+def test_history_top_tropes_prefer_justified_over_slug_fallbacks(two_user_client, db_url):
+    """#70 display fix: slug fallbacks carry default relevance 1.0 with NULL justification;
+    real scout tropes (justified, lower relevance) must still win the top-3."""
+    from agentic_librarian.db.models import Trope, WorkTrope
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = AuthorModel(name="Slugged Author")
+        work = Work(
+            title="Slugged Book",
+            genres=["Fantasy"],
+            moods=["Dark", "Sad"],
+            contributors=[WorkContributor(author=author, role="Author")],
+        )
+        edition = Edition(work=work, format="ebook")
+        session.add_all([author, work, edition])
+        session.flush()
+        links = [
+            ("Dark", 1.0, None),  # slug fallbacks: NULL justification, default relevance
+            ("Sad", 1.0, None),
+            ("Fantasy", 1.0, None),
+            ("Heist Gone Wrong", 0.70, "the vault job unravels"),  # real scout tropes
+            ("Reluctant Mentor", 0.90, "trains the thief against his will"),
+        ]
+        for name, score, just in links:
+            trope = Trope(name=name)
+            session.add(trope)
+            session.flush()
+            session.add(WorkTrope(work_id=work.id, trope_id=trope.id, relevance_score=score, justification=just))
+        session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2026, 1, 3)))
+        session.flush()
+
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    row = next(r for r in rows if r["title"] == "Slugged Book")
+    # Both justified tropes lead (relevance desc) despite lower scores; ONE slug fills slot 3.
+    assert row["tropes"] == ["Reluctant Mentor", "Heist Gone Wrong", "Dark"]
+
+
 def test_history_no_tropes_returns_empty_list(two_user_client):
     rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
     shared = next(r for r in rows if r["title"] == "Shared Book")

--- a/test/unit/test_api_history.py
+++ b/test/unit/test_api_history.py
@@ -139,3 +139,60 @@ def test_get_history_limit_cap_enforced():
     assert client.get("/history?limit=500").status_code == 422
     assert client.get("/history?limit=0").status_code == 422
     assert client.get("/history?offset=-1").status_code == 422
+
+
+def _mock_work_trope(name, *, relevance, justification):
+    wt = MagicMock()
+    wt.trope.name = name
+    wt.relevance_score = relevance
+    wt.justification = justification
+    return wt
+
+
+@pytest.mark.parametrize(
+    ("tropes", "expected_names"),
+    [
+        pytest.param(
+            [
+                _mock_work_trope("Slow Burn", relevance=0.9, justification="found in scout summary"),
+                _mock_work_trope("Found Family", relevance=0.7, justification="found in scout summary"),
+                _mock_work_trope("Dark", relevance=1.0, justification=None),
+                _mock_work_trope("Sad", relevance=1.0, justification=None),
+                _mock_work_trope("Fantasy", relevance=1.0, justification=None),
+            ],
+            ["Slow Burn", "Found Family", "Dark"],
+            id="justified_tropes_outrank_slugs_top_3",
+        ),
+        pytest.param(
+            [
+                _mock_work_trope("Fantasy", relevance=1.0, justification=None),
+                _mock_work_trope("Dark", relevance=1.0, justification=None),
+            ],
+            ["Dark", "Fantasy"],
+            id="slug_only_work_still_shows_slugs",
+        ),
+    ],
+)
+def test_get_history_tropes_prefer_real_over_slugs(tropes, expected_names):
+    with patch("agentic_librarian.api.main.db_manager") as mock_db:
+        mock_session = MagicMock()
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+
+        mock_history = MagicMock()
+        mock_history.id = "test-id"
+        mock_history.date_completed = date(2024, 1, 1)
+        mock_history.user_rating = 5
+        mock_history.edition.format = "hardcover"
+        mock_history.edition.work.title = "Test Book"
+        mock_contributor = MagicMock()
+        mock_contributor.author.name = "Test Author"
+        mock_contributor.role = "Author"
+        mock_history.edition.work.contributors = [mock_contributor]
+        mock_history.edition.work.tropes = tropes
+
+        _history_chain(mock_session, [mock_history])
+
+        response = client.get("/history")
+        assert response.status_code == 200
+        data = response.json()
+        assert data[0]["tropes"] == expected_names

--- a/test/unit/test_api_works.py
+++ b/test/unit/test_api_works.py
@@ -118,3 +118,30 @@ def test_get_works_limit_cap_enforced():
     assert client.get("/works?limit=500").status_code == 422
     assert client.get("/works?limit=0").status_code == 422
     assert client.get("/works?offset=-1").status_code == 422
+
+
+def _mock_work_trope(name, *, relevance, justification):
+    wt = MagicMock()
+    wt.trope.name = name
+    wt.relevance_score = relevance
+    wt.justification = justification
+    return wt
+
+
+def test_get_works_tropes_ordered_justified_first():
+    with patch("agentic_librarian.api.main.db_manager") as mock_db:
+        mock_session = MagicMock()
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+        work = _mock_work()
+        work.tropes = [
+            _mock_work_trope("Dark", relevance=1.0, justification=None),
+            _mock_work_trope("Slow Burn", relevance=0.9, justification="found in scout summary"),
+            _mock_work_trope("Fantasy", relevance=1.0, justification=None),
+            _mock_work_trope("Found Family", relevance=0.7, justification="found in scout summary"),
+        ]
+        _mock_chain(mock_session, [work])
+
+        response = client.get("/works")
+        assert response.status_code == 200
+        entry = response.json()[0]
+        assert entry["tropes"] == ["Slow Burn", "Found Family", "Dark", "Fantasy"]


### PR DESCRIPTION
Live-report follow-up to the #70 repair (works *Empire in Black and Gold* / *Beware of Chicken* showing only slug tropes on the history view despite fresh real tropes in the DB).

## What

Slug fallback links carry default `relevance_score = 1.0`, so `_history_item`'s top-3-by-relevance always picked `Dark, Sad, Fantasy` over a work's real narrative tropes (which score below 1.0). The `/works` catalog listing had the same problem in arbitrary-order form.

Shared `_ranked_tropes` helper: **justified links first, then relevance desc, then name** (deterministic ties). History card top-3 and catalog trope lists now lead with real tropes; slug-only works still show their slugs (nothing is filtered).

Data note: this is display-ordering only — slug relevance staying at 1.0 for *retrieval* is intentional (genre/mood matching weight), and the underlying links are all correct post-repair.

## Tests

New parametrized cases: mixed work (2 justified + 3 slugs → top-3 = both real tropes then one slug), slug-only work still displays, catalog list ordered justified-first. Full unit suite green modulo the known env-dependent failures (stash-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
