### PR TITLE
fix: explicit SPA cache policy — no-cache shell, immutable hashed assets

### DIFF
--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -490,8 +490,17 @@ def _spa_dir() -> str:
     return os.environ.get("SPA_DIST_DIR", "/app/static")
 
 
+# Cache policy (2026-07-19 mobile stale-bundle incident): index.html names the hashed
+# bundles, so it must ALWAYS revalidate — without an explicit Cache-Control, mobile
+# browsers heuristically cache it and keep serving a stale shell after deploys (the
+# ETag makes revalidation a cheap 304). Vite content-hashes everything under /assets/,
+# so those are immutable; unhashed root files (favicons) revalidate like the shell.
+_SHELL_CACHE = "no-cache"
+_HASHED_ASSET_CACHE = "public, max-age=31536000, immutable"
+
+
 def _spa_index() -> FileResponse:
-    return FileResponse(os.path.join(_spa_dir(), "index.html"))
+    return FileResponse(os.path.join(_spa_dir(), "index.html"), headers={"Cache-Control": _SHELL_CACHE})
 
 
 @app.get("/")
@@ -509,5 +518,7 @@ def spa_catch_all(full_path: str):
     root = os.path.realpath(_spa_dir())
     candidate = os.path.realpath(os.path.join(root, full_path))
     if (candidate == root or candidate.startswith(root + os.sep)) and os.path.isfile(candidate):
-        return FileResponse(candidate)
+        hashed = candidate.startswith(os.path.join(root, "assets") + os.sep)
+        cache = _HASHED_ASSET_CACHE if hashed else _SHELL_CACHE
+        return FileResponse(candidate, headers={"Cache-Control": cache})
     return _spa_index()

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -2,6 +2,7 @@
 for client-side routes, real built files served as-is, API routes taking precedence, and a
 path-traversal guard on the catch-all."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from agentic_librarian.api.main import app
@@ -11,6 +12,7 @@ def _build_dist(root):
     (root / "assets").mkdir()
     (root / "index.html").write_text('<!doctype html><div id="root"></div>')
     (root / "assets" / "app.js").write_text('console.log("spa")')
+    (root / "favicon.svg").write_text("<svg/>")
     return root
 
 
@@ -36,6 +38,39 @@ def test_real_asset_is_served(tmp_path, monkeypatch):
     r = TestClient(app).get("/assets/app.js")
     assert r.status_code == 200
     assert 'console.log("spa")' in r.text
+
+
+# Cache policy (2026-07-19 mobile stale-bundle incident): without an explicit
+# Cache-Control, mobile browsers heuristically cache index.html and keep serving a
+# stale shell that points at old hashed bundles. index.html (and any unhashed root
+# file) must always revalidate; the content-hashed /assets/* never change and are
+# immutable.
+@pytest.mark.parametrize("path", ["/", "/add", "/index.html"])
+def test_index_and_fallback_are_no_cache(tmp_path, monkeypatch, path):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path)
+    assert r.status_code == 200
+    assert r.headers["cache-control"] == "no-cache"
+    assert 'id="root"' in r.text
+
+
+def test_hashed_asset_is_immutable(tmp_path, monkeypatch):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/assets/app.js")
+    assert r.status_code == 200
+    assert r.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+def test_unhashed_root_file_is_no_cache(tmp_path, monkeypatch):
+    # favicon.svg comes from frontend/public/ unhashed — a new one must be picked up.
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/favicon.svg")
+    assert r.status_code == 200
+    assert r.headers["cache-control"] == "no-cache"
+    assert "<svg/>" in r.text
 
 
 def test_api_route_wins_over_spa_catch_all(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Post-#148 deploy, the new Picks button didn't appear on mobile. Diagnosis: prod serves `index.html` with an `ETag` but **no `Cache-Control`**, so mobile browsers heuristically cache the shell and keep serving a stale copy that references the *old* hashed bundle — every future deploy would hit the same wall for returning mobile users. (The deployed bundle itself was verified correct.)

## What

The SPA-serving handlers in `api/main.py` now send an explicit policy:
- `index.html` (root, SPA fallback, direct request) and unhashed root files (favicons): `Cache-Control: no-cache` — always revalidate; the existing ETag makes that a cheap 304.
- Content-hashed `/assets/*`: `Cache-Control: public, max-age=31536000, immutable`.

Net effect: new deploys are picked up on the next load, while hashed assets stay fully cached.

## Testing

- 5 new unit tests in `test_spa_serving.py` (parametrized shell/fallback/direct-index no-cache; immutable hashed asset; no-cache unhashed root file) — TDD red→green.
- Full unit suite: 822 passed (only the 5 known env-dependent failures).
- Path-traversal guard and catch-all behavior unchanged (existing 7 tests still green).

One-time note: users currently stuck on the stale shell will still need one manual refresh — this header only prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJm935pp6vTjw6j2rATxY9