### PR TITLE
fix(etl): works-merge ISBN evidence requires matching titles; report-only edges can't grow applyable clusters

### DIFF
--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -14,6 +14,8 @@
   python scripts/clean_catalog.py --repair-fallbacks-apply --yes --report data/reports/fallback-repair-<ts>.txt
   python scripts/clean_catalog.py --merge-works
   python scripts/clean_catalog.py --merge-works-apply --yes --report data/reports/works-merge-<ts>.txt
+  python scripts/clean_catalog.py --promote-pair WORK_ID_A WORK_ID_B --yes
+  python scripts/clean_catalog.py --promote-pair A1 B1 --promote-pair A2 B2 --yes
 
 Run against LIVE prod via the app container + Cloud SQL proxy. Refuses --apply on sqlite/backup/localhost.
 --dedup-for-constraints --apply re-plans from scratch and cross-checks the fresh plan against
@@ -22,7 +24,11 @@ the reviewed --report (default: newest data/reports/dedup-*.txt) — refuses if 
 no default — GH #70). --merge-works (Spec 2026-07-14 PR-2 part 1) is detection/planning ONLY —
 always a dry-run. --merge-works-apply (PR-2 part 2, H2) executes the merge composition (editions/
 suggestions/trope+style links/contributors/detected_duplicates/Work-row deletion) behind the same
-drift-refusing gate — requires --yes and --report (no default, same as --repair-fallbacks-apply)."""
+drift-refusing gate — requires --yes and --report (no default, same as --repair-fallbacks-apply).
+--promote-pair (H4) is the operator's front door for hand-promoting a duplicate pair the detection
+classes missed (e.g. a works_fuzzy_report_only pair, or one an operator just spots by eye): it
+inserts a source='operator' row into the detected_duplicates feed --merge-works's
+works_detected_duplicates class already reads — repeatable in one invocation, requires --yes."""
 
 from __future__ import annotations
 
@@ -30,6 +36,7 @@ import argparse
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import UUID
 
 from sqlalchemy import func
 
@@ -361,6 +368,61 @@ def _run_merge_works_apply(manager: DatabaseManager, args, url: str, safe: str) 
         return 0
 
 
+def _run_promote_pair(manager: DatabaseManager, args, url: str, safe: str) -> int:
+    """--promote-pair (H4): operator front door into the works-merge detection feed. WRITES one
+    detected_duplicates row per pair (source='operator') — same --yes / is_prod_url guard shape
+    as every other write mode (mirrors --repair-fallbacks-apply exactly), checked BEFORE any
+    UUID parsing so a guard failure never depends on the pair arguments being well-formed.
+
+    UUID parsing is pure string handling done HERE, before any session opens (a malformed token
+    should never touch the DB). Everything DB-touching — the self-pair rejection, the
+    both-ids-exist check, and the ON CONFLICT DO NOTHING insert itself — lives in
+    dedup_backfill.promote_detected_duplicate_pair, the CLI helper function db_integration tests
+    drive directly. All pairs are parsed before the session opens, and a validation failure on
+    ANY pair (self-pair / unknown id) propagates OUT of the `with manager.get_session()` block
+    uncaught, so DatabaseManager.get_session's own except-clause rolls back the whole
+    transaction — a bad pair anywhere in a multi-pair invocation refuses ALL of it, never leaving
+    earlier pairs promoted while a later one silently fails."""
+    print(f"DB target: …@{safe}")
+    if not args.yes:
+        print("\nREFUSING --promote-pair without --yes.")
+        return 2
+    if not is_prod_url(url):
+        print(f"\nREFUSING --promote-pair: '{safe}' is not a live prod DB (sqlite/backup/localhost).")
+        return 2
+
+    parsed_pairs: list[tuple[UUID, UUID]] = []
+    for raw_a, raw_b in args.promote_pair:
+        try:
+            work_id_a = UUID(raw_a)
+        except ValueError:
+            print(f"\nREFUSING --promote-pair: {raw_a!r} is not a valid UUID.")
+            return 1
+        try:
+            work_id_b = UUID(raw_b)
+        except ValueError:
+            print(f"\nREFUSING --promote-pair: {raw_b!r} is not a valid UUID.")
+            return 1
+        parsed_pairs.append((work_id_a, work_id_b))
+
+    try:
+        with manager.get_session() as session:
+            for work_id_a, work_id_b in parsed_pairs:
+                result = dedup_backfill.promote_detected_duplicate_pair(session, work_id_a, work_id_b)
+                status = "already promoted" if result.already_existed else "promoted"
+                print(f"{status}: {result.title_a} {result.work_id_a} + {result.title_b} {result.work_id_b}")
+    except ValueError as exc:
+        # dedup_backfill.promote_detected_duplicate_pair's self-pair ValueError and
+        # UnknownWorkIdsError (a ValueError subclass) both land here — the session block above
+        # has already been unwound (rolled back) by DatabaseManager.get_session's except-clause
+        # by the time this runs.
+        print(f"\nREFUSING --promote-pair: {exc}")
+        return 1
+
+    print("\nre-run --merge-works for a fresh gated report.")
+    return 0
+
+
 def _run_repair_fallbacks_apply(manager: DatabaseManager, args, url: str, safe: str) -> int:
     """--repair-fallbacks-apply: guards first (no session needed for those), THEN warms in its
     own short session, THEN opens the work session that re-plans fresh and applies — see
@@ -520,6 +582,25 @@ def main(argv: list[str] | None = None) -> int:
             "its reviewed report explicitly)."
         ),
     )
+    ap.add_argument(
+        "--promote-pair",
+        action="append",
+        nargs=2,
+        metavar=("WORK_ID_A", "WORK_ID_B"),
+        default=None,
+        help=(
+            "H4: operator promotion of a hand-picked duplicate work pair into the works-merge "
+            "detection feed (writes a source='operator' row into detected_duplicates — the same "
+            "feed --merge-works's works_detected_duplicates class reads). Repeatable: pass "
+            "--promote-pair twice for two pairs in one invocation. Each pair is validated (both "
+            "ids must be well-formed UUIDs, distinct, and name existing works) before anything is "
+            "written; a bad pair anywhere refuses the WHOLE invocation. Idempotent — re-running "
+            "the same pair is a no-op (ON CONFLICT DO NOTHING), so it is safe to re-run. Requires "
+            "--yes and a live prod DB (same is_prod_url guard as every other write mode). After "
+            "promoting, re-run --merge-works for a fresh gated report — the pair only becomes "
+            "applyable on the NEXT dry-run/apply cycle, never in this same invocation."
+        ),
+    )
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--apply", action="store_true")
     ap.add_argument("--yes", action="store_true", help="required confirmation for --apply")
@@ -554,6 +635,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_merge_works(manager, safe)
     if args.merge_works_apply:
         return _run_merge_works_apply(manager, args, url, safe)
+    if args.promote_pair:
+        return _run_promote_pair(manager, args, url, safe)
 
     with manager.get_session() as session:
         print(f"DB target: …@{safe}")
@@ -745,7 +828,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             "Nothing to do. Pass --inventory, --contributors, --prune-fallbacks, --tropes, "
             "--requeue-unenriched, --dedup-for-constraints, --repair-fallbacks, "
-            "--repair-fallbacks-apply, --merge-works, or --merge-works-apply."
+            "--repair-fallbacks-apply, --merge-works, --merge-works-apply, or --promote-pair."
         )
         return 1
 

--- a/scripts/clean_catalog.py
+++ b/scripts/clean_catalog.py
@@ -284,6 +284,7 @@ def _run_merge_works(manager: DatabaseManager, safe: str) -> int:
                 print(f"  cluster {cluster.work_ids}  survivor={cluster.survivor_id}  titles={cluster.titles}")
 
         _print_clusters("works_same_isbn", clusters.same_isbn, never_applied=False)
+        _print_clusters("works_same_isbn_title_mismatch", clusters.same_isbn_title_mismatch, never_applied=True)
         _print_clusters("works_same_identity", clusters.same_identity, never_applied=False)
         _print_clusters("works_detected_duplicates", clusters.detected_duplicates, never_applied=False)
         _print_clusters("works_fuzzy_report_only", clusters.fuzzy_report_only, never_applied=True)
@@ -472,11 +473,16 @@ def main(argv: list[str] | None = None) -> int:
         "--merge-works",
         action="store_true",
         help=(
-            "Spec 2026-07-14 PR-2: DETECTION + COMPOSITION PLANNING for the works-merge tool — "
-            "always a dry-run, this flag never applies. Prints the four detection classes "
-            "(strongest evidence first): works_same_isbn, works_same_identity, "
+            "Spec 2026-07-14 PR-2 (hardened 2026-07-15 after a prod dry-run caught two "
+            "amplifiers): DETECTION + COMPOSITION PLANNING for the works-merge tool — always a "
+            "dry-run, this flag never applies. Prints the detection classes (strongest evidence "
+            "first): works_same_isbn (now requires folded-title agreement within an ISBN group — "
+            "shared ISBN alone is not applyable evidence, this catalog has ISBN pollution), "
+            "works_same_isbn_title_mismatch (an ISBN-sharing pair whose titles DISAGREE — report "
+            "only, e.g. a sequel carrying its predecessor's ISBN), works_same_identity, "
             "works_detected_duplicates (the #141/#143 feed), and works_fuzzy_report_only "
-            "(NEVER applied by design — operator promotes pairs by hand). Each cluster shows "
+            "(NEVER applied by design — operator promotes pairs by hand). Report-only classes "
+            "each cluster independently and can never grow an applyable cluster. Each cluster shows "
             "its deterministic survivor pick (most justified trope links -> newest "
             "deep_enriched_at -> most editions -> lowest UUID), plus the per-cluster merge "
             "composition (editions/suggestions/trope+style links/contributors/detected_"
@@ -496,9 +502,9 @@ def main(argv: list[str] | None = None) -> int:
             "same ids counts) — see etl/dedup_backfill.py's apply_works_merge. Requires --yes "
             "and --report (no default, same as --repair-fallbacks-apply — a distinct "
             "destructive operation that deletes Work rows carrying live user reading history; "
-            "must name its reviewed report explicitly). works_fuzzy_report_only clusters are "
-            "structurally unreachable by this gate — they are never part of the applyable "
-            "composition, by construction, not by a runtime check."
+            "must name its reviewed report explicitly). works_same_isbn_title_mismatch and "
+            "works_fuzzy_report_only clusters are structurally unreachable by this gate — they "
+            "are never part of the applyable composition, by construction, not by a runtime check."
         ),
     )
     ap.add_argument(

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -1116,7 +1116,11 @@ def _classify_isbn_group_pairs(
     mismatch: list[tuple[UUID, UUID]] = []
     for i, wa in enumerate(ordered):
         for wb in ordered[i + 1 :]:
-            if fold_by_work.get(wa) == fold_by_work.get(wb):
+            # Direct indexing on purpose (Gemini review, #146): callers guarantee every id is
+            # in fold_by_work (unknown ids are dropped at the edition scan). A .get() here
+            # once let two UNTRACKED ids match None == None into an APPLYABLE pair — the
+            # wrong failure direction for a destructive tool; a KeyError is the honest one.
+            if fold_by_work[wa] == fold_by_work[wb]:
                 applyable.append((wa, wb))
             else:
                 mismatch.append((wa, wb))
@@ -1140,7 +1144,12 @@ def _detect_same_isbn_pairs(
     rows = session.query(Edition.work_id, Edition.isbn_13).filter(Edition.isbn_13.isnot(None)).all()
     groups: dict[str, set[UUID]] = defaultdict(set)
     for work_id, isbn in rows:
-        groups[isbn].add(work_id)
+        # Gemini review (#146): a work created between the caller's works scan and this
+        # edition scan has no fold/stats entry — skip it (next plan run sees it) instead of
+        # letting unknown ids match None == None into an applyable pair or KeyError at
+        # cluster build.
+        if work_id in fold_by_work:
+            groups[isbn].add(work_id)
     applyable: list[tuple[UUID, UUID]] = []
     mismatch: list[tuple[UUID, UUID]] = []
     for work_ids in groups.values():

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -723,30 +723,54 @@ def _plan_duplicate_works(session: Session) -> list[WorkDupReport]:
 # lives in the SAME FILE (per the design spec: "extend etl/dedup_backfill.py... do NOT build a
 # parallel tool") but does not thread through the constraint-gate's plan/apply machinery.
 #
-# Four detection classes, evidence-strongest first — each produces UNORDERED work-pair
-# groupings (a work id pair is a 2-tuple but is always compared/deduped as a frozenset so
-# (A, B) and (B, A) collapse to the same pair):
-#   1. works_same_isbn        — works sharing a non-null editions.isbn_13.
-#   2. works_same_identity    — fold(title) equal AND author-token overlap >= 1 full token,
-#                                with the series guard blocking sequel titles from matching.
-#   3. works_detected_duplicates — rows from the #141/#143 detected_duplicates feed, deduped as
-#                                unordered pairs (the table's composite PK is (work_id_a,
-#                                work_id_b), NOT order-normalized — both rows of one cluster can
-#                                exist; see DetectedDuplicate's docstring in db/models.py).
-#   4. works_fuzzy_report_only — token-set similarity on folded titles above a threshold, minus
-#                                pairs already caught by a stronger class above. REPORT ONLY
+# Detection classes, evidence-strongest first — each produces UNORDERED work-pair groupings (a
+# work id pair is a 2-tuple but is always compared/deduped as a frozenset so (A, B) and (B, A)
+# collapse to the same pair). THREE are applyable; TWO are report-only forever:
+#   1. works_same_isbn        — APPLYABLE. Two works sharing a non-null editions.isbn_13 AND
+#                                agreeing folded titles (fold(title_a) == fold(title_b)). A prod
+#                                dry-run (2026-07-15) found isbn_13 pollution in this catalog:
+#                                distinct books share an ISBN (chained 14 different novels into
+#                                one bogus cluster) and a sequel can carry its predecessor's ISBN
+#                                (Beware of Chicken 2 sharing book 1's ISBN) — "shared ISBN" alone
+#                                is no longer strong enough evidence to apply on its own.
+#   1b. works_same_isbn_title_mismatch — REPORT ONLY. The other half of an ISBN group: two works
+#                                sharing an ISBN whose folded titles DISAGREE. Never promoted to
+#                                applyable by this tool — operator triage only (a real typo pair
+#                                like 'Exit Stategy'/'Exit Strategy' the operator can promote by
+#                                hand, vs. the pollution/sequel shapes above that must never
+#                                merge). Structurally separate field, same treatment as fuzzy.
+#   2. works_same_identity    — APPLYABLE. fold(title) equal AND author-token overlap >= 1 full
+#                                token, with the series guard blocking sequel titles from matching.
+#   3. works_detected_duplicates — APPLYABLE. Rows from the #141/#143 detected_duplicates feed,
+#                                deduped as unordered pairs (the table's composite PK is
+#                                (work_id_a, work_id_b), NOT order-normalized — both rows of one
+#                                cluster can exist; see DetectedDuplicate's docstring in
+#                                db/models.py).
+#   4. works_fuzzy_report_only — REPORT ONLY. Token-set similarity on folded titles above a
+#                                threshold, minus pairs already caught by a stronger class above
+#                                (now including works_same_isbn_title_mismatch — a differing-title
+#                                ISBN pair should not ALSO show up as a fuzzy pair). REPORT ONLY
 #                                FOREVER: never promoted to an applyable class by this tool (the
-#                                design spec: "operator promotes pairs by hand if real"). Marked
-#                                structurally via WorksMergeClusters.fuzzy_report_only being a
-#                                SEPARATE field from the three applyable-shape lists, exactly the
-#                                way duplicate_works_report_only is a separate field on DedupPlan
-#                                — H2's future apply step can only reach the applyable fields.
+#                                design spec: "operator promotes pairs by hand if real").
 #
-# A pair that matches more than one class is reported ONCE, in its single strongest class
-# (works_same_isbn > works_same_identity > works_detected_duplicates > works_fuzzy_report_only).
-# Pairs are then unioned into transitive clusters (A~B, B~C -> one {A, B, C} cluster) via a
-# simple union-find; a cluster's reported class is the STRONGEST class of any edge that built
-# it, so a cluster with even one same_isbn edge is never fuzzy-report-only.
+# A pair that matches more than one class is reported ONCE, in its single strongest class,
+# ranked ONLY among the three applyable classes (works_same_isbn > works_same_identity >
+# works_detected_duplicates). Applyable pairs are unioned into transitive clusters (A~B, B~C ->
+# one {A, B, C} cluster) via ONE union-find over just those three classes; a cluster's reported
+# class is the STRONGEST applyable class of any edge that built it.
+#
+# CONTRACT REVERSAL (2026-07-15, the same prod dry-run): report-only classes
+# (works_same_isbn_title_mismatch, works_fuzzy_report_only) are NEVER part of that union-find —
+# each clusters in its OWN INDEPENDENT union-find, entirely separate from the applyable one and
+# from each other. The old contract ("a fuzzy-only edge pulled into a same_isbn cluster is
+# reported under same_isbn") is REVERSED: a report-only edge can never grow, shrink, or relabel
+# an applyable cluster — it is structurally incapable of adding a work to an applyable merge, not
+# just excluded by convention. (Previously, ONE union-find ran over every class's pairs together,
+# so a single report-only edge touching an applyable cluster silently added its other endpoint to
+# that applyable merge — the exact amplification the prod dry-run caught.) A report-only pair
+# whose both endpoints already sit together in one applyable cluster is dropped entirely (nothing
+# left to triage, it's merging anyway); a pair spanning two different applyable clusters, or
+# reaching a work outside any applyable cluster, is kept for operator-facing display.
 # --------------------------------------------------------------------------------------------
 
 _SERIES_TOKEN_WORDS = {"book", "volume", "vol", "part", "no"}
@@ -875,6 +899,7 @@ class WorksMergeCluster:
     it, and the per-work stats used for that selection (so the report/CLI can show its work)."""
 
     class_name: str  # one of "works_same_isbn" / "works_same_identity" / "works_detected_duplicates"
+    # (applyable) / "works_same_isbn_title_mismatch" / "works_fuzzy_report_only" (report only)
     work_ids: list[UUID]
     titles: list[str]
     survivor_id: UUID
@@ -883,14 +908,20 @@ class WorksMergeCluster:
 
 @dataclass
 class WorksMergeClusters:
-    """The four detection classes' output, evidence-strongest first. Only the first three are
-    ever eligible for a future apply step; fuzzy_report_only is a STRUCTURALLY separate field
-    (never merged into the other three, never given an apply-shaped dataclass) so a future
-    apply_works_merge (H2) cannot reach it by construction, not just by convention."""
+    """The detection classes' output, evidence-strongest first. Only same_isbn / same_identity /
+    detected_duplicates are ever eligible for a future apply step; same_isbn_title_mismatch and
+    fuzzy_report_only are STRUCTURALLY separate fields (never merged into the applyable three,
+    never given an apply-shaped dataclass, and — since the 2026-07-15 hardening — clustered in
+    their OWN independent union-finds rather than sharing the applyable one) so apply_works_merge
+    cannot reach them by construction, not just by convention, and a report-only edge can never
+    grow an applyable cluster."""
 
     same_isbn: list[WorksMergeCluster] = field(default_factory=list)
     same_identity: list[WorksMergeCluster] = field(default_factory=list)
     detected_duplicates: list[WorksMergeCluster] = field(default_factory=list)
+    # REPORT ONLY (2026-07-15 hardening): an ISBN group whose members' folded titles disagree —
+    # shared-ISBN pollution or a sequel carrying its predecessor's ISBN, never applyable.
+    same_isbn_title_mismatch: list[WorksMergeCluster] = field(default_factory=list)
     fuzzy_report_only: list[WorksMergeCluster] = field(default_factory=list)
     # Self-referential detected_duplicates feed rows (work_id_a == work_id_b) skipped at
     # ingestion — see _dedupe_detected_duplicate_rows. Surfaced here (not just logged) so a bad
@@ -900,6 +931,7 @@ class WorksMergeClusters:
     def summary(self) -> dict[str, int]:
         return {
             "works_same_isbn": len(self.same_isbn),
+            "works_same_isbn_title_mismatch": len(self.same_isbn_title_mismatch),
             "works_same_identity": len(self.same_identity),
             "works_detected_duplicates": len(self.detected_duplicates),
             "works_fuzzy_report_only": len(self.fuzzy_report_only),
@@ -907,13 +939,25 @@ class WorksMergeClusters:
         }
 
 
-# Class strength order, strongest first — index is used as the precedence rank (lower wins).
-_WORKS_MERGE_CLASS_ORDER = (
+# Applyable class strength order, strongest first — index is used as the precedence rank (lower
+# wins) among the THREE classes eligible for a future apply step. Report-only classes are never
+# ranked here (see _REPORT_ONLY_CLASSES) — each clusters independently, never joining this order.
+_APPLYABLE_CLASS_ORDER = (
     "works_same_isbn",
     "works_same_identity",
     "works_detected_duplicates",
+)
+
+# Report-only classes, each clustered in its own independent union-find (see
+# plan_works_merge_clusters) — never ranked against each other or against _APPLYABLE_CLASS_ORDER.
+_REPORT_ONLY_CLASSES = (
+    "works_same_isbn_title_mismatch",
     "works_fuzzy_report_only",
 )
+
+# Display ordering only (e.g. a future report iterating "every class in evidence-strength order")
+# — NOT used for precedence ranking; see _APPLYABLE_CLASS_ORDER for that.
+_WORKS_MERGE_CLASS_ORDER = _APPLYABLE_CLASS_ORDER + _REPORT_ONLY_CLASSES
 
 
 class _UnionFind:
@@ -937,6 +981,19 @@ class _UnionFind:
             self._parent[ra] = rb
 
 
+def _build_cluster(class_name: str, members: set[UUID], stats_by_work: dict[UUID, WorkStats]) -> WorksMergeCluster:
+    ordered = sorted(members, key=str)
+    candidates = [stats_by_work[wid] for wid in ordered]
+    survivor = pick_survivor(candidates)
+    return WorksMergeCluster(
+        class_name=class_name,
+        work_ids=ordered,
+        titles=[stats_by_work[wid].title for wid in ordered],
+        survivor_id=survivor.work_id,
+        stats_by_work={wid: stats_by_work[wid] for wid in ordered},
+    )
+
+
 def plan_works_merge_clusters(
     *,
     same_isbn_pairs: list[tuple[UUID, UUID]],
@@ -944,27 +1001,35 @@ def plan_works_merge_clusters(
     detected_duplicate_pairs: list[tuple[UUID, UUID]],
     fuzzy_pairs: list[tuple[UUID, UUID]],
     stats_by_work: dict[UUID, WorkStats],
+    same_isbn_mismatch_pairs: list[tuple[UUID, UUID]] = (),
 ) -> WorksMergeClusters:
     """Pure composition core (no DB access): given each class's already-detected pairs (as
     plain (id, id) 2-tuples — order does not matter, they are deduped as unordered pairs
     below), resolve cross-class overlap (a pair appears once, in its strongest class), collapse
     transitive clusters via union-find, and pick each cluster's survivor.
 
-    A cluster's reported class is the STRONGEST class of any edge that built it (see the
-    module-level comment above this section) — this is what makes
-    test_transitive_cluster_takes_the_strongest_class_of_any_edge pass: a fuzzy-only edge that
-    gets pulled into a same_isbn cluster is reported under same_isbn, not fuzzy."""
-    pairs_by_class: dict[str, list[frozenset]] = {
+    Two SEPARATE union-finds, per the 2026-07-15 hardening (see the module-level comment above
+    this section for the prod-dry-run contract reversal this fixes):
+
+    1. APPLYABLE union-find over ONLY same_isbn_pairs + same_identity_pairs +
+       detected_duplicate_pairs. A cluster's reported class is the STRONGEST of these three
+       classes among the edges that built it — this is what
+       test_fuzzy_edge_contagion_regression pins: a fuzzy-only edge touching an applyable
+       cluster can never add its other endpoint to that applyable cluster.
+    2. REPORT-ONLY clustering: same_isbn_mismatch_pairs and fuzzy_pairs each get their OWN
+       independent union-find (never each other's, never the applyable one). A report-only pair
+       whose both endpoints already sit together in one applyable cluster is dropped (nothing
+       left to triage — it's merging anyway); any other report-only pair is kept for display."""
+    applyable_pairs_by_class: dict[str, list[frozenset]] = {
         "works_same_isbn": [frozenset(p) for p in same_isbn_pairs],
         "works_same_identity": [frozenset(p) for p in same_identity_pairs],
         "works_detected_duplicates": [frozenset(p) for p in detected_duplicate_pairs],
-        "works_fuzzy_report_only": [frozenset(p) for p in fuzzy_pairs],
     }
 
-    # Cross-class precedence: a pair keeps only its strongest class's edge.
+    # Cross-class precedence (applyable classes only): a pair keeps only its strongest class's edge.
     best_class_for_pair: dict[frozenset, str] = {}
-    for class_name in _WORKS_MERGE_CLASS_ORDER:
-        for pair in pairs_by_class[class_name]:
+    for class_name in _APPLYABLE_CLASS_ORDER:
+        for pair in applyable_pairs_by_class[class_name]:
             if pair not in best_class_for_pair:
                 best_class_for_pair[pair] = class_name
 
@@ -974,14 +1039,14 @@ def plan_works_merge_clusters(
         uf.union(a, b)
 
     # Group surviving (deduped, precedence-resolved) pair edges by their cluster root, and
-    # track the strongest class among the edges that built each cluster.
+    # track the strongest applyable class among the edges that built each cluster.
     cluster_root_class_rank: dict[UUID, int] = {}
     cluster_members: dict[UUID, set[UUID]] = defaultdict(set)
     for pair, class_name in best_class_for_pair.items():
         a, b = tuple(pair)
         root = uf.find(a)
         cluster_members[root].update((a, b))
-        rank = _WORKS_MERGE_CLASS_ORDER.index(class_name)
+        rank = _APPLYABLE_CLASS_ORDER.index(class_name)
         cluster_root_class_rank[root] = min(rank, cluster_root_class_rank.get(root, rank))
 
     out = WorksMergeClusters()
@@ -989,41 +1054,101 @@ def plan_works_merge_clusters(
         "works_same_isbn": out.same_isbn,
         "works_same_identity": out.same_identity,
         "works_detected_duplicates": out.detected_duplicates,
-        "works_fuzzy_report_only": out.fuzzy_report_only,
     }
+    # applyable_root_by_work: which applyable cluster (by root id) each work currently sits in,
+    # used below to drop report-only pairs that are entirely subsumed by one applyable cluster.
+    applyable_root_by_work: dict[UUID, UUID] = {}
     # Deterministic ordering: iterate roots sorted by string so plan output (and therefore any
     # future report/token emission) is stable across re-plans of unchanged data.
     for root in sorted(cluster_members, key=str):
         members = cluster_members[root]
-        class_name = _WORKS_MERGE_CLASS_ORDER[cluster_root_class_rank[root]]
-        candidates = [stats_by_work[wid] for wid in members]
-        survivor = pick_survivor(candidates)
-        cluster = WorksMergeCluster(
-            class_name=class_name,
-            work_ids=sorted(members, key=str),
-            titles=[stats_by_work[wid].title for wid in sorted(members, key=str)],
-            survivor_id=survivor.work_id,
-            stats_by_work={wid: stats_by_work[wid] for wid in members},
-        )
+        class_name = _APPLYABLE_CLASS_ORDER[cluster_root_class_rank[root]]
+        cluster = _build_cluster(class_name, members, stats_by_work)
         dest_by_class_name[class_name].append(cluster)
+        for wid in members:
+            applyable_root_by_work[wid] = root
+
+    def _cluster_report_only(class_name: str, pairs: list[tuple[UUID, UUID]]) -> list[WorksMergeCluster]:
+        """Independent union-find for ONE report-only class — never shares a union-find with any
+        other class, applyable or report-only (see this function's docstring)."""
+        uf_report = _UnionFind()
+        kept_pairs: set[frozenset] = set()
+        for a, b in pairs:
+            pair = frozenset((a, b))
+            if pair in kept_pairs:
+                continue
+            root_a = applyable_root_by_work.get(a)
+            root_b = applyable_root_by_work.get(b)
+            if root_a is not None and root_a == root_b:
+                continue  # both endpoints already merging in the SAME applyable cluster
+            kept_pairs.add(pair)
+            uf_report.union(a, b)
+
+        members_by_root: dict[UUID, set[UUID]] = defaultdict(set)
+        for pair in kept_pairs:
+            a, b = tuple(pair)
+            root = uf_report.find(a)
+            members_by_root[root].update((a, b))
+
+        return [
+            _build_cluster(class_name, members_by_root[root], stats_by_work)
+            for root in sorted(members_by_root, key=str)
+        ]
+
+    out.same_isbn_title_mismatch = _cluster_report_only("works_same_isbn_title_mismatch", same_isbn_mismatch_pairs)
+    out.fuzzy_report_only = _cluster_report_only("works_fuzzy_report_only", fuzzy_pairs)
     return out
 
 
-def _detect_same_isbn_pairs(session: Session) -> list[tuple[UUID, UUID]]:
-    """works_same_isbn: two+ works sharing a non-null editions.isbn_13. Column-explicit (no
-    Work entity load) — matches the house convention elsewhere in this module, though this
-    query does not touch deep_enriched_at itself (the caller gathers WorkStats separately)."""
+def _classify_isbn_group_pairs(
+    work_ids: list[UUID], fold_by_work: dict[UUID, str]
+) -> tuple[list[tuple[UUID, UUID]], list[tuple[UUID, UUID]]]:
+    """Pure (no session): given ONE ISBN group's work ids, classify every pairwise combination
+    (full O(n^2) — groups are tiny in practice, see the module comment's Fix-1 note) by folded-
+    title agreement into (applyable_pairs, mismatch_pairs). Star-pairing (only ordered[0] vs the
+    rest) is NOT enough here even though the union-find would still transitively close the
+    applyable side: the mismatch side needs every member compared against every OTHER member so
+    a mismatching outlier (e.g. a sequel carrying its predecessor's ISBN) is visible against
+    every equal-fold member it was grouped with, not just the group's first id."""
+    ordered = sorted(work_ids, key=str)
+    applyable: list[tuple[UUID, UUID]] = []
+    mismatch: list[tuple[UUID, UUID]] = []
+    for i, wa in enumerate(ordered):
+        for wb in ordered[i + 1 :]:
+            if fold_by_work.get(wa) == fold_by_work.get(wb):
+                applyable.append((wa, wb))
+            else:
+                mismatch.append((wa, wb))
+    return applyable, mismatch
+
+
+def _detect_same_isbn_pairs(
+    session: Session, fold_by_work: dict[UUID, str]
+) -> tuple[list[tuple[UUID, UUID]], list[tuple[UUID, UUID]]]:
+    """works_same_isbn (+ its report-only sibling works_same_isbn_title_mismatch): two+ works
+    sharing a non-null editions.isbn_13. Column-explicit (no Work entity load) — matches the
+    house convention elsewhere in this module, though this query does not touch
+    deep_enriched_at itself (the caller gathers WorkStats separately).
+
+    2026-07-15 hardening: shared ISBN alone is no longer applyable evidence — this prod catalog
+    has ISBN pollution (distinct books sharing an isbn_13, a sequel carrying its predecessor's)
+    that chained 14 unrelated books into one bogus applyable cluster in a real dry-run. A pair
+    is applyable ONLY if its members' folded titles also agree; otherwise it is reported under
+    works_same_isbn_title_mismatch (operator triage only, never applied by this tool). Returns
+    (applyable_pairs, mismatch_pairs)."""
     rows = session.query(Edition.work_id, Edition.isbn_13).filter(Edition.isbn_13.isnot(None)).all()
     groups: dict[str, set[UUID]] = defaultdict(set)
     for work_id, isbn in rows:
         groups[isbn].add(work_id)
-    pairs: list[tuple[UUID, UUID]] = []
+    applyable: list[tuple[UUID, UUID]] = []
+    mismatch: list[tuple[UUID, UUID]] = []
     for work_ids in groups.values():
         if len(work_ids) < 2:
             continue
-        ordered = sorted(work_ids, key=str)
-        pairs.extend((ordered[0], wid) for wid in ordered[1:])
-    return pairs
+        group_applyable, group_mismatch = _classify_isbn_group_pairs(list(work_ids), fold_by_work)
+        applyable.extend(group_applyable)
+        mismatch.extend(group_mismatch)
+    return applyable, mismatch
 
 
 def _author_tokens(name: str) -> set[str]:
@@ -1163,8 +1288,9 @@ def plan_works_merge(session: Session) -> WorksMergeClusters:
     this plan's clusters."""
     stats_by_work = _gather_work_stats(session)
     title_by_work = {wid: s.title for wid, s in stats_by_work.items()}
+    fold_by_work = {wid: _fold(title) for wid, title in title_by_work.items()}
 
-    same_isbn_pairs = _detect_same_isbn_pairs(session)
+    same_isbn_pairs, same_isbn_mismatch_pairs = _detect_same_isbn_pairs(session, fold_by_work)
     same_identity_pairs = [
         (a, b)
         for a, b in _detect_same_identity_pairs(session)
@@ -1172,11 +1298,18 @@ def plan_works_merge(session: Session) -> WorksMergeClusters:
     ]
     detected_duplicate_pairs, ignored_self_detections = _detect_detected_duplicate_pairs(session)
 
-    already_paired = {frozenset(p) for p in same_isbn_pairs + same_identity_pairs + detected_duplicate_pairs}
+    # already_paired also includes same_isbn_mismatch_pairs (Fix 2's note): a differing-title
+    # ISBN pair is already visible under works_same_isbn_title_mismatch and should not ALSO show
+    # up as a fuzzy pair.
+    already_paired = {
+        frozenset(p)
+        for p in same_isbn_pairs + same_isbn_mismatch_pairs + same_identity_pairs + detected_duplicate_pairs
+    }
     fuzzy_pairs = _detect_fuzzy_pairs(title_by_work, already_paired)
 
     clusters = plan_works_merge_clusters(
         same_isbn_pairs=same_isbn_pairs,
+        same_isbn_mismatch_pairs=same_isbn_mismatch_pairs,
         same_identity_pairs=same_identity_pairs,
         detected_duplicate_pairs=detected_duplicate_pairs,
         fuzzy_pairs=fuzzy_pairs,
@@ -1192,9 +1325,9 @@ def render_works_merge_report(clusters: WorksMergeClusters, *, db_target: str | 
     write_report): a summary block, then per-class cluster sections showing every work id +
     title in the cluster and which one was picked as survivor. No machine-readable token block
     here — plan_id_set-shaped token emission is H2's job (the apply step doesn't exist yet), so
-    there is nothing to gate against drift yet. fuzzy_report_only is called out explicitly as
-    NEVER APPLIED so an operator reading a persisted copy of this text (not just the live CLI
-    output) sees the same warning."""
+    there is nothing to gate against drift yet. same_isbn_title_mismatch and fuzzy_report_only
+    are both called out explicitly as NEVER APPLIED so an operator reading a persisted copy of
+    this text (not just the live CLI output) sees the same warning."""
     lines: list[str] = ["Works-merge plan report", "=" * 60, ""]
     if db_target is not None:
         lines.append(f"db target: {db_target}")
@@ -1223,6 +1356,7 @@ def render_works_merge_report(clusters: WorksMergeClusters, *, db_target: str | 
         lines.append("")
 
     _render_section("works_same_isbn", clusters.same_isbn, never_applied=False)
+    _render_section("works_same_isbn_title_mismatch", clusters.same_isbn_title_mismatch, never_applied=True)
     _render_section("works_same_identity", clusters.same_identity, never_applied=False)
     _render_section("works_detected_duplicates", clusters.detected_duplicates, never_applied=False)
     _render_section("works_fuzzy_report_only", clusters.fuzzy_report_only, never_applied=True)
@@ -1832,11 +1966,12 @@ def compose_cluster_merge(session: Session, cluster: WorksMergeCluster) -> WorkM
 def applyable_works_merge_clusters(clusters: WorksMergeClusters) -> list[WorksMergeCluster]:
     """The ONLY clusters compose_cluster_merge/apply_works_merge ever iterate — same_isbn,
     same_identity, detected_duplicates, in that (evidence-strongest-first) order.
-    fuzzy_report_only is NEVER included: this is the single choke point that keeps the fuzzy
-    class structurally unreachable by apply (see the module comment above compose_cluster_merge)
-    — every caller (plan_works_merge_apply, apply_works_merge, the token/report functions below)
-    goes through this function rather than reading WorksMergeClusters' fields directly, so
-    "never apply fuzzy" is enforced in exactly one place."""
+    same_isbn_title_mismatch and fuzzy_report_only are NEVER included: this is the single choke
+    point that keeps both report-only classes structurally unreachable by apply (see the module
+    comment above compose_cluster_merge) — every caller (plan_works_merge_apply,
+    apply_works_merge, the token/report functions below) goes through this function rather than
+    reading WorksMergeClusters' fields directly, so "never apply report-only" is enforced in
+    exactly one place."""
     return [*clusters.same_isbn, *clusters.same_identity, *clusters.detected_duplicates]
 
 

--- a/src/agentic_librarian/etl/dedup_backfill.py
+++ b/src/agentic_librarian/etl/dedup_backfill.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from uuid import UUID
 
 from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from agentic_librarian.db.models import (
@@ -2445,3 +2446,69 @@ def apply_works_merge(session: Session, reviewed_report_path: Path) -> dict[str,
             result["orphaned_authors_pointer"] += 1
 
     return result
+
+
+# --------------------------------------------------------------------------------------------
+# --promote-pair (H4): operator promotion of a hand-picked duplicate pair into the
+# detected_duplicates feed. This is the ONLY way a works_fuzzy_report_only pair (or any pair the
+# operator spots by eye, never surfaced by any detection class) becomes applyable — by writing a
+# source='operator' row into the SAME feed the #141/#143 deep-pass redirect writes into, so
+# plan_works_merge's existing works_detected_duplicates class picks it up on the next
+# --merge-works dry-run with zero new planner logic. Mirrors two_phase.enrich_deep's ON CONFLICT
+# DO NOTHING insert shape exactly (see test_detected_duplicates_upsert.py) — a re-run of the same
+# ordered pair is a no-op, not a duplicate row.
+# --------------------------------------------------------------------------------------------
+
+
+class UnknownWorkIdsError(ValueError):
+    """Raised by promote_detected_duplicate_pair when one or both work ids don't exist."""
+
+    def __init__(self, missing_ids: list[UUID]):
+        self.missing_ids = missing_ids
+        joined = ", ".join(str(i) for i in missing_ids)
+        super().__init__(f"unknown work id(s): {joined}")
+
+
+@dataclass
+class PromoteDuplicatePairResult:
+    work_id_a: UUID
+    work_id_b: UUID
+    title_a: str
+    title_b: str
+    already_existed: bool  # True when the (work_id_a, work_id_b) row was already present
+
+
+def promote_detected_duplicate_pair(session: Session, work_id_a: UUID, work_id_b: UUID) -> PromoteDuplicatePairResult:
+    """The CLI helper function scripts/clean_catalog.py's --promote-pair mode calls per pair
+    (after UUID parsing, which is pure string handling done by the caller before any session is
+    open). Owns every DB-touching guard: rejects a self-pair (a work is never its own duplicate —
+    the SAME structural rule _dedupe_detected_duplicate_rows already enforces on the read side),
+    verifies BOTH work ids exist (raises UnknownWorkIdsError naming exactly which one(s) don't —
+    never a bare 'not found'), then inserts a source='operator' detected_duplicates row with the
+    same ON CONFLICT DO NOTHING shape two_phase.enrich_deep's redirect insert uses (conflict
+    target = the composite PK), so re-running the exact same ordered pair is idempotent — no
+    second row, no error. already_existed is determined by a pre-insert session.get check (not by
+    trusting driver-specific rowcount semantics), so it's stable across DB-API drivers."""
+    if work_id_a == work_id_b:
+        raise ValueError(f"cannot promote {work_id_a} as a duplicate of itself")
+
+    found = dict(session.query(Work.id, Work.title).filter(Work.id.in_([work_id_a, work_id_b])).all())
+    missing = [wid for wid in (work_id_a, work_id_b) if wid not in found]
+    if missing:
+        raise UnknownWorkIdsError(missing)
+
+    already_existed = session.get(DetectedDuplicate, {"work_id_a": work_id_a, "work_id_b": work_id_b}) is not None
+    session.execute(
+        pg_insert(DetectedDuplicate)
+        .values(work_id_a=work_id_a, work_id_b=work_id_b, source="operator")
+        .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
+    )
+    session.flush()
+
+    return PromoteDuplicatePairResult(
+        work_id_a=work_id_a,
+        work_id_b=work_id_b,
+        title_a=found[work_id_a],
+        title_b=found[work_id_b],
+        already_existed=already_existed,
+    )

--- a/test/integration/test_works_merge.py
+++ b/test/integration/test_works_merge.py
@@ -309,3 +309,87 @@ def test_render_works_merge_report_never_applied_marker_present(db_url):
         assert "works_fuzzy_report_only" in report
         assert "NEVER APPLIED" in report
         assert "localhost/test" in report
+
+
+# --------------------------------------------------------------------------------------------
+# --promote-pair (H4): db_integration coverage for the CLI helper function
+# dedup_backfill.promote_detected_duplicate_pair — driven directly (not through the CLI/argparse
+# layer, which is covered by test/unit/test_clean_catalog_promote_pair_cli.py with the seam
+# mocked). Two titles chosen deliberately unrelated (no shared ISBN, no author overlap, no
+# fold-equal/fuzzy title match) so the ONLY way this pair could ever land in a plan is via the
+# operator promotion itself — proving the feed integration, not some other class accidentally
+# catching the same pair.
+# --------------------------------------------------------------------------------------------
+
+
+def test_promote_pair_lands_as_applyable_detected_duplicates_cluster(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w1 = _work("Calling Bullshit")
+        w2 = _work("The Tao of Pooh", deep_enriched_at=datetime(2026, 7, 1, tzinfo=UTC))
+        session.add_all([w1, w2])
+        session.flush()
+
+        # Sanity: unrelated titles never cluster on their own.
+        assert db_.plan_works_merge(session).summary()["works_detected_duplicates"] == 0
+
+        result = db_.promote_detected_duplicate_pair(session, w1.id, w2.id)
+        assert result.already_existed is False
+        assert result.title_a == "Calling Bullshit"
+        assert result.title_b == "The Tao of Pooh"
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_detected_duplicates"] == 1
+        cluster = clusters.detected_duplicates[0]
+        assert set(cluster.work_ids) == {w1.id, w2.id}
+        assert cluster.survivor_id == w2.id  # more-enriched work wins
+
+        applyable_ids = {wid for c in db_.applyable_works_merge_clusters(clusters) for wid in c.work_ids}
+        assert applyable_ids == {w1.id, w2.id}
+
+
+def test_promote_pair_rerun_is_idempotent_row_count_unchanged(db_url):
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        w1 = _work("Calling Bullshit")
+        w2 = _work("The Tao of Pooh")
+        session.add_all([w1, w2])
+        session.flush()
+
+        first = db_.promote_detected_duplicate_pair(session, w1.id, w2.id)
+        second = db_.promote_detected_duplicate_pair(session, w1.id, w2.id)
+
+        assert first.already_existed is False
+        assert second.already_existed is True
+        assert session.query(DetectedDuplicate).count() == 1
+
+
+def test_promote_pair_then_flows_through_apply_works_merge_e2e(db_url):
+    """Promoted pair -> plan -> compose -> report -> apply_works_merge: the merge succeeds (one
+    work survives) and the promoted detection row is consumed (deleted) by the apply, same as any
+    other detected_duplicates-class cluster."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        survivor = _work("The Tao of Pooh", deep_enriched_at=datetime(2026, 7, 1, tzinfo=UTC))
+        loser = _work("Calling Bullshit")
+        session.add_all([survivor, loser])
+        session.flush()
+
+        db_.promote_detected_duplicate_pair(session, loser.id, survivor.id)
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_detected_duplicates"] == 1
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["delete_work"] == 1
+        assert applied["delete_detection"] == 1
+        assert session.get(Work, survivor.id) is not None
+        assert session.get(Work, loser.id) is None
+        assert session.query(DetectedDuplicate).count() == 0
+
+        # A fresh re-plan converges to zero clusters.
+        assert db_.plan_works_merge(session).summary()["works_detected_duplicates"] == 0

--- a/test/integration/test_works_merge.py
+++ b/test/integration/test_works_merge.py
@@ -38,6 +38,7 @@ def test_empty_db_plan_is_empty(db_url):
         clusters = db_.plan_works_merge(session)
         assert clusters.summary() == {
             "works_same_isbn": 0,
+            "works_same_isbn_title_mismatch": 0,
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 0,
@@ -125,11 +126,71 @@ def test_beware_of_chicken_2_sequel_is_never_a_pair(db_url):
         clusters = db_.plan_works_merge(session)
         assert clusters.summary() == {
             "works_same_isbn": 0,
+            "works_same_isbn_title_mismatch": 0,
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 0,
             "ignored_self_detections": 0,
         }
+
+
+def test_beware_shaped_triple_plan_applyable_pair_plus_mismatch_sequel(db_url):
+    """H3 hardening (2026-07-15, real prod dry-run): TWO 'Beware of Chicken' works sharing an
+    ISBN (a genuine duplicate pair) PLUS 'Beware of Chicken 2' sharing THE SAME ISBN (the
+    sequel carrying its predecessor's ISBN — real prod pollution). plan_works_merge must
+    produce ONE applyable same_isbn cluster (just the two equal-fold works) and mismatch report
+    entries for the sequel — the sequel must never enter an applyable cluster."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="CasualFarmer")
+        boc_dirty = _work("Beware of Chicken")
+        boc_clean = _work("Beware of Chicken", deep_enriched_at=datetime(2026, 6, 12, tzinfo=UTC))
+        boc_2 = _work("Beware of Chicken 2")
+        session.add_all([author, boc_dirty, boc_clean, boc_2])
+        session.flush()
+        session.add(WorkContributor(work_id=boc_dirty.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=boc_clean.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=boc_2.id, author_id=author.id, role="Author"))
+        session.add(Edition(work_id=boc_dirty.id, isbn_13="9781039452275", format="ebook"))
+        session.add(Edition(work_id=boc_clean.id, isbn_13="9781039452275", format="audiobook"))
+        session.add(Edition(work_id=boc_2.id, isbn_13="9781039452275", format="ebook"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+
+        assert clusters.summary()["works_same_isbn"] == 1
+        assert set(clusters.same_isbn[0].work_ids) == {boc_dirty.id, boc_clean.id}
+
+        mismatch_ids = {wid for c in clusters.same_isbn_title_mismatch for wid in c.work_ids}
+        assert boc_2.id in mismatch_ids
+
+        applyable_ids = {wid for c in db_.applyable_works_merge_clusters(clusters) for wid in c.work_ids}
+        assert boc_2.id not in applyable_ids
+        assert applyable_ids == {boc_dirty.id, boc_clean.id}
+
+
+def test_ender_shaped_chain_plan_zero_applyable_clusters(db_url):
+    """The prod dry-run's actual false-merge shape: several DISTINCT books sharing ONE bogus
+    ISBN (the real report chained 14 unrelated novels this way). plan_works_merge must produce
+    ZERO applyable same_isbn clusters — only a report-only mismatch cluster, visible for
+    operator triage."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        titles = ["Ender's Game", "Ender's Shadow", "Shadow of the Hegemon", "The Shadow Cabinet"]
+        works = [_work(t) for t in titles]
+        session.add_all(works)
+        session.flush()
+        for w in works:
+            session.add(Edition(work_id=w.id, isbn_13="9780000000000", format="ebook"))
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+
+        assert clusters.same_isbn == []
+        assert clusters.summary()["works_same_isbn"] == 0
+        mismatch_ids = {wid for c in clusters.same_isbn_title_mismatch for wid in c.work_ids}
+        assert mismatch_ids == {w.id for w in works}
+        assert db_.applyable_works_merge_clusters(clusters) == []
 
 
 def test_detected_duplicates_row_lands_in_its_own_class_with_correct_survivor(db_url):

--- a/test/integration/test_works_merge_apply.py
+++ b/test/integration/test_works_merge_apply.py
@@ -659,6 +659,7 @@ def test_beware_shaped_full_e2e_through_apply(db_url):
         converged = db_.plan_works_merge(session)
         assert converged.summary() == {
             "works_same_isbn": 0,
+            "works_same_isbn_title_mismatch": 0,
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 0,
@@ -749,6 +750,7 @@ def test_fuzzy_only_cluster_never_consumes_tokens_through_apply(db_url):
         clusters = db_.plan_works_merge(session)
         assert clusters.summary() == {
             "works_same_isbn": 0,
+            "works_same_isbn_title_mismatch": 0,
             "works_same_identity": 0,
             "works_detected_duplicates": 0,
             "works_fuzzy_report_only": 1,
@@ -853,3 +855,105 @@ def test_narrator_union_through_apply_repoint_and_drop(db_url):
             ).all()
         }
         assert remaining_narrators == {shared_narrator.id, new_narrator.id}
+
+
+# --------------------------------------------------------------------------------------------
+# 8. H3 hardening (2026-07-15, real prod dry-run): the ISBN-title-mismatch gate through the
+# REAL apply path — the exact false-merge shapes the dry-run caught must survive the actual
+# apply gate correctly, not just the pure planner.
+# --------------------------------------------------------------------------------------------
+
+
+def test_beware_shaped_triple_apply_merges_only_equal_pair_sequel_untouched(db_url):
+    """The prod shape through the ACTUAL apply gate: {BoC, BoC, BoC2} all sharing one ISBN.
+    apply_works_merge must merge ONLY the two equal-fold 'Beware of Chicken' works; the sequel
+    (mismatch, report-only) survives completely untouched — including its own edition and
+    reading history — never folded into the merge."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        author = Author(name="CasualFarmer")
+        boc_dirty = _work("Beware of Chicken")
+        boc_clean = _work("Beware of Chicken", deep_enriched_at=datetime(2026, 6, 12, tzinfo=UTC))
+        boc_2 = _work("Beware of Chicken 2")
+        session.add_all([author, boc_dirty, boc_clean, boc_2])
+        session.flush()
+        session.add(WorkContributor(work_id=boc_dirty.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=boc_clean.id, author_id=author.id, role="Author"))
+        session.add(WorkContributor(work_id=boc_2.id, author_id=author.id, role="Author"))
+        dirty_edition = Edition(work_id=boc_dirty.id, isbn_13="9781039452275", format="ebook")
+        clean_edition = Edition(work_id=boc_clean.id, isbn_13="9781039452275", format="audiobook")
+        sequel_edition = Edition(work_id=boc_2.id, isbn_13="9781039452275", format="ebook")
+        session.add_all([dirty_edition, clean_edition, sequel_edition])
+        session.flush()
+        sequel_read = ReadingHistory(
+            edition_id=sequel_edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2024, 6, 1)
+        )
+        session.add(sequel_read)
+        session.flush()
+
+        clusters = db_.plan_works_merge(session)
+        assert clusters.summary()["works_same_isbn"] == 1
+        assert boc_2.id in {wid for c in clusters.same_isbn_title_mismatch for wid in c.work_ids}
+
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["delete_work"] == 1
+        assert session.query(Work).count() == 2
+
+        # The sequel survived completely untouched — same id, same edition, same read.
+        surviving_sequel = session.get(Work, boc_2.id)
+        assert surviving_sequel is not None
+        assert surviving_sequel.title == "Beware of Chicken 2"
+        surviving_sequel_edition = session.get(Edition, sequel_edition.id)
+        assert surviving_sequel_edition is not None
+        assert surviving_sequel_edition.work_id == boc_2.id
+        remaining_sequel_reads = session.query(ReadingHistory).filter_by(edition_id=sequel_edition.id).all()
+        assert [rh.id for rh in remaining_sequel_reads] == [sequel_read.id]
+
+        # Exactly one of {dirty, clean} survives — deep_enriched_at newest wins the tiebreak.
+        assert session.get(Work, boc_dirty.id) is None
+        assert session.get(Work, boc_clean.id) is not None
+
+        converged = db_.plan_works_merge(session)
+        assert converged.summary()["works_same_isbn"] == 0
+
+
+def test_ender_shaped_chain_apply_is_a_no_op_snapshot_equality(db_url):
+    """The prod dry-run's actual false-merge shape through the real apply gate: several
+    DISTINCT books sharing one bogus ISBN. Zero applyable clusters means apply_works_merge
+    composes and executes nothing for this chain — a full works/editions snapshot is
+    byte-identical before and after."""
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        titles = ["Ender's Game", "Ender's Shadow", "Shadow of the Hegemon", "The Shadow Cabinet"]
+        works = [_work(t) for t in titles]
+        session.add_all(works)
+        session.flush()
+        for w in works:
+            session.add(Edition(work_id=w.id, isbn_13="9780000000000", format="ebook"))
+        session.flush()
+
+        def _snapshot():
+            return {
+                "works": {(w.id, w.title) for w in session.query(Work).all()},
+                "editions": {(e.id, e.work_id, e.isbn_13, e.format) for e in session.query(Edition).all()},
+            }
+
+        before = _snapshot()
+
+        clusters = db_.plan_works_merge(session)
+        assert db_.applyable_works_merge_clusters(clusters) == []
+        compositions = [db_.compose_cluster_merge(session, c) for c in db_.applyable_works_merge_clusters(clusters)]
+        assert compositions == []
+        report_path = db_.write_works_merge_apply_report(clusters, compositions)
+
+        applied = db_.apply_works_merge(session, report_path)
+        session.flush()
+
+        assert applied["delete_work"] == 0
+        after = _snapshot()
+        assert after == before

--- a/test/unit/test_clean_catalog_promote_pair_cli.py
+++ b/test/unit/test_clean_catalog_promote_pair_cli.py
@@ -1,0 +1,177 @@
+"""CLI-level tests for --promote-pair (H4) — mirrors test_clean_catalog_merge_works_apply_cli.py's
+structure (same --yes / prod-url guard shape). The domain logic itself (self-pair rejection,
+both-ids-exist check, ON CONFLICT DO NOTHING insert) lives in
+dedup_backfill.promote_detected_duplicate_pair and is covered by
+test/integration/test_works_merge.py (db_integration) plus test_detected_duplicates_upsert.py's
+compile-inspect sibling for the ON CONFLICT shape; this file is about the CLI's own UUID-parsing,
+guard, and print/dispatch wiring, with the insert seam mocked."""
+
+import importlib.util
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "clean_catalog", Path(__file__).resolve().parents[2] / "scripts" / "clean_catalog.py"
+)
+clean_catalog = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clean_catalog)
+
+
+class _Sess:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _patch_db(monkeypatch, *, url="postgresql://u:p@prod-host/db"):
+    monkeypatch.setattr(clean_catalog, "resolve_database_url", lambda: url)
+    monkeypatch.setattr(
+        clean_catalog, "DatabaseManager", lambda db_url: type("M", (), {"get_session": lambda s: _Sess()})()
+    )
+
+
+WORK_A = str(uuid4())
+WORK_B = str(uuid4())
+
+
+@pytest.mark.parametrize(
+    "argv, expected_rc, expected_message",
+    [
+        (
+            ["--promote-pair", WORK_A, WORK_B],
+            2,
+            "REFUSING --promote-pair without --yes",
+        ),
+        (
+            ["--promote-pair", "not-a-uuid", WORK_B, "--yes"],
+            1,
+            "REFUSING --promote-pair: 'not-a-uuid' is not a valid UUID.",
+        ),
+        (
+            ["--promote-pair", WORK_A, "also-not-a-uuid", "--yes"],
+            1,
+            "REFUSING --promote-pair: 'also-not-a-uuid' is not a valid UUID.",
+        ),
+    ],
+    ids=["missing_yes", "non_uuid_a", "non_uuid_b"],
+)
+def test_promote_pair_cli_guards(monkeypatch, capsys, argv, expected_rc, expected_message):
+    _patch_db(monkeypatch)
+    rc = clean_catalog.main(argv)
+    assert rc == expected_rc
+    assert expected_message in capsys.readouterr().out
+
+
+def test_promote_pair_refused_on_non_prod_url(monkeypatch, capsys):
+    _patch_db(monkeypatch, url="postgresql://u:p@localhost/db")
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_B, "--yes"])
+    assert rc == 2
+    assert "REFUSING --promote-pair: 'localhost/db' is not a live prod DB" in capsys.readouterr().out
+
+
+def test_promote_pair_self_pair_refused(monkeypatch, capsys):
+    """A==B is rejected by dedup_backfill.promote_detected_duplicate_pair (a ValueError naming
+    the id) — the CLI catches it and refuses with exit 1."""
+    _patch_db(monkeypatch)
+
+    def _raise_self_pair(session, work_id_a, work_id_b):
+        raise ValueError(f"cannot promote {work_id_a} as a duplicate of itself")
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "promote_detected_duplicate_pair", _raise_self_pair)
+
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_A, "--yes"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "REFUSING --promote-pair" in out
+    assert WORK_A in out
+
+
+def test_promote_pair_missing_work_id_refused(monkeypatch, capsys):
+    """UnknownWorkIdsError (a ValueError subclass) is caught the same way and lists the
+    missing id(s)."""
+    _patch_db(monkeypatch)
+    missing_id = UUID(WORK_B)
+
+    def _raise_missing(session, work_id_a, work_id_b):
+        raise clean_catalog.dedup_backfill.UnknownWorkIdsError([missing_id])
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "promote_detected_duplicate_pair", _raise_missing)
+
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_B, "--yes"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "REFUSING --promote-pair" in out
+    assert WORK_B in out
+
+
+def test_promote_pair_happy_path_prints_and_reminds(monkeypatch, capsys):
+    """Insert seam mocked — asserts the CLI's own print/dispatch wiring: per-pair 'promoted:'
+    line plus the final --merge-works reminder."""
+    _patch_db(monkeypatch)
+
+    def _fake_promote(session, work_id_a, work_id_b):
+        return clean_catalog.dedup_backfill.PromoteDuplicatePairResult(
+            work_id_a=work_id_a,
+            work_id_b=work_id_b,
+            title_a="Title A",
+            title_b="Title B",
+            already_existed=False,
+        )
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "promote_detected_duplicate_pair", _fake_promote)
+
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_B, "--yes"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"promoted: Title A {WORK_A} + Title B {WORK_B}" in out
+    assert "re-run --merge-works for a fresh gated report." in out
+
+
+def test_promote_pair_already_promoted_prints_already_promoted(monkeypatch, capsys):
+    _patch_db(monkeypatch)
+
+    def _fake_promote(session, work_id_a, work_id_b):
+        return clean_catalog.dedup_backfill.PromoteDuplicatePairResult(
+            work_id_a=work_id_a,
+            work_id_b=work_id_b,
+            title_a="Title A",
+            title_b="Title B",
+            already_existed=True,
+        )
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "promote_detected_duplicate_pair", _fake_promote)
+
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_B, "--yes"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"already promoted: Title A {WORK_A} + Title B {WORK_B}" in out
+
+
+def test_promote_pair_repeatable_flag_promotes_two_pairs(monkeypatch, capsys):
+    """--promote-pair passed twice (argparse action='append') promotes both pairs in one
+    invocation — the insert seam is called once per pair."""
+    _patch_db(monkeypatch)
+    work_c, work_d = str(uuid4()), str(uuid4())
+    calls = []
+
+    def _fake_promote(session, work_id_a, work_id_b):
+        calls.append((work_id_a, work_id_b))
+        return clean_catalog.dedup_backfill.PromoteDuplicatePairResult(
+            work_id_a=work_id_a,
+            work_id_b=work_id_b,
+            title_a="Title",
+            title_b="Title",
+            already_existed=False,
+        )
+
+    monkeypatch.setattr(clean_catalog.dedup_backfill, "promote_detected_duplicate_pair", _fake_promote)
+
+    rc = clean_catalog.main(["--promote-pair", WORK_A, WORK_B, "--promote-pair", work_c, work_d, "--yes"])
+    assert rc == 0
+    assert calls == [(UUID(WORK_A), UUID(WORK_B)), (UUID(work_c), UUID(work_d))]
+    out = capsys.readouterr().out
+    assert out.count("promoted: Title") == 2

--- a/test/unit/test_promote_detected_duplicate_pair.py
+++ b/test/unit/test_promote_detected_duplicate_pair.py
@@ -1,0 +1,128 @@
+"""H4: pure/compile-inspect unit tests for dedup_backfill.promote_detected_duplicate_pair — the
+CLI helper function scripts/clean_catalog.py's --promote-pair mode calls per pair. Mirrors
+test_detected_duplicates_upsert.py's compile-inspect idiom (house rule 4: pg-dialect statements
+get compile-inspect locally, execute in CI/db_integration) — the real insert/existence-check
+mechanics against a live Postgres session are covered by test/integration/test_works_merge.py."""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from agentic_librarian.db.models import DetectedDuplicate
+from agentic_librarian.etl import dedup_backfill as db_
+
+
+def test_promote_pair_insert_conflict_target_is_the_composite_pk():
+    """Standalone statement, same shape promote_detected_duplicate_pair issues — mirrors
+    test_detected_duplicates_upsert.py's first test exactly, source='operator' instead of
+    'deep_pass_redirect'."""
+    work_id_a, work_id_b = uuid4(), uuid4()
+    stmt = (
+        pg_insert(DetectedDuplicate)
+        .values(work_id_a=work_id_a, work_id_b=work_id_b, source="operator")
+        .on_conflict_do_nothing(index_elements=["work_id_a", "work_id_b"])
+    )
+
+    compiled = str(stmt.compile(dialect=postgresql.dialect()))
+
+    assert "INSERT INTO detected_duplicates" in compiled
+    assert "ON CONFLICT (work_id_a, work_id_b) DO NOTHING" in compiled
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *a, **k):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    """Captures the ACTUAL statement promote_detected_duplicate_pair executes, same idiom as
+    test_detected_duplicates_upsert.py's test_two_phase_redirect_issues_the_same_upsert_shape."""
+
+    def __init__(self, rows, *, existing: bool):
+        self._rows = rows
+        self._existing = existing
+        self.executed = None
+
+    def query(self, *entities):
+        return _FakeQuery(self._rows)
+
+    def get(self, model, pk):
+        return object() if self._existing else None
+
+    def execute(self, stmt):
+        self.executed = stmt
+
+    def flush(self):
+        pass
+
+
+def test_promote_pair_issues_the_same_upsert_shape_with_operator_source():
+    work_id_a, work_id_b = uuid4(), uuid4()
+    session = _FakeSession([(work_id_a, "Title A"), (work_id_b, "Title B")], existing=False)
+
+    result = db_.promote_detected_duplicate_pair(session, work_id_a, work_id_b)
+
+    assert result.already_existed is False
+    assert result.title_a == "Title A"
+    assert result.title_b == "Title B"
+    compiled = str(session.executed.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert "INSERT INTO detected_duplicates" in compiled
+    assert "ON CONFLICT (work_id_a, work_id_b) DO NOTHING" in compiled
+    assert "'operator'" in compiled
+    assert str(work_id_a) in compiled
+    assert str(work_id_b) in compiled
+
+
+def test_promote_pair_already_existed_reflects_pre_insert_check():
+    work_id_a, work_id_b = uuid4(), uuid4()
+    session = _FakeSession([(work_id_a, "Title A"), (work_id_b, "Title B")], existing=True)
+
+    result = db_.promote_detected_duplicate_pair(session, work_id_a, work_id_b)
+
+    assert result.already_existed is True
+
+
+def test_promote_pair_self_pair_rejected_names_the_id():
+    work_id = uuid4()
+    session = _FakeSession([(work_id, "Title")], existing=False)
+
+    with pytest.raises(ValueError, match=str(work_id)):
+        db_.promote_detected_duplicate_pair(session, work_id, work_id)
+
+
+@pytest.mark.parametrize(
+    "known_rows, missing_expected_index",
+    [
+        ([], "both"),
+        ("only_a", "b"),
+        ("only_b", "a"),
+    ],
+    ids=["both_missing", "b_missing", "a_missing"],
+)
+def test_promote_pair_missing_work_ids_raise_unknown_work_ids_error(known_rows, missing_expected_index):
+    work_id_a, work_id_b = uuid4(), uuid4()
+    if known_rows == "only_a":
+        rows = [(work_id_a, "Title A")]
+    elif known_rows == "only_b":
+        rows = [(work_id_b, "Title B")]
+    else:
+        rows = []
+    session = _FakeSession(rows, existing=False)
+
+    with pytest.raises(db_.UnknownWorkIdsError) as exc_info:
+        db_.promote_detected_duplicate_pair(session, work_id_a, work_id_b)
+
+    if missing_expected_index == "both":
+        assert set(exc_info.value.missing_ids) == {work_id_a, work_id_b}
+    elif missing_expected_index == "a":
+        assert exc_info.value.missing_ids == [work_id_a]
+    else:
+        assert exc_info.value.missing_ids == [work_id_b]

--- a/test/unit/test_works_merge.py
+++ b/test/unit/test_works_merge.py
@@ -167,6 +167,39 @@ def test_classify_isbn_group_pairs_applyable_count(case_name, titles, expect_app
     assert len(applyable) + len(mismatch) == math.comb(len(titles), 2)
 
 
+def test_classify_isbn_group_pairs_raises_on_unknown_work_id():
+    """Gemini review (#146): an id missing from fold_by_work must FAIL LOUD (KeyError), never
+    match None == None into an applyable pair. The edition scan filters unknown ids before
+    grouping (test below); this pins the honest-failure contract if that filter ever regresses."""
+    ids, fold_by_work = _fold_ids("Beware of Chicken")
+    stranger = uuid4()  # never registered in fold_by_work
+    with pytest.raises(KeyError):
+        _classify_isbn_group_pairs([ids[0], stranger], fold_by_work)
+
+
+def test_detect_same_isbn_pairs_skips_works_unknown_to_the_plan():
+    """A work created between the plan's works scan and its edition scan (no fold/stats entry)
+    is skipped — it becomes next plan run's problem instead of a None-matched applyable pair
+    or a KeyError at cluster build (Gemini review, #146)."""
+    from unittest.mock import MagicMock
+
+    from agentic_librarian.etl.dedup_backfill import _detect_same_isbn_pairs
+
+    known_a, known_b = uuid4(), uuid4()
+    stranger = uuid4()
+    fold_by_work = {known_a: _fold("Beware of Chicken"), known_b: _fold("Beware of Chicken")}
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = [
+        (known_a, "9781039452275"),
+        (known_b, "9781039452275"),
+        (stranger, "9781039452275"),  # mid-plan newcomer: same ISBN, unknown to the plan
+        (stranger, "9990000000000"),  # and alone on another ISBN
+    ]
+    applyable, mismatch = _detect_same_isbn_pairs(session, fold_by_work)
+    assert applyable == [tuple(sorted((known_a, known_b), key=str))]
+    assert mismatch == []  # the stranger produced neither applyable nor mismatch pairs
+
+
 def test_classify_isbn_group_pairs_beware_shaped_sequel_never_applyable():
     """The prod shape exactly: two equal-fold 'Beware of Chicken' works pair up applyable; the
     differently-folded 'Beware of Chicken 2' sequel pairs with EACH of them as mismatch — never

--- a/test/unit/test_works_merge.py
+++ b/test/unit/test_works_merge.py
@@ -14,6 +14,7 @@ House rule: case-driven tests are parametrized, never loops inside one test body
 
 from __future__ import annotations
 
+import math
 from uuid import uuid4
 
 import pytest
@@ -24,9 +25,12 @@ from agentic_librarian.etl.dedup_backfill import (
     WorksMergeCluster,
     WorksMergeClusters,
     WorkStats,
+    _classify_isbn_group_pairs,
     _dedupe_detected_duplicate_rows,
+    _detect_fuzzy_pairs,
     _fold,
     _series_guard_blocks,
+    applyable_works_merge_clusters,
     fuzzy_similarity,
     parse_works_merge_report,
     pick_survivor,
@@ -105,6 +109,81 @@ def test_series_guard_symmetric():
     """The guard must not depend on argument order — (A, B) and (B, A) agree."""
     a, b = "Beware of Chicken", "Beware of Chicken 2"
     assert _series_guard_blocks(a, b) == _series_guard_blocks(b, a)
+
+
+# --------------------------------------------------------------------------------------------
+# H3 hardening (2026-07-15, real prod dry-run): _classify_isbn_group_pairs — an ISBN group's
+# pairwise classification into applyable (folded titles agree) vs mismatch (folded titles
+# disagree — report-only, never applied). The prod dry-run's real false-merge shapes are the
+# fixtures here: a 14-book "Ender chain" (one bogus shared ISBN, all titles distinct — must
+# produce ZERO applyable pairs), the Beware-of-Chicken-shaped group (a genuine same-ISBN
+# duplicate pair PLUS a sequel sharing its predecessor's ISBN), and a real typo pair (shared
+# ISBN, near-identical but non-equal folded titles).
+# --------------------------------------------------------------------------------------------
+
+
+def _fold_ids(*titles: str) -> tuple[list, dict]:
+    ids = [uuid4() for _ in titles]
+    fold_by_work = {wid: _fold(title) for wid, title in zip(ids, titles, strict=True)}
+    return ids, fold_by_work
+
+
+@pytest.mark.parametrize(
+    "case_name, titles, expect_applyable_count",
+    [
+        ("typo_pair_exit_strategy", ["Exit Stategy", "Exit Strategy"], 0),
+        (
+            "beware_group_one_applyable_pair_plus_sequel",
+            ["Beware of Chicken", "Beware of Chicken", "Beware of Chicken 2"],
+            1,
+        ),
+        (
+            "ender_chain_fourteen_distinct_titles_zero_applyable",
+            [
+                "Ender's Game",
+                "Ender's Shadow",
+                "Shadow of the Hegemon",
+                "The Hunger of the Gods",
+                "Fury of the Gods",
+                "The Silence of Unworthy Gods",
+                "The Gate of the Feral Gods",
+                "Shadow of the Giant",
+                "The Fury",
+                "The Shadow of the Gods",
+                "The Shadow",
+                "The Brightest Shadow",
+                "The Shadow Cabinet",
+                "The Gate of the Feral Gods: Dungeon Crawler Carl Book 4",
+            ],
+            0,
+        ),
+    ],
+)
+def test_classify_isbn_group_pairs_applyable_count(case_name, titles, expect_applyable_count):
+    ids, fold_by_work = _fold_ids(*titles)
+    applyable, mismatch = _classify_isbn_group_pairs(ids, fold_by_work)
+    assert len(applyable) == expect_applyable_count
+    # every pairwise combination is classified exactly once, into exactly one of the two lists
+    assert len(applyable) + len(mismatch) == math.comb(len(titles), 2)
+
+
+def test_classify_isbn_group_pairs_beware_shaped_sequel_never_applyable():
+    """The prod shape exactly: two equal-fold 'Beware of Chicken' works pair up applyable; the
+    differently-folded 'Beware of Chicken 2' sequel pairs with EACH of them as mismatch — never
+    applyable, and visible against every non-matching member it shares the ISBN group with."""
+    ids, fold_by_work = _fold_ids("Beware of Chicken", "Beware of Chicken", "Beware of Chicken 2")
+    boc_a, boc_b, boc_2 = ids
+    applyable, mismatch = _classify_isbn_group_pairs(ids, fold_by_work)
+
+    assert {frozenset(p) for p in applyable} == {frozenset((boc_a, boc_b))}
+    assert {frozenset(p) for p in mismatch} == {frozenset((boc_a, boc_2)), frozenset((boc_b, boc_2))}
+
+
+def test_classify_isbn_group_pairs_typo_pair_is_mismatch_only():
+    ids, fold_by_work = _fold_ids("Exit Stategy", "Exit Strategy")
+    applyable, mismatch = _classify_isbn_group_pairs(ids, fold_by_work)
+    assert applyable == []
+    assert {frozenset(p) for p in mismatch} == {frozenset(ids)}
 
 
 # --------------------------------------------------------------------------------------------
@@ -268,8 +347,29 @@ def test_transitive_cluster_collapses_into_one_cluster_one_survivor():
 
 
 def test_transitive_cluster_takes_the_strongest_class_of_any_edge():
-    """A~B is same_isbn (strong), B~C is fuzzy (weak) — the merged cluster is reported under
-    same_isbn, not fuzzy, and is therefore NOT report-only."""
+    """Among the THREE applyable classes only: A~B is same_isbn (strong), B~C is same_identity
+    (also applyable) — the merged cluster is reported under same_isbn (the strongest applyable
+    edge), still one cluster of all three."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1), c: _stats(c, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_identity_pairs=[(b, c)],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn) == 1
+    assert set(clusters.same_isbn[0].work_ids) == {a, b, c}
+
+
+def test_fuzzy_edge_contagion_regression():
+    """H3 CONTRACT REVERSAL (2026-07-15): A~B is same_isbn (applyable), B~C is fuzzy
+    (report-only). Before the fix, ONE shared union-find let this fuzzy edge pull C into the
+    applyable same_isbn cluster (the exact amplification the prod dry-run caught). After the
+    fix: the applyable cluster stays EXACTLY {A, B}; C shows up only in the fuzzy report-only
+    cluster, and applyable_works_merge_clusters (the sole choke point apply reads through) never
+    contains C."""
     a, b, c = uuid4(), uuid4(), uuid4()
     stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1), c: _stats(c, trope_links=1)}
     clusters = plan_works_merge_clusters(
@@ -280,8 +380,14 @@ def test_transitive_cluster_takes_the_strongest_class_of_any_edge():
         stats_by_work=stats,
     )
     assert len(clusters.same_isbn) == 1
-    assert set(clusters.same_isbn[0].work_ids) == {a, b, c}
-    assert clusters.fuzzy_report_only == []
+    assert set(clusters.same_isbn[0].work_ids) == {a, b}
+
+    fuzzy_ids = {wid for cluster in clusters.fuzzy_report_only for wid in cluster.work_ids}
+    assert c in fuzzy_ids
+
+    applyable_ids = {wid for cluster in applyable_works_merge_clusters(clusters) for wid in cluster.work_ids}
+    assert c not in applyable_ids
+    assert applyable_ids == {a, b}
 
 
 def test_fuzzy_only_cluster_lands_in_fuzzy_report_only():
@@ -298,6 +404,181 @@ def test_fuzzy_only_cluster_lands_in_fuzzy_report_only():
     assert clusters.same_isbn == []
     assert clusters.same_identity == []
     assert clusters.detected_duplicates == []
+
+
+# --------------------------------------------------------------------------------------------
+# H3 hardening (2026-07-15): works_same_isbn_title_mismatch is a report-only class that clusters
+# in its OWN independent union-find — it can never join, grow, or relabel an applyable cluster.
+# The prod dry-run's real false-merge shapes are the fixtures: the Ender chain (14 distinct
+# books chained by one bogus shared ISBN — must produce ZERO applyable clusters), the
+# Beware-of-Chicken-shaped group (a real duplicate pair PLUS a sequel sharing the predecessor's
+# ISBN — the sequel must never enter an applyable cluster), and a real typo pair (report-only,
+# operator promotes by hand).
+# --------------------------------------------------------------------------------------------
+
+
+def test_isbn_mismatch_only_pair_never_applyable_typo_pair_shaped():
+    """'Exit Stategy'/'Exit Strategy'-shaped: shared ISBN, differing folds — mismatch report-only,
+    never in works_same_isbn, never applyable."""
+    a, b = uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[],
+        same_isbn_mismatch_pairs=[(a, b)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert clusters.same_isbn == []
+    assert len(clusters.same_isbn_title_mismatch) == 1
+    assert set(clusters.same_isbn_title_mismatch[0].work_ids) == {a, b}
+    assert applyable_works_merge_clusters(clusters) == []
+
+
+def test_beware_shaped_group_one_applyable_pair_sequel_never_applyable():
+    """The prod shape exactly: {BoC, BoC, BoC2} within one ISBN group — one applyable pair (the
+    two equal-fold BoC works) and mismatch report entries for the sequel; the sequel must NEVER
+    appear in an applyable cluster."""
+    boc_a, boc_b, boc_2 = uuid4(), uuid4(), uuid4()
+    stats = {
+        boc_a: _stats(boc_a, trope_links=1, editions=1),
+        boc_b: _stats(boc_b, trope_links=15, editions=2),
+        boc_2: _stats(boc_2, trope_links=7, editions=1),
+    }
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(boc_a, boc_b)],
+        same_isbn_mismatch_pairs=[(boc_a, boc_2), (boc_b, boc_2)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn) == 1
+    assert set(clusters.same_isbn[0].work_ids) == {boc_a, boc_b}
+
+    mismatch_ids = {wid for cluster in clusters.same_isbn_title_mismatch for wid in cluster.work_ids}
+    assert boc_2 in mismatch_ids
+
+    applyable_ids = {wid for cluster in applyable_works_merge_clusters(clusters) for wid in cluster.work_ids}
+    assert boc_2 not in applyable_ids
+    assert applyable_ids == {boc_a, boc_b}
+
+
+def test_ender_shaped_chain_zero_applyable_clusters():
+    """The prod dry-run's actual false-merge shape: N books all sharing one bogus ISBN, all
+    titles distinct -> every pairwise combination in the group is a mismatch, ZERO applyable
+    pairs, ZERO applyable clusters. Fed straight from _classify_isbn_group_pairs' real output so
+    this test exercises the same shape plan_works_merge would build from a live DB scan."""
+    titles = [
+        "Ender's Game",
+        "Ender's Shadow",
+        "Shadow of the Hegemon",
+        "The Hunger of the Gods",
+        "Fury of the Gods",
+        "The Silence of Unworthy Gods",
+        "The Gate of the Feral Gods",
+        "Shadow of the Giant",
+        "The Fury",
+        "The Shadow of the Gods",
+        "The Shadow",
+        "The Brightest Shadow",
+        "The Shadow Cabinet",
+        "The Gate of the Feral Gods: Dungeon Crawler Carl Book 4",
+    ]
+    ids = [uuid4() for _ in titles]
+    fold_by_work = {wid: _fold(title) for wid, title in zip(ids, titles, strict=True)}
+    applyable_pairs, mismatch_pairs = _classify_isbn_group_pairs(ids, fold_by_work)
+    assert applyable_pairs == []
+
+    stats = {wid: _stats(wid, trope_links=1) for wid in ids}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=applyable_pairs,
+        same_isbn_mismatch_pairs=mismatch_pairs,
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert clusters.same_isbn == []
+    assert applyable_works_merge_clusters(clusters) == []
+    # Visible for operator triage, not silently dropped.
+    mismatch_ids = {wid for cluster in clusters.same_isbn_title_mismatch for wid in cluster.work_ids}
+    assert mismatch_ids == set(ids)
+
+
+def test_mismatch_pair_dropped_when_both_members_already_in_one_applyable_cluster():
+    """A report-only pair is only useful for triage if it points somewhere NEW — if both its
+    endpoints already sit together in one applyable cluster (e.g. same_isbn joined A-B, and
+    same_identity separately joined B-C into the SAME applyable cluster), a mismatch edge
+    between A and C adds nothing and must be dropped entirely, not shown as a redundant cluster."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1), c: _stats(c, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b)],
+        same_isbn_mismatch_pairs=[(a, c)],
+        same_identity_pairs=[(b, c)],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert set(clusters.same_isbn[0].work_ids) == {a, b, c}
+    assert clusters.same_isbn_title_mismatch == []
+
+
+def test_mismatch_pair_kept_when_spanning_two_different_applyable_clusters():
+    """A mismatch pair whose two endpoints sit in TWO DIFFERENT applyable clusters (not one) is
+    still real triage information — kept for display, its own independent report-only cluster."""
+    a, b, c, d = uuid4(), uuid4(), uuid4(), uuid4()
+    stats = {x: _stats(x, trope_links=1) for x in (a, b, c, d)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[(a, b), (c, d)],
+        same_isbn_mismatch_pairs=[(a, c)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[],
+        stats_by_work=stats,
+    )
+    assert {frozenset(cl.work_ids) for cl in clusters.same_isbn} == {frozenset((a, b)), frozenset((c, d))}
+    assert len(clusters.same_isbn_title_mismatch) == 1
+    assert set(clusters.same_isbn_title_mismatch[0].work_ids) == {a, c}
+
+
+def test_mismatch_and_fuzzy_cluster_independently_never_share_a_union_find():
+    """A same_isbn_mismatch pair (A, B) and a fuzzy pair (B, C) share endpoint B but must NOT
+    merge into one report-only cluster — each report-only class clusters in its OWN independent
+    union-find (never each other's, per the module contract)."""
+    a, b, c = uuid4(), uuid4(), uuid4()
+    stats = {a: _stats(a, trope_links=1), b: _stats(b, trope_links=1), c: _stats(c, trope_links=1)}
+    clusters = plan_works_merge_clusters(
+        same_isbn_pairs=[],
+        same_isbn_mismatch_pairs=[(a, b)],
+        same_identity_pairs=[],
+        detected_duplicate_pairs=[],
+        fuzzy_pairs=[(b, c)],
+        stats_by_work=stats,
+    )
+    assert len(clusters.same_isbn_title_mismatch) == 1
+    assert set(clusters.same_isbn_title_mismatch[0].work_ids) == {a, b}
+    assert len(clusters.fuzzy_report_only) == 1
+    assert set(clusters.fuzzy_report_only[0].work_ids) == {b, c}
+
+
+# --------------------------------------------------------------------------------------------
+# H3 hardening: _detect_fuzzy_pairs must exclude pairs already caught by works_same_isbn_title_
+# mismatch — a differing-title ISBN pair is already visible under that class and should not ALSO
+# show up as a fuzzy pair.
+# --------------------------------------------------------------------------------------------
+
+
+def test_detect_fuzzy_pairs_excludes_mismatch_pair_via_already_paired():
+    a, b = uuid4(), uuid4()
+    title_by_work = {a: "Exit Stategy", b: "Exit Strategy"}
+    already_paired = {frozenset((a, b))}  # as plan_works_merge now seeds it from same_isbn_mismatch_pairs
+
+    pairs = _detect_fuzzy_pairs(title_by_work, already_paired)
+
+    assert pairs == []
 
 
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
Urgent follow-up to #144, found by the merge tool's own dry-run gate against prod (report `works-merge-20260715T121805395085Z.txt`) — the apply was withheld. Two structural detection flaws, one data finding (#145):

## What the gate caught

1. **Prod ISBNs are polluted** (#145): distinct works share `isbn_13` values. The `works_same_isbn` class ("strongest evidence") chained **14 different books** (*Ender's Game* … *The Shadow Cabinet*) into one applyable merge cluster, and pulled ***Beware of Chicken 2*** (a sequel carrying book 1's ISBN) into the Beware cluster — the series guard never ran because ISBN evidence bypassed it.
2. **Report-only wasn't report-only cluster-wise**: fuzzy edges joined the same union-find as applyable edges, and clusters take the strongest edge's class — so a fuzzy pair touching an applyable cluster silently grew the merge.

## The fixes

- **ISBN evidence now requires folded-title agreement.** Same-ISBN pairs with differing folds land in a new `works_same_isbn_title_mismatch` REPORT-ONLY class (operator triage — the *Exit Stategy/Strategy* typo pair and any genuine unequal-fold dup get hand-promoted). Group classification is full pairwise, so mismatch visibility is complete.
- **Report-only classes cluster in their own union-finds** — structurally unable to grow an applyable cluster. The applyable choke point (`applyable_works_merge_clusters`) and the whole token/parser/drift gate are byte-untouched; a pre-hardening report drift-refuses against a post-hardening plan (verified against the real prod report: the Beware cluster's loser list changed → new token → refusal).

All five prod false-cluster shapes are pinned as fixtures (the Ender 14-chain test uses the real 14 titles); the legitimate equal-fold clusters (*The Innocent*, *Calling Bullshit*, *Eruption*, the Beware true pair) still merge.

## Tests

72 unit + 35 db_integration works-merge + 28 gated-suite regressions, executed against real Postgres. Review verified the hand-simulation of every prod shape and the gate-compatibility reasoning.

Operator note: genuine duplicates with unequal folds (e.g. the real *Dungeon Crawler Carl 4* title-variant pair inside the Ender chain) now require hand promotion from the mismatch report — the intended trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYmZqK5pwwYDNbSfJZeVxF
