### PR TITLE
feat(etl): works-merge — gated duplicate-work collapse with collision-safe composition

### DIFF
--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -12,12 +12,14 @@
   python scripts/clean_catalog.py --dedup-for-constraints --apply --yes --report data/reports/dedup-<ts>.txt
   python scripts/clean_catalog.py --repair-fallbacks --dry-run
   python scripts/clean_catalog.py --repair-fallbacks-apply --yes --report data/reports/fallback-repair-<ts>.txt
+  python scripts/clean_catalog.py --merge-works
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost.
 --dedup-for-constraints --apply re-plans from scratch and cross-checks the fresh plan against
 the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if the plan drifted.
 --repair-fallbacks-apply likewise re-plans fresh and refuses on any drift from --report (required,
-no default — GH #70)."""
+no default — GH #70). --merge-works (Spec 2026-07-14 PR-2 part 1) is detection/planning ONLY —
+always a dry-run, no --apply counterpart exists yet."""
 
 from __future__ import annotations
 
@@ -255,6 +257,54 @@ def _run_repair_fallbacks(manager: DatabaseManager, safe: str) -> int:
         return 0
 
 
+def _write_works_merge_report(clusters, *, db_target: str) -> Path:
+    """Persist the works-merge dry-run plan to data/reports/works-merge-<UTC>.txt (Spec
+    2026-07-14 PR-2), reusing render_works_merge_report's human-readable text and the same
+    microsecond-timestamp collision avoidance as _write_dedup_report / fallback_repair's
+    write_report. PLANNING ONLY — there is no apply step yet (H2), so unlike those two reports
+    this one carries no machine-readable token block to gate an apply against."""
+    reports_dir = Path("data/reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    ts = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
+    path = reports_dir / f"works-merge-{ts}.txt"
+    path.write_text(dedup_backfill.render_works_merge_report(clusters, db_target=db_target), encoding="utf-8")
+    return path
+
+
+def _run_merge_works(manager: DatabaseManager, safe: str) -> int:
+    """--merge-works: DETECTION/PLANNING ONLY (PR-2 part 1) — always a dry-run, never applies.
+    Reuses the --repair-fallbacks CLI conventions: prints the DB target before opening the work
+    session, prints per-class cluster summaries + survivor picks, writes the full report to
+    data/reports/works-merge-<UTC>.txt for operator review. apply arrives in a follow-up
+    task (H2), which builds the merge composition (editions/suggestions/trope-links/
+    contributors/Work-row deletion) on top of this plan's clusters — see docs/superpowers/
+    specs/2026-07-14-works-merge-tool-design.md."""
+    print(f"DB target: …@{safe}")
+    with manager.get_session() as session:
+        clusters = dedup_backfill.plan_works_merge(session)
+        summary = clusters.summary()
+        print("\n=== works-merge plan (DETECTION ONLY — PR-2 part 1) ===")
+        for key, count in summary.items():
+            print(f"  {key:32} {count}")
+
+        def _print_clusters(title: str, class_clusters, *, never_applied: bool) -> None:
+            suffix = "  (NEVER APPLIED — operator triage only)" if never_applied else ""
+            print(f"\n--- {title}{suffix} ---")
+            for cluster in class_clusters[:20]:
+                print(f"  cluster {cluster.work_ids}  survivor={cluster.survivor_id}  titles={cluster.titles}")
+
+        _print_clusters("works_same_isbn", clusters.same_isbn, never_applied=False)
+        _print_clusters("works_same_identity", clusters.same_identity, never_applied=False)
+        _print_clusters("works_detected_duplicates", clusters.detected_duplicates, never_applied=False)
+        _print_clusters("works_fuzzy_report_only", clusters.fuzzy_report_only, never_applied=True)
+
+        report_path = _write_works_merge_report(clusters, db_target=safe)
+        print(f"\nfull plan (every cluster) written to {report_path} — review this before any apply.")
+        print("\napply arrives in a follow-up (H2) — this command never mutates data.")
+        return 0
+
+
 def _run_repair_fallbacks_apply(manager: DatabaseManager, args, url: str, safe: str) -> int:
     """--repair-fallbacks-apply: guards first (no session needed for those), THEN warms in its
     own short session, THEN opens the work session that re-plans fresh and applies — see
@@ -364,6 +414,23 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     ap.add_argument(
+        "--merge-works",
+        action="store_true",
+        help=(
+            "Spec 2026-07-14 PR-2 part 1: DETECTION/PLANNING ONLY for the works-merge tool — "
+            "always a dry-run, this flag never applies. Prints the four detection classes "
+            "(strongest evidence first): works_same_isbn, works_same_identity, "
+            "works_detected_duplicates (the #141/#143 feed), and works_fuzzy_report_only "
+            "(NEVER applied by design — operator promotes pairs by hand). Each cluster shows "
+            "its deterministic survivor pick (most justified trope links -> newest "
+            "deep_enriched_at -> most editions -> lowest UUID). Writes "
+            "data/reports/works-merge-<UTC timestamp>.txt for review. Apply (the merge "
+            "composition: editions/suggestions/trope-links/contributors/Work-row deletion) "
+            "arrives in a follow-up task — see etl/dedup_backfill.py's plan_works_merge and "
+            "docs/superpowers/specs/2026-07-14-works-merge-tool-design.md."
+        ),
+    )
+    ap.add_argument(
         "--repair-fallbacks-apply",
         action="store_true",
         help=(
@@ -406,6 +473,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_repair_fallbacks(manager, safe)
     if args.repair_fallbacks_apply:
         return _run_repair_fallbacks_apply(manager, args, url, safe)
+    if args.merge_works:
+        return _run_merge_works(manager, safe)
 
     with manager.get_session() as session:
         print(f"DB target: …@{safe}")
@@ -596,8 +665,8 @@ def main(argv: list[str] | None = None) -> int:
 
         print(
             "Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, "
-            "--requeue-unenriched, --dedup-for-constraints, --repair-fallbacks, or "
-            "--repair-fallbacks-apply."
+            "--requeue-unenriched, --dedup-for-constraints, --repair-fallbacks, "
+            "--repair-fallbacks-apply, or --merge-works."
         )
         return 1
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -13,13 +13,16 @@
   python scripts/clean_catalog.py --repair-fallbacks --dry-run
   python scripts/clean_catalog.py --repair-fallbacks-apply --yes --report data/reports/fallback-repair-<ts>.txt
   python scripts/clean_catalog.py --merge-works
+  python scripts/clean_catalog.py --merge-works-apply --yes --report data/reports/works-merge-<ts>.txt
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost.
 --dedup-for-constraints --apply re-plans from scratch and cross-checks the fresh plan against
 the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if the plan drifted.
 --repair-fallbacks-apply likewise re-plans fresh and refuses on any drift from --report (required,
 no default — GH #70). --merge-works (Spec 2026-07-14 PR-2 part 1) is detection/planning ONLY —
-always a dry-run, no --apply counterpart exists yet."""
+always a dry-run. --merge-works-apply (PR-2 part 2, H2) executes the merge composition (editions/
+suggestions/trope+style links/contributors/detected_duplicates/Work-row deletion) behind the same
+drift-refusing gate — requires --yes and --report (no default, same as --repair-fallbacks-apply)."""
 
 from __future__ import annotations
 
@@ -257,34 +260,20 @@ def _run_repair_fallbacks(manager: DatabaseManager, safe: str) -> int:
         return 0
 
 
-def _write_works_merge_report(clusters, *, db_target: str) -> Path:
-    """Persist the works-merge dry-run plan to data/reports/works-merge-<UTC>.txt (Spec
-    2026-07-14 PR-2), reusing render_works_merge_report's human-readable text and the same
-    microsecond-timestamp collision avoidance as _write_dedup_report / fallback_repair's
-    write_report. PLANNING ONLY — there is no apply step yet (H2), so unlike those two reports
-    this one carries no machine-readable token block to gate an apply against."""
-    reports_dir = Path("data/reports")
-    reports_dir.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(UTC)
-    ts = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
-    path = reports_dir / f"works-merge-{ts}.txt"
-    path.write_text(dedup_backfill.render_works_merge_report(clusters, db_target=db_target), encoding="utf-8")
-    return path
-
-
 def _run_merge_works(manager: DatabaseManager, safe: str) -> int:
-    """--merge-works: DETECTION/PLANNING ONLY (PR-2 part 1) — always a dry-run, never applies.
-    Reuses the --repair-fallbacks CLI conventions: prints the DB target before opening the work
-    session, prints per-class cluster summaries + survivor picks, writes the full report to
-    data/reports/works-merge-<UTC>.txt for operator review. apply arrives in a follow-up
-    task (H2), which builds the merge composition (editions/suggestions/trope-links/
-    contributors/Work-row deletion) on top of this plan's clusters — see docs/superpowers/
-    specs/2026-07-14-works-merge-tool-design.md."""
+    """--merge-works: DETECTION + COMPOSITION PLANNING (PR-2 parts 1+2) — always a dry-run,
+    never applies. Prints the DB target before opening the work session, prints per-class
+    cluster summaries + survivor picks, writes the full report (H1's human-readable cluster
+    sections + H2's per-composition op summary + the machine-readable token block) to
+    data/reports/works-merge-<UTC>.txt — the SAME report --merge-works-apply's drift gate
+    cross-checks a fresh re-plan against (dedup_backfill.render_works_merge_apply_report /
+    write_works_merge_apply_report), so a --merge-works dry-run report is always a valid
+    --report argument for --merge-works-apply."""
     print(f"DB target: …@{safe}")
     with manager.get_session() as session:
         clusters = dedup_backfill.plan_works_merge(session)
         summary = clusters.summary()
-        print("\n=== works-merge plan (DETECTION ONLY — PR-2 part 1) ===")
+        print("\n=== works-merge plan (detection — PR-2 part 1) ===")
         for key, count in summary.items():
             print(f"  {key:32} {count}")
 
@@ -299,9 +288,72 @@ def _run_merge_works(manager: DatabaseManager, safe: str) -> int:
         _print_clusters("works_detected_duplicates", clusters.detected_duplicates, never_applied=False)
         _print_clusters("works_fuzzy_report_only", clusters.fuzzy_report_only, never_applied=True)
 
-        report_path = _write_works_merge_report(clusters, db_target=safe)
-        print(f"\nfull plan (every cluster) written to {report_path} — review this before any apply.")
-        print("\napply arrives in a follow-up (H2) — this command never mutates data.")
+        compositions = [
+            dedup_backfill.compose_cluster_merge(session, cluster)
+            for cluster in dedup_backfill.applyable_works_merge_clusters(clusters)
+        ]
+        print(f"\n=== apply composition (PR-2 part 2) — {len(compositions)} applyable clusters ===")
+        for comp in compositions[:20]:
+            print(
+                f"  survivor={comp.survivor_id}  losers={comp.loser_ids}  "
+                f"repoint_editions={len(comp.repoint_edition_ids)}  merge_editions={len(comp.merge_editions)}  "
+                f"dropped_duplicate_reads={comp.dropped_duplicate_reads}  "
+                f"repoint_suggestions={len(comp.repoint_suggestion_ids)}  "
+                f"drop_duplicate_suggestions={len(comp.drop_duplicate_suggestion_ids)}  "
+                f"copy_links={len(comp.copy_trope_links) + len(comp.copy_style_links)}  "
+                f"copy_contributors={len(comp.copy_contributors)}  "
+                f"delete_detections={len(comp.delete_detection_pairs)}  "
+                f"delete_works={len(comp.delete_work_ids)}"
+            )
+            if comp.malformed_author_candidates:
+                print(f"    malformed_author_candidates={comp.malformed_author_candidates} (report-only)")
+
+        report_path = dedup_backfill.write_works_merge_apply_report(clusters, compositions, db_target=safe)
+        print(f"\nfull plan (every cluster + composition token) written to {report_path} — review before applying.")
+        print(f"\napply with: --merge-works-apply --yes --report {report_path}")
+        return 0
+
+
+def _run_merge_works_apply(manager: DatabaseManager, args, url: str, safe: str) -> int:
+    """--merge-works-apply: guards first (mirrors --repair-fallbacks-apply exactly), THEN opens
+    the work session that re-plans fresh and applies — see dedup_backfill.apply_works_merge.
+    No embedding warm-up needed here (unlike --repair-fallbacks-apply): works-merge composition
+    never calls get_cached_embedding, only plan_works_merge's own detection queries, which are
+    already embedding-free (survivor selection uses trope-link COUNTS, not similarity)."""
+    print(f"DB target: …@{safe}")
+    if not args.yes:
+        print("\nREFUSING --merge-works-apply without --yes.")
+        return 2
+    if not is_prod_url(url):
+        print(f"\nREFUSING --merge-works-apply: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+        return 2
+    if args.report is None:
+        print(
+            "\nREFUSING --merge-works-apply: --report is required (no default — "
+            "name the reviewed --merge-works dry-run report explicitly)."
+        )
+        return 1
+
+    with manager.get_session() as session:
+        try:
+            applied = dedup_backfill.apply_works_merge(session, args.report)
+        except dedup_backfill.WorksMergeDriftError as exc:
+            print(f"\nREFUSING --merge-works-apply: {exc}")
+            print(f"New tokens present in the fresh plan but NOT in the reviewed report: +{len(exc.delta)}")
+            for token in sorted(exc.delta)[:40]:
+                print(f"  {token}")
+            print(
+                f"\nre-review {exc.fresh_report_path}, then re-run "
+                f"--merge-works-apply --yes --report {exc.fresh_report_path}"
+            )
+            return 1
+        except (OSError, ValueError) as exc:
+            print(f"\nREFUSING --merge-works-apply: {exc}")
+            return 1
+
+        print("\napplied:")
+        for key, count in applied.items():
+            print(f"  {key:32} {count}")
         return 0
 
 
@@ -417,17 +469,33 @@ def main(argv: list[str] | None = None) -> int:
         "--merge-works",
         action="store_true",
         help=(
-            "Spec 2026-07-14 PR-2 part 1: DETECTION/PLANNING ONLY for the works-merge tool — "
+            "Spec 2026-07-14 PR-2: DETECTION + COMPOSITION PLANNING for the works-merge tool — "
             "always a dry-run, this flag never applies. Prints the four detection classes "
             "(strongest evidence first): works_same_isbn, works_same_identity, "
             "works_detected_duplicates (the #141/#143 feed), and works_fuzzy_report_only "
             "(NEVER applied by design — operator promotes pairs by hand). Each cluster shows "
             "its deterministic survivor pick (most justified trope links -> newest "
-            "deep_enriched_at -> most editions -> lowest UUID). Writes "
-            "data/reports/works-merge-<UTC timestamp>.txt for review. Apply (the merge "
-            "composition: editions/suggestions/trope-links/contributors/Work-row deletion) "
-            "arrives in a follow-up task — see etl/dedup_backfill.py's plan_works_merge and "
-            "docs/superpowers/specs/2026-07-14-works-merge-tool-design.md."
+            "deep_enriched_at -> most editions -> lowest UUID), plus the per-cluster merge "
+            "composition (editions/suggestions/trope+style links/contributors/detected_"
+            "duplicates/Work-row deletion) that --merge-works-apply would execute. Writes "
+            "data/reports/works-merge-<UTC timestamp>.txt for review — the same report "
+            "--merge-works-apply's drift gate cross-checks a fresh re-plan against."
+        ),
+    )
+    ap.add_argument(
+        "--merge-works-apply",
+        action="store_true",
+        help=(
+            "Apply the works-merge composition (Spec 2026-07-14 PR-2 part 2, H2). A SEPARATE "
+            "invocation from the reviewed --merge-works dry-run: re-plans (detection + "
+            "composition) from scratch and REFUSES (exit 1) if the fresh plan contains any "
+            "token the operator never reviewed (op-tagged, so even an operation flip on the "
+            "same ids counts) — see etl/dedup_backfill.py's apply_works_merge. Requires --yes "
+            "and --report (no default, same as --repair-fallbacks-apply — a distinct "
+            "destructive operation that deletes Work rows carrying live user reading history; "
+            "must name its reviewed report explicitly). works_fuzzy_report_only clusters are "
+            "structurally unreachable by this gate — they are never part of the applyable "
+            "composition, by construction, not by a runtime check."
         ),
     )
     ap.add_argument(
@@ -475,6 +543,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_repair_fallbacks_apply(manager, args, url, safe)
     if args.merge_works:
         return _run_merge_works(manager, safe)
+    if args.merge_works_apply:
+        return _run_merge_works_apply(manager, args, url, safe)
 
     with manager.get_session() as session:
         print(f"DB target: …@{safe}")
@@ -666,7 +736,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, "
             "--requeue-unenriched, --dedup-for-constraints, --repair-fallbacks, "
-            "--repair-fallbacks-apply, or --merge-works."
+            "--repair-fallbacks-apply, --merge-works, or --merge-works-apply."
         )
         return 1
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -354,6 +354,9 @@ def _run_merge_works_apply(manager: DatabaseManager, args, url: str, safe: str) 
         print("\napplied:")
         for key, count in applied.items():
             print(f"  {key:32} {count}")
+        orphaned_pointer = applied.get("orphaned_authors_pointer", 0)
+        if orphaned_pointer:
+            print(f"\n{orphaned_pointer} author(s) may be orphaned — run --dedup-for-constraints dry-run to sweep.")
         return 0
 
 

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -38,8 +38,10 @@ this migration adds no columns to those tables.
 
 from __future__ import annotations
 
+import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -48,6 +50,7 @@ from sqlalchemy.orm import Session
 from agentic_librarian.db.models import (
     Author,
     AuthorStyle,
+    DetectedDuplicate,
     Edition,
     Narrator,
     NarratorStyle,
@@ -55,6 +58,7 @@ from agentic_librarian.db.models import (
     Suggestions,
     Work,
     WorkContributor,
+    WorkTrope,
     edition_narrators,
 )
 from agentic_librarian.enrichment.two_phase import _normalize
@@ -701,6 +705,486 @@ def _plan_duplicate_works(session: Session) -> list[WorkDupReport]:
             continue
         out.append(WorkDupReport(work_ids=[wid for wid, _ in entries], titles=[t for _, t in entries], norm_key=key))
     return out
+
+
+# --------------------------------------------------------------------------------------------
+# Works-merge detection (PR-2 part 1, Spec 2026-07-14: docs/superpowers/specs/
+# 2026-07-14-works-merge-tool-design.md). PLANNING/DETECTION ONLY — plan_works_merge is
+# read-only, same as plan_dedup; there is no apply_works_merge here (that is a follow-up task,
+# H2, which builds the merge COMPOSITION on top of this module's plan output).
+#
+# Deliberately independent of DedupPlan / plan_dedup / apply_dedup / PLAN_ID_SET_CLASSES above:
+# those exist for the #95 pre-constraint-migration gate (a narrower, already-shipped tool with
+# its own pinned tests — duplicate_works_report_only/_plan_duplicate_works/WorkDupReport are
+# untouched by this section). The works-merge tool is a separate, later-stage cleanup with its
+# own detection classes, its own survivor-selection rule, and its own eventual apply gate; it
+# lives in the SAME FILE (per the design spec: "extend etl/dedup_backfill.py... do NOT build a
+# parallel tool") but does not thread through the constraint-gate's plan/apply machinery.
+#
+# Four detection classes, evidence-strongest first — each produces UNORDERED work-pair
+# groupings (a work id pair is a 2-tuple but is always compared/deduped as a frozenset so
+# (A, B) and (B, A) collapse to the same pair):
+#   1. works_same_isbn        — works sharing a non-null editions.isbn_13.
+#   2. works_same_identity    — fold(title) equal AND author-token overlap >= 1 full token,
+#                                with the series guard blocking sequel titles from matching.
+#   3. works_detected_duplicates — rows from the #141/#143 detected_duplicates feed, deduped as
+#                                unordered pairs (the table's composite PK is (work_id_a,
+#                                work_id_b), NOT order-normalized — both rows of one cluster can
+#                                exist; see DetectedDuplicate's docstring in db/models.py).
+#   4. works_fuzzy_report_only — token-set similarity on folded titles above a threshold, minus
+#                                pairs already caught by a stronger class above. REPORT ONLY
+#                                FOREVER: never promoted to an applyable class by this tool (the
+#                                design spec: "operator promotes pairs by hand if real"). Marked
+#                                structurally via WorksMergeClusters.fuzzy_report_only being a
+#                                SEPARATE field from the three applyable-shape lists, exactly the
+#                                way duplicate_works_report_only is a separate field on DedupPlan
+#                                — H2's future apply step can only reach the applyable fields.
+#
+# A pair that matches more than one class is reported ONCE, in its single strongest class
+# (works_same_isbn > works_same_identity > works_detected_duplicates > works_fuzzy_report_only).
+# Pairs are then unioned into transitive clusters (A~B, B~C -> one {A, B, C} cluster) via a
+# simple union-find; a cluster's reported class is the STRONGEST class of any edge that built
+# it, so a cluster with even one same_isbn edge is never fuzzy-report-only.
+# --------------------------------------------------------------------------------------------
+
+_SERIES_TOKEN_WORDS = {"book", "volume", "vol", "part", "no"}
+
+
+def _fold(title: str) -> str:
+    """fold() per the works-merge design spec: the existing _normalize (lowercase, strip,
+    collapse whitespace) PLUS punctuation folding so title variants that differ only by
+    punctuation choice compare equal — catches the real 'We Are Legion (We Are Bob)' vs
+    'We are Legion; We are Bob' pair. Punctuation class matches the spec exactly:
+    [;:()\\[\\]&.,!?'"-] -> space, then whitespace collapse (re-run through _normalize so a
+    punctuation char abutting a word doesn't leave a double space)."""
+    folded = re.sub(r"""[;:()\[\]&.,!?'"-]""", " ", title or "")
+    return _normalize(folded)
+
+
+def _roman_numeral_token(token: str) -> bool:
+    """True if `token` is a (non-empty) run of valid roman-numeral letters. Deliberately loose
+    (does not validate strict subtractive-notation ordering, e.g. accepts 'IIII') — this is a
+    series-guard heuristic over real-world sequel titles, not a roman-numeral parser; the cost
+    of a false positive (blocking a legitimate non-sequel match) is low and no observed catalog
+    title needs the stricter form."""
+    return bool(token) and all(ch in "ivxlcdm" for ch in token)
+
+
+def _strip_trailing_volume_token(folded_title: str) -> tuple[str, bool]:
+    """Given an already-`_fold`ed title, strip a trailing volume/sequel token if present:
+    a bare number ('2'), a roman numeral ('ii'), a '#' + number (folded to '# 2' since '#' is
+    not in the punctuation-fold set... but '#' IS punctuation-like; see note below), or a
+    series word ('book'/'volume'/'vol'/'part'/'no') immediately followed by a number. Returns
+    (title_with_token_removed, True) if a token was found, else (folded_title, False).
+
+    Note: '#' is not in the fold-punctuation set (spec's list is `[;:()\\[\\]&.,!?'"-]`), so
+    '#2' survives folding as a single token '#2' — handled directly below alongside the
+    bare-number and roman-numeral cases."""
+    tokens = folded_title.split(" ")
+    if not tokens or tokens[-1] == "":
+        return folded_title, False
+
+    last = tokens[-1]
+    # Series-word + number ('... book 2', '... volume ii') checked BEFORE the bare
+    # number/roman-numeral case below, so 'beware of chicken volume 2' strips BOTH trailing
+    # tokens ('volume' and '2') down to 'beware of chicken', not just the trailing '2' down to
+    # the wrong 'beware of chicken volume'.
+    if len(tokens) >= 2 and tokens[-2] in _SERIES_TOKEN_WORDS and (last.isdigit() or _roman_numeral_token(last)):
+        return " ".join(tokens[:-2]).strip(), True
+    if last.isdigit() or _roman_numeral_token(last):
+        return " ".join(tokens[:-1]).strip(), True
+    if last.startswith("#") and last[1:].isdigit():
+        return " ".join(tokens[:-1]).strip(), True
+    return folded_title, False
+
+
+def _series_guard_blocks(title_a: str, title_b: str) -> bool:
+    """True if `title_a`/`title_b` differ ONLY by a trailing volume/sequel token — i.e. one
+    title, once its trailing volume token is stripped, equals the other's fold exactly, but the
+    two folded titles were NOT already equal. Symmetric in its two arguments by construction
+    (both directions are tried). 'Beware of Chicken' vs 'Beware of Chicken 2' -> blocked;
+    'Beware of Chicken' vs 'Beware of Chicken' -> NOT blocked (nothing to guard against);
+    'We Are Legion (We Are Bob)' vs 'We are Legion; We are Bob' -> NOT blocked (no trailing
+    volume token on either side, this is the punctuation-fold case fold() already handles)."""
+    fa, fb = _fold(title_a), _fold(title_b)
+    if fa == fb:
+        return False
+    stripped_a, had_a = _strip_trailing_volume_token(fa)
+    stripped_b, had_b = _strip_trailing_volume_token(fb)
+    if had_a and stripped_a == fb:
+        return True
+    return bool(had_b and stripped_b == fa)
+
+
+def fuzzy_similarity(title_a: str, title_b: str) -> float:
+    """Token-set (Jaccard) similarity on folded titles: |intersection| / |union| of each
+    title's fold()ed word set. Dependency-free (no rapidfuzz in this project) — the spec calls
+    for "trigram or token-set ratio"; token-set is chosen since it needs no new dependency and
+    is order-insensitive, which suits title variants that reorder words."""
+    tokens_a = set(_fold(title_a).split())
+    tokens_b = set(_fold(title_b).split())
+    if not tokens_a or not tokens_b:
+        return 0.0
+    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+
+
+FUZZY_SIMILARITY_THRESHOLD = 0.5
+
+
+@dataclass
+class WorkStats:
+    """Per-work data survivor selection needs, gathered once per plan_works_merge run and
+    passed around as a plain dict[UUID, WorkStats] so the pure clustering/survivor core
+    (plan_works_merge_clusters, pick_survivor) never touches a Session."""
+
+    work_id: UUID
+    title: str
+    justified_trope_links: int
+    deep_enriched_at: datetime | None
+    edition_count: int
+
+
+def pick_survivor(candidates: list[WorkStats]) -> WorkStats:
+    """Deterministic survivor selection (spec order): most justified trope links -> newest
+    deep_enriched_at (NULLs sort LAST, i.e. a work that was never deep-enriched never wins this
+    tiebreak over one that was) -> most editions -> lowest UUID string (final determinism).
+    Pure function over WorkStats; no DB access."""
+
+    def sort_key(w: WorkStats):
+        # NULLs-last on a DESCENDING sort: pair (has_timestamp, timestamp) both negated-ish via
+        # a tuple that puts "no timestamp" after "has timestamp" once the whole key is sorted
+        # ascending on its negation — simplest correct form: sort ascending on
+        # (-trope_links, null_last_date_key, -edition_count, str(id)).
+        # NULLs sort after any real timestamp.
+        date_key = (1, None) if w.deep_enriched_at is None else (0, -w.deep_enriched_at.timestamp())
+        return (-w.justified_trope_links, date_key, -w.edition_count, str(w.work_id))
+
+    return sorted(candidates, key=sort_key)[0]
+
+
+@dataclass
+class WorksMergeCluster:
+    """One merge unit: every work id folded into this cluster (transitively, via unioned pairs
+    across however many class edges connected them), the survivor plan_works_merge picked for
+    it, and the per-work stats used for that selection (so the report/CLI can show its work)."""
+
+    class_name: str  # one of "works_same_isbn" / "works_same_identity" / "works_detected_duplicates"
+    work_ids: list[UUID]
+    titles: list[str]
+    survivor_id: UUID
+    stats_by_work: dict[UUID, WorkStats] = field(default_factory=dict)
+
+
+@dataclass
+class WorksMergeClusters:
+    """The four detection classes' output, evidence-strongest first. Only the first three are
+    ever eligible for a future apply step; fuzzy_report_only is a STRUCTURALLY separate field
+    (never merged into the other three, never given an apply-shaped dataclass) so a future
+    apply_works_merge (H2) cannot reach it by construction, not just by convention."""
+
+    same_isbn: list[WorksMergeCluster] = field(default_factory=list)
+    same_identity: list[WorksMergeCluster] = field(default_factory=list)
+    detected_duplicates: list[WorksMergeCluster] = field(default_factory=list)
+    fuzzy_report_only: list[WorksMergeCluster] = field(default_factory=list)
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "works_same_isbn": len(self.same_isbn),
+            "works_same_identity": len(self.same_identity),
+            "works_detected_duplicates": len(self.detected_duplicates),
+            "works_fuzzy_report_only": len(self.fuzzy_report_only),
+        }
+
+
+# Class strength order, strongest first — index is used as the precedence rank (lower wins).
+_WORKS_MERGE_CLASS_ORDER = (
+    "works_same_isbn",
+    "works_same_identity",
+    "works_detected_duplicates",
+    "works_fuzzy_report_only",
+)
+
+
+class _UnionFind:
+    """Minimal union-find (path compression, no union-by-rank — cluster sizes here are tiny)
+    over arbitrary hashable ids, used to collapse transitive pairs (A~B, B~C) into one cluster
+    without pulling in a dependency."""
+
+    def __init__(self):
+        self._parent: dict[UUID, UUID] = {}
+
+    def find(self, x: UUID) -> UUID:
+        self._parent.setdefault(x, x)
+        while self._parent[x] != x:
+            self._parent[x] = self._parent[self._parent[x]]
+            x = self._parent[x]
+        return x
+
+    def union(self, a: UUID, b: UUID) -> None:
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[ra] = rb
+
+
+def plan_works_merge_clusters(
+    *,
+    same_isbn_pairs: list[tuple[UUID, UUID]],
+    same_identity_pairs: list[tuple[UUID, UUID]],
+    detected_duplicate_pairs: list[tuple[UUID, UUID]],
+    fuzzy_pairs: list[tuple[UUID, UUID]],
+    stats_by_work: dict[UUID, WorkStats],
+) -> WorksMergeClusters:
+    """Pure composition core (no DB access): given each class's already-detected pairs (as
+    plain (id, id) 2-tuples — order does not matter, they are deduped as unordered pairs
+    below), resolve cross-class overlap (a pair appears once, in its strongest class), collapse
+    transitive clusters via union-find, and pick each cluster's survivor.
+
+    A cluster's reported class is the STRONGEST class of any edge that built it (see the
+    module-level comment above this section) — this is what makes
+    test_transitive_cluster_takes_the_strongest_class_of_any_edge pass: a fuzzy-only edge that
+    gets pulled into a same_isbn cluster is reported under same_isbn, not fuzzy."""
+    pairs_by_class: dict[str, list[frozenset]] = {
+        "works_same_isbn": [frozenset(p) for p in same_isbn_pairs],
+        "works_same_identity": [frozenset(p) for p in same_identity_pairs],
+        "works_detected_duplicates": [frozenset(p) for p in detected_duplicate_pairs],
+        "works_fuzzy_report_only": [frozenset(p) for p in fuzzy_pairs],
+    }
+
+    # Cross-class precedence: a pair keeps only its strongest class's edge.
+    best_class_for_pair: dict[frozenset, str] = {}
+    for class_name in _WORKS_MERGE_CLASS_ORDER:
+        for pair in pairs_by_class[class_name]:
+            if pair not in best_class_for_pair:
+                best_class_for_pair[pair] = class_name
+
+    uf = _UnionFind()
+    for pair in best_class_for_pair:
+        a, b = tuple(pair)
+        uf.union(a, b)
+
+    # Group surviving (deduped, precedence-resolved) pair edges by their cluster root, and
+    # track the strongest class among the edges that built each cluster.
+    cluster_root_class_rank: dict[UUID, int] = {}
+    cluster_members: dict[UUID, set[UUID]] = defaultdict(set)
+    for pair, class_name in best_class_for_pair.items():
+        a, b = tuple(pair)
+        root = uf.find(a)
+        cluster_members[root].update((a, b))
+        rank = _WORKS_MERGE_CLASS_ORDER.index(class_name)
+        cluster_root_class_rank[root] = min(rank, cluster_root_class_rank.get(root, rank))
+
+    out = WorksMergeClusters()
+    dest_by_class_name = {
+        "works_same_isbn": out.same_isbn,
+        "works_same_identity": out.same_identity,
+        "works_detected_duplicates": out.detected_duplicates,
+        "works_fuzzy_report_only": out.fuzzy_report_only,
+    }
+    # Deterministic ordering: iterate roots sorted by string so plan output (and therefore any
+    # future report/token emission) is stable across re-plans of unchanged data.
+    for root in sorted(cluster_members, key=str):
+        members = cluster_members[root]
+        class_name = _WORKS_MERGE_CLASS_ORDER[cluster_root_class_rank[root]]
+        candidates = [stats_by_work[wid] for wid in members]
+        survivor = pick_survivor(candidates)
+        cluster = WorksMergeCluster(
+            class_name=class_name,
+            work_ids=sorted(members, key=str),
+            titles=[stats_by_work[wid].title for wid in sorted(members, key=str)],
+            survivor_id=survivor.work_id,
+            stats_by_work={wid: stats_by_work[wid] for wid in members},
+        )
+        dest_by_class_name[class_name].append(cluster)
+    return out
+
+
+def _detect_same_isbn_pairs(session: Session) -> list[tuple[UUID, UUID]]:
+    """works_same_isbn: two+ works sharing a non-null editions.isbn_13. Column-explicit (no
+    Work entity load) — matches the house convention elsewhere in this module, though this
+    query does not touch deep_enriched_at itself (the caller gathers WorkStats separately)."""
+    rows = session.query(Edition.work_id, Edition.isbn_13).filter(Edition.isbn_13.isnot(None)).all()
+    groups: dict[str, set[UUID]] = defaultdict(set)
+    for work_id, isbn in rows:
+        groups[isbn].add(work_id)
+    pairs: list[tuple[UUID, UUID]] = []
+    for work_ids in groups.values():
+        if len(work_ids) < 2:
+            continue
+        ordered = sorted(work_ids, key=str)
+        pairs.extend((ordered[0], wid) for wid in ordered[1:])
+    return pairs
+
+
+def _author_tokens(name: str) -> set[str]:
+    return set(_fold(name).split())
+
+
+def _detect_same_identity_pairs(session: Session) -> list[tuple[UUID, UUID]]:
+    """works_same_identity: fold(title) equal AND author-token-set overlap >= 1 full token,
+    with the series guard blocking sequel titles. O(n^2) within each fold(title) bucket (buckets
+    are small in practice — exact-title collisions), never across the whole catalog."""
+    rows = (
+        session.query(Work.id, Work.title, Author.name)
+        .join(WorkContributor, WorkContributor.work_id == Work.id)
+        .join(Author, Author.id == WorkContributor.author_id)
+        .filter(WorkContributor.role == "Author")
+        .order_by(Work.id)
+        .all()
+    )
+    authors_by_work: dict[UUID, set[str]] = defaultdict(set)
+    title_by_work: dict[UUID, str] = {}
+    for work_id, title, author_name in rows:
+        authors_by_work[work_id] |= _author_tokens(author_name)
+        title_by_work[work_id] = title
+
+    fold_buckets: dict[str, list[UUID]] = defaultdict(list)
+    for work_id, title in title_by_work.items():
+        fold_buckets[_fold(title)].append(work_id)
+
+    pairs: list[tuple[UUID, UUID]] = []
+    for work_ids in fold_buckets.values():
+        ordered = sorted(work_ids, key=str)
+        for i, wa in enumerate(ordered):
+            for wb in ordered[i + 1 :]:
+                if authors_by_work[wa] & authors_by_work[wb]:
+                    pairs.append((wa, wb))
+    return pairs
+
+
+def _detect_detected_duplicate_pairs(session: Session) -> list[tuple[UUID, UUID]]:
+    """works_detected_duplicates: rows from the #141/#143 detected_duplicates feed, deduped as
+    UNORDERED pairs — both (A, B) and (B, A) rows can exist for the same cluster (composite PK
+    is (work_id_a, work_id_b), not order-normalized; see DetectedDuplicate's docstring)."""
+    rows = session.query(DetectedDuplicate.work_id_a, DetectedDuplicate.work_id_b).all()
+    seen: set[frozenset] = set()
+    pairs: list[tuple[UUID, UUID]] = []
+    for a, b in rows:
+        pair = frozenset((a, b))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        pairs.append(tuple(sorted((a, b), key=str)))
+    return pairs
+
+
+def _detect_fuzzy_pairs(
+    title_by_work: dict[UUID, str], already_paired: set[frozenset], threshold: float = FUZZY_SIMILARITY_THRESHOLD
+) -> list[tuple[UUID, UUID]]:
+    """works_fuzzy_report_only: token-set similarity on folded titles above `threshold`, MINUS
+    pairs already caught by a stronger class (`already_paired`, as a set of frozensets) and
+    minus pairs the series guard blocks (a fuzzy-similar sequel title is not a duplicate).
+    O(n^2) over every work — acceptable at catalog scale (hundreds, not millions) per the
+    design spec's "retroactive global fuzzy dedup... stays report-only" framing; this is a
+    detail-list class, not a hot path."""
+    ids = sorted(title_by_work, key=str)
+    pairs: list[tuple[UUID, UUID]] = []
+    for i, wa in enumerate(ids):
+        for wb in ids[i + 1 :]:
+            pair = frozenset((wa, wb))
+            if pair in already_paired:
+                continue
+            title_a, title_b = title_by_work[wa], title_by_work[wb]
+            if _series_guard_blocks(title_a, title_b):
+                continue
+            if fuzzy_similarity(title_a, title_b) >= threshold:
+                pairs.append((wa, wb))
+    return pairs
+
+
+def _gather_work_stats(session: Session) -> dict[UUID, WorkStats]:
+    """One pass gathering everything pick_survivor needs, keyed by work id. Entity-loads Work
+    (including deep_enriched_at) — safe here (unlike plan_dedup's classes) because the
+    works-merge tool is a later-stage PR-2 cleanup that runs well after migration 48e3762d6c0c
+    (which added deep_enriched_at) and f871fd59415e (which added detected_duplicates) have both
+    landed; see this module's top docstring for the invariant that DOES still apply to
+    plan_dedup's own pre-#95-migration classes, which this function does not touch."""
+    trope_link_counts = Counter(
+        row.work_id for row in session.query(WorkTrope.work_id).filter(WorkTrope.justification.isnot(None)).all()
+    )
+    edition_counts = Counter(row.work_id for row in session.query(Edition.work_id).all())
+    out: dict[UUID, WorkStats] = {}
+    for work in session.query(Work).order_by(Work.id).all():
+        out[work.id] = WorkStats(
+            work_id=work.id,
+            title=work.title,
+            justified_trope_links=trope_link_counts.get(work.id, 0),
+            deep_enriched_at=work.deep_enriched_at,
+            edition_count=edition_counts.get(work.id, 0),
+        )
+    return out
+
+
+def plan_works_merge(session: Session) -> WorksMergeClusters:
+    """READ ONLY. Top-level works-merge detection entry point (PR-2 part 1) — gathers each
+    class's pairs from the DB, gathers per-work stats, and delegates to the pure
+    plan_works_merge_clusters for precedence resolution / transitive collapse / survivor
+    selection. No apply step exists in this module; H2 builds the merge composition on top of
+    this plan's clusters."""
+    stats_by_work = _gather_work_stats(session)
+    title_by_work = {wid: s.title for wid, s in stats_by_work.items()}
+
+    same_isbn_pairs = _detect_same_isbn_pairs(session)
+    same_identity_pairs = [
+        (a, b)
+        for a, b in _detect_same_identity_pairs(session)
+        if not _series_guard_blocks(title_by_work[a], title_by_work[b])
+    ]
+    detected_duplicate_pairs = _detect_detected_duplicate_pairs(session)
+
+    already_paired = {frozenset(p) for p in same_isbn_pairs + same_identity_pairs + detected_duplicate_pairs}
+    fuzzy_pairs = _detect_fuzzy_pairs(title_by_work, already_paired)
+
+    return plan_works_merge_clusters(
+        same_isbn_pairs=same_isbn_pairs,
+        same_identity_pairs=same_identity_pairs,
+        detected_duplicate_pairs=detected_duplicate_pairs,
+        fuzzy_pairs=fuzzy_pairs,
+        stats_by_work=stats_by_work,
+    )
+
+
+def render_works_merge_report(clusters: WorksMergeClusters, *, db_target: str | None = None) -> str:
+    """Human-readable report text, consistent with this module's existing report format
+    (dedup's `_write_dedup_report` in scripts/clean_catalog.py / fallback_repair's
+    write_report): a summary block, then per-class cluster sections showing every work id +
+    title in the cluster and which one was picked as survivor. No machine-readable token block
+    here — plan_id_set-shaped token emission is H2's job (the apply step doesn't exist yet), so
+    there is nothing to gate against drift yet. fuzzy_report_only is called out explicitly as
+    NEVER APPLIED so an operator reading a persisted copy of this text (not just the live CLI
+    output) sees the same warning."""
+    lines: list[str] = ["Works-merge plan report", "=" * 60, ""]
+    if db_target is not None:
+        lines.append(f"db target: {db_target}")
+        lines.append("")
+
+    summary = clusters.summary()
+    lines.append("summary:")
+    for key, count in summary.items():
+        lines.append(f"  {key:32} {count}")
+    lines.append("")
+
+    def _render_section(title: str, class_clusters: list[WorksMergeCluster], *, never_applied: bool) -> None:
+        suffix = "  (NEVER APPLIED — operator triage only)" if never_applied else ""
+        lines.append(f"=== {title} ({len(class_clusters)}){suffix} ===")
+        for cluster in class_clusters:
+            lines.append(f"  cluster: {cluster.work_ids}")
+            for wid in cluster.work_ids:
+                stats = cluster.stats_by_work[wid]
+                marker = " <- survivor" if wid == cluster.survivor_id else ""
+                lines.append(
+                    f"    {wid}  {stats.title!r}  "
+                    f"justified_tropes={stats.justified_trope_links} "
+                    f"deep_enriched_at={stats.deep_enriched_at} "
+                    f"editions={stats.edition_count}{marker}"
+                )
+        lines.append("")
+
+    _render_section("works_same_isbn", clusters.same_isbn, never_applied=False)
+    _render_section("works_same_identity", clusters.same_identity, never_applied=False)
+    _render_section("works_detected_duplicates", clusters.detected_duplicates, never_applied=False)
+    _render_section("works_fuzzy_report_only", clusters.fuzzy_report_only, never_applied=True)
+
+    return "\n".join(lines)
 
 
 # --------------------------------------------------------------------------------------------

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -41,7 +41,8 @@ from __future__ import annotations
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
+from pathlib import Path
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -58,6 +59,7 @@ from agentic_librarian.db.models import (
     Suggestions,
     Work,
     WorkContributor,
+    WorkStyle,
     WorkTrope,
     edition_narrators,
 )
@@ -1472,3 +1474,737 @@ def plan_delta(reviewed: dict[str, set[str]], fresh: DedupPlan) -> dict[str, set
     ordinary `skipped_stale` territory at apply time, not a plan drift)."""
     fresh_ids = plan_id_set(fresh)
     return {name: fresh_ids.get(name, set()) - reviewed.get(name, set()) for name in PLAN_ID_SET_CLASSES}
+
+
+# --------------------------------------------------------------------------------------------
+# Works-merge APPLY (H2, Spec 2026-07-14 "Merge composition" / "Gate" / item 6). Builds the
+# actual merge composition on top of plan_works_merge's clusters (same module, same file, per
+# the design spec — "extend etl/dedup_backfill.py... do NOT build a parallel tool").
+#
+# ONLY same_isbn / same_identity / detected_duplicates clusters are ever composed —
+# fuzzy_report_only is STRUCTURALLY unreachable here: compose_cluster_merge and
+# apply_works_merge only ever iterate WorksMergeClusters.same_isbn/.same_identity/
+# .detected_duplicates (see applyable_works_merge_clusters below), never .fuzzy_report_only.
+# There is no code path, however careless, that could reach it — the field simply isn't in the
+# iteration.
+#
+# DISJOINTNESS PROOF (deliverable 2 — the deferred-intersections discipline, reasoned through
+# rather than found empirically): after plan_works_merge_clusters' union-find, every cluster is a
+# disjoint SET OF WORK IDS — no work id appears in two clusters (union-find guarantees this by
+# construction: any pair that shares a work id gets unioned into the SAME cluster). Every row this
+# composition ever touches (editions, reading_history, edition_narrators, suggestions, work_tropes,
+# work_styles, work_contributors, detected_duplicates) hangs off exactly one work id via a
+# NOT-NULL foreign key (Edition.work_id, ReadingHistory.edition_id -> Edition.work_id transitively,
+# Suggestions.work_id, WorkTrope.work_id, WorkStyle.work_id, WorkContributor.work_id,
+# DetectedDuplicate.work_id_a/work_id_b). A row can only be "in play" for a cluster if its owning
+# work id is a member of that cluster's work_ids set. Since work_ids sets are disjoint across
+# clusters in one plan, a row belonging to work W can only ever be named by the ONE cluster that
+# contains W — never by two different clusters in the same plan. This rules out the dedup_backfill
+# 6.3 hazard (a row touched by two independently-computed classes from the same snapshot) BY
+# CONSTRUCTION, not by scanning for overlaps after the fact.
+#
+# The one genuine cross-cluster collision surface the spec calls out is a UNIQUENESS constraint
+# spanning rows from DIFFERENT works: uq_suggestions_active is (user_id, work_id) WHERE
+# status='Suggested' — repointing a loser's suggestion onto ITS OWN cluster's survivor can collide
+# with that survivor's own pre-existing active suggestion (handled in-cluster, below, as
+# drop_duplicate_suggestion). That collision is always WITHIN one cluster (the loser and survivor
+# are members of the same cluster, by definition of the repoint) — never across two clusters,
+# because the colliding row (survivor's own suggestion) only becomes "in play" for whichever
+# cluster its OWN work id belongs to. A genuine cross-cluster version of this (same user, active
+# suggestion on the survivors of TWO DIFFERENT clusters, where those two survivor works are
+# somehow the same book split into two separate clusters) cannot arise: if two works were the same
+# book, detection would have paired them and union-find would have merged them into ONE cluster.
+# So there is nothing to defer here — the deferred_intersections mechanism dedup_backfill needed
+# (two INDEPENDENTLY-classed groups touching the same row) has no analogue in this composition,
+# and this section documents that rather than building unused deferral plumbing. If a future
+# detection class ever produces overlapping (non-disjoint) clusters, this proof breaks and a
+# deferral mechanism would need to be added then — not before.
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class WorkMergeComposition:
+    """Every op one cluster's merge composition performs, in apply order. Built by
+    compose_cluster_merge against CURRENT session state (read-only) — apply_works_merge executes
+    exactly what this names, same "apply what was shown" discipline as apply_dedup."""
+
+    cluster: WorksMergeCluster
+    survivor_id: UUID
+    loser_ids: list[UUID]
+
+    # 1. Editions: whole-edition repoints (no format collision) vs merges (loser edition dropped,
+    # its reading_history/edition_narrators repointed onto the survivor's same-format edition).
+    repoint_edition_ids: list[UUID] = field(default_factory=list)
+    merge_editions: list[EditionMergeGroup] = field(default_factory=list)
+    dropped_duplicate_reads: int = 0
+
+    # 2. Suggestions.
+    repoint_suggestion_ids: list[UUID] = field(default_factory=list)
+    drop_duplicate_suggestion_ids: list[UUID] = field(default_factory=list)
+
+    # 3. Trope/style links: union onto the survivor.
+    copy_trope_links: list[tuple[UUID, UUID, float, str | None]] = field(default_factory=list)
+    drop_trope_links: list[tuple[UUID, UUID]] = field(default_factory=list)
+    copy_style_links: list[tuple[UUID, UUID, str]] = field(default_factory=list)
+    drop_style_links: list[tuple[UUID, UUID, str]] = field(default_factory=list)
+
+    # 4. Contributors: union by (author_id, role).
+    copy_contributors: list[tuple[UUID, str]] = field(default_factory=list)
+    drop_contributors: list[tuple[UUID, UUID, str]] = field(default_factory=list)
+    malformed_author_candidates: list[UUID] = field(default_factory=list)
+
+    # 5. detected_duplicates rows referencing ANY loser on either side — deleted before the losers.
+    delete_detection_pairs: list[tuple[UUID, UUID]] = field(default_factory=list)
+
+    # 6. Loser Work rows, deleted last.
+    delete_work_ids: list[UUID] = field(default_factory=list)
+
+
+def compose_cluster_merge(session: Session, cluster: WorksMergeCluster) -> WorkMergeComposition:
+    """READ ONLY. Composes one cluster's merge — every op needed to fold cluster.work_ids onto
+    cluster.survivor_id — against CURRENT session state. See the module-level disjointness proof
+    above for why composing clusters independently (no cross-cluster deferral) is safe.
+
+    Ordered exactly per the design spec: editions -> suggestions -> trope/style links ->
+    contributors -> detected_duplicates -> Work rows. apply_works_merge executes in this order."""
+    survivor_id = cluster.survivor_id
+    loser_ids = sorted((wid for wid in cluster.work_ids if wid != survivor_id), key=str)
+    comp = WorkMergeComposition(cluster=cluster, survivor_id=survivor_id, loser_ids=loser_ids)
+
+    # --- 1. Editions -------------------------------------------------------------------------
+    survivor_editions_by_fmt: dict[str, Edition] = {
+        (e.format or ""): e for e in session.query(Edition).filter_by(work_id=survivor_id).order_by(Edition.id).all()
+    }
+    survivor_dates_by_edition_user: dict[UUID, dict[UUID, set]] = defaultdict(lambda: defaultdict(set))
+    for survivor_edition in survivor_editions_by_fmt.values():
+        for rh in (
+            session.query(ReadingHistory).filter_by(edition_id=survivor_edition.id).order_by(ReadingHistory.id).all()
+        ):
+            survivor_dates_by_edition_user[survivor_edition.id][rh.user_id].add(rh.date_completed)
+    survivor_narrators_by_edition: dict[UUID, set[UUID]] = {}
+    for survivor_edition in survivor_editions_by_fmt.values():
+        survivor_narrators_by_edition[survivor_edition.id] = {
+            row.narrator_id
+            for row in session.execute(
+                select(edition_narrators.c.narrator_id)
+                .where(edition_narrators.c.edition_id == survivor_edition.id)
+                .order_by(edition_narrators.c.narrator_id)
+            ).all()
+        }
+
+    for loser_id in loser_ids:
+        for loser_edition in session.query(Edition).filter_by(work_id=loser_id).order_by(Edition.id).all():
+            fmt_key = loser_edition.format or ""
+            collision = survivor_editions_by_fmt.get(fmt_key)
+            if collision is None:
+                # No same-format edition on the survivor yet -> whole-edition repoint. Register
+                # it as the survivor's edition for this format so a SECOND loser edition of the
+                # same format (rare but possible across a 3+-work cluster) merges into THIS one
+                # rather than repointing independently, per the module's collision handling.
+                comp.repoint_edition_ids.append(loser_edition.id)
+                survivor_editions_by_fmt[fmt_key] = loser_edition
+                dates_by_user: dict[UUID, set] = defaultdict(set)
+                for rh in session.query(ReadingHistory).filter_by(edition_id=loser_edition.id).all():
+                    dates_by_user[rh.user_id].add(rh.date_completed)
+                survivor_dates_by_edition_user[loser_edition.id] = dates_by_user
+                survivor_narrators_by_edition[loser_edition.id] = {
+                    row.narrator_id
+                    for row in session.execute(
+                        select(edition_narrators.c.narrator_id).where(
+                            edition_narrators.c.edition_id == loser_edition.id
+                        )
+                    ).all()
+                }
+                continue
+
+            # uq_editions_work_format collision: keep the survivor's (or the first-registered)
+            # edition, merge the loser edition's reading_history + edition_narrators onto it.
+            merge_group = next((mg for mg in comp.merge_editions if mg.survivor_id == collision.id), None)
+            if merge_group is None:
+                merge_group = EditionMergeGroup(
+                    survivor_id=collision.id, work_id=survivor_id, fmt=fmt_key or None, loser_ids=[]
+                )
+                comp.merge_editions.append(merge_group)
+            merge_group.loser_ids.append(loser_edition.id)
+
+            dates_by_user = survivor_dates_by_edition_user[collision.id]
+            for rh in (
+                session.query(ReadingHistory).filter_by(edition_id=loser_edition.id).order_by(ReadingHistory.id).all()
+            ):
+                if rh.date_completed in dates_by_user.get(rh.user_id, set()):
+                    merge_group.delete_reading_history.append(rh.id)
+                    comp.dropped_duplicate_reads += 1
+                else:
+                    merge_group.repoint_reading_history.append(rh.id)
+                    dates_by_user.setdefault(rh.user_id, set()).add(rh.date_completed)
+
+            narrator_ids = survivor_narrators_by_edition.setdefault(collision.id, set())
+            for row in session.execute(
+                select(edition_narrators.c.narrator_id)
+                .where(edition_narrators.c.edition_id == loser_edition.id)
+                .order_by(edition_narrators.c.narrator_id)
+            ).all():
+                nid = row.narrator_id
+                if nid in narrator_ids:
+                    merge_group.delete_narrators.append((loser_edition.id, nid))
+                else:
+                    merge_group.repoint_narrators.append((loser_edition.id, nid))
+                    narrator_ids.add(nid)
+
+    # --- 2. Suggestions ------------------------------------------------------------------------
+    survivor_active_users = {
+        s.user_id
+        for s in session.query(Suggestions)
+        .filter_by(work_id=survivor_id, status="Suggested")
+        .order_by(Suggestions.id)
+        .all()
+    }
+    for loser_id in loser_ids:
+        for s in (
+            session.query(Suggestions).filter_by(work_id=loser_id, status="Suggested").order_by(Suggestions.id).all()
+        ):
+            if s.user_id in survivor_active_users:
+                comp.drop_duplicate_suggestion_ids.append(s.id)
+            else:
+                comp.repoint_suggestion_ids.append(s.id)
+                survivor_active_users.add(s.user_id)
+        # Non-'Suggested' (Accepted/Rejected/etc.) suggestions carry no active-uniqueness
+        # constraint — always repoint, never drop.
+        for s in (
+            session.query(Suggestions)
+            .filter(Suggestions.work_id == loser_id, Suggestions.status != "Suggested")
+            .order_by(Suggestions.id)
+            .all()
+        ):
+            comp.repoint_suggestion_ids.append(s.id)
+
+    # --- 3. Trope/style links: union ------------------------------------------------------------
+    survivor_trope_ids = {
+        wt.trope_id for wt in session.query(WorkTrope).filter_by(work_id=survivor_id).order_by(WorkTrope.trope_id).all()
+    }
+    survivor_style_keys = {
+        (ws.style_id, ws.attribute_type)
+        for ws in session.query(WorkStyle)
+        .filter_by(work_id=survivor_id)
+        .order_by(WorkStyle.style_id, WorkStyle.attribute_type)
+        .all()
+    }
+    for loser_id in loser_ids:
+        for wt in session.query(WorkTrope).filter_by(work_id=loser_id).order_by(WorkTrope.trope_id).all():
+            if wt.trope_id in survivor_trope_ids:
+                comp.drop_trope_links.append((loser_id, wt.trope_id))
+            else:
+                comp.copy_trope_links.append((loser_id, wt.trope_id, wt.relevance_score, wt.justification))
+                survivor_trope_ids.add(wt.trope_id)
+        for ws in (
+            session.query(WorkStyle)
+            .filter_by(work_id=loser_id)
+            .order_by(WorkStyle.style_id, WorkStyle.attribute_type)
+            .all()
+        ):
+            key = (ws.style_id, ws.attribute_type)
+            if key in survivor_style_keys:
+                comp.drop_style_links.append((loser_id, ws.style_id, ws.attribute_type))
+            else:
+                comp.copy_style_links.append((loser_id, ws.style_id, ws.attribute_type))
+                survivor_style_keys.add(key)
+
+    # --- 4. Contributors: union by (author_id, role) --------------------------------------------
+    survivor_contributors = (
+        session.query(WorkContributor)
+        .filter_by(work_id=survivor_id)
+        .order_by(WorkContributor.author_id, WorkContributor.role)
+        .all()
+    )
+    survivor_keys = {(wc.author_id, wc.role) for wc in survivor_contributors}
+    survivor_names_by_role: dict[str, set[str]] = defaultdict(set)
+    for wc in survivor_contributors:
+        author = session.get(Author, wc.author_id)
+        if author is not None:
+            survivor_names_by_role[wc.role].add(author.name.strip().casefold())
+
+    for loser_id in loser_ids:
+        for wc in (
+            session.query(WorkContributor)
+            .filter_by(work_id=loser_id)
+            .order_by(WorkContributor.author_id, WorkContributor.role)
+            .all()
+        ):
+            key = (wc.author_id, wc.role)
+            if key in survivor_keys:
+                comp.drop_contributors.append((loser_id, wc.author_id, wc.role))
+                continue
+            author = session.get(Author, wc.author_id)
+            name_cf = author.name.strip().casefold() if author is not None else None
+            if name_cf is not None and name_cf in survivor_names_by_role.get(wc.role, set()):
+                # A DIFFERENT Author row already on the survivor case-folds equal (the #142
+                # malformed-comma-joined-author shape) — report, never mutate an Author here.
+                comp.malformed_author_candidates.append(wc.author_id)
+                continue
+            comp.copy_contributors.append((wc.author_id, wc.role))
+            survivor_keys.add(key)
+            if name_cf is not None:
+                survivor_names_by_role[wc.role].add(name_cf)
+
+    # --- 5. detected_duplicates: delete every row referencing ANY loser on either side. Not
+    # restricted to rows where BOTH sides are cluster members: a loser could in principle be
+    # named in a detection row against a work id outside this cluster (e.g. a stale detection
+    # from before this cluster's shape settled) — the spec is unconditional ("delete ALL rows
+    # referencing any loser on EITHER side"), since the FKs fail loud on a dangling reference
+    # once the loser Work row is deleted below, and a dangling detection is never valid to keep.
+    loser_id_set = set(loser_ids)
+    for row in session.query(DetectedDuplicate.work_id_a, DetectedDuplicate.work_id_b).all():
+        a, b = row
+        if a in loser_id_set or b in loser_id_set:
+            comp.delete_detection_pairs.append((a, b))
+
+    # --- 6. Loser Work rows, last -----------------------------------------------------------------
+    comp.delete_work_ids = list(loser_ids)
+
+    return comp
+
+
+def applyable_works_merge_clusters(clusters: WorksMergeClusters) -> list[WorksMergeCluster]:
+    """The ONLY clusters compose_cluster_merge/apply_works_merge ever iterate — same_isbn,
+    same_identity, detected_duplicates, in that (evidence-strongest-first) order.
+    fuzzy_report_only is NEVER included: this is the single choke point that keeps the fuzzy
+    class structurally unreachable by apply (see the module comment above compose_cluster_merge)
+    — every caller (plan_works_merge_apply, apply_works_merge, the token/report functions below)
+    goes through this function rather than reading WorksMergeClusters' fields directly, so
+    "never apply fuzzy" is enforced in exactly one place."""
+    return [*clusters.same_isbn, *clusters.same_identity, *clusters.detected_duplicates]
+
+
+def plan_works_merge_apply(session: Session) -> list[WorkMergeComposition]:
+    """READ ONLY. Detects clusters fresh (plan_works_merge) and composes each applyable one
+    (applyable_works_merge_clusters) against CURRENT session state. This is what both the
+    dry-run report and apply_works_merge's fresh re-plan call — always the same function, so
+    "what dry-run showed" and "what a fresh re-plan sees" are computed identically."""
+    clusters = plan_works_merge(session)
+    return [compose_cluster_merge(session, cluster) for cluster in applyable_works_merge_clusters(clusters)]
+
+
+# --------------------------------------------------------------------------------------------
+# Op-tagged tokens (mirrors plan_id_set / fallback_repair.plan_tokens EXACTLY — see plan_id_set's
+# docstring for why the op-tag is load-bearing: an operation FLIP on the same id between the
+# reviewed report and a fresh apply-time re-plan must show up as a NEW token, not an unchanged
+# bare id, so plan_delta's refuse-on-addition catches it.
+# --------------------------------------------------------------------------------------------
+
+WORKS_MERGE_OPS = (
+    "repoint_edition",
+    "merge_edition",
+    "repoint_read",
+    "drop_duplicate_read",
+    "repoint_narrator",
+    "drop_narrator",
+    "repoint_suggestion",
+    "drop_duplicate_suggestion",
+    "copy_link",
+    "drop_link",
+    "copy_contributor",
+    "drop_contributor",
+    "delete_detection",
+    "delete_work",
+)
+
+
+def works_merge_tokens(compositions: list[WorkMergeComposition]) -> set[str]:
+    """Every op every composition performs, as one flat set of opaque `<op>:<...>` tokens — one
+    set (not per-class, unlike plan_id_set/fallback_repair's PLAN_*_CLASSES) since this gate has
+    a single applyable action surface, not several independently-reviewable classes. Composite
+    identifiers stringify as `<op>:<tuple-repr>`, same convention as plan_id_set."""
+    tokens: set[str] = set()
+    for comp in compositions:
+        tokens.add(f"merge_cluster:{comp.survivor_id}:{sorted(str(x) for x in comp.loser_ids)}")
+        tokens.update(f"repoint_edition:{eid}" for eid in comp.repoint_edition_ids)
+        for mg in comp.merge_editions:
+            tokens.add(f"merge_edition:{(mg.survivor_id, sorted(str(x) for x in mg.loser_ids))}")
+            tokens.update(f"repoint_read:{rh_id}" for rh_id in mg.repoint_reading_history)
+            tokens.update(f"drop_duplicate_read:{rh_id}" for rh_id in mg.delete_reading_history)
+            tokens.update(f"repoint_narrator:{item}" for item in mg.repoint_narrators)
+            tokens.update(f"drop_narrator:{item}" for item in mg.delete_narrators)
+        tokens.update(f"repoint_suggestion:{sid}" for sid in comp.repoint_suggestion_ids)
+        tokens.update(f"drop_duplicate_suggestion:{sid}" for sid in comp.drop_duplicate_suggestion_ids)
+        tokens.update(f"copy_link:trope:{item}" for item in comp.copy_trope_links)
+        tokens.update(f"drop_link:trope:{item}" for item in comp.drop_trope_links)
+        tokens.update(f"copy_link:style:{item}" for item in comp.copy_style_links)
+        tokens.update(f"drop_link:style:{item}" for item in comp.drop_style_links)
+        tokens.update(f"copy_contributor:{(comp.survivor_id, item)}" for item in comp.copy_contributors)
+        tokens.update(f"drop_contributor:{item}" for item in comp.drop_contributors)
+        tokens.update(f"delete_detection:{item}" for item in comp.delete_detection_pairs)
+        tokens.update(f"delete_work:{wid}" for wid in comp.delete_work_ids)
+    return tokens
+
+
+def works_merge_delta(reviewed: set[str], fresh_compositions: list[WorkMergeComposition]) -> set[str]:
+    """Tokens present in the FRESH compositions but NOT in the REVIEWED token set. Empty means
+    fresh is a subset of reviewed — safe to apply. Mirrors plan_delta/fallback_repair.plan_delta,
+    single flat set instead of per-class since works_merge_tokens is single-set (see its
+    docstring)."""
+    return works_merge_tokens(fresh_compositions) - reviewed
+
+
+# --------------------------------------------------------------------------------------------
+# Report: human-readable cluster sections (reuses render_works_merge_report's per-cluster
+# rendering) + the machine-readable token block + fail-closed END-marker parser. Mirrors
+# fallback_repair.write_report/parse_report EXACTLY.
+# --------------------------------------------------------------------------------------------
+
+
+def render_works_merge_apply_report(
+    clusters: WorksMergeClusters, compositions: list[WorkMergeComposition], *, db_target: str | None = None
+) -> str:
+    """Human-readable cluster sections (H1's render_works_merge_report) PLUS a per-composition
+    op summary PLUS the '== PLAN TOKENS ==' machine-readable block apply_works_merge's drift
+    gate cross-checks a fresh re-plan against. fuzzy_report_only is rendered same as before
+    (never-applied marker) — it is NEVER part of `compositions` (see
+    applyable_works_merge_clusters), so it never appears in the token block."""
+    lines: list[str] = [render_works_merge_report(clusters, db_target=db_target), ""]
+
+    lines.append("=== apply composition (per applyable cluster) ===")
+    for comp in compositions:
+        lines.append(f"  cluster survivor={comp.survivor_id}  losers={comp.loser_ids}")
+        lines.append(
+            f"    repoint_editions={comp.repoint_edition_ids}  "
+            f"merge_editions={len(comp.merge_editions)}  dropped_duplicate_reads={comp.dropped_duplicate_reads}"
+        )
+        lines.append(
+            f"    repoint_suggestions={comp.repoint_suggestion_ids}  "
+            f"drop_duplicate_suggestions={comp.drop_duplicate_suggestion_ids}"
+        )
+        lines.append(
+            f"    copy_trope_links={len(comp.copy_trope_links)}  drop_trope_links={len(comp.drop_trope_links)}  "
+            f"copy_style_links={len(comp.copy_style_links)}  drop_style_links={len(comp.drop_style_links)}"
+        )
+        lines.append(f"    copy_contributors={comp.copy_contributors}  drop_contributors={comp.drop_contributors}")
+        if comp.malformed_author_candidates:
+            lines.append(
+                f"    malformed_author_candidates={comp.malformed_author_candidates}  "
+                "(report-only — no author mutation)"
+            )
+        lines.append(f"    delete_detection_pairs={comp.delete_detection_pairs}")
+        lines.append(f"    delete_work_ids={comp.delete_work_ids}")
+    lines.append("")
+
+    lines.append("== PLAN TOKENS ==")
+    tokens = sorted(works_merge_tokens(compositions))
+    lines.append(f"[works_merge] {len(tokens)}")
+    lines.extend(tokens)
+    lines.append("== END PLAN TOKENS ==")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_works_merge_apply_report(
+    clusters: WorksMergeClusters,
+    compositions: list[WorkMergeComposition],
+    reports_dir: Path | None = None,
+    db_target: str | None = None,
+) -> Path:
+    """Persists render_works_merge_apply_report to data/reports/works-merge-<UTC>.txt —
+    SAME filename prefix as H1's planning-only report (_write_works_merge_report in
+    scripts/clean_catalog.py), since this supersedes it as the operator-facing artifact once
+    apply exists; microsecond timestamp keeps a dry-run's write and an apply's fresh-plan write
+    from colliding on the same path (mirrors _write_dedup_report's collision-avoidance
+    reasoning)."""
+    reports_dir = reports_dir or Path("data/reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    ts = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
+    path = reports_dir / f"works-merge-{ts}.txt"
+    path.write_text(render_works_merge_apply_report(clusters, compositions, db_target=db_target), encoding="utf-8")
+    return path
+
+
+def parse_works_merge_report(report_text: str) -> set[str]:
+    """Parse the '== PLAN TOKENS ==' block back into the flat token set works_merge_tokens
+    produces. Fail-closed (mirrors fallback_repair.parse_report EXACTLY): raises ValueError if
+    the start marker is missing, if the END marker is missing (truncated report), or if a
+    class-header-shaped line (`[...]`) doesn't actually parse as one."""
+    lines = report_text.splitlines()
+    try:
+        start = lines.index("== PLAN TOKENS ==")
+    except ValueError as exc:
+        raise ValueError(
+            "report has no '== PLAN TOKENS ==' section — not a works-merge apply report, or an old-format one"
+        ) from exc
+
+    try:
+        end = lines.index("== END PLAN TOKENS ==", start + 1)
+    except ValueError as exc:
+        raise ValueError("report has no '== END PLAN TOKENS ==' terminator — truncated or corrupt report") from exc
+
+    out: set[str] = set()
+    for line in lines[start + 1 : end]:
+        if line.startswith("["):
+            if "]" not in line:
+                raise ValueError(f"malformed class-header line in PLAN TOKENS block: {line!r}")
+            continue
+        if line:
+            out.add(line)
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Apply — THE USER GATE (mirrors fallback_repair.apply_fallback_repair / apply_dedup exactly)
+# --------------------------------------------------------------------------------------------
+
+
+class WorksMergeDriftError(ValueError):
+    """Raised instead of a bare ValueError when apply_works_merge's fresh re-plan drifted from
+    the reviewed report — mirrors FallbackRepairDriftError exactly. Carries the offending delta
+    TOKENS (not just a count) and the path of a fresh report written from the drifted
+    compositions, ready for immediate re-review."""
+
+    def __init__(self, delta: set[str], fresh_report_path: Path):
+        self.delta = delta
+        self.fresh_report_path = fresh_report_path
+        super().__init__(
+            f"REFUSING apply_works_merge: fresh plan drifted from the reviewed report (+{len(delta)} new "
+            f"token(s)). A fresh report was written to {fresh_report_path} — re-review it before re-applying."
+        )
+
+
+def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str, int]:
+    """--merge-works-apply is a SEPARATE invocation from the reviewed --merge-works dry-run.
+    Re-plans FRESH (plan_works_merge_apply — same function the dry-run report was built from)
+    and REFUSES (raises WorksMergeDriftError, no partial writes — nothing is flushed before the
+    drift check completes) if the fresh token set contains ANY token absent from the reviewed
+    set — including an operation flip on the same id (op-tagged tokens, see works_merge_tokens).
+    fresh ⊆ reviewed is fine (skipped_stale territory, reported not refused).
+
+    Executes ALL applyable clusters' compositions in ONE transaction, in per-cluster order
+    (editions -> suggestions -> links -> contributors -> detected_duplicates -> Work deletes),
+    matching the design spec's ordered steps. Every row lookup re-verifies against the session
+    at apply time (session.get) and anything vanished since the fresh plan was composed a moment
+    ago is counted under skipped_stale rather than raising — the ordinary "apply what was shown,
+    tolerate the sub-second race" discipline every other gated tool in this module follows.
+
+    fuzzy_report_only clusters are never in `fresh_compositions` at all (applyable_works_merge_
+    clusters) — the structural exclusion holds through this gate by construction, not by a
+    runtime check here."""
+    reviewed_tokens = parse_works_merge_report(Path(reviewed_report_path).read_text(encoding="utf-8"))
+
+    fresh_clusters = plan_works_merge(session)
+    fresh_compositions = [
+        compose_cluster_merge(session, cluster) for cluster in applyable_works_merge_clusters(fresh_clusters)
+    ]
+    fresh_tokens = works_merge_tokens(fresh_compositions)
+    delta = fresh_tokens - reviewed_tokens
+    if delta:
+        fresh_report_path = write_works_merge_apply_report(fresh_clusters, fresh_compositions)
+        raise WorksMergeDriftError(delta, fresh_report_path)
+
+    shrinkage = len(reviewed_tokens - fresh_tokens)
+
+    result = {
+        "repoint_edition": 0,
+        "merge_edition": 0,
+        "repoint_read": 0,
+        "drop_duplicate_read": 0,
+        "repoint_narrator": 0,
+        "drop_narrator": 0,
+        "repoint_suggestion": 0,
+        "drop_duplicate_suggestion": 0,
+        "copy_link": 0,
+        "drop_link": 0,
+        "copy_contributor": 0,
+        "drop_contributor": 0,
+        "delete_detection": 0,
+        "delete_work": 0,
+        "skipped_stale": shrinkage,
+    }
+
+    for comp in fresh_compositions:
+        if session.get(Work, comp.survivor_id) is None:
+            result["skipped_stale"] += 1
+            continue
+
+        # 1a. Whole-edition repoints.
+        for eid in comp.repoint_edition_ids:
+            e = session.get(Edition, eid)
+            if e is None:
+                result["skipped_stale"] += 1
+                continue
+            e.work_id = comp.survivor_id
+            result["repoint_edition"] += 1
+        session.flush()
+
+        # 1b. Edition merges (format collision).
+        for mg in comp.merge_editions:
+            if session.get(Edition, mg.survivor_id) is None:
+                result["skipped_stale"] += 1
+                continue
+            for rh_id in mg.repoint_reading_history:
+                rh = session.get(ReadingHistory, rh_id)
+                if rh is None:
+                    result["skipped_stale"] += 1
+                    continue
+                rh.edition_id = mg.survivor_id
+                result["repoint_read"] += 1
+            for rh_id in mg.delete_reading_history:
+                rh = session.get(ReadingHistory, rh_id)
+                if rh is None:
+                    result["skipped_stale"] += 1
+                    continue
+                session.delete(rh)
+                result["drop_duplicate_read"] += 1
+            session.flush()
+
+            for edition_id, narrator_id in mg.repoint_narrators:
+                exists = session.execute(
+                    select(edition_narrators.c.edition_id).where(
+                        edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+                    )
+                ).first()
+                if exists is None:
+                    result["skipped_stale"] += 1
+                    continue
+                session.execute(
+                    delete(edition_narrators).where(
+                        edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+                    )
+                )
+                session.execute(edition_narrators.insert().values(edition_id=mg.survivor_id, narrator_id=narrator_id))
+                result["repoint_narrator"] += 1
+            for edition_id, narrator_id in mg.delete_narrators:
+                session.execute(
+                    delete(edition_narrators).where(
+                        edition_narrators.c.edition_id == edition_id, edition_narrators.c.narrator_id == narrator_id
+                    )
+                )
+                result["drop_narrator"] += 1
+            session.flush()
+
+            for loser_edition_id in mg.loser_ids:
+                le = session.get(Edition, loser_edition_id)
+                if le is None:
+                    result["skipped_stale"] += 1
+                    continue
+                # Belt-and-braces (mirrors _apply_edition_group): refuse if an unplanned
+                # edition_narrators row still hangs off this loser edition — deleting it would
+                # cascade that unaccounted-for row away.
+                unplanned = session.execute(
+                    select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == loser_edition_id)
+                ).first()
+                if unplanned is not None:
+                    result["skipped_stale"] += 1
+                    continue
+                session.delete(le)
+            session.flush()
+
+        # 2. Suggestions.
+        for sid in comp.repoint_suggestion_ids:
+            s = session.get(Suggestions, sid)
+            if s is None:
+                result["skipped_stale"] += 1
+                continue
+            s.work_id = comp.survivor_id
+            result["repoint_suggestion"] += 1
+        for sid in comp.drop_duplicate_suggestion_ids:
+            s = session.get(Suggestions, sid)
+            if s is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(s)
+            result["drop_duplicate_suggestion"] += 1
+        session.flush()
+
+        # 3. Trope/style link union.
+        for loser_work_id, trope_id, relevance, justification in comp.copy_trope_links:
+            existing = session.get(WorkTrope, {"work_id": comp.survivor_id, "trope_id": trope_id})
+            source = session.get(WorkTrope, {"work_id": loser_work_id, "trope_id": trope_id})
+            if source is None:
+                result["skipped_stale"] += 1
+                continue
+            if existing is None:
+                session.add(
+                    WorkTrope(
+                        work_id=comp.survivor_id,
+                        trope_id=trope_id,
+                        relevance_score=relevance,
+                        justification=justification,
+                    )
+                )
+                result["copy_link"] += 1
+            session.delete(source)
+        for loser_work_id, trope_id in comp.drop_trope_links:
+            wt = session.get(WorkTrope, {"work_id": loser_work_id, "trope_id": trope_id})
+            if wt is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(wt)
+            result["drop_link"] += 1
+        session.flush()
+
+        for loser_work_id, style_id, attribute_type in comp.copy_style_links:
+            pk = {"work_id": comp.survivor_id, "style_id": style_id, "attribute_type": attribute_type}
+            existing = session.get(WorkStyle, pk)
+            source_pk = {"work_id": loser_work_id, "style_id": style_id, "attribute_type": attribute_type}
+            source = session.get(WorkStyle, source_pk)
+            if source is None:
+                result["skipped_stale"] += 1
+                continue
+            if existing is None:
+                session.add(WorkStyle(work_id=comp.survivor_id, style_id=style_id, attribute_type=attribute_type))
+                result["copy_link"] += 1
+            session.delete(source)
+        for loser_work_id, style_id, attribute_type in comp.drop_style_links:
+            ws = session.get(
+                WorkStyle, {"work_id": loser_work_id, "style_id": style_id, "attribute_type": attribute_type}
+            )
+            if ws is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(ws)
+            result["drop_link"] += 1
+        session.flush()
+
+        # 4. Contributors: union by (author_id, role).
+        for author_id, role in comp.copy_contributors:
+            pk = {"work_id": comp.survivor_id, "author_id": author_id, "role": role}
+            if session.get(WorkContributor, pk) is not None:
+                result["skipped_stale"] += 1
+                continue
+            session.add(WorkContributor(work_id=comp.survivor_id, author_id=author_id, role=role))
+            result["copy_contributor"] += 1
+        for loser_work_id, author_id, role in comp.drop_contributors:
+            wc = session.get(WorkContributor, {"work_id": loser_work_id, "author_id": author_id, "role": role})
+            if wc is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(wc)
+            result["drop_contributor"] += 1
+        session.flush()
+
+        # (Loser WorkContributor rows not explicitly copied/dropped above — i.e. any row this
+        # composition didn't already account for — are deleted via Work's own
+        # cascade="all, delete-orphan" relationship when the loser Work row is deleted, below.
+        # copy_contributors + drop_contributors together are exhaustive over the loser's
+        # contributor rows AT COMPOSE TIME (compose_cluster_merge iterates every row), so this is
+        # belt-and-braces for a row added between compose and this point, not an expected path.)
+
+        # 5. detected_duplicates: deleted BEFORE the Work rows they reference (FKs fail loud
+        # otherwise — see the module comment above compose_cluster_merge).
+        for a, b in comp.delete_detection_pairs:
+            row = session.get(DetectedDuplicate, {"work_id_a": a, "work_id_b": b})
+            if row is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(row)
+            result["delete_detection"] += 1
+        session.flush()
+
+        # 6. Loser Work rows, last.
+        for wid in comp.delete_work_ids:
+            w = session.get(Work, wid)
+            if w is None:
+                result["skipped_stale"] += 1
+                continue
+            session.delete(w)
+            result["delete_work"] += 1
+        session.flush()
+
+    return result

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -801,13 +801,15 @@ def _strip_trailing_volume_token(folded_title: str) -> tuple[str, bool]:
 
 
 def _series_guard_blocks(title_a: str, title_b: str) -> bool:
-    """True if `title_a`/`title_b` differ ONLY by a trailing volume/sequel token — i.e. one
-    title, once its trailing volume token is stripped, equals the other's fold exactly, but the
-    two folded titles were NOT already equal. Symmetric in its two arguments by construction
-    (both directions are tried). 'Beware of Chicken' vs 'Beware of Chicken 2' -> blocked;
-    'Beware of Chicken' vs 'Beware of Chicken' -> NOT blocked (nothing to guard against);
-    'We Are Legion (We Are Bob)' vs 'We are Legion; We are Bob' -> NOT blocked (no trailing
-    volume token on either side, this is the punctuation-fold case fold() already handles)."""
+    """True if `title_a`/`title_b` are different entries of one series — i.e. they differ
+    ONLY by trailing volume/sequel tokens. Two shapes (Gemini review, PR #144):
+      base vs volume:   'Beware of Chicken' vs 'Beware of Chicken 2' -> blocked;
+      volume vs volume: 'Beware of Chicken 2' vs 'Beware of Chicken 3' -> blocked
+                        (both carry volume tokens and share the stripped base).
+    NOT blocked: identical folds ('Beware of Chicken 2' vs itself — a true same-volume
+    duplicate must stay mergeable), and titles with no trailing volume token on either side
+    ('We Are Legion (We Are Bob)' vs 'We are Legion; We are Bob' — the punctuation-fold
+    case fold() already handles). Symmetric in its two arguments by construction."""
     fa, fb = _fold(title_a), _fold(title_b)
     if fa == fb:
         return False
@@ -815,7 +817,9 @@ def _series_guard_blocks(title_a: str, title_b: str) -> bool:
     stripped_b, had_b = _strip_trailing_volume_token(fb)
     if had_a and stripped_a == fb:
         return True
-    return bool(had_b and stripped_b == fa)
+    if had_b and stripped_b == fa:
+        return True
+    return bool(had_a and had_b and stripped_a == stripped_b)
 
 
 def fuzzy_similarity(title_a: str, title_b: str) -> float:
@@ -1102,17 +1106,25 @@ def _detect_fuzzy_pairs(
     design spec's "retroactive global fuzzy dedup... stays report-only" framing; this is a
     detail-list class, not a hot path."""
     ids = sorted(title_by_work, key=str)
+    # Gemini review (#144): fold each title ONCE — refolding inside the O(n^2) loop was
+    # redundant CPU per pair. Jaccard is computed on the precomputed token sets; the series
+    # guard still gets the raw titles (it needs fold-internal volume-token structure).
+    tokens_by_work = {wid: set(_fold(title_by_work[wid]).split()) for wid in ids}
     pairs: list[tuple[UUID, UUID]] = []
     for i, wa in enumerate(ids):
+        tokens_a = tokens_by_work[wa]
         for wb in ids[i + 1 :]:
             pair = frozenset((wa, wb))
             if pair in already_paired:
                 continue
-            title_a, title_b = title_by_work[wa], title_by_work[wb]
-            if _series_guard_blocks(title_a, title_b):
+            tokens_b = tokens_by_work[wb]
+            if not tokens_a or not tokens_b:
                 continue
-            if fuzzy_similarity(title_a, title_b) >= threshold:
-                pairs.append((wa, wb))
+            if len(tokens_a & tokens_b) / len(tokens_a | tokens_b) < threshold:
+                continue
+            if _series_guard_blocks(title_by_work[wa], title_by_work[wb]):
+                continue
+            pairs.append((wa, wb))
     return pairs
 
 
@@ -1128,13 +1140,17 @@ def _gather_work_stats(session: Session) -> dict[UUID, WorkStats]:
     )
     edition_counts = Counter(row.work_id for row in session.query(Edition.work_id).all())
     out: dict[UUID, WorkStats] = {}
-    for work in session.query(Work).order_by(Work.id).all():
-        out[work.id] = WorkStats(
-            work_id=work.id,
-            title=work.title,
-            justified_trope_links=trope_link_counts.get(work.id, 0),
-            deep_enriched_at=work.deep_enriched_at,
-            edition_count=edition_counts.get(work.id, 0),
+    # Column-explicit (Gemini review, #144): only three columns are needed — full entity
+    # hydration was pure overhead in a whole-catalog scan.
+    for work_id, title, deep_enriched_at in (
+        session.query(Work.id, Work.title, Work.deep_enriched_at).order_by(Work.id).all()
+    ):
+        out[work_id] = WorkStats(
+            work_id=work_id,
+            title=title,
+            justified_trope_links=trope_link_counts.get(work_id, 0),
+            deep_enriched_at=deep_enriched_at,
+            edition_count=edition_counts.get(work_id, 0),
         )
     return out
 
@@ -1759,41 +1775,41 @@ def compose_cluster_merge(session: Session, cluster: WorksMergeCluster) -> WorkM
                 survivor_style_keys.add(key)
 
     # --- 4. Contributors: union by (author_id, role) --------------------------------------------
+    # Author names joined in one query per work (Gemini review, #144) — the previous
+    # per-contributor session.get(Author, ...) was an N+1.
     survivor_contributors = (
-        session.query(WorkContributor)
-        .filter_by(work_id=survivor_id)
+        session.query(WorkContributor.author_id, WorkContributor.role, Author.name)
+        .join(Author, Author.id == WorkContributor.author_id)
+        .filter(WorkContributor.work_id == survivor_id)
         .order_by(WorkContributor.author_id, WorkContributor.role)
         .all()
     )
-    survivor_keys = {(wc.author_id, wc.role) for wc in survivor_contributors}
+    survivor_keys = {(author_id, role) for author_id, role, _name in survivor_contributors}
     survivor_names_by_role: dict[str, set[str]] = defaultdict(set)
-    for wc in survivor_contributors:
-        author = session.get(Author, wc.author_id)
-        if author is not None:
-            survivor_names_by_role[wc.role].add(author.name.strip().casefold())
+    for _author_id, role, name in survivor_contributors:
+        survivor_names_by_role[role].add(name.strip().casefold())
 
     for loser_id in loser_ids:
-        for wc in (
-            session.query(WorkContributor)
-            .filter_by(work_id=loser_id)
+        for author_id, role, name in (
+            session.query(WorkContributor.author_id, WorkContributor.role, Author.name)
+            .join(Author, Author.id == WorkContributor.author_id)
+            .filter(WorkContributor.work_id == loser_id)
             .order_by(WorkContributor.author_id, WorkContributor.role)
             .all()
         ):
-            key = (wc.author_id, wc.role)
+            key = (author_id, role)
             if key in survivor_keys:
-                comp.drop_contributors.append((loser_id, wc.author_id, wc.role))
+                comp.drop_contributors.append((loser_id, author_id, role))
                 continue
-            author = session.get(Author, wc.author_id)
-            name_cf = author.name.strip().casefold() if author is not None else None
-            if name_cf is not None and name_cf in survivor_names_by_role.get(wc.role, set()):
+            name_cf = name.strip().casefold()
+            if name_cf in survivor_names_by_role.get(role, set()):
                 # A DIFFERENT Author row already on the survivor case-folds equal (the #142
                 # malformed-comma-joined-author shape) — report, never mutate an Author here.
-                comp.malformed_author_candidates.append(wc.author_id)
+                comp.malformed_author_candidates.append(author_id)
                 continue
-            comp.copy_contributors.append((wc.author_id, wc.role))
+            comp.copy_contributors.append((author_id, role))
             survivor_keys.add(key)
-            if name_cf is not None:
-                survivor_names_by_role[wc.role].add(name_cf)
+            survivor_names_by_role[role].add(name_cf)
 
     # --- 5. detected_duplicates: delete every row referencing ANY loser on either side. Not
     # restricted to rows where BOTH sides are cluster members: a loser could in principle be

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -888,6 +888,10 @@ class WorksMergeClusters:
     same_identity: list[WorksMergeCluster] = field(default_factory=list)
     detected_duplicates: list[WorksMergeCluster] = field(default_factory=list)
     fuzzy_report_only: list[WorksMergeCluster] = field(default_factory=list)
+    # Self-referential detected_duplicates feed rows (work_id_a == work_id_b) skipped at
+    # ingestion — see _dedupe_detected_duplicate_rows. Surfaced here (not just logged) so a bad
+    # feed row is visible to the operator reading the plan/report, never silent.
+    ignored_self_detections: int = 0
 
     def summary(self) -> dict[str, int]:
         return {
@@ -895,6 +899,7 @@ class WorksMergeClusters:
             "works_same_identity": len(self.same_identity),
             "works_detected_duplicates": len(self.detected_duplicates),
             "works_fuzzy_report_only": len(self.fuzzy_report_only),
+            "ignored_self_detections": self.ignored_self_detections,
         }
 
 
@@ -1053,20 +1058,38 @@ def _detect_same_identity_pairs(session: Session) -> list[tuple[UUID, UUID]]:
     return pairs
 
 
-def _detect_detected_duplicate_pairs(session: Session) -> list[tuple[UUID, UUID]]:
-    """works_detected_duplicates: rows from the #141/#143 detected_duplicates feed, deduped as
-    UNORDERED pairs — both (A, B) and (B, A) rows can exist for the same cluster (composite PK
-    is (work_id_a, work_id_b), not order-normalized; see DetectedDuplicate's docstring)."""
-    rows = session.query(DetectedDuplicate.work_id_a, DetectedDuplicate.work_id_b).all()
+def _dedupe_detected_duplicate_rows(rows: list[tuple[UUID, UUID]]) -> tuple[list[tuple[UUID, UUID]], int]:
+    """Pure (no session): dedupe raw detected_duplicates feed rows as UNORDERED pairs — both
+    (A, B) and (B, A) rows can exist for the same cluster (composite PK is (work_id_a,
+    work_id_b), not order-normalized; see DetectedDuplicate's docstring) — and SKIP any
+    self-referential row (work_id_a == work_id_b). A work is never its own duplicate; a
+    self-pair is a bad feed row, not a real detection. Left in, `frozenset((A, A))` collapses to
+    size 1 and crashes plan_works_merge_clusters' union-find unpack (`a, b = tuple(pair)`) —
+    skipping it here, at the feed-ingestion boundary, keeps the crash from ever reaching that
+    pure composition core. Returns (pairs, ignored_self_count) so the caller can surface the
+    count in the plan summary — a bad feed row should be VISIBLE to the operator, not silently
+    dropped."""
     seen: set[frozenset] = set()
     pairs: list[tuple[UUID, UUID]] = []
+    ignored_self = 0
     for a, b in rows:
+        if a == b:
+            ignored_self += 1
+            continue
         pair = frozenset((a, b))
         if pair in seen:
             continue
         seen.add(pair)
         pairs.append(tuple(sorted((a, b), key=str)))
-    return pairs
+    return pairs, ignored_self
+
+
+def _detect_detected_duplicate_pairs(session: Session) -> tuple[list[tuple[UUID, UUID]], int]:
+    """works_detected_duplicates: rows from the #141/#143 detected_duplicates feed. See
+    _dedupe_detected_duplicate_rows (kept session-free for a fast, deterministic unit-test
+    surface) for the actual dedup/self-pair-skip logic. Returns (pairs, ignored_self_count)."""
+    rows = session.query(DetectedDuplicate.work_id_a, DetectedDuplicate.work_id_b).all()
+    return _dedupe_detected_duplicate_rows(rows)
 
 
 def _detect_fuzzy_pairs(
@@ -1131,18 +1154,20 @@ def plan_works_merge(session: Session) -> WorksMergeClusters:
         for a, b in _detect_same_identity_pairs(session)
         if not _series_guard_blocks(title_by_work[a], title_by_work[b])
     ]
-    detected_duplicate_pairs = _detect_detected_duplicate_pairs(session)
+    detected_duplicate_pairs, ignored_self_detections = _detect_detected_duplicate_pairs(session)
 
     already_paired = {frozenset(p) for p in same_isbn_pairs + same_identity_pairs + detected_duplicate_pairs}
     fuzzy_pairs = _detect_fuzzy_pairs(title_by_work, already_paired)
 
-    return plan_works_merge_clusters(
+    clusters = plan_works_merge_clusters(
         same_isbn_pairs=same_isbn_pairs,
         same_identity_pairs=same_identity_pairs,
         detected_duplicate_pairs=detected_duplicate_pairs,
         fuzzy_pairs=fuzzy_pairs,
         stats_by_work=stats_by_work,
     )
+    clusters.ignored_self_detections = ignored_self_detections
+    return clusters
 
 
 def render_works_merge_report(clusters: WorksMergeClusters, *, db_target: str | None = None) -> str:
@@ -1488,20 +1513,44 @@ def plan_delta(reviewed: dict[str, set[str]], fresh: DedupPlan) -> dict[str, set
 # There is no code path, however careless, that could reach it — the field simply isn't in the
 # iteration.
 #
+# Deliverable 5 (spec item 5, stated here so nobody "fixes" it later): the availability cache
+# (availability/overdrive.py's `availability_cache` table) and `user_libraries` are keyed by
+# TITLE/AUTHOR STRINGS, not work ids — they have no FK to Work at all. A works-merge is
+# deliberately silent about both: there is nothing to repoint, nothing to union, no row that
+# could dangle. The survivor's title/author strings are what a "where to get it" lookup already
+# keyed on before the merge, so availability continues to resolve correctly with zero action here.
+#
 # DISJOINTNESS PROOF (deliverable 2 — the deferred-intersections discipline, reasoned through
 # rather than found empirically): after plan_works_merge_clusters' union-find, every cluster is a
 # disjoint SET OF WORK IDS — no work id appears in two clusters (union-find guarantees this by
 # construction: any pair that shares a work id gets unioned into the SAME cluster). Every row this
-# composition ever touches (editions, reading_history, edition_narrators, suggestions, work_tropes,
-# work_styles, work_contributors, detected_duplicates) hangs off exactly one work id via a
-# NOT-NULL foreign key (Edition.work_id, ReadingHistory.edition_id -> Edition.work_id transitively,
-# Suggestions.work_id, WorkTrope.work_id, WorkStyle.work_id, WorkContributor.work_id,
-# DetectedDuplicate.work_id_a/work_id_b). A row can only be "in play" for a cluster if its owning
-# work id is a member of that cluster's work_ids set. Since work_ids sets are disjoint across
-# clusters in one plan, a row belonging to work W can only ever be named by the ONE cluster that
-# contains W — never by two different clusters in the same plan. This rules out the dedup_backfill
-# 6.3 hazard (a row touched by two independently-computed classes from the same snapshot) BY
-# CONSTRUCTION, not by scanning for overlaps after the fact.
+# composition touches via a SINGLE NOT-NULL foreign key (Edition.work_id, ReadingHistory.edition_id
+# -> Edition.work_id transitively, Suggestions.work_id, WorkTrope.work_id, WorkStyle.work_id,
+# WorkContributor.work_id) hangs off exactly one work id, so it can only ever be "in play" for the
+# ONE cluster containing that id.
+#
+# detected_duplicates is the one exception worth stating precisely rather than folding into the
+# above: each row carries TWO work ids (work_id_a, work_id_b), not one — so "hangs off exactly one
+# work id" does not literally hold for it. The argument for detected_duplicates is the EDGE
+# argument instead: every detected_duplicates row (after self-pair filtering, see
+# _dedupe_detected_duplicate_rows) becomes a union-find edge in plan_works_merge_clusters — ALL of
+# it, not just the pairs reported under works_detected_duplicates (a pair's CLASS LABEL is only its
+# strongest matching class for display purposes; the UNION still runs on every pair from every
+# class, see the union-find loop above). So if a detected_duplicates row names (X, Y), X and Y are
+# ALWAYS unioned into the SAME cluster by construction — its two endpoints necessarily co-cluster.
+# There is no detected_duplicates row whose two work ids could land in two DIFFERENT clusters of
+# the same plan; therefore a detected_duplicates row is still "owned" by exactly one cluster, just
+# via an edge argument rather than a single-FK argument. (compose_cluster_merge's own detected_
+# duplicates deletion step, further below, is intentionally MORE permissive than this proof
+# requires — it deletes any row naming a loser on EITHER side even against a work id outside the
+# row's own cluster, e.g. a stale detection — apply's session.get() null-check on an
+# already-deleted row from a different cluster's pass makes that safe too, via skipped_stale.)
+#
+# Since work_ids sets are disjoint across clusters in one plan, a row belonging to work W (or, for
+# detected_duplicates, a row whose edge co-clusters with W) can only ever be named by the ONE
+# cluster that contains W — never by two different clusters in the same plan. This rules out the
+# dedup_backfill 6.3 hazard (a row touched by two independently-computed classes from the same
+# snapshot) BY CONSTRUCTION, not by scanning for overlaps after the fact.
 #
 # The one genuine cross-cluster collision surface the spec calls out is a UNIQUENESS constraint
 # spanning rows from DIFFERENT works: uq_suggestions_active is (user_id, work_id) WHERE
@@ -1999,6 +2048,24 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
 
     shrinkage = len(reviewed_tokens - fresh_tokens)
 
+    # Orphan-author pointer (deliverable 1.6): every author id linked to ANY loser Work in this
+    # apply, gathered NOW — before any loser Work row (and its cascaded WorkContributor rows)
+    # gets deleted below. Re-checked AFTER the whole apply completes using the SAME structural
+    # predicate _plan_orphan_authors uses (zero work_contributors AND zero author_styles), scoped
+    # to just this apply's own candidates rather than a full-catalog scan — this is a POINTER for
+    # the operator, not a delete: actual removal stays the existing --dedup-for-constraints
+    # dry-run/apply loop's job (never mutate an Author here).
+    candidate_author_ids: set[UUID] = set()
+    for comp in fresh_compositions:
+        if not comp.loser_ids:
+            continue
+        candidate_author_ids.update(
+            row.author_id
+            for row in session.query(WorkContributor.author_id)
+            .filter(WorkContributor.work_id.in_(comp.loser_ids))
+            .all()
+        )
+
     result = {
         "repoint_edition": 0,
         "merge_edition": 0,
@@ -2015,6 +2082,7 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
         "delete_detection": 0,
         "delete_work": 0,
         "skipped_stale": shrinkage,
+        "orphaned_authors_pointer": 0,
     }
 
     for comp in fresh_compositions:
@@ -2037,6 +2105,7 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
             if session.get(Edition, mg.survivor_id) is None:
                 result["skipped_stale"] += 1
                 continue
+            result["merge_edition"] += 1
             for rh_id in mg.repoint_reading_history:
                 rh = session.get(ReadingHistory, rh_id)
                 if rh is None:
@@ -2085,11 +2154,18 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
                     continue
                 # Belt-and-braces (mirrors _apply_edition_group): refuse if an unplanned
                 # edition_narrators row still hangs off this loser edition — deleting it would
-                # cascade that unaccounted-for row away.
-                unplanned = session.execute(
+                # cascade that unaccounted-for row away. Symmetric guard (Minor 6, final review)
+                # for reading_history: unlike edition_narrators (a plain `secondary=` link table
+                # that would silently cascade), ReadingHistory.edition_id has NO cascade at all —
+                # an unplanned row here would make the delete raise an IntegrityError instead of
+                # silently losing anything, but "refuse and count skipped_stale" is still the
+                # right behavior (this composition already accounted for every row it saw at
+                # compose time; an unplanned survivor here means something changed since).
+                unplanned_narrators = session.execute(
                     select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == loser_edition_id)
                 ).first()
-                if unplanned is not None:
+                unplanned_reading_history = session.query(ReadingHistory).filter_by(edition_id=loser_edition_id).first()
+                if unplanned_narrators is not None or unplanned_reading_history is not None:
                     result["skipped_stale"] += 1
                     continue
                 session.delete(le)
@@ -2206,5 +2282,15 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
             session.delete(w)
             result["delete_work"] += 1
         session.flush()
+
+    # Re-check the candidates gathered before the loop: an author now orphaned by THIS apply
+    # (its only contributor links lived on losers this apply just deleted) — same predicate as
+    # _plan_orphan_authors, applied to the narrower candidate set so the pointer is precise about
+    # what THIS merge did, not the whole catalog's pre-existing orphan backlog.
+    for author_id in candidate_author_ids:
+        has_wc = session.query(WorkContributor).filter_by(author_id=author_id).first() is not None
+        has_as = session.query(AuthorStyle).filter_by(author_id=author_id).first() is not None
+        if not has_wc and not has_as:
+            result["orphaned_authors_pointer"] += 1
 
     return result

--- a/test/integration/test_works_merge.py
+++ b/test/integration/test_works_merge.py
@@ -41,6 +41,7 @@ def test_empty_db_plan_is_empty(db_url):
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 0,
+            "ignored_self_detections": 0,
         }
 
 
@@ -127,6 +128,7 @@ def test_beware_of_chicken_2_sequel_is_never_a_pair(db_url):
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 0,
+            "ignored_self_detections": 0,
         }
 
 
@@ -167,6 +169,26 @@ def test_detected_duplicates_unordered_pair_both_rows_collapse_to_one_cluster(db
 
         clusters = db_.plan_works_merge(session)
         assert clusters.summary()["works_detected_duplicates"] == 1
+
+
+def test_self_referential_detected_duplicate_row_ignored_not_crashed(db_url):
+    """H2 fix 1: a bad feed row where work_id_a == work_id_b (a work 'duplicate' of itself) must
+    not crash the planner — `frozenset((A, A))` used to break plan_works_merge_clusters' union-
+    find unpack (`a, b = tuple(pair)` on a size-1 frozenset). It is skipped at feed ingestion and
+    counted under ignored_self_detections, visible in the plan summary rather than silent."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w = _work("Self-Referential Work")
+        session.add(w)
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=w.id, work_id_b=w.id, source="deep_pass_redirect"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)  # must not raise
+
+        assert clusters.summary()["ignored_self_detections"] == 1
+        assert clusters.summary()["works_detected_duplicates"] == 0
+        assert clusters.detected_duplicates == []
 
 
 def test_fuzzy_class_never_contains_pairs_from_stronger_classes(db_url):

--- a/test/integration/test_works_merge.py
+++ b/test/integration/test_works_merge.py
@@ -1,0 +1,228 @@
+"""db_integration tests for plan_works_merge (PR-2 part 1, Spec 2026-07-14): the four
+detection classes exercised against a real Postgres session, seeded with the actual prod-shaped
+duplicate scenarios named in the design spec's "Verified findings" — the Beware of Chicken
+pair (same ISBN, one dirty comma-joined author), the We Are Legion pair (punctuation-variant
+titles, no shared ISBN), the Beware of Chicken 2 sequel non-pair, and a detected_duplicates row
+(#141/#143 feed).
+
+READ ONLY — plan_works_merge never mutates. No apply step exists yet (H2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.db.models import (
+    Author,
+    DetectedDuplicate,
+    Edition,
+    Work,
+    WorkContributor,
+    WorkTrope,
+)
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import dedup_backfill as db_
+
+pytestmark = pytest.mark.db_integration
+
+
+def _work(title: str, *, deep_enriched_at=None) -> Work:
+    return Work(title=title, deep_enriched_at=deep_enriched_at)
+
+
+def test_empty_db_plan_is_empty(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary() == {
+            "works_same_isbn": 0,
+            "works_same_identity": 0,
+            "works_detected_duplicates": 0,
+            "works_fuzzy_report_only": 0,
+        }
+
+
+def test_beware_of_chicken_pair_same_isbn_dirty_author(db_url):
+    """Real prod scenario: 9e9cfc45 (slug-only, malformed comma-joined author, no tropes) /
+    a5e56605 (15 justified tropes, clean author) — same ISBN 9781039452275. Highest-confidence
+    class (works_same_isbn) must catch it even though the author strings differ, and the
+    survivor must be the one with justified trope links."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        dirty_author = Author(name="Casualfarmer, CasualFarmer")
+        clean_author = Author(name="CasualFarmer")
+        w_dirty = _work("Beware of Chicken")
+        w_clean = _work("Beware of Chicken", deep_enriched_at=datetime(2026, 6, 12, tzinfo=UTC))
+        session.add_all([dirty_author, clean_author, w_dirty, w_clean])
+        session.flush()
+
+        session.add(WorkContributor(work_id=w_dirty.id, author_id=dirty_author.id, role="Author"))
+        session.add(WorkContributor(work_id=w_clean.id, author_id=clean_author.id, role="Author"))
+        session.add(Edition(work_id=w_dirty.id, isbn_13="9781039452275", format="ebook"))
+        session.add(Edition(work_id=w_clean.id, isbn_13="9781039452275", format="audiobook"))
+        session.flush()
+
+        # 15 justified tropes on the clean work (real scout output); none on the dirty one.
+        trope_id = uuid4()
+        from agentic_librarian.db.models import Trope
+
+        session.add(Trope(id=trope_id, name="Found Family"))
+        session.flush()
+        session.add(WorkTrope(work_id=w_clean.id, trope_id=trope_id, justification="scout said so"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_isbn"] == 1
+        cluster = clusters.same_isbn[0]
+        assert set(cluster.work_ids) == {w_dirty.id, w_clean.id}
+        assert cluster.survivor_id == w_clean.id  # most justified trope links wins
+
+        # Never double-counted into a weaker class.
+        assert clusters.summary()["works_same_identity"] == 0
+        assert clusters.summary()["works_fuzzy_report_only"] == 0
+
+
+def test_we_are_legion_pair_punctuation_variant_no_shared_isbn(db_url):
+    """Real prod scenario: 14c8f3b5/7fc21c9e — punctuation-variant titles, same author, no
+    shared ISBN. Must land in works_same_identity (fold() equal + author overlap), not
+    works_same_isbn (no edition/ISBN data at all here)."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="Dennis E. Taylor")
+        w1 = _work("We Are Legion (We Are Bob)")
+        w2 = _work("We are Legion; We are Bob")
+        session.add_all([author, w1, w2])
+        session.flush()
+        session.add(WorkContributor(work_id=w1.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=author.id, role="Author"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_identity"] == 1
+        cluster = clusters.same_identity[0]
+        assert set(cluster.work_ids) == {w1.id, w2.id}
+        assert clusters.summary()["works_same_isbn"] == 0
+
+
+def test_beware_of_chicken_2_sequel_is_never_a_pair(db_url):
+    """Real prod caveat from the spec: 'Beware of Chicken 2' is the SEQUEL to 'Beware of
+    Chicken', not a duplicate — the series guard must block it from every class, including
+    fuzzy (a sequel is highly title-similar by construction)."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="CasualFarmer")
+        w1 = _work("Beware of Chicken")
+        w2 = _work("Beware of Chicken 2")
+        session.add_all([author, w1, w2])
+        session.flush()
+        session.add(WorkContributor(work_id=w1.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=author.id, role="Author"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary() == {
+            "works_same_isbn": 0,
+            "works_same_identity": 0,
+            "works_detected_duplicates": 0,
+            "works_fuzzy_report_only": 0,
+        }
+
+
+def test_detected_duplicates_row_lands_in_its_own_class_with_correct_survivor(db_url):
+    """A #141/#143 detected_duplicates row (work_id_a = the invoked/dirty work, work_id_b =
+    the resolved twin) must appear under works_detected_duplicates with the more-enriched work
+    picked as survivor — independent of ISBN/title data (these two works have unrelated
+    titles, proving this class does not depend on the other three)."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        invoked = _work("Calling Bullshit")
+        twin = _work("Calling Bullshit: The Art of Skepticism", deep_enriched_at=datetime(2026, 7, 1, tzinfo=UTC))
+        session.add_all([invoked, twin])
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=invoked.id, work_id_b=twin.id, source="deep_pass_redirect"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_detected_duplicates"] == 1
+        cluster = clusters.detected_duplicates[0]
+        assert set(cluster.work_ids) == {invoked.id, twin.id}
+        assert cluster.survivor_id == twin.id
+
+
+def test_detected_duplicates_unordered_pair_both_rows_collapse_to_one_cluster(db_url):
+    """PR-2's spec item 6 note: both (A, B) and (B, A) rows can exist for the same cluster
+    (the composite PK is (work_id_a, work_id_b), not order-normalized) — detection must
+    de-duplicate by the unordered pair, not assume a single canonical row."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        a = _work("Yellowface")
+        b = _work("Yellow Face")
+        session.add_all([a, b])
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=a.id, work_id_b=b.id, source="deep_pass_redirect"))
+        session.add(DetectedDuplicate(work_id_a=b.id, work_id_b=a.id, source="deep_pass_redirect"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_detected_duplicates"] == 1
+
+
+def test_fuzzy_class_never_contains_pairs_from_stronger_classes(db_url):
+    """A same-ISBN pair plus an unrelated, merely fuzzy-similar pair: the fuzzy class must
+    contain only the pair not already caught by a stronger class."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        # Strong pair (same ISBN).
+        w1 = _work("Mistborn")
+        w2 = _work("Mistborn")
+        session.add_all([w1, w2])
+        session.flush()
+        session.add(Edition(work_id=w1.id, isbn_13="9780765350381", format="ebook"))
+        session.add(Edition(work_id=w2.id, isbn_13="9780765350381", format="audiobook"))
+
+        # Fuzzy-only pair: similar-but-not-identical folded titles, no ISBN/author overlap.
+        w3 = _work("The Way of Kings Prime")
+        w4 = _work("The Way of Kings")
+        session.add_all([w3, w4])
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_isbn"] == 1
+        fuzzy_ids = {wid for c in clusters.fuzzy_report_only for wid in c.work_ids}
+        same_isbn_ids = {wid for c in clusters.same_isbn for wid in c.work_ids}
+        assert fuzzy_ids.isdisjoint(same_isbn_ids)
+        assert {w3.id, w4.id} <= fuzzy_ids
+
+
+def test_plan_works_merge_never_mutates(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="Dennis E. Taylor")
+        w1 = _work("We Are Legion (We Are Bob)")
+        w2 = _work("We are Legion; We are Bob")
+        session.add_all([author, w1, w2])
+        session.flush()
+        session.add(WorkContributor(work_id=w1.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=author.id, role="Author"))
+        session.flush()
+
+        db_.plan_works_merge(session)
+        session.flush()
+        assert session.query(Work).count() == 2
+
+
+def test_render_works_merge_report_never_applied_marker_present(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w1 = _work("The Way of Kings Prime")
+        w2 = _work("The Way of Kings")
+        session.add_all([w1, w2])
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        report = db_.render_works_merge_report(clusters, db_target="localhost/test")
+        assert "works_fuzzy_report_only" in report
+        assert "NEVER APPLIED" in report
+        assert "localhost/test" in report

--- a/test/integration/test_works_merge_apply.py
+++ b/test/integration/test_works_merge_apply.py
@@ -1,0 +1,523 @@
+"""db_integration tests for the works-merge APPLY step (H2, Spec 2026-07-14 "Merge
+composition" / "Gate" / item 6): compose_cluster_merge (READ ONLY composition), the op-tagged
+token gate (works_merge_tokens / works_merge_delta), the report round-trip
+(write_works_merge_apply_report / parse_works_merge_report), and apply_works_merge itself (THE
+USER GATE — re-plans fresh, refuses on drift, executes in one transaction).
+
+Kept as a sibling to test/integration/test_works_merge.py (H1's detection-only tests) rather
+than extending that file: H1 asserts purely on plan_works_merge's read-only detection output;
+this file additionally seeds mutable child rows (editions, reading_history, suggestions,
+work_tropes, work_styles, work_contributors, detected_duplicates) and asserts on real DB
+mutation, so keeping the seeding/assertion shapes separate avoids the two concerns bleeding
+into one giant fixture file.
+
+House rule: case-driven tests are parametrized (pytest.mark.parametrize), never a for-loop
+inside a single test body."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.core.user_context import DEFAULT_USER_ID
+from agentic_librarian.db.models import (
+    Author,
+    DetectedDuplicate,
+    Edition,
+    ReadingHistory,
+    Style,
+    Suggestions,
+    Trope,
+    User,
+    Work,
+    WorkContributor,
+    WorkStyle,
+    WorkTrope,
+)
+from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.etl import dedup_backfill as db_
+
+pytestmark = pytest.mark.db_integration
+
+
+def _work(title: str, *, deep_enriched_at=None) -> Work:
+    return Work(title=title, deep_enriched_at=deep_enriched_at)
+
+
+def _second_user(session) -> User:
+    """DEFAULT_USER_ID is auto-seeded by conftest's autouse fixture; multi-user
+    reading_history/suggestions collision tests need a SECOND, distinct user row."""
+    user = User(email=f"{uuid4()}@example.test")
+    session.add(user)
+    session.flush()
+    return user
+
+
+def test_lone_loser_edition_repoints_onto_survivor_no_collision(db_url):
+    """Simplest composition shape: survivor has no edition at all, loser has one ebook
+    edition. compose_cluster_merge must plan a whole-edition repoint (no format collision to
+    resolve), never an edition merge."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Beware of Chicken", deep_enriched_at=datetime(2026, 6, 12, tzinfo=UTC))
+        loser = _work("Beware of Chicken")
+        session.add_all([survivor, loser])
+        session.flush()
+        loser_edition = Edition(work_id=loser.id, isbn_13="9781039452275", format="ebook")
+        session.add(loser_edition)
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_isbn",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.survivor_id == survivor.id
+        assert comp.loser_ids == [loser.id]
+        assert comp.repoint_edition_ids == [loser_edition.id]
+        assert comp.merge_editions == []
+        assert comp.dropped_duplicate_reads == 0
+
+
+@pytest.mark.parametrize(
+    "case_name, fmt",
+    [
+        ("named_format_collision", "ebook"),
+        ("null_format_collision_nulls_not_distinct", None),
+    ],
+)
+def test_edition_format_collision_merges_instead_of_repointing(db_url, case_name, fmt):
+    """uq_editions_work_format collision (including the NULLS-NOT-DISTINCT NULL-to-NULL case,
+    per the CLAUDE.md brief): the loser edition must NOT repoint — it must be folded into an
+    EditionMergeGroup targeting the survivor's existing same-format edition."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_edition = Edition(work_id=survivor.id, format=fmt)
+        loser_edition = Edition(work_id=loser.id, format=fmt)
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.repoint_edition_ids == []
+        assert len(comp.merge_editions) == 1
+        mg = comp.merge_editions[0]
+        assert mg.survivor_id == survivor_edition.id
+        assert mg.loser_ids == [loser_edition.id]
+
+
+def test_edition_merge_repoints_reading_history_no_collision(db_url):
+    """A read event on the loser edition, no colliding date on the survivor's edition -> the
+    read is repointed onto the survivor's edition, never dropped."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_edition = Edition(work_id=survivor.id, format="ebook")
+        loser_edition = Edition(work_id=loser.id, format="ebook")
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+        rh = ReadingHistory(edition_id=loser_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1))
+        session.add(rh)
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        mg = comp.merge_editions[0]
+        assert mg.repoint_reading_history == [rh.id]
+        assert mg.delete_reading_history == []
+        assert comp.dropped_duplicate_reads == 0
+
+
+def test_edition_merge_drops_duplicate_read_same_user_edition_date(db_url):
+    """The exact same read event recorded on both works (same user, same date_completed) lands
+    on the same survivor edition once repointed -> keep the survivor's pre-existing row, drop
+    the loser's, count it under dropped_duplicate_reads. Never silently lose OR duplicate a read."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_edition = Edition(work_id=survivor.id, format="ebook")
+        loser_edition = Edition(work_id=loser.id, format="ebook")
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+        survivor_rh = ReadingHistory(
+            edition_id=survivor_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1)
+        )
+        loser_rh = ReadingHistory(edition_id=loser_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 1, 1))
+        session.add_all([survivor_rh, loser_rh])
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        mg = comp.merge_editions[0]
+        assert mg.repoint_reading_history == []
+        assert mg.delete_reading_history == [loser_rh.id]
+        assert comp.dropped_duplicate_reads == 1
+
+
+def test_edition_merge_drops_duplicate_narrator_link_keeps_repoints_new(db_url):
+    """edition_narrators PK collision (survivor edition already has this narrator) -> drop the
+    loser's link (no history to lose, it's a plain link); a DIFFERENT narrator on the loser
+    edition repoints cleanly."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        from agentic_librarian.db.models import Narrator, edition_narrators
+
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_edition = Edition(work_id=survivor.id, format="audiobook")
+        loser_edition = Edition(work_id=loser.id, format="audiobook")
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+        shared_narrator = Narrator(name="Michael Kramer")
+        new_narrator = Narrator(name="Someone Else")
+        session.add_all([shared_narrator, new_narrator])
+        session.flush()
+        session.execute(
+            edition_narrators.insert().values(edition_id=survivor_edition.id, narrator_id=shared_narrator.id)
+        )
+        session.execute(edition_narrators.insert().values(edition_id=loser_edition.id, narrator_id=shared_narrator.id))
+        session.execute(edition_narrators.insert().values(edition_id=loser_edition.id, narrator_id=new_narrator.id))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        mg = comp.merge_editions[0]
+        assert set(mg.repoint_narrators) == {(loser_edition.id, new_narrator.id)}
+        assert set(mg.delete_narrators) == {(loser_edition.id, shared_narrator.id)}
+
+
+# --------------------------------------------------------------------------------------------
+# 2. Suggestions
+# --------------------------------------------------------------------------------------------
+
+
+def test_suggestion_repoints_when_no_active_collision(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        s = Suggestions(work_id=loser.id, user_id=DEFAULT_USER_ID, status="Suggested")
+        session.add(s)
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.repoint_suggestion_ids == [s.id]
+        assert comp.drop_duplicate_suggestion_ids == []
+
+
+def test_suggestion_drops_duplicate_on_active_collision(db_url):
+    """uq_suggestions_active collision (same user, both work_ids -> same survivor work_id):
+    keep the survivor's pre-existing active suggestion, drop the loser's."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_s = Suggestions(work_id=survivor.id, user_id=DEFAULT_USER_ID, status="Suggested")
+        loser_s = Suggestions(work_id=loser.id, user_id=DEFAULT_USER_ID, status="Suggested")
+        session.add_all([survivor_s, loser_s])
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.repoint_suggestion_ids == []
+        assert comp.drop_duplicate_suggestion_ids == [loser_s.id]
+
+
+def test_non_suggested_status_always_repoints_never_drops(db_url):
+    """Accepted/Rejected suggestions carry no active-uniqueness constraint — always repoint,
+    even if the survivor already has an Accepted/Rejected row for that user."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_s = Suggestions(work_id=survivor.id, user_id=DEFAULT_USER_ID, status="Accepted")
+        loser_s = Suggestions(work_id=loser.id, user_id=DEFAULT_USER_ID, status="Accepted")
+        session.add_all([survivor_s, loser_s])
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.repoint_suggestion_ids == [loser_s.id]
+        assert comp.drop_duplicate_suggestion_ids == []
+
+
+# --------------------------------------------------------------------------------------------
+# 3. Trope / style link union
+# --------------------------------------------------------------------------------------------
+
+
+def test_trope_link_union_copies_missing_drops_existing(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        shared_trope = Trope(name="Found Family")
+        new_trope = Trope(name="Chosen One")
+        session.add_all([shared_trope, new_trope])
+        session.flush()
+        session.add(WorkTrope(work_id=survivor.id, trope_id=shared_trope.id, justification="scout said so"))
+        session.add(WorkTrope(work_id=loser.id, trope_id=shared_trope.id, justification="also scout"))
+        session.add(
+            WorkTrope(work_id=loser.id, trope_id=new_trope.id, relevance_score=0.9, justification="unique to loser")
+        )
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.drop_trope_links == [(loser.id, shared_trope.id)]
+        assert comp.copy_trope_links == [(loser.id, new_trope.id, 0.9, "unique to loser")]
+
+
+def test_style_link_union_copies_missing_drops_existing(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        shared_style = Style(name="Fast-paced", category="Work")
+        new_style = Style(name="Introspective", category="Work")
+        session.add_all([shared_style, new_style])
+        session.flush()
+        session.add(WorkStyle(work_id=survivor.id, style_id=shared_style.id, attribute_type="pacing"))
+        session.add(WorkStyle(work_id=loser.id, style_id=shared_style.id, attribute_type="pacing"))
+        session.add(WorkStyle(work_id=loser.id, style_id=new_style.id, attribute_type="tone"))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.drop_style_links == [(loser.id, shared_style.id, "pacing")]
+        assert comp.copy_style_links == [(loser.id, new_style.id, "tone")]
+
+
+# --------------------------------------------------------------------------------------------
+# 4. Contributors: union by (author_id, role) + the #142 malformed-author carve-out
+# --------------------------------------------------------------------------------------------
+
+
+def test_contributor_union_copies_new_author_role_drops_exact_duplicate(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        shared_author = Author(name="Brandon Sanderson")
+        new_author = Author(name="Someone Else")
+        session.add_all([shared_author, new_author])
+        session.flush()
+        session.add(WorkContributor(work_id=survivor.id, author_id=shared_author.id, role="Author"))
+        session.add(WorkContributor(work_id=loser.id, author_id=shared_author.id, role="Author"))
+        session.add(WorkContributor(work_id=loser.id, author_id=new_author.id, role="Author"))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.drop_contributors == [(loser.id, shared_author.id, "Author")]
+        assert comp.copy_contributors == [(new_author.id, "Author")]
+        assert comp.malformed_author_candidates == []
+
+
+def test_malformed_author_casefold_duplicate_not_copied_reported_only(db_url):
+    """#142: a DIFFERENT Author row on the loser case-folds equal (after stripping) to an
+    Author already contributing to the survivor under a DIFFERENT author_id -> do NOT copy the
+    link, report the author id under malformed_author_candidates, never mutate the Author row.
+
+    The two names must be DB-distinct under uq_authors_name_lower (a raw `lower(name)` unique
+    index, no strip/casefold — the two rows in this test really can coexist on a real prod
+    schema) while still comparing equal under this module's own `.strip().casefold()` check —
+    a leading-space artifact (the realistic #142 shape: dirty import data) does exactly that:
+    lower(' casualfarmer') != lower('casualfarmer') at the DB level, but
+    ' CasualFarmer'.strip().casefold() == 'CasualFarmer'.strip().casefold()."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Beware of Chicken")
+        loser = _work("Beware of Chicken")
+        session.add_all([survivor, loser])
+        session.flush()
+        clean_author = Author(name="CasualFarmer")
+        dirty_author = Author(name=" CasualFarmer")  # leading-space artifact, DB-distinct
+        session.add_all([clean_author, dirty_author])
+        session.flush()
+        session.add(WorkContributor(work_id=survivor.id, author_id=clean_author.id, role="Author"))
+        session.add(WorkContributor(work_id=loser.id, author_id=dirty_author.id, role="Author"))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_isbn",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.copy_contributors == []
+        assert comp.drop_contributors == []
+        assert comp.malformed_author_candidates == [dirty_author.id]
+
+        # No Author mutation whatsoever — report-only.
+        assert session.get(Author, dirty_author.id) is not None
+        assert session.get(Author, dirty_author.id).name == " CasualFarmer"
+
+
+# --------------------------------------------------------------------------------------------
+# 5. detected_duplicates: deleted before Work rows, unconditional on loser-id match either side
+# --------------------------------------------------------------------------------------------
+
+
+def test_detected_duplicate_rows_referencing_loser_are_planned_for_deletion(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Calling Bullshit: The Art of Skepticism")
+        loser = _work("Calling Bullshit")
+        session.add_all([survivor, loser])
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=loser.id, work_id_b=survivor.id, source="deep_pass_redirect"))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_detected_duplicates",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.delete_detection_pairs == [(loser.id, survivor.id)]
+
+
+def test_detected_duplicate_row_against_unrelated_work_still_planned_for_deletion(db_url):
+    """A loser named in a detection row against a work id OUTSIDE this cluster (a stale
+    detection) is still planned for deletion — unconditional on loser-id match, either side,
+    per the spec's item 6."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Calling Bullshit: The Art of Skepticism")
+        loser = _work("Calling Bullshit")
+        unrelated = _work("Some Unrelated Book")
+        session.add_all([survivor, loser, unrelated])
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=loser.id, work_id_b=unrelated.id, source="deep_pass_redirect"))
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser.id],
+            titles=[survivor.title, loser.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert comp.delete_detection_pairs == [(loser.id, unrelated.id)]
+
+
+# --------------------------------------------------------------------------------------------
+# 6. Loser Work rows deleted last (composition-level: just the planned id list)
+# --------------------------------------------------------------------------------------------
+
+
+def test_delete_work_ids_is_exactly_the_loser_set(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn")
+        loser1 = _work("Mistborn")
+        loser2 = _work("Mistborn")
+        session.add_all([survivor, loser1, loser2])
+        session.flush()
+
+        cluster = db_.WorksMergeCluster(
+            class_name="works_same_identity",
+            work_ids=[survivor.id, loser1.id, loser2.id],
+            titles=[survivor.title, loser1.title, loser2.title],
+            survivor_id=survivor.id,
+        )
+        comp = db_.compose_cluster_merge(session, cluster)
+
+        assert set(comp.delete_work_ids) == {loser1.id, loser2.id}
+        assert survivor.id not in comp.delete_work_ids

--- a/test/integration/test_works_merge_apply.py
+++ b/test/integration/test_works_merge_apply.py
@@ -20,12 +20,14 @@ from datetime import UTC, date, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from agentic_librarian.core.user_context import DEFAULT_USER_ID
 from agentic_librarian.db.models import (
     Author,
     DetectedDuplicate,
     Edition,
+    Narrator,
     ReadingHistory,
     Style,
     Suggestions,
@@ -35,6 +37,7 @@ from agentic_librarian.db.models import (
     WorkContributor,
     WorkStyle,
     WorkTrope,
+    edition_narrators,
 )
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.etl import dedup_backfill as db_
@@ -193,8 +196,6 @@ def test_edition_merge_drops_duplicate_narrator_link_keeps_repoints_new(db_url):
     edition repoints cleanly."""
     manager = DatabaseManager(db_url)
     with manager.get_session() as session:
-        from agentic_librarian.db.models import Narrator, edition_narrators
-
         survivor = _work("Mistborn")
         loser = _work("Mistborn")
         session.add_all([survivor, loser])
@@ -521,3 +522,334 @@ def test_delete_work_ids_is_exactly_the_loser_set(db_url):
 
         assert set(comp.delete_work_ids) == {loser1.id, loser2.id}
         assert survivor.id not in comp.delete_work_ids
+
+
+# --------------------------------------------------------------------------------------------
+# 7. apply_works_merge itself — THE USER GATE. plan -> report -> apply, driven through the real
+# functions end to end (mirrors test/integration/test_fallback_repair.py's e2e shapes).
+# --------------------------------------------------------------------------------------------
+
+
+def test_beware_shaped_full_e2e_through_apply(db_url):
+    """The brief's canonical shape: two works sharing an ISBN AND edition format (works_same_isbn
+    class, ALSO an edition-format collision -> merge_edition), reads split across two users plus
+    one user with reads on BOTH works (one date collides with an existing survivor read, one is
+    distinct), an active suggestion on the loser, richer survivor tropes plus one loser-only
+    trope (relevance/justification carried), and detected_duplicates rows in BOTH orders.
+    Asserts: one work survives; every read is preserved or counted dropped; the suggestion is
+    repointed; the trope union is exact; both detection rows are gone; the EXACT per-op counts
+    map (including merge_edition >= 1); the orphan-author pointer; and a fresh re-plan converges
+    to zero clusters."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        second_user = _second_user(session)
+
+        survivor = _work("Beware of Chicken", deep_enriched_at=datetime(2026, 6, 12, tzinfo=UTC))
+        loser = _work("Beware of Chicken")
+        session.add_all([survivor, loser])
+        session.flush()
+
+        survivor_edition = Edition(work_id=survivor.id, isbn_13="9781039452275", format="ebook")
+        loser_edition = Edition(work_id=loser.id, isbn_13="9781039452275", format="ebook")
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+
+        # second_user: one read, only on the loser -> distinct -> repoint.
+        session.add(
+            ReadingHistory(edition_id=loser_edition.id, user_id=second_user.id, date_completed=date(2024, 3, 1))
+        )
+        # DEFAULT_USER_ID: a read on the survivor, AND two reads on the loser — one whose date
+        # collides with the survivor's own read (dropped-as-duplicate), one whose date is
+        # distinct (repointed).
+        session.add(
+            ReadingHistory(edition_id=survivor_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2023, 1, 1))
+        )
+        session.add(
+            ReadingHistory(edition_id=loser_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2023, 1, 1))
+        )
+        session.add(
+            ReadingHistory(edition_id=loser_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 5, 5))
+        )
+        session.flush()
+
+        session.add(Suggestions(work_id=loser.id, user_id=second_user.id, status="Suggested"))
+        session.flush()
+
+        survivor_trope_1 = Trope(name="Found Family")
+        survivor_trope_2 = Trope(name="Chosen One")
+        loser_only_trope = Trope(name="Slow Burn")
+        session.add_all([survivor_trope_1, survivor_trope_2, loser_only_trope])
+        session.flush()
+        session.add(WorkTrope(work_id=survivor.id, trope_id=survivor_trope_1.id, justification="scout said so"))
+        session.add(WorkTrope(work_id=survivor.id, trope_id=survivor_trope_2.id, justification="scout said so too"))
+        session.add(
+            WorkTrope(
+                work_id=loser.id,
+                trope_id=loser_only_trope.id,
+                relevance_score=0.75,
+                justification="loser-only context",
+            )
+        )
+        session.flush()
+
+        session.add(DetectedDuplicate(work_id_a=loser.id, work_id_b=survivor.id, source="deep_pass_redirect"))
+        session.add(DetectedDuplicate(work_id_a=survivor.id, work_id_b=loser.id, source="deep_pass_redirect"))
+        session.flush()
+
+        # --- plan + report ---
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_isbn"] == 1
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        # --- apply ---
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied == {
+            "repoint_edition": 0,
+            "merge_edition": 1,
+            "repoint_read": 2,
+            "drop_duplicate_read": 1,
+            "repoint_narrator": 0,
+            "drop_narrator": 0,
+            "repoint_suggestion": 1,
+            "drop_duplicate_suggestion": 0,
+            "copy_link": 1,
+            "drop_link": 0,
+            "copy_contributor": 0,
+            "drop_contributor": 0,
+            "delete_detection": 2,
+            "delete_work": 1,
+            "skipped_stale": 0,
+            "orphaned_authors_pointer": 0,
+        }
+
+        assert session.query(Work).count() == 1
+        assert session.get(Work, survivor.id) is not None
+        assert session.get(Work, loser.id) is None
+        assert session.get(Edition, loser_edition.id) is None
+
+        remaining_reads = session.query(ReadingHistory).all()
+        assert len(remaining_reads) == 3  # one dropped-as-duplicate, none silently lost
+        assert all(rh.edition_id == survivor_edition.id for rh in remaining_reads)
+        read_keys = {(rh.user_id, rh.date_completed) for rh in remaining_reads}
+        assert read_keys == {
+            (second_user.id, date(2024, 3, 1)),
+            (DEFAULT_USER_ID, date(2023, 1, 1)),
+            (DEFAULT_USER_ID, date(2024, 5, 5)),
+        }
+
+        suggestion = session.query(Suggestions).filter_by(user_id=second_user.id).one()
+        assert suggestion.work_id == survivor.id
+
+        survivor_tropes = {
+            (wt.trope_id, wt.relevance_score, wt.justification)
+            for wt in session.query(WorkTrope).filter_by(work_id=survivor.id).all()
+        }
+        assert survivor_tropes == {
+            (survivor_trope_1.id, 1.0, "scout said so"),
+            (survivor_trope_2.id, 1.0, "scout said so too"),
+            (loser_only_trope.id, 0.75, "loser-only context"),
+        }
+        assert session.query(WorkTrope).filter_by(work_id=loser.id).all() == []
+
+        assert session.query(DetectedDuplicate).count() == 0
+
+        converged = db_.plan_works_merge(session)
+        assert converged.summary() == {
+            "works_same_isbn": 0,
+            "works_same_identity": 0,
+            "works_detected_duplicates": 0,
+            "works_fuzzy_report_only": 0,
+            "ignored_self_detections": 0,
+        }
+
+
+def test_drift_refusal_e2e_full_snapshot_equality(db_url):
+    """A SEPARATE duplicate pair mints between the reviewed dry-run and apply — refuses (drift
+    error carrying the delta + a fresh report path) and changes NOTHING: a full snapshot across
+    works/editions/reading_history/suggestions/work_tropes/detected_duplicates is byte-identical
+    before and after the refused apply (mirrors test_fallback_repair.py's drift test)."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn", deep_enriched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        session.add(Edition(work_id=survivor.id, isbn_13="9780765311788", format="ebook"))
+        session.add(Edition(work_id=loser.id, isbn_13="9780765311788", format="audiobook"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        # live traffic in the gap: a brand-new duplicate pair appears, unrelated to the reviewed
+        # cluster.
+        new_a = _work("Elantris", deep_enriched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        new_b = _work("Elantris")
+        session.add_all([new_a, new_b])
+        session.flush()
+        session.add(DetectedDuplicate(work_id_a=new_a.id, work_id_b=new_b.id, source="deep_pass_redirect"))
+        session.flush()
+
+        def _snapshot():
+            return {
+                "works": {(w.id, w.title) for w in session.query(Work).all()},
+                "editions": {(e.id, e.work_id, e.isbn_13, e.format) for e in session.query(Edition).all()},
+                "reading_history": {
+                    (rh.id, rh.edition_id, rh.user_id, rh.date_completed) for rh in session.query(ReadingHistory).all()
+                },
+                "suggestions": {(s.id, s.work_id, s.user_id, s.status) for s in session.query(Suggestions).all()},
+                "work_tropes": {
+                    (wt.work_id, wt.trope_id, wt.relevance_score, wt.justification)
+                    for wt in session.query(WorkTrope).all()
+                },
+                "detected_duplicates": {(d.work_id_a, d.work_id_b) for d in session.query(DetectedDuplicate).all()},
+            }
+
+        before = _snapshot()
+
+        with pytest.raises(db_.WorksMergeDriftError, match="drifted") as exc_info:
+            db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert any(
+            t.startswith("delete_work:") and (str(new_a.id) in t or str(new_b.id) in t) for t in exc_info.value.delta
+        )
+        assert exc_info.value.fresh_report_path.exists()
+        fresh_reviewable = db_.parse_works_merge_report(exc_info.value.fresh_report_path.read_text(encoding="utf-8"))
+        assert exc_info.value.delta <= fresh_reviewable  # every delta token is present, re-reviewable
+
+        after = _snapshot()
+        assert after == before
+
+
+def test_fuzzy_only_cluster_never_consumes_tokens_through_apply(db_url):
+    """A fuzzy-only cluster (no shared ISBN, no shared identity, no detected_duplicates row —
+    the ONLY edge is title similarity) appears in the plan/report but apply consumes ZERO tokens
+    from it and never composes it — the structural exclusion (applyable_works_merge_clusters
+    never includes fuzzy_report_only) holds all the way through the gate, both works survive."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author_a = Author(name="Author A")
+        author_b = Author(name="Author B")
+        work_a = _work("Calling Bullshit Now")
+        work_b = _work("Calling Bullshit")
+        session.add_all([author_a, author_b, work_a, work_b])
+        session.flush()
+        # DIFFERENT authors (keeps this OUT of works_same_identity), no ISBN (OUT of
+        # works_same_isbn), no detected_duplicates row -> the only edge left is fuzzy title
+        # similarity.
+        session.add(WorkContributor(work_id=work_a.id, author_id=author_a.id, role="Author"))
+        session.add(WorkContributor(work_id=work_b.id, author_id=author_b.id, role="Author"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary() == {
+            "works_same_isbn": 0,
+            "works_same_identity": 0,
+            "works_detected_duplicates": 0,
+            "works_fuzzy_report_only": 1,
+            "ignored_self_detections": 0,
+        }
+
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        assert compositions == []  # fuzzy is structurally never composed
+
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+        report_text = report_path.read_text(encoding="utf-8")
+        assert "NEVER APPLIED" in report_text
+        assert "Calling Bullshit" in report_text
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["delete_work"] == 0
+        assert session.get(Work, work_a.id) is not None
+        assert session.get(Work, work_b.id) is not None
+
+
+def test_identity_cluster_merges_through_apply_no_shared_isbn(db_url):
+    """We-Are-Legion-shaped: punctuation-variant titles + shared author, no shared ISBN at all
+    -> works_same_identity, merged through the real apply gate."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="Dennis E. Taylor")
+        w1 = _work("We Are Legion (We Are Bob)")
+        w2 = _work("We are Legion; We are Bob", deep_enriched_at=datetime(2026, 6, 1, tzinfo=UTC))
+        session.add_all([author, w1, w2])
+        session.flush()
+        session.add(WorkContributor(work_id=w1.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=w2.id, author_id=author.id, role="Author"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_identity"] == 1
+        assert clusters.summary()["works_same_isbn"] == 0
+
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["delete_work"] == 1
+        assert applied["drop_contributor"] == 1  # shared (author, role) pair, not duplicated
+        assert applied["copy_contributor"] == 0
+        assert session.query(Work).count() == 1
+        survivor = session.query(Work).one()
+        assert survivor.id == w2.id  # deep_enriched_at newest wins the survivor tiebreak
+        assert session.query(WorkContributor).filter_by(work_id=survivor.id).count() == 1
+
+        converged = db_.plan_works_merge(session)
+        assert converged.summary()["works_same_identity"] == 0
+
+
+def test_narrator_union_through_apply_repoint_and_drop(db_url):
+    """Format-collision merge (both editions 'audiobook') where the loser edition carries a
+    narrator absent on the survivor edition (repoint_narrator) AND a narrator already shared
+    with the survivor (drop_narrator) — both paths execute and count through the real apply
+    gate, not just compose_cluster_merge's plan."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("Mistborn", deep_enriched_at=datetime(2026, 1, 1, tzinfo=UTC))
+        loser = _work("Mistborn")
+        session.add_all([survivor, loser])
+        session.flush()
+        survivor_edition = Edition(work_id=survivor.id, isbn_13="9780765311788", format="audiobook")
+        loser_edition = Edition(work_id=loser.id, isbn_13="9780765311788", format="audiobook")
+        session.add_all([survivor_edition, loser_edition])
+        session.flush()
+
+        shared_narrator = Narrator(name="Michael Kramer")
+        new_narrator = Narrator(name="Someone Else")
+        session.add_all([shared_narrator, new_narrator])
+        session.flush()
+        session.execute(
+            edition_narrators.insert().values(edition_id=survivor_edition.id, narrator_id=shared_narrator.id)
+        )
+        session.execute(edition_narrators.insert().values(edition_id=loser_edition.id, narrator_id=shared_narrator.id))
+        session.execute(edition_narrators.insert().values(edition_id=loser_edition.id, narrator_id=new_narrator.id))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["merge_edition"] == 1
+        assert applied["repoint_narrator"] == 1
+        assert applied["drop_narrator"] == 1
+        assert session.get(Edition, loser_edition.id) is None
+
+        remaining_narrators = {
+            row.narrator_id
+            for row in session.execute(
+                select(edition_narrators.c.narrator_id).where(edition_narrators.c.edition_id == survivor_edition.id)
+            ).all()
+        }
+        assert remaining_narrators == {shared_narrator.id, new_narrator.id}

--- a/test/unit/test_clean_catalog_merge_works_apply_cli.py
+++ b/test/unit/test_clean_catalog_merge_works_apply_cli.py
@@ -1,0 +1,128 @@
+"""CLI-level guard tests for --merge-works-apply (Spec 2026-07-14 PR-2 part 2, H2) — mirrors
+test_clean_catalog_repair_fallbacks_cli.py's structure exactly (same --yes / prod-url / --report
+guard shape, same drift-refusal printout shape). The planner/composition/gate mechanics
+themselves are covered by test/unit/test_works_merge.py (pure) and
+test/integration/test_works_merge_apply.py (db_integration); this file is about the CLI's own
+guards and its drift-refusal printout wiring."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_db(monkeypatch, *, url="postgresql://u:p@prod-host/db"):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: url)
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda db_url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+
+
+@pytest.mark.parametrize(
+    "argv, expected_rc, expected_message",
+    [
+        (
+            ["--merge-works-apply", "--report", "data/reports/fake.txt"],
+            2,
+            "REFUSING --merge-works-apply without --yes",
+        ),
+        (
+            ["--merge-works-apply", "--yes"],
+            1,
+            "REFUSING --merge-works-apply: --report is required",
+        ),
+    ],
+    ids=["missing_yes", "missing_report"],
+)
+def test_merge_works_apply_refused(monkeypatch, capsys, argv, expected_rc, expected_message):
+    _patch_db(monkeypatch)
+    rc = clean_catalog.main(argv)
+    assert rc == expected_rc
+    assert expected_message in capsys.readouterr().out
+
+
+def test_merge_works_apply_refused_on_non_prod_url(monkeypatch, capsys, tmp_path):
+    _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
+    report = tmp_path / "works-merge-fake.txt"
+    report.write_text("== PLAN TOKENS ==\n== END PLAN TOKENS ==\n", encoding="utf-8")
+    rc = clean_catalog.main(["--merge-works-apply", "--yes", "--report", str(report)])
+    assert rc == 2
+    assert "REFUSING --merge-works-apply: 'localhost/db' is not a live prod DB" in capsys.readouterr().out
+
+
+def test_merge_works_apply_drift_refusal_printout(monkeypatch, capsys, tmp_path):
+    """apply_works_merge raising WorksMergeDriftError is caught and its delta tokens + fresh
+    report path are printed for re-review — mirrors --repair-fallbacks-apply's refusal UX. Only
+    the CLI's own catch/print wiring is under test here; apply_works_merge itself is stubbed
+    (its re-plan/refuse mechanics are covered by test/integration/test_works_merge_apply.py's
+    drift e2e)."""
+    _patch_db(monkeypatch)
+    report = tmp_path / "works-merge-reviewed.txt"
+    report.write_text("== PLAN TOKENS ==\n== END PLAN TOKENS ==\n", encoding="utf-8")
+    fresh_report_path = tmp_path / "works-merge-fresh.txt"
+    delta = {"delete_work:11111111-1111-1111-1111-111111111111"}
+
+    def _raise_drift(session, reviewed_report_path):
+        raise clean_catalog.dedup_backfill.WorksMergeDriftError(delta, fresh_report_path)
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "apply_works_merge", _raise_drift)
+
+    rc = clean_catalog.main(["--merge-works-apply", "--yes", "--report", str(report)])
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "REFUSING --merge-works-apply" in out
+    assert "drifted" in out
+    for token in delta:
+        assert token in out
+    assert str(fresh_report_path) in out
+    assert f"--merge-works-apply --yes --report {fresh_report_path}" in out
+
+
+def test_merge_works_apply_success_prints_applied_counts_and_orphan_pointer(monkeypatch, capsys, tmp_path):
+    """The generic 'applied:' counts loop plus the orphan-author pointer sentence (deliverable
+    1.6) — printed only when the count is non-zero."""
+    _patch_db(monkeypatch)
+    report = tmp_path / "works-merge-reviewed.txt"
+    report.write_text("== PLAN TOKENS ==\n== END PLAN TOKENS ==\n", encoding="utf-8")
+
+    applied = {
+        "repoint_edition": 0,
+        "merge_edition": 1,
+        "repoint_read": 0,
+        "drop_duplicate_read": 0,
+        "repoint_narrator": 0,
+        "drop_narrator": 0,
+        "repoint_suggestion": 0,
+        "drop_duplicate_suggestion": 0,
+        "copy_link": 0,
+        "drop_link": 0,
+        "copy_contributor": 0,
+        "drop_contributor": 0,
+        "delete_detection": 0,
+        "delete_work": 1,
+        "skipped_stale": 0,
+        "orphaned_authors_pointer": 2,
+    }
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "apply_works_merge", lambda session, report_path: applied)
+
+    rc = clean_catalog.main(["--merge-works-apply", "--yes", "--report", str(report)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "merge_edition" in out
+    assert "2 author(s) may be orphaned — run --dedup-for-constraints dry-run to sweep." in out

--- a/test/unit/test_clean_catalog_merge_works_cli.py
+++ b/test/unit/test_clean_catalog_merge_works_cli.py
@@ -1,9 +1,10 @@
-"""CLI-level test for --merge-works (Spec 2026-07-14 PR-2 part 1) — mirrors
+"""CLI-level test for --merge-works (Spec 2026-07-14 PR-2, H1+H2) — mirrors
 test_clean_catalog_repair_fallbacks_cli.py's dry-run-only structure. --merge-works is
-detection/planning ONLY (no apply counterpart exists yet), so unlike --repair-fallbacks-apply
-there is no --yes / prod-url / --report guard to test here — just the report-write/return-0
-wiring. The planner/report mechanics themselves are covered by test/unit/test_works_merge.py
-(pure) and test/integration/test_works_merge.py (db_integration)."""
+ALWAYS a dry-run (no --yes / prod-url / --report guard to test here — just the report-write/
+return-0 wiring), but since H2 it also composes the merge plan and writes the token-bearing
+apply report. The planner/report mechanics themselves are covered by test/unit/test_works_merge.py
+(pure) and test/integration/test_works_merge.py (db_integration); --merge-works-apply's own
+guard/drift-gate CLI wiring is covered by test/unit/test_clean_catalog_merge_works_apply_cli.py."""
 
 import importlib.util
 from pathlib import Path
@@ -34,7 +35,8 @@ def test_merge_works_dry_run_never_applies(monkeypatch, capsys, tmp_path):
     """--merge-works always writes a report and returns 0 without --yes or a prod URL — it's
     read-only by construction, even against what CLI dispatch treats as a non-prod localhost
     URL. plan_works_merge itself does real SQLAlchemy query-building — stub it, same as the
-    repair-fallbacks CLI test stubs plan_fallback_repair."""
+    repair-fallbacks CLI test stubs plan_fallback_repair. An empty WorksMergeClusters has no
+    applyable clusters, so compose_cluster_merge is never called and needs no stub."""
     _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
     monkeypatch.setattr(
         clean_catalog.dedup_backfill,
@@ -45,9 +47,13 @@ def test_merge_works_dry_run_never_applies(monkeypatch, capsys, tmp_path):
     rc = clean_catalog.main(["--merge-works"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "works-merge plan (DETECTION ONLY" in out
-    assert "apply arrives in a follow-up" in out
+    assert "works-merge plan (detection" in out
+    assert "apply composition (PR-2 part 2)" in out
+    assert "apply with: --merge-works-apply --yes --report" in out
     assert (tmp_path / "data" / "reports").exists()
     written = list((tmp_path / "data" / "reports").glob("works-merge-*.txt"))
     assert len(written) == 1
-    assert "NEVER APPLIED" in written[0].read_text(encoding="utf-8")
+    report_text = written[0].read_text(encoding="utf-8")
+    assert "NEVER APPLIED" in report_text
+    assert "== PLAN TOKENS ==" in report_text
+    assert "== END PLAN TOKENS ==" in report_text

--- a/test/unit/test_clean_catalog_merge_works_cli.py
+++ b/test/unit/test_clean_catalog_merge_works_cli.py
@@ -1,0 +1,53 @@
+"""CLI-level test for --merge-works (Spec 2026-07-14 PR-2 part 1) — mirrors
+test_clean_catalog_repair_fallbacks_cli.py's dry-run-only structure. --merge-works is
+detection/planning ONLY (no apply counterpart exists yet), so unlike --repair-fallbacks-apply
+there is no --yes / prod-url / --report guard to test here — just the report-write/return-0
+wiring. The planner/report mechanics themselves are covered by test/unit/test_works_merge.py
+(pure) and test/integration/test_works_merge.py (db_integration)."""
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_db(monkeypatch, *, url="postgresql://u:p@localhost/db"):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: url)
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda db_url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+
+
+def test_merge_works_dry_run_never_applies(monkeypatch, capsys, tmp_path):
+    """--merge-works always writes a report and returns 0 without --yes or a prod URL — it's
+    read-only by construction, even against what CLI dispatch treats as a non-prod localhost
+    URL. plan_works_merge itself does real SQLAlchemy query-building — stub it, same as the
+    repair-fallbacks CLI test stubs plan_fallback_repair."""
+    _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
+    monkeypatch.setattr(
+        clean_catalog.dedup_backfill,
+        "plan_works_merge",
+        lambda session: clean_catalog.dedup_backfill.WorksMergeClusters(),
+    )
+    monkeypatch.chdir(tmp_path)
+    rc = clean_catalog.main(["--merge-works"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "works-merge plan (DETECTION ONLY" in out
+    assert "apply arrives in a follow-up" in out
+    assert (tmp_path / "data" / "reports").exists()
+    written = list((tmp_path / "data" / "reports").glob("works-merge-*.txt"))
+    assert len(written) == 1
+    assert "NEVER APPLIED" in written[0].read_text(encoding="utf-8")

--- a/test/unit/test_works_merge.py
+++ b/test/unit/test_works_merge.py
@@ -1,0 +1,281 @@
+"""Pure-logic unit tests for the works-merge detection classes (PR-2 part 1, Spec
+2026-07-14): fold(), the series guard, per-class pair detection, unordered-pair dedup,
+cross-class precedence, transitive cluster collapse, and survivor selection — all exercised
+WITHOUT a live Postgres session (that's the db_integration suite's job,
+test/integration/test_works_merge.py).
+
+Lives alongside etl/dedup_backfill.py's own tests (same module, per the works-merge design
+spec: "extend etl/dedup_backfill.py... do NOT build a parallel tool") but in its own test file
+since the detection classes here are functionally independent of DedupPlan/plan_dedup/
+apply_dedup (the pre-migration constraint gate) — see dedup_backfill.py's module docstring for
+why duplicate_works_report_only/_plan_duplicate_works stay untouched.
+
+House rule: case-driven tests are parametrized, never loops inside one test body."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.etl.dedup_backfill import (
+    WorkStats,
+    _fold,
+    _series_guard_blocks,
+    fuzzy_similarity,
+    pick_survivor,
+    plan_works_merge_clusters,
+)
+
+# --------------------------------------------------------------------------------------------
+# fold()
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case_name, a, b, expect_equal",
+    [
+        (
+            "we_are_legion_punctuation_variant",
+            "We Are Legion (We Are Bob)",
+            "We are Legion; We are Bob",
+            True,
+        ),
+        ("case_only", "Beware of Chicken", "beware of chicken", True),
+        ("ampersand_vs_and_word", "Fire & Blood", "Fire and Blood", False),
+        ("colon_subtitle", "Mistborn: The Final Empire", "Mistborn The Final Empire", True),
+        ("bracket_variant", "The Song [Special Edition]", "The Song Special Edition", True),
+        ("apostrophe_and_quote", "Ender's Game", 'Ender"s Game', True),
+        ("trailing_bang_and_question", "Yellowface!", "Yellowface?", True),
+        ("double_space_collapse", "The   Dark  Forest", "The Dark Forest", True),
+        ("distinct_titles_never_equal", "Beware of Chicken", "Calling Bullshit", False),
+    ],
+)
+def test_fold_table(case_name, a, b, expect_equal):
+    assert (_fold(a) == _fold(b)) is expect_equal
+
+
+# --------------------------------------------------------------------------------------------
+# Series guard
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case_name, base_title, variant_title, expect_blocked",
+    [
+        ("plain_number", "Beware of Chicken", "Beware of Chicken 2", True),
+        ("roman_numeral", "Beware of Chicken", "Beware of Chicken II", True),
+        ("hash_number", "Beware of Chicken", "Beware of Chicken #2", True),
+        ("book_word_number", "Beware of Chicken", "Beware of Chicken Book 2", True),
+        ("volume_word_number", "Beware of Chicken", "Beware of Chicken Volume 2", True),
+        ("identical_titles_not_blocked", "Beware of Chicken", "Beware of Chicken", False),
+        (
+            "punctuation_variant_not_blocked",
+            "We Are Legion (We Are Bob)",
+            "We are Legion; We are Bob",
+            False,
+        ),
+        ("unrelated_titles_not_blocked", "Beware of Chicken", "Calling Bullshit", False),
+    ],
+)
+def test_series_guard_table(case_name, base_title, variant_title, expect_blocked):
+    assert _series_guard_blocks(base_title, variant_title) is expect_blocked
+
+
+def test_series_guard_symmetric():
+    """The guard must not depend on argument order — (A, B) and (B, A) agree."""
+    a, b = "Beware of Chicken", "Beware of Chicken 2"
+    assert _series_guard_blocks(a, b) == _series_guard_blocks(b, a)
+
+
+# --------------------------------------------------------------------------------------------
+# fuzzy_similarity — token-set similarity on folded titles
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case_name, a, b, expect_high",
+    [
+        ("near_identical_word_order", "The Chicken and the Farm", "The Farm and the Chicken", True),
+        ("one_extra_word", "Calling Bullshit Now", "Calling Bullshit", True),
+        ("mostly_disjoint_subset", "Calling Bullshit The Art of Skepticism", "Calling Bullshit", False),
+        ("totally_different", "Beware of Chicken", "Yellowface", False),
+    ],
+)
+def test_fuzzy_similarity_directional(case_name, a, b, expect_high):
+    score = fuzzy_similarity(a, b)
+    assert 0.0 <= score <= 1.0
+    if expect_high:
+        assert score >= 0.5
+    else:
+        assert score < 0.5
+
+
+# --------------------------------------------------------------------------------------------
+# Survivor selection (pick_survivor) — deterministic tiebreak order:
+# most justified trope links -> newest deep_enriched_at (NULLs last) -> most editions ->
+# lowest UUID string.
+# --------------------------------------------------------------------------------------------
+
+
+def _stats(work_id, *, trope_links=0, deep_enriched_at=None, editions=0):
+    return WorkStats(
+        work_id=work_id,
+        title="irrelevant",
+        justified_trope_links=trope_links,
+        deep_enriched_at=deep_enriched_at,
+        edition_count=editions,
+    )
+
+
+def test_pick_survivor_most_trope_links_wins():
+    lo, hi = uuid4(), uuid4()
+    candidates = [_stats(lo, trope_links=1), _stats(hi, trope_links=15)]
+    assert pick_survivor(candidates).work_id == hi
+
+
+def test_pick_survivor_falls_back_to_newest_deep_enriched_at_on_trope_tie():
+    older, newer = uuid4(), uuid4()
+    import datetime as dt
+
+    t_old = dt.datetime(2026, 1, 1, tzinfo=dt.UTC)
+    t_new = dt.datetime(2026, 6, 1, tzinfo=dt.UTC)
+    candidates = [
+        _stats(older, trope_links=3, deep_enriched_at=t_old),
+        _stats(newer, trope_links=3, deep_enriched_at=t_new),
+    ]
+    assert pick_survivor(candidates).work_id == newer
+
+
+def test_pick_survivor_deep_enriched_at_nulls_last():
+    never, enriched = uuid4(), uuid4()
+    import datetime as dt
+
+    candidates = [
+        _stats(never, trope_links=3, deep_enriched_at=None),
+        _stats(enriched, trope_links=3, deep_enriched_at=dt.datetime(2026, 1, 1, tzinfo=dt.UTC)),
+    ]
+    assert pick_survivor(candidates).work_id == enriched
+
+
+def test_pick_survivor_falls_back_to_most_editions_on_trope_and_date_tie():
+    fewer, more = uuid4(), uuid4()
+    candidates = [_stats(fewer, trope_links=3, editions=1), _stats(more, trope_links=3, editions=4)]
+    assert pick_survivor(candidates).work_id == more
+
+
+def test_pick_survivor_falls_back_to_lowest_uuid_string_on_full_tie():
+    ids = sorted([uuid4(), uuid4()], key=str)
+    lowest, highest = ids[0], ids[1]
+    candidates = [_stats(highest, trope_links=2, editions=2), _stats(lowest, trope_links=2, editions=2)]
+    assert pick_survivor(candidates).work_id == lowest
+
+
+# --------------------------------------------------------------------------------------------
+# Cross-class precedence + unordered-pair dedup + transitive cluster collapse
+#
+# plan_works_merge_clusters is the pure composition core: given per-class pair lists (already
+# computed as unordered (id, id) frozensets) and per-work stats, it dedups, resolves overlap by
+# class strength, collapses transitive clusters, and returns one merge unit per cluster with its
+# survivor. This is the piece H2's plan_works_merge(session) calls after gathering DB-derived
+# pairs — kept DB-free here so the composition logic has a fast, deterministic test surface.
+# --------------------------------------------------------------------------------------------
+
+
+def test_unordered_pair_dedup_both_orders_collapse_to_one_cluster():
+    a, b = uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[(a, b), (b, a)],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert len(clusters.detected_duplicates) == 1
+    assert set(clusters.detected_duplicates[0].work_ids) == {a, b}
+
+
+def test_cross_class_precedence_pair_appears_once_in_strongest_class():
+    """A pair caught by BOTH works_same_isbn and works_detected_duplicates appears only in
+    the stronger (same_isbn) class."""
+    a, b = uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[(a, b)],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn) == 1
+    assert len(clusters.detected_duplicates) == 0
+
+
+def test_fuzzy_class_never_contains_a_pair_from_a_stronger_class():
+    a, b = uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[(a, b)],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn) == 1
+    assert len(clusters.fuzzy_report_only) == 0
+
+
+def test_transitive_cluster_collapses_into_one_cluster_one_survivor():
+    """A~B via same_isbn, B~C via same_identity: one cluster {A, B, C}, one survivor."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    stats = {
+        a: _stats(a, trope_links=1),
+        b: _stats(b, trope_links=1),
+        c: _stats(c, trope_links=10),  # c should win survivor
+    }
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_identity_pairs=[(b, c)],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    all_clusters = clusters.same_isbn + clusters.same_identity
+    assert len(all_clusters) == 1
+    cluster = all_clusters[0]
+    assert set(cluster.work_ids) == {a, b, c}
+    assert cluster.survivor_id == c
+
+
+def test_transitive_cluster_takes_the_strongest_class_of_any_edge():
+    """A~B is same_isbn (strong), B~C is fuzzy (weak) — the merged cluster is reported under
+    same_isbn, not fuzzy, and is therefore NOT report-only."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1), c: _stats(c, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[(b, c)],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn) == 1
+    assert set(clusters.same_isbn[0].work_ids) == {a, b, c}
+    assert clusters.fuzzy_report_only == []
+
+
+def test_fuzzy_only_cluster_lands_in_fuzzy_report_only():
+    a, b = uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[(a, b)],
+        stats_by_work=stats,
+    )
+    assert len(clusters.fuzzy_report_only) == 1
+    assert clusters.same_isbn == []
+    assert clusters.same_identity == []
+    assert clusters.detected_duplicates == []

--- a/test/unit/test_works_merge.py
+++ b/test/unit/test_works_merge.py
@@ -86,6 +86,15 @@ def test_fold_table(case_name, a, b, expect_equal):
             False,
         ),
         ("unrelated_titles_not_blocked", "Beware of Chicken", "Calling Bullshit", False),
+        # Gemini review (#144): volume-vs-volume — two sequels of one series must block
+        # (the operator is about to read Beware of Chicken 3; it must never pair with 2).
+        ("volume_vs_volume_blocked", "Beware of Chicken 2", "Beware of Chicken 3", True),
+        ("volume_vs_volume_roman_blocked", "Beware of Chicken II", "Beware of Chicken 3", True),
+        ("volume_vs_volume_hash_blocked", "Beware of Chicken #2", "Beware of Chicken #3", True),
+        # Same volume twice = a genuine duplicate pair — must stay mergeable (folds equal).
+        ("same_volume_dup_not_blocked", "Beware of Chicken 2", "Beware of Chicken 2", False),
+        # Volume tokens on DIFFERENT bases: not one series — the guard must not block.
+        ("volume_tokens_different_bases_not_blocked", "Beware of Chicken 2", "Mistborn 3", False),
     ],
 )
 def test_series_guard_table(case_name, base_title, variant_title, expect_blocked):

--- a/test/unit/test_works_merge.py
+++ b/test/unit/test_works_merge.py
@@ -19,12 +19,22 @@ from uuid import uuid4
 import pytest
 
 from agentic_librarian.etl.dedup_backfill import (
+    EditionMergeGroup,
+    WorkMergeComposition,
+    WorksMergeCluster,
+    WorksMergeClusters,
     WorkStats,
+    _dedupe_detected_duplicate_rows,
     _fold,
     _series_guard_blocks,
     fuzzy_similarity,
+    parse_works_merge_report,
     pick_survivor,
     plan_works_merge_clusters,
+    render_works_merge_apply_report,
+    works_merge_delta,
+    works_merge_tokens,
+    write_works_merge_apply_report,
 )
 
 # --------------------------------------------------------------------------------------------
@@ -279,3 +289,219 @@ def test_fuzzy_only_cluster_lands_in_fuzzy_report_only():
     assert clusters.same_isbn == []
     assert clusters.same_identity == []
     assert clusters.detected_duplicates == []
+
+
+# --------------------------------------------------------------------------------------------
+# H2 fix 1: self-referential detected_duplicates feed rows (work_id_a == work_id_b) must be
+# skipped at ingestion, not fed to plan_works_merge_clusters' union-find — `frozenset((A, A))`
+# has size 1, and `a, b = tuple(pair)` on a size-1 frozenset used to crash the planner.
+# _dedupe_detected_duplicate_rows is the pure (session-free) helper _detect_detected_duplicate_
+# pairs now delegates to, so this is testable without a live Postgres session.
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "case_name, rows_fn, expect_pair_count, expect_ignored_self",
+    [
+        ("no_self_pairs", lambda a, b, c: [(a, b)], 1, 0),
+        ("single_self_pair_alone", lambda a, b, c: [(a, a)], 0, 1),
+        ("self_pair_mixed_with_real_pair", lambda a, b, c: [(a, a), (a, b)], 1, 1),
+        (
+            "self_pair_plus_both_orders_of_a_real_pair_dedup_to_one",
+            lambda a, b, c: [(a, a), (a, b), (b, a)],
+            1,
+            1,
+        ),
+        ("multiple_distinct_self_pairs_all_ignored", lambda a, b, c: [(a, a), (b, b), (c, c)], 0, 3),
+        ("no_rows_at_all", lambda a, b, c: [], 0, 0),
+    ],
+)
+def test_dedupe_detected_duplicate_rows_skips_self_pairs(case_name, rows_fn, expect_pair_count, expect_ignored_self):
+    a, b, c = uuid4(), uuid4(), uuid4()
+    pairs, ignored_self = _dedupe_detected_duplicate_rows(rows_fn(a, b, c))
+    assert len(pairs) == expect_pair_count
+    assert ignored_self == expect_ignored_self
+
+
+def test_dedupe_detected_duplicate_rows_self_pair_never_reaches_union_find_crash():
+    """The regression itself: an ungated self-pair fed straight to plan_works_merge_clusters
+    used to raise ValueError unpacking a size-1 frozenset (`a, b = tuple(pair)`). Routing every
+    detected_duplicates row through _dedupe_detected_duplicate_rows first (as plan_works_merge
+    now does) filters the self-pair out before it ever becomes a union-find edge — this proves
+    plan_works_merge_clusters never even sees the ill-shaped input, not just that the helper
+    itself is safe."""
+    a = uuid4()
+    pairs, ignored_self = _dedupe_detected_duplicate_rows([(a, a)])
+    assert pairs == []
+    assert ignored_self == 1
+
+    stats = {a: _stats(a, trope_links=1)}
+    clusters = plan_works_merge_clusters(  # must not raise
+        same_isbn_pairs=[],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=pairs,
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert clusters.detected_duplicates == []
+
+
+# --------------------------------------------------------------------------------------------
+# Op-tagged token round-trip + fail-closed parser (mirrors test_fallback_repair.py's unit
+# suite). Pure-dataclass fixtures — WorkMergeComposition/WorksMergeCluster/EditionMergeGroup are
+# hand-built here rather than produced by compose_cluster_merge, so these run without a session
+# (compose_cluster_merge's own DB-driven semantics are covered by test/integration/
+# test_works_merge_apply.py).
+# --------------------------------------------------------------------------------------------
+
+
+def _composition(*, survivor=None, loser=None, with_edition_merge_group=False):
+    survivor = survivor if survivor is not None else uuid4()
+    loser = loser if loser is not None else uuid4()
+    cluster = WorksMergeCluster(
+        class_name="works_same_isbn", work_ids=[survivor, loser], titles=["A", "A"], survivor_id=survivor
+    )
+    comp = WorkMergeComposition(
+        cluster=cluster,
+        survivor_id=survivor,
+        loser_ids=[loser],
+        repoint_edition_ids=[uuid4()],
+        delete_work_ids=[loser],
+    )
+    if with_edition_merge_group:
+        mg = EditionMergeGroup(
+            survivor_id=uuid4(),
+            work_id=survivor,
+            fmt="audiobook",
+            loser_ids=[uuid4()],
+            repoint_reading_history=[uuid4()],
+            delete_reading_history=[uuid4()],
+            repoint_narrators=[(uuid4(), uuid4())],
+            delete_narrators=[(uuid4(), uuid4())],
+        )
+        comp.merge_editions = [mg]
+    return comp
+
+
+def test_token_round_trip_write_parse_equal(tmp_path):
+    comp = _composition(with_edition_merge_group=True)
+    expected = works_merge_tokens([comp])
+    assert expected  # sanity: the fixture actually produced tokens
+
+    report_path = write_works_merge_apply_report(WorksMergeClusters(), [comp], reports_dir=tmp_path)
+    parsed = parse_works_merge_report(report_path.read_text(encoding="utf-8"))
+
+    assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    "mutate, match",
+    [
+        (
+            lambda lines: [line for line in lines if line != "== END PLAN TOKENS =="],
+            "END PLAN TOKENS",
+        ),
+        (
+            lambda lines: [("[works_merge 3" if line.startswith("[works_merge]") else line) for line in lines],
+            "malformed class-header",
+        ),
+        (
+            lambda _lines: ["== PLAN IDS ==", "delete:1234", "== END PLAN IDS =="],
+            "PLAN TOKENS",
+        ),
+    ],
+    ids=["missing_end_marker", "malformed_header_line", "dedup_report_handed_to_merge_parser"],
+)
+def test_parse_works_merge_report_fails_closed(mutate, match):
+    """Mirrors test_fallback_repair.py's test_parse_report_fails_closed. The third case is the
+    works-merge-specific one: a --dedup-for-constraints report (marker '== PLAN IDS ==', not
+    '== PLAN TOKENS ==') handed to parse_works_merge_report — the wrong report type for this
+    gate must fail closed, not silently parse as an empty/bogus token set."""
+    comp = _composition()
+    report_text = render_works_merge_apply_report(WorksMergeClusters(), [comp])
+    lines = report_text.splitlines()
+    corrupted = "\n".join(mutate(lines))
+
+    with pytest.raises(ValueError, match=match):
+        parse_works_merge_report(corrupted)
+
+
+# --------------------------------------------------------------------------------------------
+# Drift delta (works_merge_delta) — addition, op-flip on the same id, survivor-flip (the
+# merge_cluster binding token), and fresh subset of reviewed (no refusal).
+# --------------------------------------------------------------------------------------------
+
+
+def test_works_merge_delta_addition_is_flagged():
+    comp = _composition()
+    reviewed = works_merge_tokens([comp])
+
+    extra_edition_id = uuid4()
+    fresh_comp = _composition(survivor=comp.survivor_id, loser=comp.loser_ids[0])
+    fresh_comp.repoint_edition_ids = [*comp.repoint_edition_ids, extra_edition_id]
+
+    delta = works_merge_delta(reviewed, [fresh_comp])
+
+    assert delta == {f"repoint_edition:{extra_edition_id}"}
+
+
+def test_works_merge_delta_op_flip_on_same_id_is_flagged():
+    """The reviewed report named this edition id as a whole-edition repoint; the fresh re-plan
+    (e.g. a concurrent write introduced a same-format collision in the gap) instead folds it
+    into a merge_edition group — an operation flip on the same underlying edition id must show
+    up as a NEW token, never hidden behind an unchanged bare id."""
+    survivor, loser = uuid4(), uuid4()
+    edition_id = uuid4()
+    cluster = WorksMergeCluster(
+        class_name="works_same_isbn", work_ids=[survivor, loser], titles=["A", "A"], survivor_id=survivor
+    )
+    reviewed_comp = WorkMergeComposition(
+        cluster=cluster, survivor_id=survivor, loser_ids=[loser], repoint_edition_ids=[edition_id]
+    )
+    reviewed = works_merge_tokens([reviewed_comp])
+
+    mg = EditionMergeGroup(survivor_id=uuid4(), work_id=survivor, fmt="ebook", loser_ids=[edition_id])
+    fresh_comp = WorkMergeComposition(cluster=cluster, survivor_id=survivor, loser_ids=[loser], merge_editions=[mg])
+
+    delta = works_merge_delta(reviewed, [fresh_comp])
+
+    assert any(t.startswith("merge_edition:") for t in delta)
+    assert not any(t.startswith("repoint_edition:") for t in delta)
+
+
+def test_works_merge_delta_survivor_flip_on_merge_cluster_token_is_flagged():
+    """The merge_cluster:<survivor>:<losers> token is survivor-BOUND — if the deterministic
+    survivor pick flips between review and apply (e.g. deep-enrichment landed on the OTHER work
+    in the gap), the whole cluster's binding token changes even though the work id SET is
+    unchanged, and so does which work is now the planned delete_work."""
+    work_a, work_b = uuid4(), uuid4()
+    cluster_a_survivor = WorksMergeCluster(
+        class_name="works_same_isbn", work_ids=[work_a, work_b], titles=["A", "A"], survivor_id=work_a
+    )
+    reviewed_comp = WorkMergeComposition(
+        cluster=cluster_a_survivor, survivor_id=work_a, loser_ids=[work_b], delete_work_ids=[work_b]
+    )
+    reviewed = works_merge_tokens([reviewed_comp])
+
+    cluster_b_survivor = WorksMergeCluster(
+        class_name="works_same_isbn", work_ids=[work_a, work_b], titles=["A", "A"], survivor_id=work_b
+    )
+    fresh_comp = WorkMergeComposition(
+        cluster=cluster_b_survivor, survivor_id=work_b, loser_ids=[work_a], delete_work_ids=[work_a]
+    )
+
+    delta = works_merge_delta(reviewed, [fresh_comp])
+
+    assert any(t.startswith("merge_cluster:") for t in delta)
+    assert f"delete_work:{work_a}" in delta  # work_a flipped from survivor to loser
+
+
+def test_works_merge_delta_fresh_subset_of_reviewed_is_empty():
+    """fresh ⊂ reviewed (every reviewed op already applied/vanished by apply time) is fine — no
+    refusal; the shrinkage is ordinary skipped_stale territory at apply time, not a drift."""
+    comp = _composition(with_edition_merge_group=True)
+    reviewed = works_merge_tokens([comp])
+
+    delta = works_merge_delta(reviewed, [])  # everything vanished since review
+
+    assert delta == set()


### PR DESCRIPTION
PR-2 of the works-merge design (`docs/superpowers/specs/2026-07-14-works-merge-tool-design.md`; PR-1 was #143). Builds the gated tool that collapses duplicate Work rows — the known clusters carry live user reading history split across copies.

## What

Extends `etl/dedup_backfill.py` (same module, same proven gate — no parallel tool):

**Detection** (strongest evidence first): `works_same_isbn` (catches the *Beware of Chicken* pair), `works_same_identity` (punctuation-folded title + author-token overlap — catches the *We Are Legion* pair; series guard keeps *Beware of Chicken 2* out, hand-verified across 9 punctuation shapes), `works_detected_duplicates` (#141's feed, deduped as unordered pairs, self-pairs ignored-and-reported), `works_fuzzy_report_only` (Jaccard 0.5 — structurally unreachable by apply, forever). Transitive clusters collapse via union-find; survivor selection is deterministic (justified tropes → newest stamp → editions → UUID).

**Merge composition** (single transaction, per-cluster ordered): edition repoint with format-collision merges; reading history repointed with duplicate read events counted (`dropped_duplicate_reads`) — never silently lost; suggestion repoint honoring active-uniqueness; trope/style link union carrying relevance/justification; contributor union with `malformed_author_candidates` reported; `detected_duplicates` cleanup before work deletion (fail-loud FKs); orphan-author pointer to the existing sweep. Cross-cluster disjointness is proven in a module comment (union-find + FK topology + the detection-edge argument).

**Gate**: 14 distinct op-tagged token types + a `merge_cluster` binding token (survivor flips are drift), DB-target-stamped report, fail-closed parser, apply re-plans fresh and refuses on any addition/op-flip before any write, `skipped_stale` shrinkage, per-op count map. CLI: `--merge-works` dry-run / `--merge-works-apply --yes --report <path>`, mirroring the repair tool exactly.

## Tests

54 unit + 31 db_integration + 30 neighboring gated-suite regressions — **executed against real Postgres, not collected**: Beware-shaped full e2e (split reads across users, both-order detections, exact per-op counts, convergence), drift refusal with full-snapshot equality, fuzzy-through-gate zero-consumption, identity-cluster merge, narrator union through apply, fail-closed parser table, drift-delta table incl. op-flip and survivor-flip, (A,A) crash regression.

Process note: the original apply implementer was orphaned by a process exit; its (sound) code was salvaged, and the review round rebuilt the missing test suite + fixed 3 defects it hadn't reached ((A,A) planner crash, `merge_edition` counter, orphan pointer). Known residual for a follow-up: the orphan-pointer nonzero path is unit/CLI-tested but lacks a real-apply db_integration case.

## Operator sequence after merge (the usual gate)

Deploy → `--merge-works` dry-run against prod → operator reviews the cluster report (expected: Beware pair, We Are Legion pair, *Calling Bullshit*, *Yellowface*; fuzzy section report-only) → approval → `--merge-works-apply` → convergence dry-run → one `--requeue-unenriched` check (the merged-away `9e9cfc45` should vanish from `pending_merge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
