### PR TITLE
fix(enrichment): deep pass pins its work id + import author-cell normalization

### DIFF
--- a/alembic/versions/f871fd59415e_detected_duplicates.py
+++ b/alembic/versions/f871fd59415e_detected_duplicates.py
@@ -1,0 +1,41 @@
+"""detected_duplicates — GH #141 deep-pass redirect feed for the works-merge tool
+
+Revision ID: f871fd59415e
+Revises: 48e3762d6c0c
+Create Date: 2026-07-14 00:00:00.000000
+
+Rule 11 note: this migration only ADDS a table; it alters nothing existing, so the
+pre-migration-schema rehearsal pressure that applies to migration-gating tools (dedup,
+requeue) is nil here — no query against an existing model changes shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f871fd59415e"
+down_revision: str | None = "48e3762d6c0c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "detected_duplicates",
+        sa.Column("work_id_a", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("work_id_b", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("detected_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["work_id_a"], ["works.id"]),
+        sa.ForeignKeyConstraint(["work_id_b"], ["works.id"]),
+        sa.PrimaryKeyConstraint("work_id_a", "work_id_b"),
+    )
+    op.create_index("ix_detected_duplicates_work_id_b", "detected_duplicates", ["work_id_b"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_detected_duplicates_work_id_b", table_name="detected_duplicates")
+    op.drop_table("detected_duplicates")

--- a/docs/superpowers/specs/2026-07-14-works-merge-tool-design.md
+++ b/docs/superpowers/specs/2026-07-14-works-merge-tool-design.md
@@ -97,6 +97,14 @@ then `deep_enriched_at` newest, then most editions, then lowest UUID (tie determ
    action (state this in the module docstring so nobody "fixes" it later).
 6. Loser Work row deleted last; orphaned Authors reported via the existing
    `_plan_orphan_authors` loop discipline (re-run dry-run until clean, the 6.3 pattern).
+   Deleting a work must first delete its `detected_duplicates` rows on BOTH sides
+   (`work_id_a` and `work_id_b`) — the FKs deliberately have no ON DELETE behavior (a
+   dangling detection referencing a now-gone work is a plan bug, and the deliberate choice
+   is to fail loud on the FK rather than silently cascade). PR-2 must also treat the
+   `detected_duplicates` feed as UNORDERED pairs: both `(A, B)` and `(B, A)` rows can exist
+   for the same cluster (the composite PK is `(work_id_a, work_id_b)`, not order-normalized),
+   so detection/planning must de-duplicate by the unordered pair, not assume a single
+   canonical row per cluster.
 
 **Gate:** identical to dedup/repair: op-tagged tokens per action (repoint/drop/link-copy
 tagged with their op + ids), report under `data/reports/works-merge-<UTC>.txt` with the DB

--- a/docs/superpowers/specs/2026-07-14-works-merge-tool-design.md
+++ b/docs/superpowers/specs/2026-07-14-works-merge-tool-design.md
@@ -1,0 +1,130 @@
+# Works-Merge Tool + Duplicate-Work Prevention (Design)
+
+**Date:** 2026-07-14 · **Issues:** #141 (unpinned deep pass) #142 (comma-joined authors) +
+the dup triage backlog · **Spec status:** self-approved per ground rules (user directive
+2026-07-14: "spec the works merge tool").
+
+## Goal
+
+One book = one Work row. Merge the known duplicate clusters (with live user history split
+across copies), and close the two mechanisms that mint new duplicates so the merge isn't a
+treadmill.
+
+## Verified findings (prod forensics 2026-07-14)
+
+1. **Known duplicate clusters:** *Beware of Chicken* pair `9e9cfc45` (slug-only, malformed
+   author `'Casualfarmer, CasualFarmer'`, Justin's 2026-06-19 read) / `a5e56605` (15
+   justified tropes, clean author, suggested 2026-06-12) — **same ISBN 9781039452275**;
+   *We Are Legion* pair `14c8f3b5`/`7fc21c9e` (punctuation-variant titles); the 6.3
+   report-only trio (*Calling Bullshit*, *Yellowface*, and what was then a Beware pair);
+   *Wrath of Poseidon* duplicated contributor rows (related but a contributor-level fix).
+   Note: *Beware of Chicken 2* is the sequel, NOT a dup — title-prefix matching must not
+   collapse series entries.
+2. **Why dups mint:** creation-time work matching is identity-based (normalized title +
+   author); VARIANT identity defeats it — dirty author strings (#142's comma-joined
+   artifact) and punctuation-variant titles. The 6.3 machinery (advisory lock,
+   insert_or_requery, normalized-title re-check) prevents same-identity RACE dups only.
+3. **Live bug (#141):** the deep-enrichment pass does not pin the invoked work id — its
+   persist-side dedup re-check re-resolves by scout-canonical identity and can land
+   tropes + the `deep_enriched_at` stamp on a DIFFERENT row (observed: sweep enqueued
+   `9e9cfc45`, stamp+tropes landed on `a5e56605` at 21:03:05Z). The invoked row stays
+   `never_deep_enriched` forever → requeue loop burning a paid pass per sweep.
+4. **Reusable machinery already exists:** `etl/dedup_backfill.py` detects
+   `duplicate_works` as a REPORT-ONLY class and owns the proven op-tagged-token gate
+   (plan → persisted report → re-plan-fresh apply refusing on any drift, END-marker
+   fail-closed parser). The 6.3 rollout also proved the cross-class composition hazard
+   (narrator×edition, edition×reading-history cascades lose rows when composed from one
+   snapshot) and the deferred-intersections loop discipline — a works merge triggers
+   exactly those cascades and must own them internally.
+
+## Delivery shape: two PRs + gated ops
+
+### PR-1 `fix/enrich-pins-work-id` (#141 + #142 — prevention first, it's live)
+
+1. **Pin the invoked work.** The deep pass persists tropes/styles/stamp against the work
+   id it was invoked with, full stop. If the persist-side dedup re-check resolves the
+   scout-canonical identity to a DIFFERENT existing work: do NOT write there; stamp the
+   invoked row (the pass DID complete), and record the detection — insert into a small
+   `detected_duplicates` side table (work_id_a, work_id_b, detected_at, source) or, if a
+   table feels heavy, log at WARNING with a stable grep token AND surface it in the merge
+   tool's plan as a high-confidence input. Recommended: the table — the merge tool then
+   has a queryable feed, and the #97 sweep stops re-listing the row. (Migration: one
+   table, nullable-free, no backfill.)
+2. **Author-cell parsing (#142):** split/normalize comma-joined author fields at import
+   parse time. Disambiguation rule: one comma + both tokens re-case-match a single
+   plausible name ("Last, First") → single author; otherwise split on commas/`&`/" and ".
+   When genuinely ambiguous, single-author wins (fail-safe: a wrong single author is
+   mergeable; a wrongly-split author mints entities). Parametrized table of the real
+   Goodreads/Libby author-cell shapes. Include a one-off repair query for EXISTING
+   comma-joined author rows in the dup triage (report class in the merge tool, not
+   auto-fixed).
+3. Rehearsal rule 11 applies to the `detected_duplicates` migration: the merge tool (PR-2)
+   must not entity-load any model this PR alters when run pre-migration.
+
+### PR-2 `feat/works-merge` — the gated merge tool
+
+Extend `etl/dedup_backfill.py` (same module, same gate, same CLI home in
+`scripts/clean_catalog.py`) — do NOT build a parallel tool:
+
+**Detection (plan classes), strongest-evidence first:**
+1. `works_same_isbn`: two+ works sharing an `editions.isbn_13` (non-null). Highest
+   confidence (catches the Beware pair).
+2. `works_same_identity`: normalized(title) equal AND author-token-set overlap ≥ one
+   full token (catches exact-title dups with dirty author variants). Normalization =
+   the existing `_normalize` PLUS punctuation folding (`[;:()\[\]&.,!?'"-]` → space,
+   whitespace collapse) so the *We Are Legion* pair matches. Series guard: works whose
+   titles differ by a trailing number/volume token NEVER match (Beware of Chicken 2).
+3. `works_detected_duplicates`: rows from #141's detection feed.
+4. `works_fuzzy_report_only`: high-similarity title pairs (trigram or token-set ratio)
+   — REPORT ONLY, never auto-applied; operator promotes pairs by hand if real.
+
+**Survivor selection (deterministic, stated in the report):** most justified trope links,
+then `deep_enriched_at` newest, then most editions, then lowest UUID (tie determinism).
+
+**Merge composition (single transaction per cluster, internally ordered):**
+1. Editions: repoint loser editions to survivor; on `uq_editions_work_format` collision,
+   merge the edition pair — keep survivor's edition row, repoint the loser edition's
+   `reading_history` and `edition_narrators` to it (reading_history collisions on
+   `uq_reading_history_user_edition_date` = the same read event recorded twice → keep
+   survivor's row, drop the loser's; COUNT and report as `dropped_duplicate_reads`).
+2. Suggestions: repoint to survivor; on `uq_suggestions_active` collision keep the
+   survivor's active row (drop loser's; count).
+3. Trope/style links: union — insert loser links missing on survivor (carry
+   justification/relevance), drop the rest.
+4. Contributors: union by (author_id, role); the #142 malformed-author rows do NOT get
+   copied when a clean equivalent exists on the survivor (report them).
+5. Availability cache/user_libraries: keyed by title/author strings, not work id — no
+   action (state this in the module docstring so nobody "fixes" it later).
+6. Loser Work row deleted last; orphaned Authors reported via the existing
+   `_plan_orphan_authors` loop discipline (re-run dry-run until clean, the 6.3 pattern).
+
+**Gate:** identical to dedup/repair: op-tagged tokens per action (repoint/drop/link-copy
+tagged with their op + ids), report under `data/reports/works-merge-<UTC>.txt` with the DB
+target header, apply re-plans fresh and refuses on ANY addition or op-flip, single
+transaction, per-class applied counts, convergence loop (steps 2→3 of the 6.3 runbook).
+The deferred-intersections lesson applies WITHIN this tool: a cluster whose merge
+composition would touch a reading_history row twice in one plan defers the second
+composition to the next dry-run loop rather than composing from one snapshot.
+
+**Tests (the 6.3 bar):** parametrized unit tables for detection (incl. the series guard,
+the sequel non-match, punctuation folding) and survivor selection; e2e-shaped
+db_integration round-trips: full merge of a Beware-shaped cluster (split read events →
+one work, both reads preserved, no constraint violations), collision classes
+(same-format editions, same-day duplicate reads, double active suggestions), drift-gate
+refusal with zero mutations, convergence re-plan. Fixture test that DROPS
+`detected_duplicates` to mirror pre-migration prod (rule 11) if PR-1's migration hasn't
+been applied when the tool runs.
+
+### Ops (after both PRs, the usual gate)
+
+Deploy → dry-run → operator reviews the cluster report (expected: Beware pair,
+We Are Legion pair, Calling Bullshit, Yellowface; fuzzy class report-only) → approval →
+apply → convergence dry-run. Then one `--requeue-unenriched` check: `9e9cfc45` disappears
+from the plan (merged away), closing the #141 requeue loop for good.
+
+## Out of scope
+
+- Wrath of Poseidon's duplicated CONTRIBUTOR rows (same author twice on one work) — a
+  contributor-level dedup, add as a small report class if cheap, else separate.
+- Retroactive global fuzzy dedup beyond the known clusters — the fuzzy class stays
+  report-only until the operator has seen a few reports' precision.

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -479,8 +479,12 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.requeue_unenriched:
             candidates = enrichment_sweep.plan_requeue(session)
-            print(f"\n{len(candidates)} works would be requeued for deep enrichment.")
-            for c in candidates[:80]:
+            # GH #141: pending_merge works need the works-merge tool, not another paid deep
+            # pass — split them out of the enqueue loop and print under their own heading.
+            enrichable = [c for c in candidates if c.reason != "pending_merge"]
+            pending_merge = [c for c in candidates if c.reason == "pending_merge"]
+            print(f"\n{len(enrichable)} works would be requeued for deep enrichment.")
+            for c in enrichable[:80]:
                 # Adversarial-pass finding (#95 #97): show deep_enriched_at next to no_real_trope
                 # entries so a REPEAT sweep lets the operator see "already re-attempted after X"
                 # — see the runbook's step 6 repeat-cost warning (each re-enqueue costs up to 9
@@ -488,13 +492,16 @@ def main(argv: list[str] | None = None) -> int:
                 # re-enqueued forever).
                 stamp = f"  (deep_enriched_at={c.deep_enriched_at})" if c.deep_enriched_at else ""
                 print(f"  [{c.reason:20}] {c.title[:60]}  ({c.work_id}){stamp}")
+            print(f"\n{len(pending_merge)} works are pending a merge (see the works-merge tool) — NEVER enqueued:")
+            for c in pending_merge[:80]:
+                print(f"  [pending_merge        ] {c.title[:60]}  ({c.work_id})")
             early = _refuse(args, url, safe)
             if early is not None:
                 return early
             from agentic_librarian.enrichment.tasks import enqueue_enrichment
 
-            enqueued = sum(1 for c in candidates if enqueue_enrichment(str(c.work_id)))
-            print(f"\napplied: enqueued {enqueued}/{len(candidates)} works (see logs for any that skipped).")
+            enqueued = sum(1 for c in enrichable if enqueue_enrichment(str(c.work_id)))
+            print(f"\napplied: enqueued {enqueued}/{len(enrichable)} works (see logs for any that skipped).")
             return 0
 
         if args.dedup_for_constraints:

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -94,6 +94,12 @@ def enrich(
     if result == "missing":
         # Non-retryable: the work no longer exists. 404 stops Cloud Tasks from retrying.
         raise HTTPException(status_code=404, detail="work not found")
+    if result == "redirected":
+        # GH #141: the pass completed but persist landed its data on a different (twin) work
+        # — a detected_duplicates row now records it for the works-merge tool. Non-retryable
+        # success: the invoked work IS stamped, and retrying would only burn another paid
+        # deep pass for data that already lives on the twin.
+        return {"work_id": str(work_id), "status": "redirected"}
     if result == "empty":
         if _has_real_trope(work_id):
             # The work already has a real fingerprint from a prior pass; this empty pass

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -390,6 +390,23 @@ class AvailabilityCache(Base):
     )  # caller always supplies the fetch time; no default by design
 
 
+class DetectedDuplicate(Base):
+    """GH #141: recorded when the deep pass's write-session dedup re-check resolves the
+    invoked work's scout-canonical identity to a DIFFERENT existing work (a "redirect") —
+    the persist legitimately lands on the twin (same book), so this table is the works-merge
+    tool's queryable feed instead of a silent mis-stamp. work_id_a = the invoked/dirty work,
+    work_id_b = the resolved twin. Composite PK so a repeat detection (e.g. a redelivered
+    Cloud Tasks retry) upserts-or-ignores rather than piling up duplicate rows — see
+    two_phase.enrich_deep's ON CONFLICT DO NOTHING insert."""
+
+    __tablename__ = "detected_duplicates"
+
+    work_id_a: Mapped[UUID] = mapped_column(ForeignKey("works.id"), primary_key=True, nullable=False)
+    work_id_b: Mapped[UUID] = mapped_column(ForeignKey("works.id"), primary_key=True, nullable=False, index=True)
+    source: Mapped[str] = mapped_column(String, nullable=False)
+    detected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
 class ImportJob(Base):
     """One bulk-import upload (Spec 2026-06-18). Progress is derived from import_rows,
     not stored here — so Cloud Tasks redelivery can never double-count."""

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -24,10 +24,11 @@ from uuid import UUID
 
 from sqlalchemy import func
 from sqlalchemy import text as sa_text  # aliased: a loop variable in _warm_embeddings shadows 'text' (F402)
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.get_or_create import get_or_create
-from agentic_librarian.db.models import Author, Edition, ReadingHistory, Work, WorkContributor
+from agentic_librarian.db.models import Author, DetectedDuplicate, Edition, ReadingHistory, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl.persist import collect_embedding_texts, persist_enriched_work
 from agentic_librarian.orchestration.definitions import (
@@ -182,24 +183,40 @@ def enrich_deep(work_id: UUID) -> str:
     at enrich-queue concurrency 4, where a late transient failure also re-paid every LLM
     call), then re-persist in a fresh session.
 
+    GH #141: the write session's persist_enriched_work re-checks dedup by SCOUT-CANONICAL
+    identity (title + author as the scouts now report them), which can differ from the
+    invoked work's own (possibly dirty) identity and resolve to a DIFFERENT existing Work
+    — the invoked row's twin. This is not undone (the persist legitimately lands on the
+    twin — it's the same book); refusing would require re-plumbing persist_enriched_work's
+    many callers for zero data benefit. Instead the redirect is recorded in
+    detected_duplicates (the works-merge tool's feed) and the INVOKED row is stamped, so
+    the requeue sweep stops re-listing it (closing the paid-pass-burning loop).
+
     Returns one of:
-      "missing" — no Work has that id, or it has no linked Author (non-retryable). Also
-                  returned (final-review Minor 7 honesty fix) if the write session's
-                  persist_enriched_work returns None — nothing was persisted and
-                  deep_enriched_at was never stamped, so "done" would be a lie; "missing" tells
-                  the caller (api/internal.py) this is non-retryable the same way an
-                  already-gone Work is, rather than falsely reporting success. Also returned
-                  (PR #126 review) if the empty-path stamp session finds the Work gone —
-                  it was deleted while the slow scouts were running with no session held.
-      "empty"   — the scouts yielded nothing to add this pass, and the Work still exists. A
-                  SHORT session stamps work.deep_enriched_at = now() anyway (GH #97): the
-                  timestamp means "the deep pass COMPLETED", including confirmed-empty — the
-                  caller (api/internal.py) decides retryability from the work's real-trope
-                  state, not from this string alone. An exception raised before this point
-                  propagates uncaught, leaving deep_enriched_at unstamped so Cloud Tasks
-                  retries the whole pass.
-      "done"    — the scouts found something AND the write session actually persisted +
-                  stamped deep_enriched_at on the SAME Work in the SAME session."""
+      "missing"    — no Work has that id, or it has no linked Author (non-retryable). Also
+                     returned (final-review Minor 7 honesty fix) if the write session's
+                     persist_enriched_work returns None — nothing was persisted and
+                     deep_enriched_at was never stamped, so "done" would be a lie; "missing"
+                     tells the caller (api/internal.py) this is non-retryable the same way an
+                     already-gone Work is, rather than falsely reporting success. Also
+                     returned (PR #126 review) if the empty-path stamp session finds the Work
+                     gone — it was deleted while the slow scouts were running with no session
+                     held. Also returned (#141) if the redirect path's re-load of the invoked
+                     row by id finds it gone — same deleted-mid-pass honesty rule.
+      "empty"      — the scouts yielded nothing to add this pass, and the Work still exists. A
+                     SHORT session stamps work.deep_enriched_at = now() anyway (GH #97): the
+                     timestamp means "the deep pass COMPLETED", including confirmed-empty — the
+                     caller (api/internal.py) decides retryability from the work's real-trope
+                     state, not from this string alone. An exception raised before this point
+                     propagates uncaught, leaving deep_enriched_at unstamped so Cloud Tasks
+                     retries the whole pass.
+      "done"       — the scouts found something AND the write session actually persisted +
+                     stamped deep_enriched_at on the SAME Work in the SAME session.
+      "redirected" — (#141) the scouts found something, but persist landed it on a DIFFERENT
+                     existing Work (the twin) instead of the invoked one. The invoked row is
+                     stamped deep_enriched_at (the pass DID complete) and a detected_duplicates
+                     row is recorded; the twin's data is untouched by this function beyond
+                     persist's own write. Non-retryable success — see api/internal.py."""
     with db_manager.get_session() as session:
         work = session.get(Work, work_id)
         if work is None:
@@ -228,14 +245,33 @@ def enrich_deep(work_id: UUID) -> str:
     _warm_embeddings(row)
 
     with db_manager.get_session() as session:
-        work = _persist_row(session, row)
-        if work is None:
+        persisted = _persist_row(session, row)
+        if persisted is None:
             # Nothing was persisted (e.g. the scouted row had no usable contributor to attach
             # to — persist_enriched_work's own "no work" case) and deep_enriched_at was never
             # stamped. Reporting "done" here would be dishonest: the caller would treat a
             # no-op as success. "missing" makes it non-retryable the same way an already-gone
             # Work is (final-review Minor 7).
             return "missing"
-        work.deep_enriched_at = datetime.now(UTC)
+        if persisted.id == work_id:
+            persisted.deep_enriched_at = datetime.now(UTC)
+            session.flush()
+            return "done"
+
+        # #141: persist's dedup re-check resolved a DIFFERENT existing work (the twin) — same
+        # book, dirty invoked-row identity. Do NOT undo the twin's write. Record the redirect
+        # (upsert-or-ignore: a redelivered Cloud Tasks retry must not pile up duplicate rows)
+        # and stamp the INVOKED row, re-loaded by id since `persisted` is the twin, not it.
+        session.execute(
+            pg_insert(DetectedDuplicate)
+            .values(work_id_a=work_id, work_id_b=persisted.id, source="deep_pass_redirect")
+            .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
+        )
+        invoked = session.get(Work, work_id)
+        if invoked is None:
+            # The invoked row was deleted while the slow scouts were running (same
+            # deleted-mid-pass honesty rule as the other "missing" cases above).
+            return "missing"
+        invoked.deep_enriched_at = datetime.now(UTC)
         session.flush()
-    return "done"
+        return "redirected"

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -216,7 +216,19 @@ def enrich_deep(work_id: UUID) -> str:
                      existing Work (the twin) instead of the invoked one. The invoked row is
                      stamped deep_enriched_at (the pass DID complete) and a detected_duplicates
                      row is recorded; the twin's data is untouched by this function beyond
-                     persist's own write. Non-retryable success — see api/internal.py."""
+                     persist's own write. Non-retryable success — see api/internal.py.
+
+    Reviewer-found bug (fixed here): the redirect branch used to INSERT the detected_duplicates
+    row (work_id_a=work_id) BEFORE re-loading the invoked work by id. If the invoked row had
+    been deleted mid-pass, that insert FK-violated on work_id_a, and the raised exception rolled
+    back the WHOLE write session — including the twin's already-`persist`ed pass data in the
+    same transaction — even though the function documents a clean "missing" return for exactly
+    this case. The existence check now runs FIRST, before any write, so a vanished invoked row
+    takes the "missing" path without touching the twin's legitimately-persisted data. Residual:
+    there is still a TOCTOU window between this get() and the session's eventual commit — the
+    invoked row could be deleted in that gap and the FK violation is possible in principle, but
+    it is now a millisecond window instead of spanning the full scout call, matching the same
+    residual accepted elsewhere in this module (#94/#95)."""
     with db_manager.get_session() as session:
         work = session.get(Work, work_id)
         if work is None:
@@ -262,16 +274,25 @@ def enrich_deep(work_id: UUID) -> str:
         # book, dirty invoked-row identity. Do NOT undo the twin's write. Record the redirect
         # (upsert-or-ignore: a redelivered Cloud Tasks retry must not pile up duplicate rows)
         # and stamp the INVOKED row, re-loaded by id since `persisted` is the twin, not it.
-        session.execute(
-            pg_insert(DetectedDuplicate)
-            .values(work_id_a=work_id, work_id_b=persisted.id, source="deep_pass_redirect")
-            .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
-        )
+        #
+        # Existence check FIRST, before the detected_duplicates insert (reviewer finding): the
+        # invoked row may have been deleted while the slow scouts ran with no session held. If
+        # it's gone, work_id_a=work_id would FK-violate on insert and roll back this whole write
+        # session — including the twin's persist above, in the SAME transaction — turning the
+        # documented "missing" return into unreachable dead code and destroying the twin's
+        # legitimate data as collateral damage. Checking first keeps the vanished-row case a
+        # clean no-op read. A millisecond TOCTOU window remains between this get() and commit
+        # (same residual accepted elsewhere in this module, #94/#95).
         invoked = session.get(Work, work_id)
         if invoked is None:
             # The invoked row was deleted while the slow scouts were running (same
             # deleted-mid-pass honesty rule as the other "missing" cases above).
             return "missing"
+        session.execute(
+            pg_insert(DetectedDuplicate)
+            .values(work_id_a=work_id, work_id_b=persisted.id, source="deep_pass_redirect")
+            .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
+        )
         invoked.deep_enriched_at = datetime.now(UTC)
         session.flush()
         return "redirected"

--- a/src/agentic_librarian/etl/enrichment_sweep.py
+++ b/src/agentic_librarian/etl/enrichment_sweep.py
@@ -10,7 +10,13 @@ plan_requeue(session) surfaces both classes so an operator can re-enqueue them v
 scripts/clean_catalog.py --requeue-unenriched. Read-only; session in, list out — the thin
 CLI (scripts/clean_catalog.py) does the printing/gating/enqueue, per the tag_backfill /
 trope_backfill house pattern. Join pattern for trope links borrowed from
-etl/trope_backfill.py's plan_fallback_prune."""
+etl/trope_backfill.py's plan_fallback_prune.
+
+GH #141: a work appearing on EITHER side of detected_duplicates needs the works-merge tool,
+not another paid deep pass — it is excluded from both enrichable classes above and reported
+separately as "pending_merge". This query assumes the detected_duplicates migration is
+already applied — see the migration's own docstring for why rule 11 pressure is nil here
+(this module only ADDS a table; it alters nothing this branch's other queries touch)."""
 
 from __future__ import annotations
 
@@ -21,10 +27,10 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.models import DetectedDuplicate, Trope, Work, WorkTrope
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
-RequeueReason = Literal["never_deep_enriched", "no_real_trope"]
+RequeueReason = Literal["never_deep_enriched", "no_real_trope", "pending_merge"]
 
 
 @dataclass
@@ -41,8 +47,13 @@ class RequeueCandidate:
 
 
 def plan_requeue(session: Session) -> list[RequeueCandidate]:
-    """Works that need their deep-enrichment pass (re)queued:
+    """Works that need their deep-enrichment pass (re)queued, or need the works-merge tool
+    instead:
 
+      - "pending_merge": the work appears on either side of detected_duplicates (GH #141) —
+        it needs a merge, not another paid deep pass. Checked FIRST and wins over the other
+        two reasons regardless of the work's own deep_enriched_at/trope state, so a
+        redirected invoked row (stamped, zero real tropes of its own) is never re-enqueued.
       - "never_deep_enriched": deep_enriched_at IS NULL — no deep pass has ever completed
         (including a confirmed-empty one) for this work.
       - "no_real_trope": deep_enriched_at IS SET, but every trope link this work has is
@@ -50,16 +61,24 @@ def plan_requeue(session: Session) -> list[RequeueCandidate]:
         a poison task that exhausted Cloud Tasks retries without ever landing a genuine
         narrative trope.
 
-    A work matching both conditions is impossible (no_real_trope requires deep_enriched_at
-    to be set), but if logic ever changes, never_deep_enriched wins and the work appears
-    exactly once. Read-only."""
+    A work matching both never_deep_enriched and no_real_trope is impossible (no_real_trope
+    requires deep_enriched_at to be set), but if logic ever changes, never_deep_enriched wins
+    and the work appears exactly once. Read-only."""
     rows = session.query(WorkTrope.work_id, Trope.name).join(Trope, Trope.id == WorkTrope.trope_id).all()
     trope_names_by_work: dict[UUID, list[str]] = {}
     for work_id, name in rows:
         trope_names_by_work.setdefault(work_id, []).append(name)
 
+    pending_merge_ids: set[UUID] = set()
+    for a_id, b_id in session.query(DetectedDuplicate.work_id_a, DetectedDuplicate.work_id_b).all():
+        pending_merge_ids.add(a_id)
+        pending_merge_ids.add(b_id)
+
     out: list[RequeueCandidate] = []
     for work in session.query(Work).all():
+        if work.id in pending_merge_ids:
+            out.append(RequeueCandidate(work.id, work.title, "pending_merge"))
+            continue
         if work.deep_enriched_at is None:
             out.append(RequeueCandidate(work.id, work.title, "never_deep_enriched"))
             continue

--- a/src/agentic_librarian/imports/parsing.py
+++ b/src/agentic_librarian/imports/parsing.py
@@ -95,6 +95,80 @@ def _norm(s: str | None) -> str:
     return " ".join((s or "").strip().lower().split())
 
 
+# Splits a raw author cell into candidate author segments: commas, or the explicit
+# multi-author separators " and " / " & " (case-insensitive, requires surrounding spaces
+# so it doesn't fire inside a name like "Andy" or "A&W"). Matched against the UNSTRIPPED
+# text so a cell that is only a separator (" and ", " & ") still splits into empty segments
+# rather than surviving as a bare "and"/"&" once outer whitespace is trimmed.
+_AUTHOR_SPLIT = re.compile(r",|\s+and\s+|\s+&\s+", re.IGNORECASE)
+
+# A segment reads as "a full name" (rather than a bare initial/given name fragment) when it
+# has 2+ whitespace tokens and the last token isn't a single-letter initial like "K." —
+# this is what distinguishes "Jane Doe, John Smith" (split) from "Le Guin, Ursula K."
+# (a single "Last, First M." name — keep whole).
+_INITIAL_TOKEN = re.compile(r"^[A-Za-z]\.?$")
+
+
+def _is_full_name(segment: str) -> bool:
+    tokens = segment.split()
+    return len(tokens) >= 2 and not _INITIAL_TOKEN.match(tokens[-1])
+
+
+def _primary_author(text: str) -> str:
+    """Collapse a comma/'and'/'&'-joined author cell to its primary author.
+
+    Import author cells are sometimes a single string holding multiple names or a
+    duplicated name (observed prod artifact: 'Casualfarmer, CasualFarmer', one Goodreads
+    cell stored verbatim). A dirty author identity defeats work get-or-create matching and
+    can seed duplicate works. This normalizes at parse time, before raw_author reaches the
+    matcher.
+
+    Decision table:
+      - Empty/whitespace-only -> "".
+      - No comma/' and '/' & ' -> the trimmed text as-is.
+      - Two or more separators, OR all segments case-insensitively equal (the
+        'Casualfarmer, CasualFarmer' case), OR an explicit ' and '/' & ' separator ->
+        the first segment.
+      - Exactly one comma and BOTH segments look like full names (2+ words, not ending in
+        a bare initial, e.g. "Jane Doe, John Smith") -> the first segment.
+      - Exactly one comma otherwise -> the WHOLE CELL, unchanged. This is plausibly a
+        "Last, First" single name (e.g. "Ware, Ruth", "Le Guin, Ursula K."); splitting a
+        real person's name is worse than leaving a splittable one intact. Accepted
+        residual: such cells keep their comma form and may still mint a variant author
+        identity distinct from a "First Last"-formatted row for the same person — the
+        works-merge tool is the backstop (spec 2026-07-14-works-merge-tool-design.md).
+    """
+    stripped = text.strip()
+    if not stripped:
+        return ""
+
+    # Split the ORIGINAL (unstripped) text: the " and "/" & " separators require
+    # surrounding whitespace to match, which a pre-strip would remove from a
+    # separator-only cell like " and ", leaving a bare "and" that looks like a name.
+    raw_segments = [seg.strip() for seg in _AUTHOR_SPLIT.split(text)]
+    segments = [seg for seg in raw_segments if seg]
+    if not segments:
+        return ""  # cell was only separators, e.g. " and " / " & " / ", "
+    if len(raw_segments) == 1:
+        return segments[0]  # no separator matched -> as-is (trimmed)
+
+    has_and_separator = bool(re.search(r"\s+(?:and|&)\s+", stripped, re.IGNORECASE))
+    comma_count = stripped.count(",")
+
+    if comma_count >= 2 or has_and_separator:
+        return segments[0]
+
+    all_equal = len({seg.lower() for seg in segments}) == 1
+    if all_equal:
+        return segments[0]
+
+    if comma_count == 1 and all(_is_full_name(seg) for seg in segments):
+        return segments[0]
+
+    # Single comma, not all-equal, not two full names -> plausibly "Last, First"; keep whole.
+    return stripped
+
+
 def sniff_source(headers: list[str]) -> str:
     return "goodreads" if set(headers) >= _GOODREADS_SIGNATURE else "generic"
 
@@ -171,7 +245,7 @@ def parse_rows(rows: list[dict], mapping: dict[str, str | None]) -> list[ParsedR
         out.append(
             ParsedRow(
                 raw_title=_cell(row, mapping.get("title")),
-                raw_author=_cell(row, mapping.get("author")),
+                raw_author=_primary_author(_cell(row, mapping.get("author"))),
                 raw_format=_normalize_format(_cell(row, mapping.get("format"))),
                 raw_date=raw_date,
                 date_completed=parsed_date,

--- a/src/agentic_librarian/imports/parsing.py
+++ b/src/agentic_librarian/imports/parsing.py
@@ -158,11 +158,24 @@ def _primary_author(text: str) -> str:
     has_and_separator = bool(re.search(r"\s+(?:and|&)\s+", stripped, re.IGNORECASE))
     comma_count = stripped.count(",")
 
-    if comma_count >= 2 or has_and_separator:
-        return segments[0]
-
+    # Checked BEFORE the multi-separator arm: a triple like 'Casualfarmer, CasualFarmer,
+    # CasualFarmer' must collapse to one name, not fall into Last-First preservation.
     all_equal = len({seg.lower() for seg in segments}) == 1
     if all_equal:
+        return segments[0]
+
+    if comma_count >= 2 or has_and_separator:
+        # Gemini review (#143): a "Last, First" PRIMARY followed by more authors
+        # ('Ware, Ruth, John Smith') must keep the full primary name — truncating to the
+        # bare surname 'Ware' is the least matchable identity of all. The first two comma
+        # segments are one person when they DIFFER and don't both look like full names.
+        if (
+            comma_count >= 1
+            and len(segments) >= 2
+            and segments[0].lower() != segments[1].lower()
+            and not (_is_full_name(segments[0]) and _is_full_name(segments[1]))
+        ):
+            return f"{segments[0]}, {segments[1]}"
         return segments[0]
 
     if comma_count == 1 and all(_is_full_name(seg) for seg in segments):

--- a/src/agentic_librarian/imports/parsing.py
+++ b/src/agentic_librarian/imports/parsing.py
@@ -81,7 +81,10 @@ _ISO_DATETIME_PREFIX = re.compile(r"\d{4}-\d{2}-\d{2}[T ]")
 @dataclass
 class ParsedRow:
     raw_title: str
-    raw_author: str
+    raw_author: str  # parse-normalized primary author (#142, via _primary_author) — NOT the
+    # verbatim CSV cell; a comma/'and'/'&'-joined cell is already collapsed here. Preview and
+    # commit both call parse_rows, so they re-parse identically and the user previews exactly
+    # what will be created.
     raw_format: str  # normalized vocab; defaults to 'ebook'
     raw_date: str  # original text (may be '')
     date_completed: date | None  # parsed; None if blank/unparseable/future

--- a/test/integration/test_enrichment_sweep.py
+++ b/test/integration/test_enrichment_sweep.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from agentic_librarian.db.models import Trope, Work, WorkTrope
+from agentic_librarian.db.models import DetectedDuplicate, Trope, Work, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl.enrichment_sweep import plan_requeue
 
@@ -92,3 +92,37 @@ def test_plan_requeue_never_deep_enriched_wins_over_no_real_trope(db_url):
     matches = [c for c in plan if c.work_id == work_id]
     assert len(matches) == 1
     assert matches[0].reason == "never_deep_enriched"
+
+
+@pytest.mark.parametrize(
+    "side",
+    [
+        pytest.param("work_id_a", id="invoked-side"),
+        pytest.param("work_id_b", id="twin-side"),
+    ],
+)
+def test_plan_requeue_excludes_works_on_either_side_of_detected_duplicates(db_url, side):
+    """GH #141: a work appearing on EITHER side of detected_duplicates needs the merge tool,
+    not another paid deep pass — excluded from both enrichable classes and reported
+    separately as "pending_merge", regardless of its own deep_enriched_at/trope state."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as s:
+        # never_deep_enriched shape on BOTH rows — would normally be candidates.
+        a = Work(title="Pending Merge A", deep_enriched_at=None)
+        b = Work(title="Pending Merge B", deep_enriched_at=None)
+        s.add_all([a, b])
+        s.flush()
+        s.add(DetectedDuplicate(work_id_a=a.id, work_id_b=b.id, source="deep_pass_redirect"))
+        s.flush()
+        a_id, b_id = a.id, b.id
+        target_id = a_id if side == "work_id_a" else b_id
+
+    with manager.get_session() as s:
+        plan = plan_requeue(s)
+
+    by_id = {c.work_id: c for c in plan}
+    assert by_id[a_id].reason == "pending_merge"
+    assert by_id[b_id].reason == "pending_merge"
+    assert by_id[target_id].reason == "pending_merge"
+    assert all(c.reason != "never_deep_enriched" for c in plan if c.work_id in (a_id, b_id))
+    assert all(c.reason != "no_real_trope" for c in plan if c.work_id in (a_id, b_id))

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -87,6 +87,22 @@ def test_bad_token_signature_is_forbidden(client, monkeypatch):
     assert resp.status_code == 403
 
 
+def test_redirected_deep_pass_returns_200_non_retryable(client, db_url, monkeypatch):
+    """GH #141: a "redirected" pass completed and stamped the invoked work — its data
+    lives on the twin, recorded in detected_duplicates. Retrying would burn another paid
+    deep pass for nothing, so this must be a 2xx, not a 5xx."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", lambda wid: "redirected")
+
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "redirected"}
+
+
 def test_unknown_work_returns_404(client, monkeypatch):
     monkeypatch.setattr(
         internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -189,6 +189,89 @@ def test_enrich_deep_redirect_pins_invoked_work_and_records_detection(db_url, mo
         assert detections[0].source == "deep_pass_redirect"
 
 
+class _DeletingFakeManager:
+    """Same scout-seam shape as _FakeManager, but its enrich() call also deletes the
+    invoked work -- standing in for "the invoked row was deleted by something else while
+    the slow scouts ran with no session held" (the reviewer's repro for the mid-pass
+    deletion). enrich_deep's read session that captured title/author is already closed by
+    the time this runs, matching the real no-session-during-scouts window (#94)."""
+
+    def __init__(self, result, *, manager, invoked_id):
+        self._result = result
+        self._manager = manager
+        self._invoked_id = invoked_id
+
+    def enrich(self, title, author, format="Paperback", **kwargs):
+        from agentic_librarian.db.models import Edition as _Edition
+        from agentic_librarian.db.models import Work as _Work
+        from agentic_librarian.db.models import WorkContributor as _WorkContributor
+
+        with self._manager.get_session() as s:
+            work = s.get(_Work, self._invoked_id)
+            if work is not None:
+                # Hard-delete the invoked row's dependents first (editions.work_id and
+                # work_contributors.work_id are NOT NULL with no ORM delete-orphan cascade
+                # configured on Work.editions/contributors -- session.delete(work) alone would
+                # try to null those FKs instead of removing the rows, which is not what a real
+                # mid-pass deletion of the work would leave behind).
+                s.query(_Edition).filter_by(work_id=self._invoked_id).delete()
+                s.query(_WorkContributor).filter_by(work_id=self._invoked_id).delete()
+                s.delete(work)
+        return self._result
+
+
+def test_enrich_deep_redirect_missing_invoked_row_leaves_twin_data_intact_no_detection(db_url, monkeypatch):
+    """Reviewer finding (I1): the invoked work is deleted mid-pass (between the read session
+    that captured its identity and the write session that would stamp/insert against it).
+    The write session's persist re-check still resolves the twin and legitimately writes the
+    tropes there. Before the fix, the detected_duplicates INSERT (work_id_a=invoked_id) ran
+    BEFORE the existence check and FK-violated for real against Postgres, rolling back the
+    WHOLE write-session transaction -- destroying the twin's just-persisted tropes along with
+    it. This test pins the real behavior: "missing" is returned, the twin KEEPS its
+    legitimately-persisted pass data, and no detected_duplicates row exists (the insert must
+    never have been attempted, or it would have aborted the transaction)."""
+    from agentic_librarian.db.models import DetectedDuplicate
+    from agentic_librarian.enrichment import two_phase
+    from agentic_librarian.scouts import style_manager, trope_manager
+
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    monkeypatch.setattr(trope_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+    monkeypatch.setattr(style_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(two_phase, "db_manager", manager)
+    deep = {
+        "enriched_tropes": [{"trope_name": "Found Family", "relevance_score": 0.9}],
+        "narrator_names": [],
+        "contributors": [{"name": "Casualfarmer, CasualFarmer", "role": "Author"}],
+    }
+
+    twin_id, invoked_id = _seed_duplicate_identity_pair(
+        manager, title="Beware of Chicken", author="Casualfarmer, CasualFarmer"
+    )
+
+    monkeypatch.setattr(
+        two_phase,
+        "create_deep_scout_manager",
+        lambda: _DeletingFakeManager(deep, manager=manager, invoked_id=invoked_id),
+    )
+
+    assert two_phase.enrich_deep(invoked_id) == "missing"
+
+    with manager.get_session() as s:
+        # the invoked row is really gone
+        assert s.get(Work, invoked_id) is None
+
+        # the twin's persist was NOT rolled back -- it keeps its legitimately-written tropes
+        twin_links = s.query(WorkTrope).filter_by(work_id=twin_id).all()
+        assert len(twin_links) == 1
+
+        # no detection row: the insert referencing the vanished invoked id must never have
+        # landed (the pre-fix code would have FK-violated attempting exactly this insert)
+        detections = s.query(DetectedDuplicate).filter_by(work_id_b=twin_id).all()
+        assert len(detections) == 0
+
+
 def test_enrich_deep_redirect_is_idempotent_on_redelivery(db_url, monkeypatch):
     """Cloud Tasks may redeliver: re-running enrich_deep on the same invoked row again must
     stay "redirected" and must NOT pile up a second detected_duplicates row for the same

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -113,6 +113,115 @@ def test_enrich_deep_returns_missing_not_done_when_nothing_was_persisted(db_url,
         assert work.deep_enriched_at is None
 
 
+def _seed_duplicate_identity_pair(manager, *, title, author, fmt="ebook"):
+    """Seed TWO Work rows sharing the exact same (title, author) identity — a raw duplicate
+    pair that predates any unique constraint on works (only Author.name is unique). This is
+    the structural shape that makes persist_enriched_work's exact-match Work lookup
+    (`Work.title == ... AND Author.name == ...`) resolve to whichever row it created FIRST
+    (the .first() winner) regardless of which row enrich_deep was invoked with — the live
+    #141 shape (prod: sweep enqueued 9e9cfc45, the stamp+tropes landed on twin a5e56605).
+    Returns (twin_id, invoked_id) — twin seeded first so it wins the lookup."""
+    from agentic_librarian.db.models import Author
+
+    with manager.get_session() as s:
+        a = Author(name=author)
+        s.add(a)
+        s.flush()
+
+        twin = Work(title=title)
+        s.add(twin)
+        s.flush()
+        s.add(WorkContributor(work_id=twin.id, author_id=a.id, role="Author"))
+        s.add(Edition(work_id=twin.id, format=fmt))
+
+        invoked = Work(title=title)
+        s.add(invoked)
+        s.flush()
+        s.add(WorkContributor(work_id=invoked.id, author_id=a.id, role="Author"))
+        s.add(Edition(work_id=invoked.id, format=fmt))
+
+        s.flush()
+        return twin.id, invoked.id
+
+
+def test_enrich_deep_redirect_pins_invoked_work_and_records_detection(db_url, monkeypatch):
+    """GH #141: when the write session's persist re-check resolves a DIFFERENT existing
+    work (the twin), enrich_deep must NOT undo the twin's write. It must: leave the tropes
+    on the twin, stamp the INVOKED row (not the twin), record a detected_duplicates row,
+    and return "redirected"."""
+    from agentic_librarian.db.models import DetectedDuplicate
+    from agentic_librarian.enrichment import two_phase
+    from agentic_librarian.scouts import style_manager, trope_manager
+
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    monkeypatch.setattr(trope_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+    monkeypatch.setattr(style_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(two_phase, "db_manager", manager)
+    deep = {
+        "enriched_tropes": [{"trope_name": "Found Family", "relevance_score": 0.9}],
+        "narrator_names": [],
+        "contributors": [{"name": "Casualfarmer, CasualFarmer", "role": "Author"}],
+    }
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+
+    twin_id, invoked_id = _seed_duplicate_identity_pair(
+        manager, title="Beware of Chicken", author="Casualfarmer, CasualFarmer"
+    )
+
+    assert two_phase.enrich_deep(invoked_id) == "redirected"
+
+    with manager.get_session() as s:
+        invoked = s.get(Work, invoked_id)
+
+        # the twin got the tropes (persist legitimately landed there — same book, not undone)
+        twin_links = s.query(WorkTrope).filter_by(work_id=twin_id).all()
+        assert len(twin_links) == 1
+
+        # the invoked row is stamped and gained NO tropes of its own
+        assert invoked.deep_enriched_at is not None
+        invoked_links = s.query(WorkTrope).filter_by(work_id=invoked_id).all()
+        assert len(invoked_links) == 0
+
+        detections = s.query(DetectedDuplicate).filter_by(work_id_a=invoked_id, work_id_b=twin_id).all()
+        assert len(detections) == 1
+        assert detections[0].source == "deep_pass_redirect"
+
+
+def test_enrich_deep_redirect_is_idempotent_on_redelivery(db_url, monkeypatch):
+    """Cloud Tasks may redeliver: re-running enrich_deep on the same invoked row again must
+    stay "redirected" and must NOT pile up a second detected_duplicates row for the same
+    (work_id_a, work_id_b) pair (ON CONFLICT DO NOTHING on the composite PK)."""
+    from agentic_librarian.db.models import DetectedDuplicate
+    from agentic_librarian.enrichment import two_phase
+    from agentic_librarian.scouts import style_manager, trope_manager
+
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    monkeypatch.setattr(trope_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+    monkeypatch.setattr(style_manager, "get_cached_embedding", lambda *a, **k: [0.1] * 1536)
+
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(two_phase, "db_manager", manager)
+    deep = {
+        "enriched_tropes": [{"trope_name": "Found Family", "relevance_score": 0.9}],
+        "narrator_names": [],
+        "contributors": [{"name": "Casualfarmer, CasualFarmer", "role": "Author"}],
+    }
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+
+    twin_id, invoked_id = _seed_duplicate_identity_pair(
+        manager, title="Beware of Chicken", author="Casualfarmer, CasualFarmer"
+    )
+
+    assert two_phase.enrich_deep(invoked_id) == "redirected"
+    assert two_phase.enrich_deep(invoked_id) == "redirected"  # redelivery-safe
+
+    with manager.get_session() as s:
+        detections = s.query(DetectedDuplicate).filter_by(work_id_a=invoked_id, work_id_b=twin_id).all()
+        assert len(detections) == 1  # no pile-up despite two redirect passes
+
+
 def test_enrich_deep_returns_false_for_unknown_work(db_url, monkeypatch):
     from uuid import uuid4
 

--- a/test/unit/test_clean_catalog_cli.py
+++ b/test/unit/test_clean_catalog_cli.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+from uuid import uuid4
 
 spec = importlib.util.spec_from_file_location(
     "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
@@ -41,3 +42,55 @@ def test_apply_refused_without_yes(monkeypatch, capsys):
     rc = clean_catalog.main(["--contributors", "--apply"])  # no --yes
     assert rc == 2
     assert "REFUSING --apply without --yes" in capsys.readouterr().out
+
+
+def test_requeue_never_enqueues_pending_merge_candidates(monkeypatch, capsys):
+    """GH #141: plan_requeue can return a "pending_merge" candidate (a work on either side
+    of detected_duplicates) alongside real enrichable candidates. The CLI's --apply enqueue
+    loop must filter to the two enrichable reasons only — pending_merge candidates are
+    reported under their own heading and NEVER passed to enqueue_enrichment."""
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: "postgresql://u:p@prod-host/db")
+
+    class _Sess:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def query(self, *a, **k):
+            return self
+
+        def scalar(self):
+            return 0
+
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+
+    never_id, no_real_id, pending_id = uuid4(), uuid4(), uuid4()
+    requeue_candidate = clean_catalog.enrichment_sweep.RequeueCandidate
+    candidates = [
+        requeue_candidate(never_id, "Never Enriched", "never_deep_enriched"),
+        requeue_candidate(no_real_id, "No Real Trope", "no_real_trope"),
+        requeue_candidate(pending_id, "Pending Merge", "pending_merge"),
+    ]
+    monkeypatch.setattr(clean_catalog.enrichment_sweep, "plan_requeue", lambda session: candidates)
+
+    enqueued_ids: list[str] = []
+    monkeypatch.setattr(
+        "agentic_librarian.enrichment.tasks.enqueue_enrichment",
+        lambda work_id: enqueued_ids.append(work_id) or True,
+    )
+
+    rc = clean_catalog.main(["--requeue-unenriched", "--apply", "--yes"])
+
+    assert rc == 0
+    assert str(pending_id) not in enqueued_ids
+    assert str(never_id) in enqueued_ids
+    assert str(no_real_id) in enqueued_ids
+    assert len(enqueued_ids) == 2
+
+    out = capsys.readouterr().out
+    assert "pending a merge" in out
+    assert "Pending Merge" in out

--- a/test/unit/test_detected_duplicates_upsert.py
+++ b/test/unit/test_detected_duplicates_upsert.py
@@ -1,0 +1,86 @@
+"""GH #141: compile-inspect the ON CONFLICT DO NOTHING insert enrich_deep's redirect path
+issues against detected_duplicates — house rule 4 (pg-dialect statements get compile-inspect
+locally, execute in CI/db_integration). Mirrors test_availability_batch.py's pattern."""
+
+from uuid import uuid4
+
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from agentic_librarian.db.models import DetectedDuplicate
+
+
+def test_detected_duplicates_insert_conflict_target_is_the_composite_pk():
+    work_id_a, work_id_b = uuid4(), uuid4()
+    stmt = (
+        pg_insert(DetectedDuplicate)
+        .values(work_id_a=work_id_a, work_id_b=work_id_b, source="deep_pass_redirect")
+        .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
+    )
+
+    compiled = str(stmt.compile(dialect=postgresql.dialect()))
+
+    assert "INSERT INTO detected_duplicates" in compiled
+    assert "ON CONFLICT (work_id_a, work_id_b) DO NOTHING" in compiled
+
+
+def test_two_phase_redirect_issues_the_same_upsert_shape(monkeypatch):
+    """Drives enrich_deep's real redirect branch and compile-inspects the ACTUAL statement
+    it executes (not a standalone equivalent) — same conflict target, same source literal."""
+    from unittest.mock import MagicMock
+
+    import agentic_librarian.enrichment.two_phase as two_phase_mod
+
+    captured = {}
+    invoked_id, twin_id = uuid4(), uuid4()
+
+    invoked_contributor = MagicMock(role="Author")
+    invoked_contributor.author.name = "A"
+    invoked_work = MagicMock(id=invoked_id, title="T", contributors=[invoked_contributor], editions=[])
+
+    invoked_row_after_redirect = MagicMock(deep_enriched_at=None)
+    twin = MagicMock(id=twin_id)
+
+    class _ReadSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, model, work_id):
+            return invoked_work
+
+    class _WriteSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, model, work_id):
+            return invoked_row_after_redirect
+
+        def execute(self, stmt):
+            captured["stmt"] = stmt
+
+        def flush(self):
+            pass
+
+    sessions = [_ReadSession(), _WriteSession()]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase_mod, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase_mod, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase_mod, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase_mod, "_persist_row", lambda session, row: twin)
+
+    result = two_phase_mod.enrich_deep(invoked_id)
+
+    assert result == "redirected"
+    compiled = str(captured["stmt"].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert "INSERT INTO detected_duplicates" in compiled
+    assert "ON CONFLICT (work_id_a, work_id_b) DO NOTHING" in compiled
+    assert "'deep_pass_redirect'" in compiled
+    assert str(invoked_id) in compiled
+    assert str(twin_id) in compiled

--- a/test/unit/test_import_parsing.py
+++ b/test/unit/test_import_parsing.py
@@ -208,6 +208,7 @@ def test_parse_rows_flags_future_and_unparseable_dates_and_defaults_format():
         ("A, B, C", "A", "two_plus_commas_take_first_segment"),
         ("Author A, Author B, Author A", "Author A", "three_commas_take_first_segment"),
         ("Jane Doe and John Smith", "Jane Doe", "explicit_and_separator_takes_first"),
+        ("X and Y", "X", "single_token_names_and_separator_takes_first"),
         ("Jane Doe & John Smith", "Jane Doe", "explicit_ampersand_separator_takes_first"),
         (
             "Jane Doe, John Smith",

--- a/test/unit/test_import_parsing.py
+++ b/test/unit/test_import_parsing.py
@@ -205,8 +205,19 @@ def test_parse_rows_flags_future_and_unparseable_dates_and_defaults_format():
             "Casualfarmer",
             "duplicate_segments_with_whitespace_around_separator",
         ),
-        ("A, B, C", "A", "two_plus_commas_take_first_segment"),
-        ("Author A, Author B, Author A", "Author A", "three_commas_take_first_segment"),
+        # Single-letter segments read as a Last-First primary under the #143 heuristic —
+        # degenerate input, accepted: 'A, B' is at least a mergeable identity.
+        ("A, B, C", "A, B", "two_plus_commas_degenerate_single_letters"),
+        ("Jane Doe, John Smith, Bob Lee", "Jane Doe", "two_plus_commas_full_names_take_first"),
+        # Gemini review (#143): "Last, First" primary + additional authors keeps the full
+        # primary name instead of truncating to the bare surname.
+        ("Ware, Ruth, John Smith", "Ware, Ruth", "multi_comma_last_first_primary_kept"),
+        ("Ware, Ruth and John Smith", "Ware, Ruth", "comma_and_mix_last_first_primary_kept"),
+        ("Casualfarmer, CasualFarmer, CasualFarmer", "Casualfarmer", "all_equal_triple_collapses"),
+        ("Casualfarmer, CasualFarmer, John Smith", "Casualfarmer", "partial_dup_takes_first_not_joined"),
+        # Full-name fixtures: names ending in a bare initial ('Author A') read as
+        # Last-First pairs under the #143 heuristic — covered by its own rows above.
+        ("Amy North, Bea South, Amy North", "Amy North", "three_commas_take_first_segment"),
         ("Jane Doe and John Smith", "Jane Doe", "explicit_and_separator_takes_first"),
         ("X and Y", "X", "single_token_names_and_separator_takes_first"),
         ("Jane Doe & John Smith", "Jane Doe", "explicit_ampersand_separator_takes_first"),

--- a/test/unit/test_import_parsing.py
+++ b/test/unit/test_import_parsing.py
@@ -184,3 +184,62 @@ def test_parse_rows_flags_future_and_unparseable_dates_and_defaults_format():
     assert all(p.raw_format == "ebook" for p in parsed)  # unmapped format -> default
     assert all(p.date_completed is None and p.bad_date is True for p in parsed)
     assert all(p.shelf == "" for p in parsed)  # unmapped shelf -> ''
+
+
+# --- _primary_author (#142): comma-joined/multi-author cells collapse to the primary
+# author at parse time so raw_author is clean before work get-or-create matching. ---
+@pytest.mark.parametrize(
+    ("raw", "expected", "case_id"),
+    [
+        ("", "", "empty_string"),
+        ("   ", "", "whitespace_only"),
+        ("Frank Herbert", "Frank Herbert", "no_separator_returned_trimmed"),
+        ("  Frank Herbert  ", "Frank Herbert", "no_separator_trims_surrounding_whitespace"),
+        (
+            "Casualfarmer, CasualFarmer",
+            "Casualfarmer",
+            "case_insensitive_duplicate_segments_take_first",
+        ),
+        (
+            "  Casualfarmer ,  CasualFarmer  ",
+            "Casualfarmer",
+            "duplicate_segments_with_whitespace_around_separator",
+        ),
+        ("A, B, C", "A", "two_plus_commas_take_first_segment"),
+        ("Author A, Author B, Author A", "Author A", "three_commas_take_first_segment"),
+        ("Jane Doe and John Smith", "Jane Doe", "explicit_and_separator_takes_first"),
+        ("Jane Doe & John Smith", "Jane Doe", "explicit_ampersand_separator_takes_first"),
+        (
+            "Jane Doe, John Smith",
+            "Jane Doe",
+            "single_comma_both_segments_multiword_takes_first",
+        ),
+        ("Ware, Ruth", "Ware, Ruth", "single_comma_last_first_kept_unchanged"),
+        (
+            "Le Guin, Ursula K.",
+            "Le Guin, Ursula K.",
+            "single_comma_last_first_with_initial_kept_unchanged",
+        ),
+        (", ", "", "degenerate_only_separator_yields_empty"),
+        (" and ", "", "degenerate_only_and_separator_yields_empty"),
+        (" & ", "", "degenerate_only_ampersand_separator_yields_empty"),
+    ],
+    ids=lambda param: param if isinstance(param, str) and param.isidentifier() else None,
+)
+def test_primary_author_decision_table(raw, expected, case_id):
+    assert parsing._primary_author(raw) == expected
+
+
+def test_parse_rows_normalizes_malformed_author_cell():
+    mapping = {
+        "title": "t",
+        "author": "a",
+        "format": None,
+        "date_completed": None,
+        "rating": None,
+        "notes": None,
+        "shelf": None,
+    }
+    rows = [{"t": "Beware of Chicken", "a": "Casualfarmer, CasualFarmer"}]
+    parsed = parsing.parse_rows(rows, mapping)
+    assert parsed[0].raw_author == "Casualfarmer"

--- a/test/unit/test_two_phase_redirect.py
+++ b/test/unit/test_two_phase_redirect.py
@@ -1,0 +1,204 @@
+"""GH #141: enrich_deep pins the invoked work id. If the write-session persist re-check
+resolves the scout-canonical identity to a DIFFERENT existing work (a "redirect"), the
+invoked row must still be stamped deep_enriched_at, the redirect recorded in
+detected_duplicates, and "redirected" returned — never silently landing on the twin with
+the invoked row left never_deep_enriched forever (the live #141 bug)."""
+
+from unittest.mock import MagicMock
+
+from agentic_librarian.enrichment import two_phase
+
+
+class _FakeReadSession:
+    """First `with db_manager.get_session()` block in enrich_deep: reads the invoked
+    work's identity (title/author/format)."""
+
+    def __init__(self, work):
+        self._work = work
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, model, work_id):
+        return self._work
+
+
+class _FakeWriteSession:
+    """Second `with` block: persists via _persist_row, records seen calls for assertions."""
+
+    def __init__(self, invoked_id, persisted_work, calls):
+        self._invoked_id = invoked_id
+        self._persisted_work = persisted_work
+        self._calls = calls
+        self._invoked_row = MagicMock(deep_enriched_at=None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, model, work_id):
+        # used to re-load the invoked row by id when persist resolved elsewhere
+        self._calls.append(("get", work_id))
+        if work_id == self._invoked_id:
+            return self._invoked_row
+        return None
+
+    def execute(self, *a, **k):
+        self._calls.append(("execute", a, k))
+
+    def flush(self):
+        self._calls.append(("flush",))
+
+
+def _make_work(work_id, title="T", author="A"):
+    contributor = MagicMock(role="Author")
+    contributor.author.name = author
+    work = MagicMock()
+    work.id = work_id
+    work.title = title
+    work.contributors = [contributor]
+    work.editions = []
+    return work
+
+
+def test_enrich_deep_same_id_persist_reports_done_unchanged(monkeypatch):
+    from uuid import uuid4
+
+    work_id = uuid4()
+    invoked_work = _make_work(work_id)
+    calls = []
+
+    persisted = MagicMock()
+    persisted.id = work_id  # persist landed on the SAME row invoked
+
+    sessions = [_FakeReadSession(invoked_work), _FakeWriteSession(work_id, persisted, calls)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase, "_persist_row", lambda session, row: persisted)
+
+    result = two_phase.enrich_deep(work_id)
+
+    assert result == "done"
+    assert persisted.deep_enriched_at is not None
+    # no detected_duplicates insert on the same-id path
+    assert not any(c[0] == "execute" for c in calls)
+
+
+def test_enrich_deep_none_persist_reports_missing_unchanged(monkeypatch):
+    from uuid import uuid4
+
+    work_id = uuid4()
+    invoked_work = _make_work(work_id)
+    calls = []
+
+    sessions = [_FakeReadSession(invoked_work), _FakeWriteSession(work_id, None, calls)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase, "_persist_row", lambda session, row: None)
+
+    result = two_phase.enrich_deep(work_id)
+
+    assert result == "missing"
+    assert not any(c[0] == "execute" for c in calls)
+
+
+def test_enrich_deep_different_id_persist_redirects(monkeypatch):
+    """The persist-side dedup re-check resolved a DIFFERENT existing work (the twin) —
+    same book, dirty invoked-row identity. Must NOT undo the twin's write: instead record
+    the redirect, stamp the INVOKED row, and return "redirected"."""
+    from uuid import uuid4
+
+    invoked_id = uuid4()
+    twin_id = uuid4()
+    invoked_work = _make_work(invoked_id, author="Casualfarmer, CasualFarmer")
+    calls = []
+
+    twin = MagicMock()
+    twin.id = twin_id  # persist landed on the TWIN, not the invoked row
+
+    sessions = [_FakeReadSession(invoked_work), _FakeWriteSession(invoked_id, twin, calls)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase, "_persist_row", lambda session, row: twin)
+
+    result = two_phase.enrich_deep(invoked_id)
+
+    assert result == "redirected"
+    # the invoked row (re-loaded by id) is stamped, NOT the twin
+    assert any(c[0] == "get" and c[1] == invoked_id for c in calls)
+    assert any(c[0] == "execute" for c in calls)  # the ON CONFLICT DO NOTHING insert
+    assert any(c[0] == "flush" for c in calls)
+
+
+def test_enrich_deep_redirect_stamps_invoked_row_not_twin(monkeypatch):
+    from uuid import uuid4
+
+    invoked_id = uuid4()
+    twin_id = uuid4()
+    invoked_work = _make_work(invoked_id, author="Casualfarmer, CasualFarmer")
+    calls = []
+
+    twin = MagicMock()
+    twin.id = twin_id
+    twin.deep_enriched_at = None
+
+    write_session = _FakeWriteSession(invoked_id, twin, calls)
+    sessions = [_FakeReadSession(invoked_work), write_session]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase, "_persist_row", lambda session, row: twin)
+
+    result = two_phase.enrich_deep(invoked_id)
+
+    assert result == "redirected"
+    assert write_session._invoked_row.deep_enriched_at is not None
+    assert twin.deep_enriched_at is None  # the twin's stamp is untouched by THIS function
+
+
+def test_enrich_deep_redirect_invoked_row_vanished_mid_pass(monkeypatch):
+    """If the invoked row vanished mid-pass (deleted while the slow scouts ran with no
+    session held) by the time the redirect stamp tries to re-load it, treat this the same
+    as the existing deleted-mid-pass path: "missing", not a lie."""
+    from uuid import uuid4
+
+    invoked_id = uuid4()
+    twin_id = uuid4()
+    invoked_work = _make_work(invoked_id, author="Casualfarmer, CasualFarmer")
+    calls = []
+
+    twin = MagicMock()
+    twin.id = twin_id
+
+    class _VanishedWriteSession(_FakeWriteSession):
+        def get(self, model, work_id):
+            calls.append(("get", work_id))
+            return None  # invoked row is gone no matter which id is requested
+
+    sessions = [_FakeReadSession(invoked_work), _VanishedWriteSession(invoked_id, twin, calls)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    monkeypatch.setattr(two_phase, "_run_scouts", lambda manager, **kwargs: {"row": "data"})
+    monkeypatch.setattr(two_phase, "_warm_embeddings", lambda row: None)
+    monkeypatch.setattr(two_phase, "_persist_row", lambda session, row: twin)
+
+    result = two_phase.enrich_deep(invoked_id)
+
+    assert result == "missing"

--- a/test/unit/test_two_phase_redirect.py
+++ b/test/unit/test_two_phase_redirect.py
@@ -174,8 +174,14 @@ def test_enrich_deep_redirect_stamps_invoked_row_not_twin(monkeypatch):
 
 def test_enrich_deep_redirect_invoked_row_vanished_mid_pass(monkeypatch):
     """If the invoked row vanished mid-pass (deleted while the slow scouts ran with no
-    session held) by the time the redirect stamp tries to re-load it, treat this the same
-    as the existing deleted-mid-pass path: "missing", not a lie."""
+    session held), enrich_deep must report "missing" -- and, per the reviewer finding, it
+    must do so WITHOUT ever attempting the detected_duplicates insert, since work_id_a
+    would reference a work id that no longer exists. A fake session's no-op execute() can't
+    see a real FK violation, so this test asserts on call ORDER (get before execute) and
+    that execute is never reached at all -- the only way a unit test (no real Postgres) can
+    certify the fix without a full db_integration round-trip (see
+    test/integration/test_two_phase_deep.py::test_enrich_deep_redirect_missing_invoked_row_
+    leaves_twin_data_intact_no_detection for the real-FK version)."""
     from uuid import uuid4
 
     invoked_id = uuid4()
@@ -202,3 +208,9 @@ def test_enrich_deep_redirect_invoked_row_vanished_mid_pass(monkeypatch):
     result = two_phase.enrich_deep(invoked_id)
 
     assert result == "missing"
+    # the existence check must run BEFORE the detected_duplicates insert is attempted --
+    # this is the actual fix: previously execute() ran first and would FK-violate for real
+    # (rolling back the twin's persist in the same transaction) instead of short-circuiting
+    # here. A fake session can't raise the FK error itself, so we pin the call ordering.
+    assert calls == [("get", invoked_id)]
+    assert not any(c[0] == "execute" for c in calls)


### PR DESCRIPTION
Closes #141, closes #142 (PR-1 of the works-merge design: `docs/superpowers/specs/2026-07-14-works-merge-tool-design.md`, committed here). Prevention first — both duplicate-minting mechanisms were live.

## What

**#141 — the deep pass pins its invoked work.** `enrich_deep` persisted via scout-canonical identity re-resolution, so a dirty-identity work's pass landed tropes + `deep_enriched_at` on its duplicate twin (prod-observed: sweep enqueued `9e9cfc45`, everything landed on `a5e56605`), leaving the invoked row `never_deep_enriched` forever — a paid-pass-burning requeue loop. Now:

- The persist may still resolve the twin (same book — its data is kept), but the redirect is recorded in the new **`detected_duplicates` table** (composite PK, ON CONFLICT DO NOTHING; the works-merge tool's queryable feed) and the INVOKED row is stamped, in the same transaction.
- New `enrich_deep` return literal `"redirected"`; the Cloud Tasks receiver treats it as non-retryable success (all other literals byte-identical).
- `plan_requeue` reports detected-duplicate works as a `pending_merge` class that the CLI **never enqueues** — they need the merge tool, not another paid pass.
- Review-caught hardening: the invoked-work existence check precedes the detection insert (a mid-pass deletion previously FK-violated and rolled back the twin's legitimate data — reproduced against real Postgres, now pinned by a db_integration regression test).

**#142 — author-cell normalization.** `'Casualfarmer, CasualFarmer'` stored as one author name seeded the duplicate. `_primary_author` at import parse time: collapses duplicated-name cells, splits multi-author cells ("A, B, C", "X and Y", "Jane Doe, John Smith"), and deliberately KEEPS "Last, First"-shaped single names ("Ware, Ruth", "Le Guin, Ursula K." — bare-initial-aware heuristic; wrongly splitting a person's name is worse than keeping a mergeable variant, documented residual). 16-case parametrized decision table.

## ⚠️ Operator: migrate before merge

New table `detected_duplicates` (one revision, no backfill, symmetric downgrade). Per house rule: run `alembic upgrade head` from this branch against prod BEFORE merging (lift1 runbook §3 mechanics; the ADR-058 guard makes the ordering safe — if merged first, the new revision fails loudly at startup and traffic stays on the old one).

## Tests

TDD throughout; 69 focused unit + 26 db_integration executed against real local Postgres (redirect round-trip + Cloud Tasks redelivery idempotency + deleted-mid-pass FK regression + pending_merge gating + migration/model parity via the schema-drift test). Full unit suite green modulo the known env-dependent failures (stash-verified).

Follow-up (spec-recorded for PR-2): the merge must consume `detected_duplicates` as unordered pairs and delete detection rows before deleting a work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
