### PR TITLE
feat: history format edit with targeted edition-completion enrichment

### DIFF
--- a/docs/project_notes/issues.md
+++ b/docs/project_notes/issues.md
@@ -399,3 +399,11 @@ This file tracks work history and ticket references.
 - **Description**: Rebuilt the Analysis word clouds (signature tropes + style) from a `flex-wrap` list into a packed/rotated/frequency-accentuated cloud on `@isoterik/react-word-cloud`'s `useWordCloud` hook (own SVG render → `--cat` palette + Literata + theme via CSS). Cloud-local split `/` + strip articles + merge-sum; width-responsive font max (≈38px mobile / 60px desktop). Frontend-only — no backend/schema.
 - **URL**: PR #86 (closes #83)
 - **Notes**: ADR-056. Two findings (bugs.md 2026-06-26): `useWordCloud@1.3.0` silently ignores `random` (dead seed → removed); layout stability/no-loop = memoising the hook inputs. Built brainstorm→spec→plan→subagent-driven (5 tasks, each spec+quality reviewed + final whole-branch review, which caught the `random` gotcha). QC at mobile+desktop both themes via the harness (jsdom can't run d3-cloud's canvas). Gemini: applied round-width / `computedWords=[]` / clamp size `norm` (NaN guard) + test; declined an `Array.isArray` guard (typed input, consistent w/ sibling components). The predicted `docs/project_notes/*` append-overlap with Safari-auth PR #85 (which merged first, ADR-055) was resolved by merging `origin/main` into the branch — kept both ADR-055 + ADR-056 (`439a57f`).
+
+### 2026-07-18 - History format edit (spec 2026-07-18)
+- **Status**: PR open
+- **Description**: PATCH /history accepts format (vocab-validated); repoints to sibling
+  (work_id, format) Edition; 409 on uq_reading_history collisions (incl. the pre-existing
+  date-edit 500 hole); async /internal/complete-edition pass fills ISBN/pages/audio +
+  narrators/styles for audiobooks — never the paid trope/style deep pass.
+- **Notes**: merge_edition_and_narrators extracted from persist_enriched_work (shared).

--- a/docs/superpowers/plans/2026-07-18-history-format-edit.md
+++ b/docs/superpowers/plans/2026-07-18-history-format-edit.md
@@ -1,0 +1,1390 @@
+# History Format Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users change a history entry's format via `PATCH /history/{id}`, repointing the row to the right sibling `Edition` and asynchronously filling that edition's metadata (ISBN, page/audio counts; narrators + narrator styles for audiobooks) via a new targeted Cloud Tasks pass.
+
+**Architecture:** `format` lives on `Edition` (unique `(work_id, format)`, `NULLS NOT DISTINCT`), so a format change is a repoint to a get-or-created sibling edition of the same Work — never a mutation of the shared edition. A new `complete_edition(work_id, fmt)` pass in `two_phase.py` (short read session → scouts with NO session held, the #94 rule → fresh write session) runs the fast API scouts plus, for audiobooks, the audiobook LLM scouts and per-narrator style scouting — never `LLMTropeScout` or author/work-style scouting. Persistence reuses the "Edition & Narrators" section of `persist_enriched_work`, extracted into a shared helper.
+
+**Tech Stack:** FastAPI + SQLAlchemy 2 (Postgres-only models — never run them on sqlite), Cloud Tasks (OIDC-gated internal endpoints), React + vitest frontend, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-18-history-format-edit-design.md`
+
+## Global Constraints
+
+- Tests: `.venv/Scripts/python -m pytest ...` from repo root (Windows host venv). Full **unit** suite before each commit.
+- `db_integration`-marked tests are **deselected locally** (no Postgres) — CI is their gate. They must still be written to pass in CI on the first run.
+- Suite policy: `filterwarnings = ["error::sqlalchemy.exc.SAWarning"]` — never downgrade; if an SAWarning appears you have found a bug.
+- Case-driven tests are parametrized (`pytest.mark.parametrize` / `test.each`), each case atomic and named — never loops inside one test body.
+- Lint AND format before every commit: `uvx ruff check <files>` **and** `uvx ruff format <files>`.
+- No `[skip ci]` anywhere in commit messages.
+- Format vocab (exact strings, lowercase): `ebook`, `audiobook`, `paperback`, `hardcover`.
+- Commit messages end with the Co-Authored-By / Claude-Session trailer per session convention.
+- Work on a feature branch (e.g. `feat/history-format-edit`), not `main`; squash-merge PR at the end per repo convention.
+
+---
+
+### Task 1: Extract `merge_edition_and_narrators` from `persist_enriched_work` (pure refactor)
+
+**Files:**
+- Modify: `src/agentic_librarian/etl/persist.py` (the "# 3. Edition & Narrators" section, ~L264–353)
+
+**Interfaces:**
+- Produces: `merge_edition_and_narrators(session, *, work_id, fmt, isbn_13=None, page_count=None, audio_minutes=None, publication_date=None, narrator_names=None, narrator_styles=None, style_manager, apply_metadata=True) -> Edition` in `agentic_librarian.etl.persist`. Task 3 imports and calls it.
+- Behavior contract (must be preserved EXACTLY — this is a lift-and-call refactor, not a rewrite):
+  - Case-insensitive narrator reuse; `insert_or_requery` #95 backstops for Narrator and Edition; narrator-name dedup via `norm_name`; NaN/non-list coercion of `narrator_names`/`narrator_styles`.
+  - New edition: created with all metadata + narrators via `insert_or_requery`, then `session.flush()` (id must be populated for the caller's ReadingHistory block).
+  - Existing edition: metadata merge (`isbn_13 = isbn_13 or edition.isbn_13`, same for `page_count`, `audio_minutes`; `publication_date` is NOT updated on existing editions) gated by `apply_metadata`; narrator merge (`set` union) NOT gated.
+  - Narrator styles standardized via `style_manager.standardize_style` through the existing `_safe_standardize`/`_iter_style_items` helpers, with the existing-link dedup query.
+
+- [ ] **Step 1: Write the helper and re-wire the call site**
+
+In `src/agentic_librarian/etl/persist.py`, add a new module-level function ABOVE `persist_enriched_work` (move the existing GH #95 comments with the code they explain):
+
+```python
+def merge_edition_and_narrators(
+    session,
+    *,
+    work_id,
+    fmt,
+    isbn_13=None,
+    page_count=None,
+    audio_minutes=None,
+    publication_date=None,
+    narrator_names=None,
+    narrator_styles=None,
+    style_manager,
+    apply_metadata=True,
+):
+    """Resolve narrators (+ narrator styles) and get-or-create/merge the (work_id, fmt)
+    Edition. Extracted from persist_enriched_work (history-format-edit spec) so the
+    format-completion pass (two_phase.complete_edition) shares the exact same merge
+    semantics. apply_metadata=False (persist's skip_enrichment rows) still merges
+    narrators, mirroring the original gating. Returns the Edition, flushed when newly
+    created so its id is populated for the caller."""
+    edition = session.query(Edition).filter_by(work_id=work_id, format=fmt).first()
+
+    # A row may carry narrator_names/styles as NaN (float) — pandas fills the column with
+    # NaN for rows that lack it. Coerce non-list/dict to empty so this never crashes.
+    if not isinstance(narrator_names, list):
+        narrator_names = []
+    # Keep only non-empty strings: a malformed/NaN element would crash norm_name/.lower().
+    narrator_names = [n for n in narrator_names if isinstance(n, str) and n.strip()]
+    if not isinstance(narrator_styles, dict):
+        narrator_styles = {}
+
+    seen_narr: set[str] = set()
+    deduped_names = []
+    for n_name in narrator_names:
+        k = norm_name(n_name)
+        if k not in seen_narr:
+            seen_narr.add(k)
+            deduped_names.append(n_name)
+    narrator_names = deduped_names
+
+    narrator_objs = []
+    for n_name in narrator_names:
+        # Case-insensitive lookup so a casing variant reuses the existing Narrator row.
+        narrator = session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
+        if not narrator:
+            # GH #95: uq_narrators_name_lower — same case-insensitive requery pattern as Author.
+            narrator, _created = insert_or_requery(
+                session,
+                Narrator(name=n_name),
+                lambda n_name=n_name: (
+                    session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
+                ),
+            )
+
+        n_style_data = narrator_styles.get(n_name, {})
+        if n_style_data:
+            for attr_type, style_name in _iter_style_items(n_style_data, f"Narrator '{n_name}'"):
+                standard_style = _safe_standardize(
+                    style_manager.standardize_style, style_name, category="Narrator", label=f"style {style_name!r}"
+                )
+                if standard_style is None:
+                    continue
+                existing_link = (
+                    session.query(NarratorStyle)
+                    .filter_by(narrator_id=narrator.id, style_id=standard_style.id, attribute_type=attr_type)
+                    .first()
+                )
+                if not existing_link:
+                    session.add(NarratorStyle(narrator=narrator, style=standard_style, attribute_type=attr_type))
+
+        narrator_objs.append(narrator)
+
+    if not edition:
+        # GH #95: uq_editions_work_format backstops the SELECT-then-INSERT race above; a
+        # concurrent persist for the same (work_id, format) recovers via requery instead of
+        # a 500. narrators/other creation-only fields only apply on the winning insert.
+        # work_id= (not work=) so the not-yet-added Edition never lands in work.editions via
+        # the back_populates backref before session.add — that dangling membership is exactly
+        # what trips "Object of type <Edition> not in session" as an SAWarning-promoted error.
+        edition, _created = insert_or_requery(
+            session,
+            Edition(
+                work_id=work_id,
+                isbn_13=isbn_13,
+                format=fmt,
+                page_count=page_count,
+                audio_minutes=audio_minutes,
+                publication_date=publication_date,
+                narrators=narrator_objs,
+            ),
+            lambda: session.query(Edition).filter_by(work_id=work_id, format=fmt).first(),
+        )
+        session.flush()  # Ensure edition.id is populated for the caller's ReadingHistory check
+    else:
+        if apply_metadata:
+            # Update existing edition if new metadata found (publication_date intentionally
+            # not updated on existing editions — original behavior preserved).
+            edition.isbn_13 = isbn_13 or edition.isbn_13
+            edition.page_count = page_count or edition.page_count
+            edition.audio_minutes = audio_minutes or edition.audio_minutes
+        if narrator_objs:
+            edition.narrators = list(set(edition.narrators) | set(narrator_objs))
+
+    return edition
+```
+
+Then replace the entire `# 3. Edition & Narrators` block inside `persist_enriched_work` (from the `edition = session.query(Edition)...` line through the `edition.narrators = list(set(...))` line inclusive) with:
+
+```python
+    # 3. Edition & Narrators (shared with two_phase.complete_edition — history-format-edit)
+    edition = merge_edition_and_narrators(
+        session,
+        work_id=work.id,
+        fmt=row.get("format"),
+        isbn_13=isbn_13,
+        page_count=page_count,
+        audio_minutes=audio_minutes,
+        publication_date=publication_date,
+        narrator_names=row.get("narrator_names"),
+        narrator_styles=row.get("narrator_styles"),
+        style_manager=style_manager,
+        apply_metadata=not row.get("skip_enrichment"),
+    )
+```
+
+(Note the one intentional unification: the original block read `row["format"]` in the SELECT but `row.get("format")` at creation; the helper uses one `fmt` value for both. Every caller populates `"format"`, so behavior is unchanged.)
+
+- [ ] **Step 2: Run the persist-touching unit tests**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_persist_styles.py test/unit/test_two_phase_fallback_flag.py test/unit/test_two_phase_redirect.py test/unit/test_two_phase_sessions.py -v`
+Expected: ALL PASS (pure refactor — any failure means the extraction changed behavior; fix the extraction, not the tests).
+
+- [ ] **Step 3: Run the full unit suite**
+
+Run: `.venv/Scripts/python -m pytest test/unit -v`
+Expected: PASS (known env-dependent exceptions: live-network, `db` hostname, optional `claude_agent_sdk` — name them explicitly if they appear).
+
+- [ ] **Step 4: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/etl/persist.py; uvx ruff format src/agentic_librarian/etl/persist.py
+git add src/agentic_librarian/etl/persist.py
+git commit -m "refactor(etl): extract merge_edition_and_narrators from persist_enriched_work"
+```
+(The `db_integration` persist suites — `test_persist_enriched.py`, `test_persist_styles`' DB cousins etc. — execute FIRST in CI and are the real gate for this refactor.)
+
+---
+
+### Task 2: `create_completion_scout_manager` factory
+
+**Files:**
+- Modify: `src/agentic_librarian/orchestration/definitions.py`
+- Test: `test/unit/test_scout_factories.py`
+
+**Interfaces:**
+- Produces: `create_completion_scout_manager() -> ScoutManager` registering EXACTLY `HardcoverScout(priority=1)`, `GoogleBooksScout(2)`, `AudiobookScout(3)`, `DirectKnowledgeScout(4)`. No `StyleScout`, no `LLMTropeScout`. (Audiobook/DirectKnowledge self-skip inside `ScoutManager.enrich` when `"audiobook" not in format.lower()` — so this one manager serves every format.) Task 3 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/unit/test_scout_factories.py` (match the file's existing import style):
+
+```python
+def test_completion_manager_composition():
+    """Format-completion pass (history-format-edit spec): fast API scouts + audiobook
+    scouts ONLY — never LLMTropeScout (paid trope pass) or StyleScout (author/work
+    styles); narrator styles are scouted directly by two_phase.complete_edition."""
+    from agentic_librarian.orchestration.definitions import create_completion_scout_manager
+    from agentic_librarian.scouts.metadata_scout import (
+        AudiobookScout,
+        DirectKnowledgeScout,
+        GoogleBooksScout,
+        HardcoverScout,
+    )
+
+    manager = create_completion_scout_manager()
+    assert [type(s) for s, _priority in manager.scouts] == [
+        HardcoverScout,
+        GoogleBooksScout,
+        AudiobookScout,
+        DirectKnowledgeScout,
+    ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_scout_factories.py::test_completion_manager_composition -v`
+Expected: FAIL with `ImportError: cannot import name 'create_completion_scout_manager'`
+
+- [ ] **Step 3: Implement the factory**
+
+In `src/agentic_librarian/orchestration/definitions.py`, after `create_deep_scout_manager`:
+
+```python
+def create_completion_scout_manager() -> ScoutManager:
+    """Format-completion pass (history-format-edit): the fast API scouts fetch the new
+    format's edition metadata (ISBN, pages/audio minutes, publication date); the audiobook
+    scouts (which self-skip on non-audiobook formats) add narrators. Deliberately NO
+    LLMTropeScout and NO StyleScout — tropes and author/work styles belong to the Work,
+    which a format change does not touch; narrator styles are scouted directly by
+    two_phase.complete_edition."""
+    manager = ScoutManager()
+    manager.register_scout(HardcoverScout(), priority=1)
+    manager.register_scout(GoogleBooksScout(), priority=2)
+    manager.register_scout(AudiobookScout(), priority=3)
+    manager.register_scout(DirectKnowledgeScout(), priority=4)
+    return manager
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_scout_factories.py -v`
+Expected: PASS (whole file — the existing factory tests must stay green).
+
+- [ ] **Step 5: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/orchestration/definitions.py test/unit/test_scout_factories.py; uvx ruff format src/agentic_librarian/orchestration/definitions.py test/unit/test_scout_factories.py
+git add src/agentic_librarian/orchestration/definitions.py test/unit/test_scout_factories.py
+git commit -m "feat(scouts): completion scout manager for the format-completion pass"
+```
+
+---
+
+### Task 3: `complete_edition` pass in `two_phase.py`
+
+**Files:**
+- Modify: `src/agentic_librarian/enrichment/two_phase.py`
+- Test: `test/unit/test_edition_completion.py` (new)
+
+**Interfaces:**
+- Consumes: `merge_edition_and_narrators` (Task 1), `create_completion_scout_manager` (Task 2), existing `StyleScout.scout_narrator_style(name) -> dict`, `get_cached_embedding(EMBED_MODEL, text)`.
+- Produces: `complete_edition(work_id: UUID, fmt: str) -> str` returning `"missing" | "empty" | "done"`. Task 5's endpoint consumes it. Statuses: `"missing"` = work/author/edition gone (non-retryable); `"empty"` = no scout contributed (final, 200); `"done"` = merged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/unit/test_edition_completion.py`:
+
+```python
+"""complete_edition (history-format-edit): targeted format-completion pass.
+
+Session discipline (#94), status contract, and scout composition — narrator styles are
+scouted ONLY for audiobook formats, and only via scout_narrator_style (never
+StyleScout.search, which would re-scout author/work styles)."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.enrichment import two_phase
+
+
+class _FakeSession:
+    """Counting session double (the house #94 pattern, test_two_phase_sessions.py)."""
+
+    def __init__(self, state, work, edition):
+        self._state = state
+        self._work = work
+        self._edition = edition
+
+    def __enter__(self):
+        self._state["open"] += 1
+        m = MagicMock()
+        m.get.return_value = self._work
+        m.query.return_value.filter_by.return_value.first.return_value = self._edition
+        return m
+
+    def __exit__(self, *a):
+        self._state["open"] -= 1
+        return False
+
+
+def _work_double(title="T", author="A"):
+    work = MagicMock()
+    work.title = title
+    contrib = MagicMock(role="Author")
+    contrib.author.name = author
+    work.contributors = [contrib]
+    return work
+
+
+def _wire(monkeypatch, *, work, edition, enriched, state=None):
+    state = state if state is not None else {"open": 0}
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: _FakeSession(state, work, edition)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = enriched
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    return state, scout_mgr
+
+
+def test_scouts_run_outside_any_session(monkeypatch):
+    state, scout_mgr = _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched={})
+    seen = {}
+    scout_mgr.enrich.side_effect = lambda **kw: seen.setdefault("open_during_scout", state["open"]) or {}
+    assert two_phase.complete_edition(uuid4(), "ebook") == "empty"
+    assert seen["open_during_scout"] == 0  # THE #94 assertion
+
+
+@pytest.mark.parametrize(
+    ("work", "edition"),
+    [
+        pytest.param(None, MagicMock(), id="work_gone"),
+        pytest.param(_work_double(), None, id="edition_gone"),
+        pytest.param(MagicMock(title="T", contributors=[]), MagicMock(), id="no_author"),
+    ],
+)
+def test_missing_paths(monkeypatch, work, edition):
+    _wire(monkeypatch, work=work, edition=edition, enriched={})
+    assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
+
+
+def test_empty_scouts_is_final(monkeypatch):
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched={})
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "empty"
+
+
+def test_done_merges_scouted_values_for_audiobook(monkeypatch):
+    enriched = {
+        "isbn_13": "9780000000000",
+        "page_count": 300,
+        "audio_minutes": 600,
+        "publication_date": "2020-01-01",
+        "narrator_names": ["Ray Porter"],
+        "source_priority": ["Hardcover"],
+    }
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
+    style_scout = MagicMock()
+    style_scout.scout_narrator_style.return_value = {"pacing": "brisk"}
+    monkeypatch.setattr(two_phase, "StyleScout", lambda: style_scout)
+    merged = {}
+
+    def fake_merge(session, **kwargs):
+        merged.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(two_phase, "merge_edition_and_narrators", fake_merge)
+
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "done"
+    style_scout.scout_narrator_style.assert_called_once_with("Ray Porter")
+    assert merged["fmt"] == "audiobook"
+    assert merged["isbn_13"] == "9780000000000"
+    assert merged["audio_minutes"] == 600
+    assert merged["narrator_names"] == ["Ray Porter"]
+    assert merged["narrator_styles"] == {"Ray Porter": {"pacing": "brisk"}}
+
+
+def test_non_audiobook_never_scouts_narrator_styles(monkeypatch):
+    enriched = {"isbn_13": "9780000000001", "narrator_names": [], "source_priority": ["Hardcover"]}
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "merge_edition_and_narrators", lambda session, **kw: MagicMock())
+    with patch.object(two_phase, "StyleScout") as style_cls:
+        assert two_phase.complete_edition(uuid4(), "paperback") == "done"
+    style_cls.assert_not_called()
+
+
+def test_style_scout_failure_degrades_to_no_styles(monkeypatch):
+    enriched = {"narrator_names": ["Ray Porter"], "source_priority": ["Audible"]}
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
+    broken = MagicMock()
+    broken.scout_narrator_style.side_effect = RuntimeError("LLM down")
+    monkeypatch.setattr(two_phase, "StyleScout", lambda: broken)
+    merged = {}
+    monkeypatch.setattr(
+        two_phase, "merge_edition_and_narrators", lambda session, **kw: merged.update(kw) or MagicMock()
+    )
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "done"
+    assert merged["narrator_styles"] == {}  # narrators still merge; styles degrade
+
+
+def test_work_deleted_mid_pass_returns_missing(monkeypatch):
+    """The write session re-checks existence (same honesty rule as enrich_deep)."""
+    enriched = {"isbn_13": "9780000000002", "narrator_names": [], "source_priority": ["Hardcover"]}
+    state = {"open": 0, "calls": 0}
+
+    work = _work_double()
+
+    class _VanishingSession(_FakeSession):
+        def __enter__(self):
+            self._state["open"] += 1
+            self._state["calls"] += 1
+            m = MagicMock()
+            # First (read) session sees the work; second (write) session finds it gone.
+            m.get.return_value = work if self._state["calls"] == 1 else None
+            m.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+            return m
+
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: _VanishingSession(state, work, MagicMock())
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = enriched
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_edition_completion.py -v`
+Expected: FAIL with `AttributeError: module ... has no attribute 'complete_edition'` (and missing imports).
+
+- [ ] **Step 3: Implement `complete_edition`**
+
+In `src/agentic_librarian/enrichment/two_phase.py`:
+
+Add imports (extend existing import lines where the module already imports from that source):
+
+```python
+from agentic_librarian.etl.persist import collect_embedding_texts, merge_edition_and_narrators, persist_enriched_work
+from agentic_librarian.orchestration.definitions import (
+    create_completion_scout_manager,
+    create_deep_scout_manager,
+    create_fast_scout_manager,
+)
+from agentic_librarian.scouts.metadata_scout import StyleScout
+```
+
+Add after `add_read_event`:
+
+```python
+def complete_edition(work_id: UUID, fmt: str) -> str:
+    """Format-completion pass (history-format-edit spec): fill the (work_id, fmt)
+    edition's metadata after a history-entry format change. Fast API scouts always
+    (ISBN, pages/audio minutes, publication date); audiobook scouts + per-narrator
+    style scouting only when fmt is an audiobook. Deliberately NEVER LLMTropeScout or
+    author/work-style scouting — the Work is unchanged; this pass must not touch
+    deep_enriched_at or the deep pass's retry gating.
+
+    Same session discipline as the other passes here (#94): short read session, scouts
+    with NO session held, fresh write session. Idempotent (all merges) — Cloud Tasks
+    redelivery is safe.
+
+    Returns:
+      "missing" — work, its Author link, or the (work_id, fmt) edition no longer exists
+                  (also when the work vanished while scouts ran). Non-retryable.
+      "empty"   — no scout contributed anything. Final state: the entry itself is already
+                  saved, and unlike the deep pass there is no requeue-sweep backstop
+                  economics to protect — do not retry-loop.
+      "done"    — scouted values merged onto the edition."""
+    fmt = (fmt or "")[:50]
+
+    with db_manager.get_session() as session:
+        work = session.get(Work, work_id)
+        if work is None:
+            return "missing"
+        author = next((c.author.name for c in work.contributors if c.role == "Author"), None)
+        if author is None:
+            return "missing"
+        title = work.title  # scalars captured before close (detached-instance rule)
+        edition = session.query(Edition).filter_by(work_id=work_id, format=fmt).first()
+        if edition is None:
+            return "missing"
+
+    enriched = create_completion_scout_manager().enrich(title=title, author=author, format=fmt)
+    if not enriched:
+        return "empty"
+
+    narrator_names = [n for n in (enriched.get("narrator_names") or []) if isinstance(n, str) and n.strip()]
+    narrator_styles: dict[str, dict] = {}
+    if "audiobook" in fmt.lower() and narrator_names:
+        style_scout = StyleScout()
+        for n_name in narrator_names:
+            try:
+                narrator_styles[n_name] = style_scout.scout_narrator_style(n_name)
+            except Exception:  # noqa: BLE001 - style scouting is additive; narrators still merge without it
+                logger.warning("narrator style scout failed for %r — merging narrator without styles", n_name)
+
+    # GH #123: warm the embedding LRU for every style string the persist will standardize,
+    # so no network embed happens inside the write session.
+    for style_map in narrator_styles.values():
+        for style_text in style_map.values():
+            try:
+                get_cached_embedding(EMBED_MODEL, style_text)
+            except Exception:  # noqa: BLE001 - warming is best-effort; _safe_standardize degrades in-session
+                logger.warning("embed warm failed for %r — persist will retry in-session", style_text)
+
+    with db_manager.get_session() as session:
+        if session.get(Work, work_id) is None:
+            # Deleted while the scouts ran with no session held — same honesty rule as
+            # enrich_deep's empty path.
+            return "missing"
+        merge_edition_and_narrators(
+            session,
+            work_id=work_id,
+            fmt=fmt,
+            isbn_13=enriched.get("isbn_13"),
+            page_count=enriched.get("page_count"),
+            audio_minutes=enriched.get("audio_minutes"),
+            publication_date=enriched.get("publication_date"),
+            narrator_names=narrator_names,
+            narrator_styles=narrator_styles,
+            style_manager=StyleManager(session=session),
+        )
+        session.flush()
+    return "done"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_edition_completion.py test/unit/test_two_phase_sessions.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/enrichment/two_phase.py test/unit/test_edition_completion.py; uvx ruff format src/agentic_librarian/enrichment/two_phase.py test/unit/test_edition_completion.py
+git add src/agentic_librarian/enrichment/two_phase.py test/unit/test_edition_completion.py
+git commit -m "feat(enrichment): complete_edition targeted format-completion pass"
+```
+
+---
+
+### Task 4: `enqueue_edition_completion` Cloud Tasks helper
+
+**Files:**
+- Modify: `src/agentic_librarian/enrichment/tasks.py`
+- Test: `test/unit/test_enqueue_enrichment.py`
+
+**Interfaces:**
+- Produces: `enqueue_edition_completion(work_id: str, fmt: str) -> bool` — True if enqueued, False when Cloud Tasks is unconfigured (local dev). Task 6 consumes it. Task URL: `POST {base}/internal/complete-edition/{work_id}?format={fmt}`; OIDC audience defaults to the URL WITHOUT the query string (`ENRICH_OIDC_AUDIENCE` overrides, as in prod).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/unit/test_enqueue_enrichment.py` (reuses that file's `_FakeClient` and `_set_env`):
+
+```python
+def test_enqueue_edition_completion_targets_the_completion_route(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook") is True
+
+    parent, task = fake.created[0]
+    assert parent == "projects/p/locations/us-central1/queues/enrich"
+    http = task["http_request"]
+    assert http["url"] == (
+        "https://librarian.example.run.app/internal/complete-edition/"
+        "11111111-1111-4111-8111-111111111111?format=audiobook"
+    )
+    assert http["oidc_token"]["service_account_email"] == "queue-invoker@p.iam.gserviceaccount.com"
+    # Audience must NOT include the query string (a per-task audience would break a fixed
+    # receiver-side ENRICH_OIDC_AUDIENCE check).
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/complete-edition/11111111-1111-4111-8111-111111111111"
+    )
+
+
+def test_enqueue_edition_completion_skips_when_not_configured(monkeypatch):
+    monkeypatch.delenv("CLOUD_TASKS_QUEUE", raising=False)
+    called = {"n": 0}
+    monkeypatch.setattr(tasks, "_client", lambda: called.__setitem__("n", called["n"] + 1))
+
+    assert tasks.enqueue_edition_completion("abc", "audiobook") is False
+    assert called["n"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_enqueue_enrichment.py -v`
+Expected: the two new tests FAIL with `AttributeError: ... 'enqueue_edition_completion'`; existing tests PASS.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/agentic_librarian/enrichment/tasks.py`, add `from urllib.parse import quote` to the imports, then after `enqueue_enrichment`:
+
+```python
+def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
+    """Enqueue the format-completion pass for (work_id, fmt) — history-format-edit spec.
+    Returns True if enqueued, False if Cloud Tasks is not configured (local dev); the
+    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved."""
+    queue = os.environ.get("CLOUD_TASKS_QUEUE")
+    base = os.environ.get("ENRICH_TARGET_BASE_URL")
+    sa = os.environ.get("ENRICH_INVOKER_SA")
+    if not (queue and base and sa):
+        logger.info("edition-completion enqueue skipped — Cloud Tasks not configured (work %s)", work_id)
+        return False
+
+    path_url = f"{base.rstrip('/')}/internal/complete-edition/{work_id}"
+    url = f"{path_url}?format={quote(fmt)}"
+    # Audience deliberately excludes the query string: the receiver verifies against a
+    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format audience would never match.
+    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or path_url
+    task = {
+        "http_request": {
+            "http_method": "POST",
+            "url": url,
+            "oidc_token": {"service_account_email": sa, "audience": audience},
+        }
+    }
+    _client().create_task(parent=queue, task=task)
+    logger.info("enqueued edition completion for work %s format %s", work_id, fmt)
+    return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_enqueue_enrichment.py test/unit/test_tasks_client_cache.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/enrichment/tasks.py test/unit/test_enqueue_enrichment.py; uvx ruff format src/agentic_librarian/enrichment/tasks.py test/unit/test_enqueue_enrichment.py
+git add src/agentic_librarian/enrichment/tasks.py test/unit/test_enqueue_enrichment.py
+git commit -m "feat(enrichment): enqueue helper for the edition-completion pass"
+```
+
+---
+
+### Task 5: internal endpoint `POST /internal/complete-edition/{work_id}`
+
+**Files:**
+- Modify: `src/agentic_librarian/api/internal.py`
+- Test: `test/integration/test_internal_complete_edition_api.py` (new)
+
+**Interfaces:**
+- Consumes: `two_phase.complete_edition(work_id, fmt) -> "missing" | "empty" | "done"` (Task 3); existing `_require_queue_caller`.
+- Produces: `POST /internal/complete-edition/{work_id}?format=<fmt>` — 401/403 per OIDC gate, 404 on `"missing"`, 422 on missing `format` query param, else 200 `{"work_id", "format", "status"}`. This is the URL Task 4 enqueues.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/integration/test_internal_complete_edition_api.py`:
+
+```python
+"""OIDC gate + status mapping for the edition-completion internal endpoint.
+
+Mirrors test_internal_enrich_api.py: db_integration because the FastAPI app import
+chain needs real settings, but complete_edition itself is monkeypatched — the pass's
+own behavior is covered by test/unit/test_edition_completion.py."""
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import internal as internal_mod
+from agentic_librarian.api import main as api_main
+
+pytestmark = pytest.mark.db_integration
+
+VALID_AUD = "https://librarian.example.run.app/internal/enrich/x"
+QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
+    monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
+    yield TestClient(api_main.app)
+
+
+def _as_queue(monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+
+
+def test_valid_queue_token_runs_completion(client, monkeypatch):
+    _as_queue(monkeypatch)
+    called = {}
+
+    def fake_complete(wid, fmt):
+        called["args"] = (wid, fmt)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert called["args"] == (wid, "audiobook")
+
+
+def test_missing_work_is_404_non_retryable(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", lambda wid, fmt: "missing")
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 404
+
+
+def test_empty_scouts_is_200_final(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", lambda wid, fmt: "empty")
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "empty"
+
+
+def test_missing_token_is_401(client):
+    assert client.post(f"/internal/complete-edition/{uuid4()}?format=ebook").status_code == 401
+
+
+def test_wrong_service_account_is_403(client, monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": "attacker@evil.com", "email_verified": True}
+    )
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 403
+
+
+def test_missing_format_param_is_422(client, monkeypatch):
+    _as_queue(monkeypatch)
+    resp = client.post(f"/internal/complete-edition/{uuid4()}", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Verify collection (local run deselects db_integration)**
+
+Run: `.venv/Scripts/python -m pytest test/integration/test_internal_complete_edition_api.py --collect-only -q`
+Expected: 6 tests collected, no import errors. (Execution is CI's job — say so honestly in the task report; with a local compose db, `POSTGRES_HOST=localhost` runs them for real.)
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `src/agentic_librarian/api/internal.py`, add `Query` to the fastapi import, then after the `enrich` route:
+
+```python
+@router.post("/internal/complete-edition/{work_id}")
+def complete_edition(
+    work_id: UUID,
+    format: str = Query(..., max_length=50),  # noqa: B008
+    authorization: str | None = Header(None),  # noqa: B008
+):
+    """Format-completion pass target (history-format-edit spec). Same OIDC gate as
+    /internal/enrich. 'missing' → 404 (non-retryable: work/edition gone); 'empty' and
+    'done' → 200 (final — no retry economics here, the history edit is already saved);
+    an unexpected exception propagates → 500 → normal Cloud Tasks retry."""
+    _require_queue_caller(authorization)
+    result = two_phase.complete_edition(work_id, format)
+    if result == "missing":
+        raise HTTPException(status_code=404, detail="work or edition not found")
+    return {"work_id": str(work_id), "format": format, "status": result}
+```
+
+- [ ] **Step 4: Re-verify collection + run the existing internal-route unit guard**
+
+Run: `.venv/Scripts/python -m pytest test/integration/test_internal_complete_edition_api.py --collect-only -q; .venv/Scripts/python -m pytest test/unit -k "internal" -v`
+Expected: collection clean; unit `internal` tests PASS.
+
+- [ ] **Step 5: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/api/internal.py test/integration/test_internal_complete_edition_api.py; uvx ruff format src/agentic_librarian/api/internal.py test/integration/test_internal_complete_edition_api.py
+git add src/agentic_librarian/api/internal.py test/integration/test_internal_complete_edition_api.py
+git commit -m "feat(api): internal complete-edition endpoint for format changes"
+```
+
+---
+
+### Task 6: `PATCH /history/{id}` format support
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py` (`HistoryUpdate` model + `update_history` handler)
+- Test: `test/unit/test_api_history.py` (validation cases), `test/integration/test_api_history_db.py` (behavior)
+
+**Interfaces:**
+- Consumes: `enqueue_edition_completion(work_id: str, fmt: str) -> bool` (Task 4), existing `get_or_create`, `_history_item`, `_history_options`.
+- Produces: `PATCH /history/{id}` accepts `format` (vocab `ebook|audiobook|paperback|hardcover`, case-normalized); 409 on collision; response = `_history_item` payload + `"enrichment_enqueued": bool`. Task 7's frontend consumes the 409 detail string and the `format` field.
+
+- [ ] **Step 1: Write the failing unit validation tests**
+
+Append to `test/unit/test_api_history.py`:
+
+```python
+def _patch_with_mock_row(json_body):
+    """PATCH against a minimal mocked row (validation-focused unit seam)."""
+    with patch("agentic_librarian.api.main.db_manager") as mock_db:
+        mock_session = MagicMock()
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+        _history_chain(mock_session, [])
+        return client.patch("/history/00000000-0000-4000-8000-00000000abcd", json=json_body)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_status"),
+    [
+        pytest.param({"format": "vinyl"}, 422, id="unknown_format_rejected"),
+        pytest.param({"format": ""}, 422, id="empty_format_rejected"),
+        pytest.param({"format": None}, 422, id="null_format_rejected"),
+        pytest.param({"format": 7}, 422, id="non_string_format_rejected"),
+    ],
+)
+def test_patch_history_format_vocab_validation(body, expected_status):
+    assert _patch_with_mock_row(body).status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    "raw", [pytest.param("Audiobook", id="capitalized"), pytest.param("  audiobook  ", id="padded")]
+)
+def test_patch_history_format_is_case_and_space_normalized(raw):
+    """Accepted spellings normalize to the canonical lowercase vocab before any DB work —
+    prove it via the pydantic model directly (the endpoint seam is mocked in this file)."""
+    from agentic_librarian.api.main import HistoryUpdate
+
+    assert HistoryUpdate(format=raw).format == "audiobook"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_api_history.py -v`
+Expected: new tests FAIL (`format` currently ignored → 404-or-500 path instead of 422; `HistoryUpdate` has no `format`). Existing tests PASS.
+
+- [ ] **Step 3: Write the failing db_integration tests**
+
+Append to `test/integration/test_api_history_db.py`:
+
+```python
+def _db(db_url):
+    return DatabaseManager(db_url)
+
+
+def _my_entry(client):
+    return next(h for h in client.get("/history").json() if h["title"] == "Shared Book")
+
+
+def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_url):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["format"] == "audiobook"
+    assert resp.json()["enrichment_enqueued"] is False  # no Cloud Tasks in tests
+    with _db(db_url).get_session() as s:
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        work_id = row.edition.work_id
+        formats = {e.format for e in s.query(Edition).filter(Edition.work_id == work_id)}
+        assert row.edition.format == "audiobook"
+        assert formats == {"ebook", "audiobook"}  # old edition intact (shared catalog object)
+        # Assertion completeness (#96 lesson): untouched fields survive; the friend's row
+        # on the ORIGINAL edition is untouched.
+        assert row.date_completed == date(2021, 1, 1)
+        friend = s.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).one()
+        assert friend.edition.format == "ebook"
+
+
+def test_patch_format_reuses_existing_sibling_edition(two_user_client, db_url):
+    with _db(db_url).get_session() as s:
+        work_id = s.query(Edition).filter(Edition.format == "ebook").first().work_id
+        s.add(Edition(work_id=work_id, format="audiobook", isbn_13="9781111111111"))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    assert client.patch(f"/history/{entry['id']}", json={"format": "audiobook"}).status_code == 200
+    with _db(db_url).get_session() as s:
+        assert s.query(Edition).filter(Edition.work_id == work_id).count() == 2  # reused, not duplicated
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        assert row.edition.isbn_13 == "9781111111111"
+
+
+def test_patch_same_format_is_a_noop(two_user_client, db_url):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    assert client.patch(f"/history/{entry['id']}", json={"format": "ebook"}).status_code == 200
+    with _db(db_url).get_session() as s:
+        work_id = s.get(ReadingHistory, UUID(entry["id"])).edition.work_id
+        assert s.query(Edition).filter(Edition.work_id == work_id).count() == 1  # nothing minted
+
+
+def test_patch_format_collision_is_409_and_rolls_back(two_user_client, db_url):
+    with _db(db_url).get_session() as s:
+        ebook = s.query(Edition).filter(Edition.format == "ebook").first()
+        audio = Edition(work_id=ebook.work_id, format="audiobook")
+        s.add(audio)
+        s.flush()
+        # Same user, same work, SAME date — but as an audiobook (an import-duplicate shape).
+        s.add(ReadingHistory(edition_id=audio.id, user_id=DEFAULT_USER_ID, date_completed=date(2021, 1, 1)))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook", "notes": "should not stick"})
+    assert resp.status_code == 409
+    assert "already logged" in resp.json()["detail"]
+    with _db(db_url).get_session() as s:
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        assert row.edition.format == "ebook"  # repoint rolled back
+        assert row.user_notes != "should not stick"  # the whole PATCH rolled back, not just format
+
+
+def test_patch_date_collision_is_409_not_500(two_user_client, db_url):
+    """Pre-existing hole the format work closes: date-only edits could always trip
+    uq_reading_history_user_edition_date; they must now 409 cleanly."""
+    with _db(db_url).get_session() as s:
+        edition_id = s.query(Edition).filter(Edition.format == "ebook").first().id
+        s.add(ReadingHistory(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=date(2020, 6, 6)))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)  # the 2021-01-01 read
+    assert client.patch(f"/history/{entry['id']}", json={"date_completed": "2020-06-06"}).status_code == 409
+
+
+def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append((wid, fmt)) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is True
+    assert len(calls) == 1 and calls[0][1] == "audiobook"
+
+
+def test_patch_format_enqueue_failure_never_fails_the_edit(two_user_client, monkeypatch):
+    def _boom(wid, fmt):
+        raise RuntimeError("tasks down")
+
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", _boom)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["format"] == "audiobook"  # the edit stuck
+    assert resp.json()["enrichment_enqueued"] is False
+
+
+def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_url, monkeypatch):
+    from agentic_librarian.db.models import Narrator
+
+    with _db(db_url).get_session() as s:
+        work_id = s.query(Edition).filter(Edition.format == "ebook").first().work_id
+        done = Edition(work_id=work_id, format="audiobook", isbn_13="9782222222222")
+        done.narrators = [Narrator(name="Ray Porter")]
+        s.add(done)
+        s.flush()
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is False
+    assert calls == []  # already complete — no paid pass
+
+
+def test_patch_notes_only_never_enqueues(two_user_client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"notes": "just notes"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is False
+    assert calls == []
+```
+
+Note for the implementer: these tests reference `Edition` and `date` — both already imported at the top of this file. `api_main` is imported as `from agentic_librarian.api import main as api_main`.
+
+- [ ] **Step 4: Verify collection**
+
+Run: `.venv/Scripts/python -m pytest test/integration/test_api_history_db.py --collect-only -q`
+Expected: all tests (old + 9 new) collected cleanly. Execution is CI's gate (or `POSTGRES_HOST=localhost` with the compose db up).
+
+- [ ] **Step 5: Implement the endpoint changes**
+
+In `src/agentic_librarian/api/main.py`:
+
+Imports — extend the existing blocks (add only what's missing):
+
+```python
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+
+from agentic_librarian.db.get_or_create import get_or_create
+from agentic_librarian.enrichment.tasks import enqueue_edition_completion
+```
+
+`HistoryUpdate` — add the field and validator (keep the existing validators):
+
+```python
+HISTORY_FORMATS = {"ebook", "audiobook", "paperback", "hardcover"}
+
+
+class HistoryUpdate(BaseModel):
+    date_completed: date | None = None
+    rating: int | None = None
+    notes: str | None = None
+    format: str | None = None
+
+    @field_validator("format")
+    @classmethod
+    def _format_vocab(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        normalized = v.strip().lower()
+        if normalized not in HISTORY_FORMATS:
+            raise ValueError("format must be one of: ebook, audiobook, paperback, hardcover")
+        return normalized
+```
+
+Replace the body of `update_history`:
+
+```python
+@app.patch("/history/{entry_id}")
+def update_history(
+    entry_id: UUID,
+    req: HistoryUpdate,
+    user: AuthenticatedUser = Depends(get_current_user),  # noqa: B008
+):
+    fields = req.model_dump(exclude_unset=True)  # only what the client actually sent
+    if "date_completed" in fields and fields["date_completed"] is None:
+        raise HTTPException(status_code=422, detail="date_completed cannot be null")
+    if "format" in fields and fields["format"] is None:
+        raise HTTPException(status_code=422, detail="format cannot be null")
+
+    needs_completion = False
+    work_id_str = fmt_str = ""
+    with db_manager.get_session() as session:
+        row = (
+            session.query(ReadingHistory)
+            .filter(ReadingHistory.id == entry_id, ReadingHistory.user_id == user.id)
+            .options(*_history_options())
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="history entry not found")
+        # Scalar edits first, so the collision check below runs against the FINAL date.
+        if "date_completed" in fields:
+            row.date_completed = fields["date_completed"]
+        if "rating" in fields:
+            row.user_rating = fields["rating"]
+        if "notes" in fields:
+            row.user_notes = fields["notes"]
+
+        target_edition = row.edition
+        new_fmt = fields.get("format")
+        if new_fmt is not None and new_fmt != (row.edition.format or "").strip().lower():
+            # Format change = repoint to the sibling (work_id, format) edition — editions are
+            # shared catalog objects, so the old one is never mutated or deleted. Reuse a
+            # casing variant if one exists (uq_editions_work_format is case-sensitive);
+            # get_or_create + the unique index backstop the concurrent-create race (#95).
+            target_edition = (
+                session.query(Edition)
+                .filter(Edition.work_id == row.edition.work_id, func.lower(Edition.format) == new_fmt)
+                .first()
+            )
+            if target_edition is None:
+                target_edition, _created = get_or_create(
+                    session, Edition, work_id=row.edition.work_id, format=new_fmt
+                )
+
+        collision_detail = (
+            f"You already logged this book as {target_edition.format or 'the same format'} "
+            f"on {row.date_completed.isoformat()}."
+        )
+        if target_edition.id != row.edition_id or "date_completed" in fields:
+            # uq_reading_history_user_edition_date pre-check; the index itself backstops the
+            # millisecond race below and maps to the same 409.
+            dup = (
+                session.query(ReadingHistory)
+                .filter(
+                    ReadingHistory.user_id == user.id,
+                    ReadingHistory.edition_id == target_edition.id,
+                    ReadingHistory.date_completed == row.date_completed,
+                    ReadingHistory.id != row.id,
+                )
+                .first()
+            )
+            if dup is not None:
+                # Raising inside the session context rolls back EVERY field edit above —
+                # a 409 must leave the row exactly as it was.
+                raise HTTPException(status_code=409, detail=collision_detail)
+
+        if target_edition.id != row.edition_id:
+            row.edition = target_edition
+            # Decide the async completion enqueue while the session is open (narrators is a
+            # lazy relationship): missing ISBN, or an audiobook with no narrators yet.
+            needs_completion = target_edition.isbn_13 is None or (
+                "audiobook" in (target_edition.format or "").lower() and not target_edition.narrators
+            )
+            work_id_str = str(target_edition.work_id)
+            fmt_str = target_edition.format or ""
+        try:
+            session.flush()
+        except IntegrityError as e:
+            raise HTTPException(status_code=409, detail=collision_detail) from e
+        payload = _history_item(row)
+
+    # After commit: best-effort enqueue in the POST /books style — a Cloud Tasks failure
+    # must never fail the edit (the completion sweep-of-one can be retriggered by any
+    # later format edit; the entry itself is saved).
+    enqueued = False
+    if needs_completion:
+        try:
+            enqueued = enqueue_edition_completion(work_id_str, fmt_str)
+        except Exception:  # noqa: BLE001 - enqueue is best-effort
+            logger.exception("edition-completion enqueue failed for work %s", work_id_str)
+    payload["enrichment_enqueued"] = enqueued
+    return payload
+```
+
+(If `main.py` has no module `logger`, add `logger = logging.getLogger(__name__)` near the top alongside the existing imports.)
+
+- [ ] **Step 6: Run unit tests to verify they pass**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_api_history.py test/unit/test_api_requires_auth.py -v`
+Expected: PASS, including the new validation cases.
+
+- [ ] **Step 7: Full unit suite + collection check of the integration file**
+
+Run: `.venv/Scripts/python -m pytest test/unit -v; .venv/Scripts/python -m pytest test/integration/test_api_history_db.py --collect-only -q`
+Expected: unit suite PASS; collection clean.
+
+- [ ] **Step 8: Lint, format, commit**
+
+```powershell
+uvx ruff check src/agentic_librarian/api/main.py test/unit/test_api_history.py test/integration/test_api_history_db.py; uvx ruff format src/agentic_librarian/api/main.py test/unit/test_api_history.py test/integration/test_api_history_db.py
+git add src/agentic_librarian/api/main.py test/unit/test_api_history.py test/integration/test_api_history_db.py
+git commit -m "feat(api): history format edit — edition repoint, 409 collisions, completion enqueue"
+```
+
+---
+
+### Task 7: Frontend — format select + 409 messaging
+
+**Files:**
+- Modify: `frontend/src/api/client.ts` (`HistoryItem`, `HistoryUpdate`, `updateHistory`, new `ApiError`)
+- Modify: `frontend/src/views/HistoryEditView.tsx`
+- Test: `frontend/src/views/HistoryEditView.test.tsx`
+
+**Interfaces:**
+- Consumes: `PATCH /history/{id}` from Task 6 (accepts `format`; 409 `{detail: string}`; response includes `enrichment_enqueued`).
+- Produces: `ApiError extends Error { status: number; detail: string }` exported from `client.ts`; `HistoryUpdate.format?: string`; `HistoryItem.enrichment_enqueued?: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `frontend/src/views/HistoryEditView.test.tsx`, add to the existing `describe` (the `row` fixture and `renderAt` helper already exist; `ApiError` import comes from the real module — add `import { ApiError } from '../api/client'` and mock it through with `vi.mock('../api/client', async (importOriginal) => ({ ...(await importOriginal<typeof import('../api/client')>()), updateHistory: vi.fn(), deleteHistory: vi.fn(), getHistory: vi.fn() }))` replacing the bare `vi.mock('../api/client')` so the real `ApiError` class survives mocking):
+
+```tsx
+  it('renders the format select prefilled with the current format', () => {
+    renderAt(row)
+    expect(screen.getByLabelText(/format/i)).toHaveValue('ebook')
+  })
+
+  it('sends format only when the user changes it', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row, format: 'audiobook' })
+    renderAt(row)
+    await userEvent.selectOptions(screen.getByLabelText(/format/i), 'audiobook')
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() =>
+      expect(client.updateHistory).toHaveBeenCalledWith('h1', expect.objectContaining({ format: 'audiobook' })),
+    )
+  })
+
+  it('omits format from the payload when unchanged', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row })
+    renderAt(row)
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() =>
+      expect(client.updateHistory).toHaveBeenCalledWith(
+        'h1',
+        expect.not.objectContaining({ format: expect.anything() }),
+      ),
+    )
+  })
+
+  it('shows the server message on a 409 collision', async () => {
+    // ...Once variant (vitest pitfall memory): a persistent mockRejectedValue leaks
+    // an unhandled rejection into later tests.
+    vi.mocked(client.updateHistory).mockRejectedValueOnce(
+      new ApiError(409, 'You already logged this book as audiobook on 2019-03-14.'),
+    )
+    renderAt(row)
+    await userEvent.selectOptions(screen.getByLabelText(/format/i), 'audiobook')
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    expect(
+      await screen.findByText('You already logged this book as audiobook on 2019-03-14.'),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to the generic message on non-409 failures', async () => {
+    vi.mocked(client.updateHistory).mockRejectedValueOnce(new Error('network'))
+    renderAt(row)
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    expect(await screen.findByText(/couldn't save those changes/i)).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run (from `frontend/`): `npx vitest run src/views/HistoryEditView.test.tsx`
+Expected: new tests FAIL (no format select; `ApiError` not exported). The two pre-existing tests PASS.
+
+- [ ] **Step 3: Implement `client.ts` changes**
+
+In `frontend/src/api/client.ts`:
+
+Add to `HistoryItem`: `enrichment_enqueued?: boolean`.
+Add to `HistoryUpdate`: `format?: string`.
+Add the error class (near the top, after imports):
+
+```ts
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public detail: string,
+  ) {
+    super(detail)
+    this.name = 'ApiError'
+  }
+}
+```
+
+Replace `updateHistory`'s failure path so the server's `detail` survives:
+
+```ts
+export async function updateHistory(id: string, body: HistoryUpdate): Promise<HistoryItem> {
+  const res = await authedFetchRaw(`/history/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    let detail = `update history → ${res.status}`
+    try {
+      const parsed = await res.json()
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+    } catch {
+      // non-JSON error body — keep the generic detail
+    }
+    throw new ApiError(res.status, detail)
+  }
+  return res.json()
+}
+```
+
+(Keep the rest of the function exactly as it is today — only the `!res.ok` branch changes.)
+
+- [ ] **Step 4: Implement the view changes**
+
+In `frontend/src/views/HistoryEditView.tsx`:
+
+Add state after the existing `useState` lines:
+
+```tsx
+  const [format, setFormat] = useState(row?.format ?? '')
+```
+
+Import `ApiError` alongside `updateHistory`. In `onSubmit`, build the body conditionally and branch the catch:
+
+```tsx
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      const body: Parameters<typeof updateHistory>[1] = {
+        rating: rating ? Number(rating) : null,
+        date_completed: dateFinished || null,
+        notes: notes.trim() || null,
+      }
+      if (format && format !== row!.format) body.format = format
+      await updateHistory(id as string, body)
+      navigate('/history')
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) setError(err.detail)
+      else setError("Couldn't save those changes — try again.")
+    } finally {
+      setBusy(false)
+    }
+  }
+```
+
+Add the select to the form, between the context paragraph's closing and the Rating label (mirrors `AddBookView`'s options; the empty option only renders for a null incoming format):
+
+```tsx
+        <label>
+          Format
+          <select value={format} onChange={(e) => setFormat(e.target.value)}>
+            {!row.format && <option value="">—</option>}
+            <option value="ebook">ebook</option>
+            <option value="audiobook">audiobook</option>
+            <option value="paperback">paperback</option>
+            <option value="hardcover">hardcover</option>
+          </select>
+        </label>
+```
+
+Also remove the now-stale ` · {row.format}` from the context paragraph ONLY if it visually duplicates the select — otherwise leave it (implementer's call; default: leave it).
+
+- [ ] **Step 5: Run the frontend tests**
+
+Run (from `frontend/`): `npx vitest run src/views/HistoryEditView.test.tsx`
+Expected: ALL PASS (2 pre-existing + 5 new).
+
+Then the full frontend suite: `npx vitest run`
+Expected: PASS (App.test.tsx mocks every view — no change needed there since no new module was created).
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add frontend/src/api/client.ts frontend/src/views/HistoryEditView.tsx frontend/src/views/HistoryEditView.test.tsx
+git commit -m "feat(frontend): format select on history edit with 409 collision messaging"
+```
+
+---
+
+### Task 8: Final verification, docs, PR
+
+**Files:**
+- Modify: `docs/project_notes/issues.md` (work-log entry)
+
+- [ ] **Step 1: Full unit suite + frontend suite**
+
+Run: `.venv/Scripts/python -m pytest test/unit -v` and (from `frontend/`) `npx vitest run`
+Expected: PASS. Name any env-dependent failures explicitly (live-network, `db` hostname, optional `claude_agent_sdk`) — verify with `git stash` that they pre-date this branch if any appear.
+
+- [ ] **Step 2: Ruff over the whole touched set**
+
+```powershell
+uvx ruff check src/agentic_librarian test; uvx ruff format src/agentic_librarian test
+```
+Expected: clean (format may rewrite — re-run unit tests if it does, then amend nothing: make a follow-up commit).
+
+- [ ] **Step 3: Log the work**
+
+Append to `docs/project_notes/issues.md` under the current section:
+
+```markdown
+### 2026-07-18 - History format edit (spec 2026-07-18)
+- **Status**: PR open
+- **Description**: PATCH /history accepts format (vocab-validated); repoints to sibling
+  (work_id, format) Edition; 409 on uq_reading_history collisions (incl. the pre-existing
+  date-edit 500 hole); async /internal/complete-edition pass fills ISBN/pages/audio +
+  narrators/styles for audiobooks — never the paid trope/style deep pass.
+- **Notes**: merge_edition_and_narrators extracted from persist_enriched_work (shared).
+```
+
+- [ ] **Step 4: Commit docs, push branch, open PR**
+
+```powershell
+git add docs/project_notes/issues.md
+git commit -m "docs(project-notes): log history-format-edit work"
+git push -u origin feat/history-format-edit
+gh pr create --title "feat: history format edit with targeted edition-completion enrichment" --body "..."
+```
+PR body: summarize the spec decisions (repoint not mutate; 409 collisions; targeted completion pass vs full deep pass; date-edit 409 fix), link the spec file, state honestly which suites executed locally vs are CI-gated (db_integration), and end with the standard generated-with footer. Gemini reviews each PR — respond per `pr-workflow-conventions` (TDD red→green fixes, reply with commit hash). **The first CI run is a merge gate: db_integration executes there for the first time.**
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage:** §1 API → Task 6; §2 completion pass → Tasks 1–5; §3 frontend → Task 7; §4 testing → embedded per task + Task 8; "Out of scope" respected (no title/author editing, no history-UI narrator display, no backfill sweep).
+- **Type consistency:** `complete_edition(work_id: UUID, fmt: str) -> "missing"|"empty"|"done"` consistent across Tasks 3/5; `enqueue_edition_completion(work_id: str, fmt: str) -> bool` consistent across Tasks 4/6; `merge_edition_and_narrators` kwargs consistent across Tasks 1/3; `ApiError(status, detail)` consistent across Task 7 files.
+- **Known judgment calls documented inline:** `row["format"]`→`fmt` unification (Task 1), audience-without-query (Task 4), case-insensitive edition reuse (Task 6), leave-the-context-line (Task 7).

--- a/docs/superpowers/specs/2026-07-18-history-format-edit-design.md
+++ b/docs/superpowers/specs/2026-07-18-history-format-edit-design.md
@@ -1,0 +1,124 @@
+# History Format Edit — Design
+
+**Date:** 2026-07-18
+**Status:** Approved (design walkthrough 2026-07-18)
+
+## Problem
+
+Users can edit a history entry's date, rating, and notes (`PATCH /history/{id}`, shipped in
+the 2026-06-16 history-edit-delete design) but not its **format**. Format is the one field
+that is not a simple column write: `format` lives on `Edition` (unique per `(work_id,
+format)`, `NULLS NOT DISTINCT`), editions are shared catalog objects, and audiobook is
+enrichment-significant — the `AudiobookScout`/`DirectKnowledgeScout` (narrators, audio
+minutes) and narrator-style scouts only run when the format string contains "audiobook".
+A work first enriched as ebook has no narrator data, and every format's edition carries its
+own `isbn_13`/`page_count`/`audio_minutes`, so a format flip leaves the target edition
+metadata-less unless an enrichment pass runs.
+
+## Decisions made during design
+
+- **Enrichment UX:** async, like imports — PATCH saves and returns immediately; a Cloud
+  Tasks pass fills edition data in later.
+- **Collision:** refuse with **409** (keep both rows); never silently merge/delete.
+- **Trigger scope:** a *targeted format-completion pass*, not the full deep pass. ISBN
+  comes from the fast API scouts (Hardcover format-matched edition selection), so **any**
+  format change gets a cheap 2-API-call completion; audiobook targets additionally get the
+  audiobook LLM scouts + narrator styles. `LLMTropeScout` and author/work-style scouting
+  never run — tropes/styles belong to the unchanged Work. (Full-deep-pass reuse was
+  rejected: it re-buys the paid trope/style pass per flip and entangles `deep_enriched_at`
+  / poison-task retry gating tuned for first-time enrichment.)
+
+## Section 1 — API & data flow (`PATCH /history/{id}`)
+
+`HistoryUpdate` gains optional `format`, validated against the UI vocab
+(`ebook | audiobook | paperback | hardcover`, lowercased). Free-text formats would mint
+junk sibling editions under `uq_editions_work_format`.
+
+When `format` is present and differs from the current `edition.format`:
+
+1. Apply date/rating/notes changes **first**, so the collision check runs against the
+   entry's final `date_completed`.
+2. `get_or_create(Edition, work_id=<current work>, format=<new>)` — the same
+   race-backstopped pattern as `add_read_event` (GH #95).
+3. Collision pre-check: another `ReadingHistory` row for `(user, target_edition, final
+   date_completed)` → 409 with a human message ("You already logged an audiobook read of
+   this book on that date"). `uq_reading_history_user_edition_date` remains the backstop
+   for the millisecond race; `IntegrityError` on flush maps to the same 409.
+4. Repoint `edition_id`. The **old edition is left in place** — shared catalog object;
+   other users and work metadata may reference it.
+5. After the write commits: enqueue the format-completion pass if the target edition is
+   missing `isbn_13`, or is an audiobook with no narrators. Enqueue is best-effort in the
+   `POST /books` style — a Cloud Tasks failure logs but never fails the PATCH.
+
+Response stays `_history_item(row)` (format now reflects the new edition) plus
+`enrichment_enqueued: bool`, mirroring the add-book response shape.
+
+## Section 2 — Format-completion pass (backend enrichment)
+
+New function in `two_phase.py` — `complete_edition(work_id, fmt)` — following the module's
+established shape (short read session → scouts with **no session held**, the #94 rule →
+fresh write session):
+
+- **Read session:** load title + primary author (scalars captured before close, detached-
+  instance rule) and the target edition's state. Work or edition gone → `"missing"`.
+- **Scouts, no session held:** always run the fast API manager (Hardcover + GoogleBooks)
+  with `format=fmt` → ISBN, page count, audio minutes, publication date. If `fmt` is
+  audiobook, additionally `AudiobookScout` + `DirectKnowledgeScout`, then
+  `scout_narrator_style` per discovered narrator. Explicitly **no** `LLMTropeScout`, no
+  author/work-style scouting.
+- **Persist:** extract `persist_enriched_work`'s "Edition & Narrators" section
+  (`etl/persist.py` ~L264–353: format-matched edition merge, case-insensitive narrator
+  get-or-create, narrator-style standardization, fill-not-clobber `isbn or existing`
+  semantics) into a shared helper used by both callers; the completion pass calls just
+  that helper. Do NOT push a sparse row through the full `persist_enriched_work` — its
+  genre/mood/trope handling would have to be carefully neutralized (fallback-trope
+  pollution risk, GH #65/#70 class).
+- **Embedding warm-up** (`get_cached_embedding`) before the write session for narrator-
+  style strings (GH #123 pool-sizing premise).
+
+**Delivery:** new internal endpoint `POST /internal/complete-edition/{work_id}` with the
+format in the task payload, on the existing enrich queue (4-concurrent/5s), gated by
+`_require_queue_caller`. Idempotent by construction (all merges) → Cloud Tasks redelivery
+safe. Scouts returning nothing = final state → 200 (no 503 retry loop — no poison-pass
+economics here; the pass is cheap and the entry is already saved). Transient scout
+exception propagates → 500 → normal Cloud Tasks retry.
+
+## Section 3 — Frontend (`HistoryEditView`)
+
+- **Format select** between the context header and Rating, reusing `AddBookView`'s four
+  options, initialized from `row.format` (null format → "—" placeholder; field omitted
+  from the PATCH if untouched).
+- `client.ts` `updateHistory` payload type gains `format?: string`; the view sends it
+  **only when changed** (endpoint is `exclude_unset`).
+- **409 handling:** distinguish 409 from other failures and surface the server's message
+  (today's catch-all "try again" is wrong for a collision the user must resolve by
+  deleting one entry).
+- **Enrichment feedback:** none for now — the history list doesn't display narrators/ISBN,
+  so no toast/spinner infra. Save navigates back to `/history` as today. Revisit when
+  narrators surface in the UI.
+
+## Section 4 — Error handling & testing
+
+- **Unit (API), parametrized atomic cases:** repoint to existing sibling edition; create
+  missing edition; same-format no-op creates nothing; invalid format → 422; collision →
+  409; combined date+format edit checks collision against the NEW date; enqueue failure
+  still returns 200. Assertion completeness (CLAUDE.md #1): repoint tests also assert the
+  old edition still exists, rating/notes survived, and another user's row on the same
+  edition is untouched.
+- **Unit (two_phase):** house session-counting fixture asserts `open_sessions == 0` during
+  scouts; composition test asserts the completion pass never invokes `LLMTropeScout` /
+  author-work style scouting; persist-helper tests assert narrator merge + `isbn_13`
+  fill-not-clobber; idempotent double-run.
+- **db_integration (CI-first merge gate):** real-Postgres PATCH repoint under the
+  `NULLS NOT DISTINCT` constraint; real 409 from the unique-index race path; internal
+  endpoint end-to-end with stubbed scouts.
+- **Frontend:** `HistoryEditView.test.tsx` — select renders with current format; PATCH
+  body includes `format` only when changed; 409 renders the server message (`...Once`
+  mock variants per the vitest rejection-path pitfall).
+
+## Out of scope
+
+- Editing title/author (work identity) — separate feature, touches dedup.
+- Displaying narrators/audio minutes in history UI (future; adds the "filling in"
+  affordance moment).
+- Sweep-based backfill of metadata-less editions created before this feature.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,16 @@
 import { getIdToken } from '../auth/firebase'
 import type { ActivityStep } from './activityLabels'
 
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public detail: string,
+  ) {
+    super(detail)
+    this.name = 'ApiError'
+  }
+}
+
 export interface HistoryItem {
   id: string
   title: string
@@ -11,6 +21,7 @@ export interface HistoryItem {
   notes?: string | null
   genre?: string | null
   tropes?: string[]
+  enrichment_enqueued?: boolean
 }
 
 export interface Recommendation {
@@ -134,6 +145,7 @@ export interface HistoryUpdate {
   date_completed?: string | null
   rating?: number | null
   notes?: string | null
+  format?: string
 }
 
 export async function updateHistory(id: string, body: HistoryUpdate): Promise<HistoryItem> {
@@ -142,7 +154,16 @@ export async function updateHistory(id: string, body: HistoryUpdate): Promise<Hi
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error(`update history → ${res.status}`)
+  if (!res.ok) {
+    let detail = `update history → ${res.status}`
+    try {
+      const parsed = await res.json()
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+    } catch {
+      // non-JSON error body — keep the generic detail
+    }
+    throw new ApiError(res.status, detail)
+  }
   return res.json()
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,12 +2,16 @@ import { getIdToken } from '../auth/firebase'
 import type { ActivityStep } from './activityLabels'
 
 export class ApiError extends Error {
-  constructor(
-    public status: number,
-    public detail: string,
-  ) {
+  // Explicit fields, not constructor parameter properties: the build runs tsc with
+  // erasableSyntaxOnly, which rejects TS-only runtime syntax (TS1294).
+  status: number
+  detail: string
+
+  constructor(status: number, detail: string) {
     super(detail)
     this.name = 'ApiError'
+    this.status = status
+    this.detail = detail
   }
 }
 

--- a/frontend/src/views/HistoryEditView.test.tsx
+++ b/frontend/src/views/HistoryEditView.test.tsx
@@ -2,10 +2,15 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router'
-import type { HistoryItem } from '../api/client'
+import { ApiError, type HistoryItem } from '../api/client'
 
 vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null) }))
-vi.mock('../api/client')
+vi.mock('../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/client')>()),
+  updateHistory: vi.fn(),
+  deleteHistory: vi.fn(),
+  getHistory: vi.fn(),
+}))
 import * as client from '../api/client'
 import HistoryEditView from './HistoryEditView'
 
@@ -40,5 +45,53 @@ describe('HistoryEditView', () => {
   it('redirects to history when opened with no router state', () => {
     renderAt(null)
     expect(screen.getByText('history-list')).toBeInTheDocument()
+  })
+
+  it('renders the format select prefilled with the current format', () => {
+    renderAt(row)
+    expect(screen.getByLabelText(/format/i)).toHaveValue('ebook')
+  })
+
+  it('sends format only when the user changes it', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row, format: 'audiobook' })
+    renderAt(row)
+    await userEvent.selectOptions(screen.getByLabelText(/format/i), 'audiobook')
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() =>
+      expect(client.updateHistory).toHaveBeenCalledWith('h1', expect.objectContaining({ format: 'audiobook' })),
+    )
+  })
+
+  it('omits format from the payload when unchanged', async () => {
+    vi.mocked(client.updateHistory).mockResolvedValueOnce({ ...row })
+    renderAt(row)
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() =>
+      expect(client.updateHistory).toHaveBeenCalledWith(
+        'h1',
+        expect.not.objectContaining({ format: expect.anything() }),
+      ),
+    )
+  })
+
+  it('shows the server message on a 409 collision', async () => {
+    // ...Once variant (vitest pitfall memory): a persistent mockRejectedValue leaks
+    // an unhandled rejection into later tests.
+    vi.mocked(client.updateHistory).mockRejectedValueOnce(
+      new ApiError(409, 'You already logged this book as audiobook on 2019-03-14.'),
+    )
+    renderAt(row)
+    await userEvent.selectOptions(screen.getByLabelText(/format/i), 'audiobook')
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    expect(
+      await screen.findByText('You already logged this book as audiobook on 2019-03-14.'),
+    ).toBeInTheDocument()
+  })
+
+  it('falls back to the generic message on non-409 failures', async () => {
+    vi.mocked(client.updateHistory).mockRejectedValueOnce(new Error('network'))
+    renderAt(row)
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    expect(await screen.findByText(/couldn't save those changes/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/views/HistoryEditView.tsx
+++ b/frontend/src/views/HistoryEditView.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from 'react'
 import { Navigate, useLocation, useNavigate, useParams } from 'react-router'
-import { updateHistory, type HistoryItem } from '../api/client'
+import { ApiError, updateHistory, type HistoryItem } from '../api/client'
 import './HistoryEditView.css'
 
 export default function HistoryEditView() {
@@ -10,6 +10,7 @@ export default function HistoryEditView() {
   const [rating, setRating] = useState(row?.rating != null ? String(row.rating) : '')
   const [dateFinished, setDateFinished] = useState(row?.date_completed ?? '')
   const [notes, setNotes] = useState(row?.notes ?? '')
+  const [format, setFormat] = useState(row?.format ?? '')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -20,14 +21,17 @@ export default function HistoryEditView() {
     setBusy(true)
     setError(null)
     try {
-      await updateHistory(id as string, {
+      const body: Parameters<typeof updateHistory>[1] = {
         rating: rating ? Number(rating) : null,
         date_completed: dateFinished || null,
         notes: notes.trim() || null,
-      })
+      }
+      if (format && format !== row!.format) body.format = format
+      await updateHistory(id as string, body)
       navigate('/history')
-    } catch {
-      setError("Couldn't save those changes — try again.")
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) setError(err.detail)
+      else setError("Couldn't save those changes — try again.")
     } finally {
       setBusy(false)
     }
@@ -43,6 +47,16 @@ export default function HistoryEditView() {
         {row.format ? ` · ${row.format}` : ''}
       </p>
       <form onSubmit={onSubmit} className="history-edit-form">
+        <label>
+          Format
+          <select value={format} onChange={(e) => setFormat(e.target.value)}>
+            {!row.format && <option value="">—</option>}
+            <option value="ebook">ebook</option>
+            <option value="audiobook">audiobook</option>
+            <option value="paperback">paperback</option>
+            <option value="hardcover">hardcover</option>
+          </select>
+        </label>
         <label>
           Rating
           <select value={rating} onChange={(e) => setRating(e.target.value)}>

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -131,8 +131,14 @@ def complete_edition(
 ):
     """Format-completion pass target (history-format-edit spec). Same OIDC gate as
     /internal/enrich. 'missing' → 404 (non-retryable: work/edition gone); 'empty' and
-    'done' → 200 (final — no retry economics here, the history edit is already saved);
-    an unexpected exception propagates → 500 → normal Cloud Tasks retry."""
+    'done' → 200 (final — no retry economics here, the history edit is already saved).
+
+    'empty' INCLUDES the all-scouts-failed case: ScoutManager.enrich swallows each scout's
+    exception internally and returns {} when nobody contributed (the GH #98 guard), so a
+    transient outage of every scout resolves to 'empty' → 200, NOT to a retry. That is
+    deliberate — the entry is already saved and a later format change re-triggers completion.
+    A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
+    (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
     result = two_phase.complete_edition(work_id, format)
     if result == "missing":

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -11,7 +11,7 @@ import logging
 import os
 from uuid import UUID
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Query
 
 from agentic_librarian.enrichment import two_phase
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
@@ -121,6 +121,23 @@ def enrich(
         # for works that exhaust retries or were never queued at all.
         raise HTTPException(status_code=503, detail={"work_id": str(work_id), "status": "empty_deep_pass"})
     return {"work_id": str(work_id), "status": "enriched"}
+
+
+@router.post("/internal/complete-edition/{work_id}")
+def complete_edition(
+    work_id: UUID,
+    format: str = Query(..., max_length=50),  # noqa: B008
+    authorization: str | None = Header(None),  # noqa: B008
+):
+    """Format-completion pass target (history-format-edit spec). Same OIDC gate as
+    /internal/enrich. 'missing' → 404 (non-retryable: work/edition gone); 'empty' and
+    'done' → 200 (final — no retry economics here, the history edit is already saved);
+    an unexpected exception propagates → 500 → normal Cloud Tasks retry."""
+    _require_queue_caller(authorization)
+    result = two_phase.complete_edition(work_id, format)
+    if result == "missing":
+        raise HTTPException(status_code=404, detail="work or edition not found")
+    return {"work_id": str(work_id), "format": format, "status": result}
 
 
 @router.post("/internal/import-row/{row_id}")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import contextlib
+import logging
 import os
 from datetime import date
 from uuid import UUID
@@ -8,7 +9,8 @@ from uuid import UUID
 from fastapi import Body, Depends, FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, field_validator
-from sqlalchemy import text
+from sqlalchemy import func, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, selectinload
 
 from agentic_librarian.agents.runtime import LibrarianConversation, astart_conversation
@@ -28,6 +30,7 @@ from agentic_librarian.api.recommendations import router as recommendations_rout
 from agentic_librarian.chat import stream, transcript
 from agentic_librarian.core import usage
 from agentic_librarian.core.user_context import as_user
+from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.migration_guard import check_migrations
 from agentic_librarian.db.models import (
     Edition,
@@ -39,8 +42,11 @@ from agentic_librarian.db.models import (
 )
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
+from agentic_librarian.enrichment.tasks import enqueue_edition_completion
 from agentic_librarian.imports import worker as imports_worker
 from agentic_librarian.mcp import server as mcp_server
+
+logger = logging.getLogger(__name__)
 
 db_manager = DatabaseManager()
 
@@ -194,10 +200,14 @@ def get_history(
         return [_history_item(h) for h in history_entries]
 
 
+HISTORY_FORMATS = {"ebook", "audiobook", "paperback", "hardcover"}
+
+
 class HistoryUpdate(BaseModel):
     date_completed: date | None = None
     rating: int | None = None
     notes: str | None = None
+    format: str | None = None
 
     @field_validator("rating", mode="before")
     @classmethod
@@ -219,6 +229,16 @@ class HistoryUpdate(BaseModel):
         if v is not None and v > date.today():
             raise ValueError("date_completed cannot be in the future")
         return v
+
+    @field_validator("format")
+    @classmethod
+    def _format_vocab(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        normalized = v.strip().lower()
+        if normalized not in HISTORY_FORMATS:
+            raise ValueError("format must be one of: ebook, audiobook, paperback, hardcover")
+        return normalized
 
 
 @app.delete("/history/{entry_id}")
@@ -245,6 +265,11 @@ def update_history(
     fields = req.model_dump(exclude_unset=True)  # only what the client actually sent
     if "date_completed" in fields and fields["date_completed"] is None:
         raise HTTPException(status_code=422, detail="date_completed cannot be null")
+    if "format" in fields and fields["format"] is None:
+        raise HTTPException(status_code=422, detail="format cannot be null")
+
+    needs_completion = False
+    work_id_str = fmt_str = ""
     with db_manager.get_session() as session:
         row = (
             session.query(ReadingHistory)
@@ -254,14 +279,77 @@ def update_history(
         )
         if row is None:
             raise HTTPException(status_code=404, detail="history entry not found")
+        # Scalar edits first, so the collision check below runs against the FINAL date.
         if "date_completed" in fields:
             row.date_completed = fields["date_completed"]
         if "rating" in fields:
             row.user_rating = fields["rating"]
         if "notes" in fields:
             row.user_notes = fields["notes"]
-        session.flush()
-        return _history_item(row)
+
+        target_edition = row.edition
+        new_fmt = fields.get("format")
+        if new_fmt is not None and new_fmt != (row.edition.format or "").strip().lower():
+            # Format change = repoint to the sibling (work_id, format) edition — editions are
+            # shared catalog objects, so the old one is never mutated or deleted. Reuse a
+            # casing variant if one exists (uq_editions_work_format is case-sensitive);
+            # get_or_create + the unique index backstop the concurrent-create race (#95).
+            target_edition = (
+                session.query(Edition)
+                .filter(Edition.work_id == row.edition.work_id, func.lower(Edition.format) == new_fmt)
+                .first()
+            )
+            if target_edition is None:
+                target_edition, _created = get_or_create(session, Edition, work_id=row.edition.work_id, format=new_fmt)
+
+        collision_detail = (
+            f"You already logged this book as {target_edition.format or 'the same format'} "
+            f"on {row.date_completed.isoformat()}."
+        )
+        if target_edition.id != row.edition_id or "date_completed" in fields:
+            # uq_reading_history_user_edition_date pre-check; the index itself backstops the
+            # millisecond race below and maps to the same 409.
+            dup = (
+                session.query(ReadingHistory)
+                .filter(
+                    ReadingHistory.user_id == user.id,
+                    ReadingHistory.edition_id == target_edition.id,
+                    ReadingHistory.date_completed == row.date_completed,
+                    ReadingHistory.id != row.id,
+                )
+                .first()
+            )
+            if dup is not None:
+                # Raising inside the session context rolls back EVERY field edit above —
+                # a 409 must leave the row exactly as it was.
+                raise HTTPException(status_code=409, detail=collision_detail)
+
+        if target_edition.id != row.edition_id:
+            row.edition = target_edition
+            # Decide the async completion enqueue while the session is open (narrators is a
+            # lazy relationship): missing ISBN, or an audiobook with no narrators yet.
+            needs_completion = target_edition.isbn_13 is None or (
+                "audiobook" in (target_edition.format or "").lower() and not target_edition.narrators
+            )
+            work_id_str = str(target_edition.work_id)
+            fmt_str = target_edition.format or ""
+        try:
+            session.flush()
+        except IntegrityError as e:
+            raise HTTPException(status_code=409, detail=collision_detail) from e
+        payload = _history_item(row)
+
+    # After commit: best-effort enqueue in the POST /books style — a Cloud Tasks failure
+    # must never fail the edit (the completion sweep-of-one can be retriggered by any
+    # later format edit; the entry itself is saved).
+    enqueued = False
+    if needs_completion:
+        try:
+            enqueued = enqueue_edition_completion(work_id_str, fmt_str)
+        except Exception:  # noqa: BLE001 - enqueue is best-effort
+            logger.exception("edition-completion enqueue failed for work %s", work_id_str)
+    payload["enrichment_enqueued"] = enqueued
+    return payload
 
 
 @app.get("/works")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -279,13 +279,17 @@ def update_history(
         )
         if row is None:
             raise HTTPException(status_code=404, detail="history entry not found")
-        # Scalar edits first, so the collision check below runs against the FINAL date.
-        if "date_completed" in fields:
-            row.date_completed = fields["date_completed"]
-        if "rating" in fields:
-            row.user_rating = fields["rating"]
-        if "notes" in fields:
-            row.user_notes = fields["notes"]
+
+        # No ORM mutation until EVERY read/pre-check is done. Mutating row.date_completed (or
+        # doing the edition repoint) before the dup pre-check query lets SQLAlchemy autoflush
+        # emit the UPDATE while that query runs, so a real collision trips
+        # uq_reading_history_user_edition_date as an IntegrityError raised OUTSIDE the flush
+        # try/except below → 500 instead of 409. The sharp sibling is a combined date+format
+        # edit that is valid at the FINAL (new_edition, new_date) but collides at the
+        # intermediate (old_edition, new_date); and get_or_create runs its own internal flush,
+        # so session.no_autoflush alone would NOT cover it. So we resolve the final target
+        # values first and pre-check against them with the row still untouched.
+        final_date = fields.get("date_completed", row.date_completed)
 
         target_edition = row.edition
         new_fmt = fields.get("format")
@@ -294,45 +298,62 @@ def update_history(
             # shared catalog objects, so the old one is never mutated or deleted. Reuse a
             # casing variant if one exists (uq_editions_work_format is case-sensitive);
             # get_or_create + the unique index backstop the concurrent-create race (#95).
+            # order_by exact-format-match first, then Edition.id (M1): a duplicate-casing
+            # catalog then can't flip the chosen target between successive edits.
             target_edition = (
                 session.query(Edition)
                 .filter(Edition.work_id == row.edition.work_id, func.lower(Edition.format) == new_fmt)
+                .order_by((Edition.format != new_fmt), Edition.id)
                 .first()
             )
             if target_edition is None:
                 target_edition, _created = get_or_create(session, Edition, work_id=row.edition.work_id, format=new_fmt)
 
         collision_detail = (
-            f"You already logged this book as {target_edition.format or 'the same format'} "
-            f"on {row.date_completed.isoformat()}."
+            f"You already logged this book as {target_edition.format or 'the same format'} on {final_date.isoformat()}."
         )
         if target_edition.id != row.edition_id or "date_completed" in fields:
-            # uq_reading_history_user_edition_date pre-check; the index itself backstops the
-            # millisecond race below and maps to the same 409.
+            # uq_reading_history_user_edition_date pre-check against the FINAL (edition, date).
+            # final_date is a plain parameter because the row is still unmutated, so this query
+            # cannot autoflush a premature UPDATE. The index itself backstops the millisecond
+            # race below and maps to the same 409.
             dup = (
                 session.query(ReadingHistory)
                 .filter(
                     ReadingHistory.user_id == user.id,
                     ReadingHistory.edition_id == target_edition.id,
-                    ReadingHistory.date_completed == row.date_completed,
+                    ReadingHistory.date_completed == final_date,
                     ReadingHistory.id != row.id,
                 )
                 .first()
             )
             if dup is not None:
-                # Raising inside the session context rolls back EVERY field edit above —
-                # a 409 must leave the row exactly as it was.
                 raise HTTPException(status_code=409, detail=collision_detail)
 
         if target_edition.id != row.edition_id:
-            row.edition = target_edition
             # Decide the async completion enqueue while the session is open (narrators is a
-            # lazy relationship): missing ISBN, or an audiobook with no narrators yet.
+            # lazy relationship): missing ISBN, or an audiobook with no narrators yet. The
+            # target_edition.narrators lazy-load is safe here precisely because nothing is
+            # pending yet — it can't autoflush a premature UPDATE.
             needs_completion = target_edition.isbn_13 is None or (
                 "audiobook" in (target_edition.format or "").lower() and not target_edition.narrators
             )
             work_id_str = str(target_edition.work_id)
             fmt_str = target_edition.format or ""
+
+        # ONLY NOW mutate: scalar edits + the repoint. Every read above ran against final
+        # values with the row untouched, so the flush below is the SINGLE UPDATE emission
+        # point and its IntegrityError genuinely maps to the millisecond-race 409. Raising
+        # inside the session context still rolls back EVERY field edit — a 409 must leave the
+        # row exactly as it was.
+        if "date_completed" in fields:
+            row.date_completed = fields["date_completed"]
+        if "rating" in fields:
+            row.user_rating = fields["rating"]
+        if "notes" in fields:
+            row.user_notes = fields["notes"]
+        if target_edition.id != row.edition_id:
+            row.edition = target_edition
         try:
             session.flush()
         except IntegrityError as e:

--- a/src/agentic_librarian/enrichment/tasks.py
+++ b/src/agentic_librarian/enrichment/tasks.py
@@ -11,7 +11,10 @@ Config (wired in prod in Stage 4; absent in local dev → enqueue is a logged no
   ENRICH_INVOKER_SA     service-account email the queue signs the OIDC token as
   ENRICH_OIDC_AUDIENCE  the OIDC audience. The enqueue side defaults it to the full task
                         URL, but the receiver (api/internal.py) hard-requires it and 403s
-                        when unset — so in prod it must be set to match on both sides."""
+                        when unset — so in prod it must be set to match on both sides.
+
+The same config env vars now also drive POST /internal/complete-edition/{work_id} (the
+edition-completion pass enqueued by enqueue_edition_completion after a history format change)."""
 
 from __future__ import annotations
 

--- a/src/agentic_librarian/enrichment/tasks.py
+++ b/src/agentic_librarian/enrichment/tasks.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
@@ -65,4 +66,32 @@ def enqueue_enrichment(work_id: str) -> bool:
     }
     _client().create_task(parent=queue, task=task)
     logger.info("enqueued deep enrichment for work %s", work_id)
+    return True
+
+
+def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
+    """Enqueue the format-completion pass for (work_id, fmt) — history-format-edit spec.
+    Returns True if enqueued, False if Cloud Tasks is not configured (local dev); the
+    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved."""
+    queue = os.environ.get("CLOUD_TASKS_QUEUE")
+    base = os.environ.get("ENRICH_TARGET_BASE_URL")
+    sa = os.environ.get("ENRICH_INVOKER_SA")
+    if not (queue and base and sa):
+        logger.info("edition-completion enqueue skipped — Cloud Tasks not configured (work %s)", work_id)
+        return False
+
+    path_url = f"{base.rstrip('/')}/internal/complete-edition/{work_id}"
+    url = f"{path_url}?format={quote(fmt)}"
+    # Audience deliberately excludes the query string: the receiver verifies against a
+    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format audience would never match.
+    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or path_url
+    task = {
+        "http_request": {
+            "http_method": "POST",
+            "url": url,
+            "oidc_token": {"service_account_email": sa, "audience": audience},
+        }
+    }
+    _client().create_task(parent=queue, task=task)
+    logger.info("enqueued edition completion for work %s format %s", work_id, fmt)
     return True

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -30,11 +30,13 @@ from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.models import Author, DetectedDuplicate, Edition, ReadingHistory, Work, WorkContributor
 from agentic_librarian.db.session import DatabaseManager
-from agentic_librarian.etl.persist import collect_embedding_texts, persist_enriched_work
+from agentic_librarian.etl.persist import collect_embedding_texts, merge_edition_and_narrators, persist_enriched_work
 from agentic_librarian.orchestration.definitions import (
+    create_completion_scout_manager,
     create_deep_scout_manager,
     create_fast_scout_manager,
 )
+from agentic_librarian.scouts.metadata_scout import StyleScout
 from agentic_librarian.scouts.style_manager import StyleManager
 from agentic_librarian.scouts.trope_manager import TropeManager
 from agentic_librarian.scouts.utils import EMBED_MODEL, get_cached_embedding
@@ -175,6 +177,83 @@ def add_read_event(work_id: UUID, *, completed, rating: int | None, notes: str |
         )
         session.flush()
         return {"read_number": len(prior_reads) + 1, "already_logged": False}
+
+
+def complete_edition(work_id: UUID, fmt: str) -> str:
+    """Format-completion pass (history-format-edit spec): fill the (work_id, fmt)
+    edition's metadata after a history-entry format change. Fast API scouts always
+    (ISBN, pages/audio minutes, publication date); audiobook scouts + per-narrator
+    style scouting only when fmt is an audiobook. Deliberately NEVER LLMTropeScout or
+    author/work-style scouting — the Work is unchanged; this pass must not touch
+    deep_enriched_at or the deep pass's retry gating.
+
+    Same session discipline as the other passes here (#94): short read session, scouts
+    with NO session held, fresh write session. Idempotent (all merges) — Cloud Tasks
+    redelivery is safe.
+
+    Returns:
+      "missing" — work, its Author link, or the (work_id, fmt) edition no longer exists
+                  (also when the work vanished while scouts ran). Non-retryable.
+      "empty"   — no scout contributed anything. Final state: the entry itself is already
+                  saved, and unlike the deep pass there is no requeue-sweep backstop
+                  economics to protect — do not retry-loop.
+      "done"    — scouted values merged onto the edition."""
+    fmt = (fmt or "")[:50]
+
+    with db_manager.get_session() as session:
+        work = session.get(Work, work_id)
+        if work is None:
+            return "missing"
+        author = next((c.author.name for c in work.contributors if c.role == "Author"), None)
+        if author is None:
+            return "missing"
+        title = work.title  # scalars captured before close (detached-instance rule)
+        edition = session.query(Edition).filter_by(work_id=work_id, format=fmt).first()
+        if edition is None:
+            return "missing"
+
+    enriched = create_completion_scout_manager().enrich(title=title, author=author, format=fmt)
+    if not enriched:
+        return "empty"
+
+    narrator_names = [n for n in (enriched.get("narrator_names") or []) if isinstance(n, str) and n.strip()]
+    narrator_styles: dict[str, dict] = {}
+    if "audiobook" in fmt.lower() and narrator_names:
+        style_scout = StyleScout()
+        for n_name in narrator_names:
+            try:
+                narrator_styles[n_name] = style_scout.scout_narrator_style(n_name)
+            except Exception:  # noqa: BLE001 - style scouting is additive; narrators still merge without it
+                logger.warning("narrator style scout failed for %r — merging narrator without styles", n_name)
+
+    # GH #123: warm the embedding LRU for every style string the persist will standardize,
+    # so no network embed happens inside the write session.
+    for style_map in narrator_styles.values():
+        for style_text in style_map.values():
+            try:
+                get_cached_embedding(EMBED_MODEL, style_text)
+            except Exception:  # noqa: BLE001 - warming is best-effort; _safe_standardize degrades in-session
+                logger.warning("embed warm failed for %r — persist will retry in-session", style_text)
+
+    with db_manager.get_session() as session:
+        if session.get(Work, work_id) is None:
+            # Deleted while the scouts ran with no session held — same honesty rule as
+            # enrich_deep's empty path.
+            return "missing"
+        merge_edition_and_narrators(
+            session,
+            work_id=work_id,
+            fmt=fmt,
+            isbn_13=enriched.get("isbn_13"),
+            page_count=enriched.get("page_count"),
+            audio_minutes=enriched.get("audio_minutes"),
+            publication_date=enriched.get("publication_date"),
+            narrator_names=narrator_names,
+            narrator_styles=narrator_styles,
+            style_manager=StyleManager(session=session),
+        )
+        session.flush()
+    return "done"
 
 
 def enrich_deep(work_id: UUID) -> str:

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -193,10 +193,17 @@ def complete_edition(work_id: UUID, fmt: str) -> str:
 
     Returns:
       "missing" — work, its Author link, or the (work_id, fmt) edition no longer exists
-                  (also when the work vanished while scouts ran). Non-retryable.
-      "empty"   — no scout contributed anything. Final state: the entry itself is already
-                  saved, and unlike the deep pass there is no requeue-sweep backstop
-                  economics to protect — do not retry-loop.
+                  (also when the work or edition vanished while scouts ran — re-checked in
+                  the write session). Non-retryable.
+      "empty"   — no scout contributed anything, INCLUDING the all-scouts-failed case: a
+                  transient outage of every scout lands here too, because ScoutManager.enrich
+                  swallows each scout's exception internally and returns {} when nobody
+                  contributed (the GH #98 guard). This is a deliberate FINAL state, not a
+                  transient error to retry-loop: the history entry is already saved, and a
+                  later format change re-triggers completion. Unlike the deep pass there is no
+                  requeue-sweep backstop economics to protect. A 500 → Cloud Tasks retry only
+                  occurs for failures OUTSIDE the scout manager (persist/DB errors), which
+                  propagate uncaught.
       "done"    — scouted values merged onto the edition."""
     fmt = (fmt or "")[:50]
 
@@ -239,6 +246,12 @@ def complete_edition(work_id: UUID, fmt: str) -> str:
         if session.get(Work, work_id) is None:
             # Deleted while the scouts ran with no session held — same honesty rule as
             # enrich_deep's empty path.
+            return "missing"
+        if session.query(Edition).filter_by(work_id=work_id, format=fmt).first() is None:
+            # The (work_id, fmt) edition was deleted mid-pass (operator cleanup tooling deletes
+            # editions for real) — re-check it in the WRITE session too, else
+            # merge_edition_and_narrators would silently RECREATE it. Same honesty rule as the
+            # Work re-check above and enrich_deep's deleted-mid-pass cases.
             return "missing"
         merge_edition_and_narrators(
             session,

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -34,6 +34,112 @@ from agentic_librarian.scouts.trope_manager import TropeManager
 logger = logging.getLogger(__name__)
 
 
+def merge_edition_and_narrators(
+    session,
+    *,
+    work_id,
+    fmt,
+    isbn_13=None,
+    page_count=None,
+    audio_minutes=None,
+    publication_date=None,
+    narrator_names=None,
+    narrator_styles=None,
+    style_manager,
+    apply_metadata=True,
+):
+    """Resolve narrators (+ narrator styles) and get-or-create/merge the (work_id, fmt)
+    Edition. Extracted from persist_enriched_work (history-format-edit spec) so the
+    format-completion pass (two_phase.complete_edition) shares the exact same merge
+    semantics. apply_metadata=False (persist's skip_enrichment rows) still merges
+    narrators, mirroring the original gating. Returns the Edition, flushed when newly
+    created so its id is populated for the caller."""
+    edition = session.query(Edition).filter_by(work_id=work_id, format=fmt).first()
+
+    # A row may carry narrator_names/styles as NaN (float) — pandas fills the column with
+    # NaN for rows that lack it. Coerce non-list/dict to empty so this never crashes.
+    if not isinstance(narrator_names, list):
+        narrator_names = []
+    # Keep only non-empty strings: a malformed/NaN element would crash norm_name/.lower().
+    narrator_names = [n for n in narrator_names if isinstance(n, str) and n.strip()]
+    if not isinstance(narrator_styles, dict):
+        narrator_styles = {}
+
+    seen_narr: set[str] = set()
+    deduped_names = []
+    for n_name in narrator_names:
+        k = norm_name(n_name)
+        if k not in seen_narr:
+            seen_narr.add(k)
+            deduped_names.append(n_name)
+    narrator_names = deduped_names
+
+    narrator_objs = []
+    for n_name in narrator_names:
+        # Case-insensitive lookup so a casing variant reuses the existing Narrator row.
+        narrator = session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
+        if not narrator:
+            # GH #95: uq_narrators_name_lower — same case-insensitive requery pattern as Author.
+            narrator, _created = insert_or_requery(
+                session,
+                Narrator(name=n_name),
+                lambda n_name=n_name: (
+                    session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
+                ),
+            )
+
+        n_style_data = narrator_styles.get(n_name, {})
+        if n_style_data:
+            for attr_type, style_name in _iter_style_items(n_style_data, f"Narrator '{n_name}'"):
+                standard_style = _safe_standardize(
+                    style_manager.standardize_style, style_name, category="Narrator", label=f"style {style_name!r}"
+                )
+                if standard_style is None:
+                    continue
+                existing_link = (
+                    session.query(NarratorStyle)
+                    .filter_by(narrator_id=narrator.id, style_id=standard_style.id, attribute_type=attr_type)
+                    .first()
+                )
+                if not existing_link:
+                    session.add(NarratorStyle(narrator=narrator, style=standard_style, attribute_type=attr_type))
+
+        narrator_objs.append(narrator)
+
+    if not edition:
+        # GH #95: uq_editions_work_format backstops the SELECT-then-INSERT race above; a
+        # concurrent persist for the same (work_id, format) recovers via requery instead of
+        # a 500. narrators/other creation-only fields only apply on the winning insert.
+        # work_id= (not work=) so the not-yet-added Edition never lands in work.editions via
+        # the back_populates backref before session.add — that dangling membership is exactly
+        # what trips "Object of type <Edition> not in session" as an SAWarning-promoted error.
+        edition, _created = insert_or_requery(
+            session,
+            Edition(
+                work_id=work_id,
+                isbn_13=isbn_13,
+                format=fmt,
+                page_count=page_count,
+                audio_minutes=audio_minutes,
+                publication_date=publication_date,
+                narrators=narrator_objs,
+            ),
+            lambda: session.query(Edition).filter_by(work_id=work_id, format=fmt).first(),
+        )
+        session.flush()  # Ensure edition.id is populated for the caller's ReadingHistory check
+    else:
+        if apply_metadata:
+            # Update existing edition if new metadata found (publication_date intentionally
+            # not updated on existing editions — original behavior preserved).
+            edition.isbn_13 = isbn_13 or edition.isbn_13
+            edition.page_count = page_count or edition.page_count
+            edition.audio_minutes = audio_minutes or edition.audio_minutes
+        if narrator_objs:
+            edition.narrators = list(set(edition.narrators) | set(narrator_objs))
+
+    return edition
+
+
 def _safe_standardize(fn, *args, label: str, **kwargs):
     """Run a standardize_* embedding call, returning its Trope/Style, or None on failure.
     An embedding API error (bad/transient key, 429/5xx) must skip that one vectorization,
@@ -261,96 +367,20 @@ def persist_enriched_work(
             if not existing_link:
                 session.add(WorkStyle(work=work, style=standard_style, attribute_type=attr_type))
 
-    # 3. Edition & Narrators
-    edition = session.query(Edition).filter_by(work_id=work.id, format=row["format"]).first()
-
-    # Resolve Narrators. A row may carry narrator_names/styles as NaN (float) — pandas fills the
-    # column with NaN for rows that lack it (e.g. skip_enrichment rows mixed with audiobook rows in
-    # the same partition DataFrame). Coerce non-list/dict to empty so persist never crashes on it.
-    narrator_objs = []
-    narrator_names = row.get("narrator_names")
-    if not isinstance(narrator_names, list):
-        narrator_names = []
-    # Keep only non-empty strings: a malformed/NaN element would crash the norm_name/.lower() calls
-    # below (mirrors the raw_contributors name guard above).
-    narrator_names = [n for n in narrator_names if isinstance(n, str) and n.strip()]
-    narrator_styles = row.get("narrator_styles")
-    if not isinstance(narrator_styles, dict):
-        narrator_styles = {}
-
-    seen_narr: set[str] = set()
-    deduped_names = []
-    for n_name in narrator_names:
-        k = norm_name(n_name)
-        if k not in seen_narr:
-            seen_narr.add(k)
-            deduped_names.append(n_name)
-    narrator_names = deduped_names
-    for n_name in narrator_names:
-        # Case-insensitive lookup so a casing variant reuses the existing Narrator row (see above).
-        narrator = session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
-        if not narrator:
-            # GH #95: uq_narrators_name_lower — same case-insensitive requery pattern as Author above.
-            narrator, _created = insert_or_requery(
-                session,
-                Narrator(name=n_name),
-                lambda n_name=n_name: (
-                    session.query(Narrator).filter(func.lower(Narrator.name) == n_name.lower()).first()
-                ),
-            )
-
-        # Process Narrator Styles
-        n_style_data = narrator_styles.get(n_name, {})
-        if n_style_data:
-            for attr_type, style_name in _iter_style_items(n_style_data, f"Narrator '{n_name}'"):
-                standard_style = _safe_standardize(
-                    style_manager.standardize_style, style_name, category="Narrator", label=f"style {style_name!r}"
-                )
-                if standard_style is None:
-                    continue
-                existing_link = (
-                    session.query(NarratorStyle)
-                    .filter_by(narrator_id=narrator.id, style_id=standard_style.id, attribute_type=attr_type)
-                    .first()
-                )
-                if not existing_link:
-                    session.add(NarratorStyle(narrator=narrator, style=standard_style, attribute_type=attr_type))
-
-        narrator_objs.append(narrator)
-
-    if not edition:
-        # GH #95: uq_editions_work_format backstops the SELECT-then-INSERT race above; a
-        # concurrent persist for the same (work_id, format) recovers via requery instead of
-        # a 500. narrators/other creation-only fields only apply on the winning insert — the
-        # loser's edition is re-queried as-is and updated by the existing-edition branch on
-        # its NEXT call (mirrors the pre-#95 eventual-consistency behavior).
-        # work_id= (not work=) so the not-yet-added Edition never lands in work.editions via
-        # the back_populates backref before session.add — that dangling membership is exactly
-        # what trips "Object of type <Edition> not in session" as an SAWarning-promoted error.
-        edition, _created = insert_or_requery(
-            session,
-            Edition(
-                work_id=work.id,
-                isbn_13=isbn_13,
-                format=row.get("format"),
-                page_count=page_count,
-                audio_minutes=audio_minutes,
-                publication_date=publication_date,
-                narrators=narrator_objs,
-            ),
-            lambda: session.query(Edition).filter_by(work_id=work.id, format=row.get("format")).first(),
-        )
-        session.flush()  # Ensure edition.id is populated for ReadingHistory check
-    else:
-        if not row.get("skip_enrichment"):
-            # Update existing edition if new metadata found
-            edition.isbn_13 = isbn_13 or edition.isbn_13
-            edition.page_count = page_count or edition.page_count
-            edition.audio_minutes = audio_minutes or edition.audio_minutes
-
-        # Update narrators if needed
-        if narrator_objs:
-            edition.narrators = list(set(edition.narrators) | set(narrator_objs))
+    # 3. Edition & Narrators (shared with two_phase.complete_edition — history-format-edit)
+    edition = merge_edition_and_narrators(
+        session,
+        work_id=work.id,
+        fmt=row.get("format"),
+        isbn_13=isbn_13,
+        page_count=page_count,
+        audio_minutes=audio_minutes,
+        publication_date=publication_date,
+        narrator_names=row.get("narrator_names"),
+        narrator_styles=row.get("narrator_styles"),
+        style_manager=style_manager,
+        apply_metadata=not row.get("skip_enrichment"),
+    )
 
     # 4. Reading History (The actual read event). pd.NaT/NaN are truthy, so guard with pd.isna
     # before calling .date() (which would raise on NaT).

--- a/src/agentic_librarian/etl/persist.py
+++ b/src/agentic_librarian/etl/persist.py
@@ -109,7 +109,9 @@ def merge_edition_and_narrators(
     if not edition:
         # GH #95: uq_editions_work_format backstops the SELECT-then-INSERT race above; a
         # concurrent persist for the same (work_id, format) recovers via requery instead of
-        # a 500. narrators/other creation-only fields only apply on the winning insert.
+        # a 500. narrators/other creation-only fields only apply on the winning insert — the
+        # loser's edition is re-queried as-is and updated by the existing-edition branch on
+        # its NEXT call (mirrors the pre-#95 eventual-consistency behavior).
         # work_id= (not work=) so the not-yet-added Edition never lands in work.editions via
         # the back_populates backref before session.add — that dangling membership is exactly
         # what trips "Object of type <Edition> not in session" as an SAWarning-promoted error.

--- a/src/agentic_librarian/orchestration/definitions.py
+++ b/src/agentic_librarian/orchestration/definitions.py
@@ -50,6 +50,21 @@ def create_deep_scout_manager() -> ScoutManager:
     return manager
 
 
+def create_completion_scout_manager() -> ScoutManager:
+    """Format-completion pass (history-format-edit): the fast API scouts fetch the new
+    format's edition metadata (ISBN, pages/audio minutes, publication date); the audiobook
+    scouts (which self-skip on non-audiobook formats) add narrators. Deliberately NO
+    LLMTropeScout and NO StyleScout — tropes and author/work styles belong to the Work,
+    which a format change does not touch; narrator styles are scouted directly by
+    two_phase.complete_edition."""
+    manager = ScoutManager()
+    manager.register_scout(HardcoverScout(), priority=1)
+    manager.register_scout(GoogleBooksScout(), priority=2)
+    manager.register_scout(AudiobookScout(), priority=3)
+    manager.register_scout(DirectKnowledgeScout(), priority=4)
+    return manager
+
+
 defs = Definitions(
     assets=all_assets,
     jobs=[jobs.enhance_job],

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -213,8 +213,12 @@ def _db(db_url):
     return DatabaseManager(db_url)
 
 
-def _my_entry(client):
-    return next(h for h in client.get("/history").json() if h["title"] == "Shared Book")
+def _my_entry(client, fmt="ebook"):
+    """The fixture's seeded read, selected by title AND format: several tests seed a second
+    'Shared Book' read at the SAME date_completed, and /history tie-breaks equal dates by
+    ReadingHistory.id — a random UUID — so title alone is a coin flip (the CI-only flake:
+    the collision test grabbed the audiobook row and its PATCH became a same-format 200)."""
+    return next(h for h in client.get("/history").json() if h["title"] == "Shared Book" and h["format"] == fmt)
 
 
 def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_url):

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -220,6 +220,8 @@ def _my_entry(client):
 def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_url):
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
+    # Seed rating + notes first so the repoint has non-null scalars to preserve (#96 lens).
+    assert client.patch(f"/history/{entry['id']}", json={"rating": 4, "notes": "keep me"}).status_code == 200
     resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["format"] == "audiobook"
@@ -230,11 +232,31 @@ def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_u
         formats = {e.format for e in s.query(Edition).filter(Edition.work_id == work_id)}
         assert row.edition.format == "audiobook"
         assert formats == {"ebook", "audiobook"}  # old edition intact (shared catalog object)
-        # Assertion completeness (#96 lesson): untouched fields survive; the friend's row
-        # on the ORIGINAL edition is untouched.
+        # Assertion completeness (#96 lesson): untouched fields survive the repoint; the
+        # friend's row on the ORIGINAL edition is untouched.
         assert row.date_completed == date(2021, 1, 1)
+        assert row.user_rating == 4
+        assert row.user_notes == "keep me"
         friend = s.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).one()
         assert friend.edition.format == "ebook"
+
+
+def test_patch_combined_date_and_format_valid_at_final_state_succeeds(two_user_client, db_url):
+    """C1 sibling: a combined date+format edit valid at the FINAL (audiobook, 2020-06-06)
+    but colliding at the INTERMEDIATE (ebook, 2020-06-06) must 200, not 500. Pre-Fix-1 the
+    autoflush of row.date_completed during the dup pre-check tripped the unique index outside
+    the flush try/except."""
+    with _db(db_url).get_session() as s:
+        edition_id = s.query(Edition).filter(Edition.format == "ebook").first().id
+        # Occupy the intermediate (ebook, 2020-06-06) pair (mirrors the date-collision setup).
+        s.add(ReadingHistory(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=date(2020, 6, 6)))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)  # the 2021-01-01 read
+    resp = client.patch(f"/history/{entry['id']}", json={"date_completed": "2020-06-06", "format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["format"] == "audiobook"
+    assert resp.json()["date_completed"] == "2020-06-06"
 
 
 def test_patch_format_reuses_existing_sibling_edition(two_user_client, db_url):

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -207,3 +207,140 @@ def test_patch_history_rejects_bad_input_and_other_users(two_user_client, db_url
     with manager.get_session() as session:
         friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
     assert client.patch(f"/history/{friend_id}", json={"rating": 3}).status_code == 404
+
+
+def _db(db_url):
+    return DatabaseManager(db_url)
+
+
+def _my_entry(client):
+    return next(h for h in client.get("/history").json() if h["title"] == "Shared Book")
+
+
+def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_url):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["format"] == "audiobook"
+    assert resp.json()["enrichment_enqueued"] is False  # no Cloud Tasks in tests
+    with _db(db_url).get_session() as s:
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        work_id = row.edition.work_id
+        formats = {e.format for e in s.query(Edition).filter(Edition.work_id == work_id)}
+        assert row.edition.format == "audiobook"
+        assert formats == {"ebook", "audiobook"}  # old edition intact (shared catalog object)
+        # Assertion completeness (#96 lesson): untouched fields survive; the friend's row
+        # on the ORIGINAL edition is untouched.
+        assert row.date_completed == date(2021, 1, 1)
+        friend = s.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).one()
+        assert friend.edition.format == "ebook"
+
+
+def test_patch_format_reuses_existing_sibling_edition(two_user_client, db_url):
+    with _db(db_url).get_session() as s:
+        work_id = s.query(Edition).filter(Edition.format == "ebook").first().work_id
+        s.add(Edition(work_id=work_id, format="audiobook", isbn_13="9781111111111"))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    assert client.patch(f"/history/{entry['id']}", json={"format": "audiobook"}).status_code == 200
+    with _db(db_url).get_session() as s:
+        assert s.query(Edition).filter(Edition.work_id == work_id).count() == 2  # reused, not duplicated
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        assert row.edition.isbn_13 == "9781111111111"
+
+
+def test_patch_same_format_is_a_noop(two_user_client, db_url):
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    assert client.patch(f"/history/{entry['id']}", json={"format": "ebook"}).status_code == 200
+    with _db(db_url).get_session() as s:
+        work_id = s.get(ReadingHistory, UUID(entry["id"])).edition.work_id
+        assert s.query(Edition).filter(Edition.work_id == work_id).count() == 1  # nothing minted
+
+
+def test_patch_format_collision_is_409_and_rolls_back(two_user_client, db_url):
+    with _db(db_url).get_session() as s:
+        ebook = s.query(Edition).filter(Edition.format == "ebook").first()
+        audio = Edition(work_id=ebook.work_id, format="audiobook")
+        s.add(audio)
+        s.flush()
+        # Same user, same work, SAME date — but as an audiobook (an import-duplicate shape).
+        s.add(ReadingHistory(edition_id=audio.id, user_id=DEFAULT_USER_ID, date_completed=date(2021, 1, 1)))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook", "notes": "should not stick"})
+    assert resp.status_code == 409
+    assert "already logged" in resp.json()["detail"]
+    with _db(db_url).get_session() as s:
+        row = s.get(ReadingHistory, UUID(entry["id"]))
+        assert row.edition.format == "ebook"  # repoint rolled back
+        assert row.user_notes != "should not stick"  # the whole PATCH rolled back, not just format
+
+
+def test_patch_date_collision_is_409_not_500(two_user_client, db_url):
+    """Pre-existing hole the format work closes: date-only edits could always trip
+    uq_reading_history_user_edition_date; they must now 409 cleanly."""
+    with _db(db_url).get_session() as s:
+        edition_id = s.query(Edition).filter(Edition.format == "ebook").first().id
+        s.add(ReadingHistory(edition_id=edition_id, user_id=DEFAULT_USER_ID, date_completed=date(2020, 6, 6)))
+        s.flush()
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)  # the 2021-01-01 read
+    assert client.patch(f"/history/{entry['id']}", json={"date_completed": "2020-06-06"}).status_code == 409
+
+
+def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append((wid, fmt)) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is True
+    assert len(calls) == 1 and calls[0][1] == "audiobook"
+
+
+def test_patch_format_enqueue_failure_never_fails_the_edit(two_user_client, monkeypatch):
+    def _boom(wid, fmt):
+        raise RuntimeError("tasks down")
+
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", _boom)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["format"] == "audiobook"  # the edit stuck
+    assert resp.json()["enrichment_enqueued"] is False
+
+
+def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_url, monkeypatch):
+    from agentic_librarian.db.models import Narrator
+
+    with _db(db_url).get_session() as s:
+        work_id = s.query(Edition).filter(Edition.format == "ebook").first().work_id
+        done = Edition(work_id=work_id, format="audiobook", isbn_13="9782222222222")
+        done.narrators = [Narrator(name="Ray Porter")]
+        s.add(done)
+        s.flush()
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is False
+    assert calls == []  # already complete — no paid pass
+
+
+def test_patch_notes_only_never_enqueues(two_user_client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
+    entry = _my_entry(client)
+    resp = client.patch(f"/history/{entry['id']}", json={"notes": "just notes"})
+    assert resp.status_code == 200
+    assert resp.json()["enrichment_enqueued"] is False
+    assert calls == []

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -1,0 +1,80 @@
+"""OIDC gate + status mapping for the edition-completion internal endpoint.
+
+Mirrors test_internal_enrich_api.py: db_integration because the FastAPI app import
+chain needs real settings, but complete_edition itself is monkeypatched — the pass's
+own behavior is covered by test/unit/test_edition_completion.py."""
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import internal as internal_mod
+from agentic_librarian.api import main as api_main
+
+pytestmark = pytest.mark.db_integration
+
+VALID_AUD = "https://librarian.example.run.app/internal/enrich/x"
+QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
+    monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
+    yield TestClient(api_main.app)
+
+
+def _as_queue(monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+
+
+def test_valid_queue_token_runs_completion(client, monkeypatch):
+    _as_queue(monkeypatch)
+    called = {}
+
+    def fake_complete(wid, fmt):
+        called["args"] = (wid, fmt)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert called["args"] == (wid, "audiobook")
+
+
+def test_missing_work_is_404_non_retryable(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", lambda wid, fmt: "missing")
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 404
+
+
+def test_empty_scouts_is_200_final(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", lambda wid, fmt: "empty")
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "empty"
+
+
+def test_missing_token_is_401(client):
+    assert client.post(f"/internal/complete-edition/{uuid4()}?format=ebook").status_code == 401
+
+
+def test_wrong_service_account_is_403(client, monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": "attacker@evil.com", "email_verified": True}
+    )
+    resp = client.post(f"/internal/complete-edition/{uuid4()}?format=ebook", headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 403
+
+
+def test_missing_format_param_is_422(client, monkeypatch):
+    _as_queue(monkeypatch)
+    resp = client.post(f"/internal/complete-edition/{uuid4()}", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 422

--- a/test/unit/test_api_history.py
+++ b/test/unit/test_api_history.py
@@ -196,3 +196,36 @@ def test_get_history_tropes_prefer_real_over_slugs(tropes, expected_names):
         assert response.status_code == 200
         data = response.json()
         assert data[0]["tropes"] == expected_names
+
+
+def _patch_with_mock_row(json_body):
+    """PATCH against a minimal mocked row (validation-focused unit seam)."""
+    with patch("agentic_librarian.api.main.db_manager") as mock_db:
+        mock_session = MagicMock()
+        mock_db.get_session.return_value.__enter__.return_value = mock_session
+        _history_chain(mock_session, [])
+        return client.patch("/history/00000000-0000-4000-8000-00000000abcd", json=json_body)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_status"),
+    [
+        pytest.param({"format": "vinyl"}, 422, id="unknown_format_rejected"),
+        pytest.param({"format": ""}, 422, id="empty_format_rejected"),
+        pytest.param({"format": None}, 422, id="null_format_rejected"),
+        pytest.param({"format": 7}, 422, id="non_string_format_rejected"),
+    ],
+)
+def test_patch_history_format_vocab_validation(body, expected_status):
+    assert _patch_with_mock_row(body).status_code == expected_status
+
+
+@pytest.mark.parametrize(
+    "raw", [pytest.param("Audiobook", id="capitalized"), pytest.param("  audiobook  ", id="padded")]
+)
+def test_patch_history_format_is_case_and_space_normalized(raw):
+    """Accepted spellings normalize to the canonical lowercase vocab before any DB work —
+    prove it via the pydantic model directly (the endpoint seam is mocked in this file)."""
+    from agentic_librarian.api.main import HistoryUpdate
+
+    assert HistoryUpdate(format=raw).format == "audiobook"

--- a/test/unit/test_edition_completion.py
+++ b/test/unit/test_edition_completion.py
@@ -1,0 +1,159 @@
+"""complete_edition (history-format-edit): targeted format-completion pass.
+
+Session discipline (#94), status contract, and scout composition — narrator styles are
+scouted ONLY for audiobook formats, and only via scout_narrator_style (never
+StyleScout.search, which would re-scout author/work styles)."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.enrichment import two_phase
+
+
+class _FakeSession:
+    """Counting session double (the house #94 pattern, test_two_phase_sessions.py)."""
+
+    def __init__(self, state, work, edition):
+        self._state = state
+        self._work = work
+        self._edition = edition
+
+    def __enter__(self):
+        self._state["open"] += 1
+        m = MagicMock()
+        m.get.return_value = self._work
+        m.query.return_value.filter_by.return_value.first.return_value = self._edition
+        return m
+
+    def __exit__(self, *a):
+        self._state["open"] -= 1
+        return False
+
+
+def _work_double(title="T", author="A"):
+    work = MagicMock()
+    work.title = title
+    contrib = MagicMock(role="Author")
+    contrib.author.name = author
+    work.contributors = [contrib]
+    return work
+
+
+def _wire(monkeypatch, *, work, edition, enriched, state=None):
+    state = state if state is not None else {"open": 0}
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: _FakeSession(state, work, edition)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = enriched
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    return state, scout_mgr
+
+
+def test_scouts_run_outside_any_session(monkeypatch):
+    state, scout_mgr = _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched={})
+    seen = {}
+    scout_mgr.enrich.side_effect = lambda **kw: seen.setdefault("open_during_scout", state["open"]) or {}
+    assert two_phase.complete_edition(uuid4(), "ebook") == "empty"
+    assert seen["open_during_scout"] == 0  # THE #94 assertion
+
+
+@pytest.mark.parametrize(
+    ("work", "edition"),
+    [
+        pytest.param(None, MagicMock(), id="work_gone"),
+        pytest.param(_work_double(), None, id="edition_gone"),
+        pytest.param(MagicMock(title="T", contributors=[]), MagicMock(), id="no_author"),
+    ],
+)
+def test_missing_paths(monkeypatch, work, edition):
+    _wire(monkeypatch, work=work, edition=edition, enriched={})
+    assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
+
+
+def test_empty_scouts_is_final(monkeypatch):
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched={})
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "empty"
+
+
+def test_done_merges_scouted_values_for_audiobook(monkeypatch):
+    enriched = {
+        "isbn_13": "9780000000000",
+        "page_count": 300,
+        "audio_minutes": 600,
+        "publication_date": "2020-01-01",
+        "narrator_names": ["Ray Porter"],
+        "source_priority": ["Hardcover"],
+    }
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
+    style_scout = MagicMock()
+    style_scout.scout_narrator_style.return_value = {"pacing": "brisk"}
+    monkeypatch.setattr(two_phase, "StyleScout", lambda: style_scout)
+    merged = {}
+
+    def fake_merge(session, **kwargs):
+        merged.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(two_phase, "merge_edition_and_narrators", fake_merge)
+
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "done"
+    style_scout.scout_narrator_style.assert_called_once_with("Ray Porter")
+    assert merged["fmt"] == "audiobook"
+    assert merged["isbn_13"] == "9780000000000"
+    assert merged["audio_minutes"] == 600
+    assert merged["narrator_names"] == ["Ray Porter"]
+    assert merged["narrator_styles"] == {"Ray Porter": {"pacing": "brisk"}}
+
+
+def test_non_audiobook_never_scouts_narrator_styles(monkeypatch):
+    enriched = {"isbn_13": "9780000000001", "narrator_names": [], "source_priority": ["Hardcover"]}
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "merge_edition_and_narrators", lambda session, **kw: MagicMock())
+    with patch.object(two_phase, "StyleScout") as style_cls:
+        assert two_phase.complete_edition(uuid4(), "paperback") == "done"
+    style_cls.assert_not_called()
+
+
+def test_style_scout_failure_degrades_to_no_styles(monkeypatch):
+    enriched = {"narrator_names": ["Ray Porter"], "source_priority": ["Audible"]}
+    _wire(monkeypatch, work=_work_double(), edition=MagicMock(), enriched=enriched)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
+    broken = MagicMock()
+    broken.scout_narrator_style.side_effect = RuntimeError("LLM down")
+    monkeypatch.setattr(two_phase, "StyleScout", lambda: broken)
+    merged = {}
+    monkeypatch.setattr(
+        two_phase, "merge_edition_and_narrators", lambda session, **kw: merged.update(kw) or MagicMock()
+    )
+    assert two_phase.complete_edition(uuid4(), "audiobook") == "done"
+    assert merged["narrator_styles"] == {}  # narrators still merge; styles degrade
+
+
+def test_work_deleted_mid_pass_returns_missing(monkeypatch):
+    """The write session re-checks existence (same honesty rule as enrich_deep)."""
+    enriched = {"isbn_13": "9780000000002", "narrator_names": [], "source_priority": ["Hardcover"]}
+    state = {"open": 0, "calls": 0}
+
+    work = _work_double()
+
+    class _VanishingSession(_FakeSession):
+        def __enter__(self):
+            self._state["open"] += 1
+            self._state["calls"] += 1
+            m = MagicMock()
+            # First (read) session sees the work; second (write) session finds it gone.
+            m.get.return_value = work if self._state["calls"] == 1 else None
+            m.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+            return m
+
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: _VanishingSession(state, work, MagicMock())
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = enriched
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    assert two_phase.complete_edition(uuid4(), "ebook") == "missing"

--- a/test/unit/test_edition_completion.py
+++ b/test/unit/test_edition_completion.py
@@ -157,3 +157,36 @@ def test_work_deleted_mid_pass_returns_missing(monkeypatch):
     scout_mgr.enrich.return_value = enriched
     monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
     assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
+
+
+def test_edition_deleted_mid_pass_returns_missing_without_merge(monkeypatch):
+    """The write session re-checks the EDITION too: the read session sees it, but an operator
+    edition delete mid-pass makes the write session's edition query return None → "missing",
+    and merge_edition_and_narrators must never run (it would silently recreate the edition)."""
+    enriched = {"isbn_13": "9780000000003", "narrator_names": [], "source_priority": ["Hardcover"]}
+    state = {"open": 0, "calls": 0}
+    work = _work_double()
+
+    class _EditionVanishesSession(_FakeSession):
+        def __enter__(self):
+            self._state["open"] += 1
+            self._state["calls"] += 1
+            m = MagicMock()
+            m.get.return_value = work  # the Work survives both sessions
+            # First (read) session sees the edition; second (write) session finds it gone.
+            edition = MagicMock() if self._state["calls"] == 1 else None
+            m.query.return_value.filter_by.return_value.first.return_value = edition
+            return m
+
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: _EditionVanishesSession(state, work, MagicMock())
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = enriched
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    merge_calls = []
+    monkeypatch.setattr(
+        two_phase, "merge_edition_and_narrators", lambda session, **kw: merge_calls.append(kw) or MagicMock()
+    )
+    assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
+    assert merge_calls == []  # the edition re-check short-circuits before any merge

--- a/test/unit/test_enqueue_enrichment.py
+++ b/test/unit/test_enqueue_enrichment.py
@@ -37,3 +37,34 @@ def test_enqueue_skips_when_queue_not_configured(monkeypatch):
 
     assert tasks.enqueue_enrichment("abc") is False  # local dev: no queue, fast pass still succeeds
     assert called["n"] == 0  # client never constructed
+
+
+def test_enqueue_edition_completion_targets_the_completion_route(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook") is True
+
+    parent, task = fake.created[0]
+    assert parent == "projects/p/locations/us-central1/queues/enrich"
+    http = task["http_request"]
+    assert http["url"] == (
+        "https://librarian.example.run.app/internal/complete-edition/"
+        "11111111-1111-4111-8111-111111111111?format=audiobook"
+    )
+    assert http["oidc_token"]["service_account_email"] == "queue-invoker@p.iam.gserviceaccount.com"
+    # Audience must NOT include the query string (a per-task audience would break a fixed
+    # receiver-side ENRICH_OIDC_AUDIENCE check).
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/complete-edition/11111111-1111-4111-8111-111111111111"
+    )
+
+
+def test_enqueue_edition_completion_skips_when_not_configured(monkeypatch):
+    monkeypatch.delenv("CLOUD_TASKS_QUEUE", raising=False)
+    called = {"n": 0}
+    monkeypatch.setattr(tasks, "_client", lambda: called.__setitem__("n", called["n"] + 1))
+
+    assert tasks.enqueue_edition_completion("abc", "audiobook") is False
+    assert called["n"] == 0

--- a/test/unit/test_scout_factories.py
+++ b/test/unit/test_scout_factories.py
@@ -1,4 +1,5 @@
 from agentic_librarian.orchestration.definitions import (
+    create_completion_scout_manager,
     create_deep_scout_manager,
     create_fast_scout_manager,
 )
@@ -24,3 +25,16 @@ def test_deep_manager_has_only_llm_scouts_in_priority_order(monkeypatch):
     mgr = create_deep_scout_manager()
     types = [type(s) for s, _ in mgr.scouts]
     assert types == [AudiobookScout, DirectKnowledgeScout, StyleScout, LLMTropeScout]
+
+
+def test_completion_manager_composition():
+    """Format-completion pass (history-format-edit spec): fast API scouts + audiobook
+    scouts ONLY — never LLMTropeScout (paid trope pass) or StyleScout (author/work
+    styles); narrator styles are scouted directly by two_phase.complete_edition."""
+    manager = create_completion_scout_manager()
+    assert [type(s) for s, _priority in manager.scouts] == [
+        HardcoverScout,
+        GoogleBooksScout,
+        AudiobookScout,
+        DirectKnowledgeScout,
+    ]

--- a/test/unit/test_scout_factories.py
+++ b/test/unit/test_scout_factories.py
@@ -27,10 +27,12 @@ def test_deep_manager_has_only_llm_scouts_in_priority_order(monkeypatch):
     assert types == [AudiobookScout, DirectKnowledgeScout, StyleScout, LLMTropeScout]
 
 
-def test_completion_manager_composition():
+def test_completion_manager_composition(monkeypatch):
     """Format-completion pass (history-format-edit spec): fast API scouts + audiobook
     scouts ONLY — never LLMTropeScout (paid trope pass) or StyleScout (author/work
     styles); narrator styles are scouted directly by two_phase.complete_edition."""
+    # AudiobookScout/DirectKnowledgeScout are LLMScouts — the base raises without a key.
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
     manager = create_completion_scout_manager()
     assert [type(s) for s, _priority in manager.scouts] == [
         HardcoverScout,


### PR DESCRIPTION
## What

Users can now change a history entry's **format** (ebook / audiobook / paperback / hardcover), not just date/rating/notes.

- **`PATCH /history/{id}` accepts `format`** (vocab-validated, case-normalized). A format change repoints the row to the sibling `(work_id, format)` Edition — get-or-created, case-insensitive reuse — and never mutates the old edition (editions are shared catalog objects).
- **Collisions with `uq_reading_history_user_edition_date` return 409** with a human-readable message, and the whole PATCH rolls back. This also closes a pre-existing hole: date-only edits could previously 500 on the same constraint. The handler resolves final values and runs the collision pre-check **before any ORM mutation** (autoflush would otherwise fire the unique index mid-query — caught in the whole-branch review, fixed in `0d01856`, regression-tested).
- **Targeted async "format-completion" pass**: when the target edition lacks metadata, the PATCH enqueues `POST /internal/complete-edition/{work_id}?format=…` (existing enrich queue, same OIDC gate). `two_phase.complete_edition` runs the fast API scouts (ISBN, page count, audio minutes, publication date) for any format, plus AudiobookScout/DirectKnowledgeScout + per-narrator style scouting for audiobooks — **never** `LLMTropeScout` or author/work-style scouting (Work-owned data; no paid deep pass re-buy). Session discipline follows the module's #94 rule; idempotent for Cloud Tasks redelivery.
- **Persistence reuse**: the "Edition & Narrators" block of `persist_enriched_work` is extracted verbatim into `merge_edition_and_narrators`, shared by both callers.
- **Frontend**: format select on the history edit view; new `ApiError` in `client.ts` surfaces the server's 409 detail instead of the generic retry message.

Spec: `docs/superpowers/specs/2026-07-18-history-format-edit-design.md` (design decisions: async enrichment, 409-keep-both on collision, targeted pass over full deep pass — ISBN comes from the fast scouts' format-matched edition selection).

## Test status (honest accounting)

**Executed locally:** unit suite 777 passed / 3 skipped, with only the 5 documented env-dependent failures (live-network scouts ×2, `db` hostname, `claude_agent_sdk` ×2 — baseline verified via `git stash`); frontend 140/140 across 30 files; `tsc --noEmit` clean; ruff check + format clean.

**Collected locally, executed first in CI (the merge gate):** 26 `db_integration` tests — 20 in `test_api_history_db.py` (repoint/reuse/no-op/409-rollback/enqueue gating, incl. two regression tests for the autoflush fix: `test_patch_date_collision_is_409_not_500` and `test_patch_combined_date_and_format_valid_at_final_state_succeeds`) and 6 in `test_internal_complete_edition_api.py`.

Review process: per-task spec+quality reviews on all 8 plan tasks, then an adversarial whole-branch review (found the autoflush Critical + 3 Importants), one fix wave, and a verified re-review: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJm935pp6vTjw6j2rATxY9