### PR TITLE
fix: refresh on a tab renders the app, not a 401 JSON page

### DIFF
--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -6,7 +6,7 @@ import os
 from datetime import date
 from uuid import UUID
 
-from fastapi import Body, Depends, FastAPI, HTTPException, Query
+from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func, text
@@ -501,6 +501,29 @@ _HASHED_ASSET_CACHE = "public, max-age=31536000, immutable"
 
 def _spa_index() -> FileResponse:
     return FileResponse(os.path.join(_spa_dir(), "index.html"), headers={"Cache-Control": _SHELL_CACHE})
+
+
+# Refresh-on-a-tab fix (2026-07-19): /history, /recommendations, /analysis are BOTH SPA
+# client routes and authed API GETs, and API routes win the router — so a browser refresh
+# on a tab rendered {"detail":"Missing bearer token."} as the page. A document NAVIGATION
+# is distinguished by its Accept header (browsers send text/html first; the SPA's fetch()
+# calls send */*): GET navigations to client routes serve the shell, fetches keep reaching
+# the API. The same middleware stamps Cache-Control: no-store on every response that set
+# no policy of its own (i.e. all API JSON) — private payloads must never be cacheable
+# (a heuristically-cached authed /history body could previously render as a page).
+_SPA_CLIENT_ROUTES = ("history", "recommendations", "analysis", "add", "import", "settings")
+
+
+@app.middleware("http")
+async def _spa_navigation_and_api_cache(request: Request, call_next):
+    if request.method == "GET" and "text/html" in request.headers.get("accept", ""):
+        first_segment = request.url.path.strip("/").split("/", 1)[0]
+        if first_segment in _SPA_CLIENT_ROUTES:
+            return _spa_index()
+    response = await call_next(request)
+    if "cache-control" not in response.headers:
+        response.headers["cache-control"] = "no-store"
+    return response
 
 
 @app.get("/")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -519,7 +519,12 @@ async def _spa_navigation_and_api_cache(request: Request, call_next):
     if request.method == "GET" and "text/html" in request.headers.get("accept", ""):
         first_segment = request.url.path.strip("/").split("/", 1)[0]
         if first_segment in _SPA_CLIENT_ROUTES:
-            return _spa_index()
+            # Internal rewrite to the shell route rather than returning a FileResponse
+            # from the middleware itself (BaseHTTPMiddleware + a directly-returned file
+            # response is a known footgun: fd lifetime, skipped inner middleware). The
+            # router then serves the shell exactly like a "/" request.
+            request.scope["path"] = "/"
+            request.scope["raw_path"] = b"/"
     response = await call_next(request)
     if "cache-control" not in response.headers:
         response.headers["cache-control"] = "no-store"

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -81,6 +81,56 @@ def test_api_route_wins_over_spa_catch_all(tmp_path, monkeypatch):
     assert r.json() == {"status": "ok"}
 
 
+# Refresh-on-a-tab collision (2026-07-19): /history, /recommendations, /analysis are BOTH
+# SPA client routes and authed API GETs. A browser NAVIGATION (refresh, bookmark, typed
+# URL — Accept prefers text/html) must get the shell; the SPA's fetch() calls
+# (Accept: */*) must keep reaching the API. The Accept header is the discriminator.
+_NAV_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/history", "/recommendations", "/analysis", "/add", "/import", "/settings", "/history/abc/edit"],
+)
+def test_browser_navigation_to_spa_route_serves_shell(tmp_path, monkeypatch, path):
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path, headers={"Accept": _NAV_ACCEPT})
+    assert r.status_code == 200
+    assert 'id="root"' in r.text
+    assert r.headers["cache-control"] == "no-cache"
+
+
+@pytest.mark.parametrize("path", ["/history", "/recommendations", "/analysis"])
+def test_fetch_style_request_still_reaches_the_api(tmp_path, monkeypatch, path):
+    # fetch() sends Accept: */* — the API route must still win (401 without a token,
+    # NOT the shell).
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path, headers={"Accept": "*/*"})
+    assert r.status_code == 401
+    assert r.json() == {"detail": "Missing bearer token."}
+
+
+def test_navigation_to_a_real_static_file_is_not_hijacked(tmp_path, monkeypatch):
+    # A navigation whose path IS a built file (e.g. the favicon opened directly) still
+    # serves the file, not the shell.
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/favicon.svg", headers={"Accept": _NAV_ACCEPT})
+    assert r.status_code == 200
+    assert "<svg/>" in r.text
+
+
+def test_api_json_responses_are_no_store(tmp_path, monkeypatch):
+    # Private API JSON must never sit in a browser/proxy cache — this is also what let a
+    # stale authed /history body render as a page after the route collision.
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get("/health")
+    assert r.headers["cache-control"] == "no-store"
+
+
 def test_path_traversal_is_blocked(tmp_path, monkeypatch):
     # Secret lives OUTSIDE the dist dir. Call the handler directly — the HTTP client would
     # normalize the `..` away before routing, so a direct call is what exercises the guard.


### PR DESCRIPTION
## Why

Refreshing (or bookmarking / typing the URL) while on the History, Picks, or Analysis tab rendered `{"detail":"Missing bearer token."}` — or occasionally a raw cached JSON body — instead of the app. Root cause: those paths are **both** SPA client routes and authenticated API GET routes, and API routes register ahead of the SPA catch-all; a browser navigation carries no bearer token, so the API route answered with 401 JSON. Reproduced with `curl -H "Accept: text/html" https://shelfwright.app/history`.

## What

New ~10-line middleware in `api/main.py`:
- A **GET whose `Accept` prefers `text/html`** (how every browser marks a document navigation) with a first path segment in the SPA client-route set (`history`, `recommendations`, `analysis`, `add`, `import`, `settings`) serves the SPA shell. The SPA's `fetch()` calls send `Accept: */*` and keep reaching the API unchanged.
- Every response that didn't set its own `Cache-Control` (i.e. all API JSON) now gets **`no-store`** — private payloads must never sit in a browser/proxy cache. This also kills the raw-JSON-as-page variant of the symptom and closes the private-data-in-disk-cache smell. Static/shell responses keep their explicit policy from #149.

## Testing

TDD in `test_spa_serving.py` (10 new parametrized/atomic cases, 24 total green):
- navigation → shell for all six tab routes + the nested `/history/:id/edit` (with `no-cache` shell header)
- fetch-style `Accept: */*` → still the API (401 `Missing bearer token.`)
- a navigation to a real static file (favicon) is not hijacked
- API JSON carries `no-store`
- all pre-existing catch-all/traversal/cache tests unchanged.

Full unit suite: 834 passed (only the 5 known env-dependent failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJm935pp6vTjw6j2rATxY9