### PR TITLE
refactor: namespace the API under /api/* (#151)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,13 +170,13 @@ jobs:
           URL="${{ steps.deploy.outputs.url }}"
           TOKEN="${{ steps.smoke-token.outputs.id_token }}"
           curl -fsS -H "Authorization: Bearer ${TOKEN}" "${URL}/health"
-          # /history is Firebase-gated (Lift 1): IAM passes via X-Serverless-Authorization,
+          # /api/history is Firebase-gated (Lift 1): IAM passes via X-Serverless-Authorization,
           # no Firebase token supplied → the app MUST answer 401. DB connectivity is now
           # verified by the operator runbook (the deployer cannot mint Firebase tokens).
           code=$(curl -s -o /dev/null -w '%{http_code}' \
-            -H "X-Serverless-Authorization: Bearer ${TOKEN}" "${URL}/history")
+            -H "X-Serverless-Authorization: Bearer ${TOKEN}" "${URL}/api/history")
           if [ "${code}" != "401" ]; then
-            echo "::error::expected 401 from unauthenticated /history, got ${code}"
+            echo "::error::expected 401 from unauthenticated /api/history, got ${code}"
             exit 1
           fi
           echo "Live smoke passed: /health green; auth layer enforcing (401 without Firebase token)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,37 +76,18 @@ that every single-pass review missed.
 - Full unit suite before each commit; focused tests while iterating.
 - No `[skip ci]` anywhere in commit messages (see bugs.md 2026-06-17 / GH #90).
 
-## Known local-only test failures — DO NOT stash-verify these
+## Local test suite is green by default — no stash-verify dance (ADR-063)
 
-A fixed, small set of unit tests **fail on the local host and pass in cloud CI**. They are
-env-dependent, not regressions. When you see ONLY these in a local run, name them and move
-on — **do not `git stash` + rerun to "confirm they're pre-existing"** (that dance is what
-this section exists to end). Refinement of guidance #9: stash-verify *unexpected* failures;
-these are the expected set. Anything outside this list is a real failure to investigate.
+`pytest`'s `addopts` now carries CI's exact filter — `-m "not api_dependent and not slow and
+not live"` — so a bare local `.venv/Scripts/python -m pytest test/unit` runs the same
+selection CI gates on and comes back **green** (live/key-dependent tests deselected; the two
+`claude_agent_sdk` tests `importorskip`-skip when the optional `claude` extra isn't installed).
+There is nothing pre-existing to filter out by eye, so **any failure is a real failure** —
+investigate it, don't `git stash` to "confirm it's baseline" (that dance is retired). This
+supersedes the earlier reading of guidance #9 for the unit suite.
 
-**Cause A — live external API / network (marker: `api_dependent`).** Already tagged; they
-require a real Gemini/Hardcover key or a live network call, so they error offline. `conftest`
-only auto-skips `db_integration`, so `api_dependent` is **not** deselected on a normal run —
-that is why they still fail rather than skip.
-- `test/unit/test_agent_runtime.py::test_live_conversation_runs`
-- `test/unit/test_agent_runtime.py::test_explorer_discovers_real_books`
-- `test/unit/test_metadata_scout.py::test_enrich_with_real_scouts_produces_styles_and_tropes`
-- `test/unit/test_metadata_scout.py::test_hardcover_live_returns_metadata_for_known_title`
-- `test/unit/test_metadata_scout.py::test_claude_grounded_scouts_produce_styles_and_tropes`
-  (also needs an authenticated `claude` CLI)
-
-**Cause B — optional `claude` extra not installed (`claude_agent_sdk` MISSING locally).**
-These import `agentic_librarian.agents.backends.claude` WITHOUT a `pytest.importorskip`
-guard, so they ERROR instead of skipping (contrast `test_claude_backend.py`,
-`test_claude_tools.py`, `test_write_authorization.py`, which guard correctly):
-- `test/unit/test_usage_recording_backends.py::test_claude_conversation_records_usage`
-- `test/unit/test_usage_recording_backends.py::test_claude_loop_thread_sees_the_user_context`
-
-**To run the suite clean locally:** `-m "not api_dependent"` deselects Cause A;
-`pip install -e '.[claude]'` (installs `claude_agent_sdk`) fixes Cause B. CI runs the full
-set with keys + the extra, so CI remains the gate for all of the above.
-
-**Durable fix (open):** wire `api_dependent`/`live` into `conftest.py`'s
-`pytest_collection_modifyitems` to auto-skip unless an opt-in env var is set (mirroring the
-`db_integration` pattern), and add `pytest.importorskip("claude_agent_sdk")` to the two
-unguarded Cause-B tests — then the local suite goes green and this whole section becomes moot.
+The excluded tests still run in CI (deploy.yml / lint.yml pass the same `-m` on the CLI, which
+overrides `addopts`, and install `.[dev,claude]`). To run them yourself: override the marker
+filter, e.g. `-m api_dependent` (needs real Gemini/Hardcover keys, and an authenticated
+`claude` CLI for `test_claude_grounded_scouts_produce_styles_and_tropes`), and
+`pip install -e '.[claude]'` for the `claude_agent_sdk` tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,38 @@ that every single-pass review missed.
   `uvx ruff format <files>` — CI pre-commit enforces format; check alone is not enough.
 - Full unit suite before each commit; focused tests while iterating.
 - No `[skip ci]` anywhere in commit messages (see bugs.md 2026-06-17 / GH #90).
+
+## Known local-only test failures — DO NOT stash-verify these
+
+A fixed, small set of unit tests **fail on the local host and pass in cloud CI**. They are
+env-dependent, not regressions. When you see ONLY these in a local run, name them and move
+on — **do not `git stash` + rerun to "confirm they're pre-existing"** (that dance is what
+this section exists to end). Refinement of guidance #9: stash-verify *unexpected* failures;
+these are the expected set. Anything outside this list is a real failure to investigate.
+
+**Cause A — live external API / network (marker: `api_dependent`).** Already tagged; they
+require a real Gemini/Hardcover key or a live network call, so they error offline. `conftest`
+only auto-skips `db_integration`, so `api_dependent` is **not** deselected on a normal run —
+that is why they still fail rather than skip.
+- `test/unit/test_agent_runtime.py::test_live_conversation_runs`
+- `test/unit/test_agent_runtime.py::test_explorer_discovers_real_books`
+- `test/unit/test_metadata_scout.py::test_enrich_with_real_scouts_produces_styles_and_tropes`
+- `test/unit/test_metadata_scout.py::test_hardcover_live_returns_metadata_for_known_title`
+- `test/unit/test_metadata_scout.py::test_claude_grounded_scouts_produce_styles_and_tropes`
+  (also needs an authenticated `claude` CLI)
+
+**Cause B — optional `claude` extra not installed (`claude_agent_sdk` MISSING locally).**
+These import `agentic_librarian.agents.backends.claude` WITHOUT a `pytest.importorskip`
+guard, so they ERROR instead of skipping (contrast `test_claude_backend.py`,
+`test_claude_tools.py`, `test_write_authorization.py`, which guard correctly):
+- `test/unit/test_usage_recording_backends.py::test_claude_conversation_records_usage`
+- `test/unit/test_usage_recording_backends.py::test_claude_loop_thread_sees_the_user_context`
+
+**To run the suite clean locally:** `-m "not api_dependent"` deselects Cause A;
+`pip install -e '.[claude]'` (installs `claude_agent_sdk`) fixes Cause B. CI runs the full
+set with keys + the extra, so CI remains the gate for all of the above.
+
+**Durable fix (open):** wire `api_dependent`/`live` into `conftest.py`'s
+`pytest_collection_modifyitems` to auto-skip unless an opt-in env var is set (mirroring the
+`db_integration` pattern), and add `pytest.importorskip("claude_agent_sdk")` to the two
+unguarded Cause-B tests — then the local suite goes green and this whole section becomes moot.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,11 @@ There is nothing pre-existing to filter out by eye, so **any failure is a real f
 investigate it, don't `git stash` to "confirm it's baseline" (that dance is retired). This
 supersedes the earlier reading of guidance #9 for the unit suite.
 
-The excluded tests still run in CI (deploy.yml / lint.yml pass the same `-m` on the CLI, which
-overrides `addopts`, and install `.[dev,claude]`). To run them yourself: override the marker
+Coverage is not lost. The two `claude_agent_sdk` tests DO run in CI — it installs
+`.[dev,claude]`, so the `importorskip` skips only locally. The `api_dependent`/`live` tests
+run in NEITHER these CI jobs NOR a bare local run — deploy.yml / lint.yml pass the same `-m`
+string on the CLI, so they are deselected there too; they execute only in operator/live
+contexts (`live` = "operator-run, never CI"). To run them yourself: override the marker
 filter, e.g. `-m api_dependent` (needs real Gemini/Hardcover keys, and an authenticated
-`claude` CLI for `test_claude_grounded_scouts_produce_styles_and_tropes`), and
+`claude` CLI for `test_claude_grounded_scouts_produce_styles_and_tropes`), plus
 `pip install -e '.[claude]'` for the `claude_agent_sdk` tests.

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1208,3 +1208,42 @@ This file documents key architectural decisions, their context, and trade-offs.
 - The client-side exact-id resolution in the "✓ I read this" prefill flow is retained as a
   belt-and-suspenders for fast-pass twin-work misses; double-resolution is idempotent.
 - Historical 'Dismissed' rows are not reclassified.
+
+### ADR-063: Known local-only test failures are a named set; CI is their gate (2026-07-25)
+
+**Context:**
+- A fixed ~7-test set fails on the local host but passes in cloud CI, and reviewers kept
+  burning time `git stash`-ing + rerunning to "confirm they're pre-existing" (guidance #9).
+- Two distinct causes were conflated as "some env failures":
+  (A) live external API/network tests, and (B) an optional dependency missing locally.
+
+**Decision:**
+- Treat these as a NAMED, enumerated set (listed in CLAUDE.md "Known local-only test
+  failures"), not a vague "~5 failures". When ONLY this set fails locally, name it and
+  proceed — do NOT stash-verify. Stash-verification is reserved for UNEXPECTED failures.
+- Cause A is the `api_dependent` pytest marker (already defined in `pyproject.toml`,
+  intent: "skipped in pre-commit"): 5 tests in `test_agent_runtime.py` +
+  `test_metadata_scout.py`. The marker is the correct differentiator; `-m "not api_dependent"`
+  deselects them locally today.
+- Cause B is the optional `claude` extra (`claude_agent_sdk`) not installed locally: 2 tests
+  in `test_usage_recording_backends.py` that import `agents.backends.claude` WITHOUT the
+  `pytest.importorskip("claude_agent_sdk")` guard their siblings use, so they ERROR not SKIP.
+
+**Alternatives Considered:**
+- Keep documenting a manual "stash to verify" dance -> rejected: it is the cost this ADR
+  removes; a named set + CI-as-gate is cheaper and less error-prone.
+- Add a brand-new marker for the live tests -> rejected: `api_dependent` already exists and
+  already tags all 5; the gap is wiring, not taxonomy.
+- Delete/disable the live + claude tests -> rejected: they are real coverage that must run
+  in CI (with keys + the extra); the fix is skip-when-unavailable, not removal.
+
+**Consequences:**
+- CI remains the gate for all of these (it has the keys and installs the extra); a green
+  local `test/unit` run is NOT expected until the durable fix lands.
+- Durable fix (OPEN, deferred to a small standalone PR after #151): (1) wire
+  `api_dependent`/`live` into `conftest.py::pytest_collection_modifyitems` to auto-skip
+  unless an opt-in env var is set — mirroring the existing `db_integration` deselection so
+  the marker's stated intent finally takes effect; (2) add `importorskip("claude_agent_sdk")`
+  to the two unguarded Cause-B tests. Then the local suite goes green and this section (and
+  the CLAUDE.md subsection) become moot.
+- `db_integration` deselection is unaffected — that path already works via the same hook.

--- a/docs/project_notes/decisions.md
+++ b/docs/project_notes/decisions.md
@@ -1238,12 +1238,14 @@ This file documents key architectural decisions, their context, and trade-offs.
   in CI (with keys + the extra); the fix is skip-when-unavailable, not removal.
 
 **Consequences:**
-- CI remains the gate for all of these (it has the keys and installs the extra); a green
-  local `test/unit` run is NOT expected until the durable fix lands.
-- Durable fix (OPEN, deferred to a small standalone PR after #151): (1) wire
-  `api_dependent`/`live` into `conftest.py::pytest_collection_modifyitems` to auto-skip
-  unless an opt-in env var is set — mirroring the existing `db_integration` deselection so
-  the marker's stated intent finally takes effect; (2) add `importorskip("claude_agent_sdk")`
-  to the two unguarded Cause-B tests. Then the local suite goes green and this section (and
-  the CLAUDE.md subsection) become moot.
-- `db_integration` deselection is unaffected — that path already works via the same hook.
+- CI remains the gate for all of these (it has the keys and installs the extra).
+- Durable fix (DONE, same #151 branch): rather than the originally-sketched conftest hook,
+  the simpler and more consistent fix was to put CI's exact filter in pytest `addopts`
+  (`-m "not api_dependent and not slow and not live"`) so a bare local `pytest` matches the
+  CI selection and is green, plus `importorskip("claude_agent_sdk")` on the two unguarded
+  Cause-B tests. Chosen over the conftest `pytest_collection_modifyitems` approach because CI
+  already uses this exact `-m` string on the CLI (which overrides `addopts`), so local now
+  simply mirrors CI with one line and zero coverage risk. Result: `test/unit` = 835 passed,
+  5 skipped, 5 deselected, 0 failed. CLAUDE.md's "stash-verify" subsection is now retired.
+- `db_integration` deselection is unaffected — that path still works via the conftest hook
+  (it is orthogonal to the `-m` marker filter).

--- a/docs/superpowers/plans/2026-07-25-api-namespacing.md
+++ b/docs/superpowers/plans/2026-07-25-api-namespacing.md
@@ -1,0 +1,305 @@
+# API `/api/*` Namespacing Implementation Plan (#151)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prefix every user-facing API route with `/api/` so SPA client routes and API paths live in disjoint namespaces and can never collide (structural cure for #150).
+
+**Architecture:** A single parent `APIRouter(prefix="/api")` in `main.py` carries all user-facing routes (inline routes switch from `@app` to `@api_router`; sub-routers are `include_router`'d into it). Machine-only endpoints (`/health`, `/internal/*`, `/__/auth/*`) stay at root. The frontend reaches everything through one `'/api'` prefix added in the `client.ts` fetch choke point. The now-redundant SPA navigation-rewrite middleware is deleted; a bare `/history` falls through to the SPA catch-all naturally.
+
+**Tech Stack:** FastAPI (Python 3.14), pytest, React + Vite + TypeScript + Vitest.
+
+## Global Constraints
+
+- **Purpose-scoped prefix only.** Prefix user-facing data routes. NEVER prefix `/health`, `/health/db`, `/internal/*`, `/__/auth/*`, `/`, or the SPA catch-all.
+- **`/import` ≠ `/internal/import-row`.** The user-facing import routes (`/import/preview`, `/import/commit`, `/import/{job_id}`, `/import/{job_id}/retry`) get prefixed. The Cloud Tasks endpoint `/internal/import-row/{row_id}` does NOT. No blind find-replace on the string "import".
+- **Router files do not change.** `recommendations.py`, `analysis.py`, `availability.py`, `books.py`, `imports.py`, `libraries.py`, `internal.py`, `firebase_auth_proxy.py` keep their existing decorator paths — the `/api` prefix comes from the parent `include_router`.
+- **No route logic, payload, auth, schema, or infra changes.** Paths only.
+- **Test style (repo + user pref):** parametrized cases, never loops inside a single test body; each case atomic.
+- **`db_integration` integration tests run in CI only** (no local Postgres) — get them right by inspection; they are the first CI gate.
+- **Before every commit:** `uvx ruff check <files>` AND `uvx ruff format <files>`. No `[skip ci]` in messages.
+- **Commit trailer:** end every commit message with
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`.
+- Run tests with `.venv/Scripts/python -m pytest ...` from repo root.
+
+---
+
+### Task 1: Backend — move user-facing routes under `/api`, delete the navigation-rewrite middleware
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py`
+- Modify (test path updates): `test/unit/test_api_history.py`, `test/unit/test_api_works.py`, `test/unit/test_api_import_commit.py`, `test/unit/test_api_import_preview.py`, `test/unit/test_api_import_routes_wired.py`, `test/unit/test_api_requires_auth.py`
+- Modify (behavior-coupled tests): `test/unit/test_spa_serving.py`
+- Modify (CI-only integration path updates): `test/integration/test_analysis_api.py`, `test/integration/test_api_history_db.py`, `test/integration/test_api_import_status.py`, `test/integration/test_api_works_db.py`, `test/integration/test_availability_api.py`, `test/integration/test_books_api.py`, `test/integration/test_chat_api.py`, `test/integration/test_libraries_api.py`, `test/integration/test_recommendations_api.py`, `test/integration/test_recommendations_read_status.py`
+- Modify: `.github/workflows/deploy.yml` (live-smoke auth probe)
+- **Do NOT touch:** `test/unit/test_internal_import_row.py`, `test/unit/test_enqueue_import_row.py`, `test/unit/test_firebase_auth_proxy.py`, and any `/health`, `/health/db`, `/internal/*` assertions.
+
+**Interfaces:**
+- Produces: all user-facing routes served under `/api/*`; bare (un-prefixed) user-facing paths fall through to the SPA shell. Consumed by Task 2 (frontend must call `/api/*`).
+
+- [ ] **Step 1: Rewrite the behavior-coupled SPA-serving test to the new contract (write the failing test first)**
+
+In `test/unit/test_spa_serving.py`, **replace** `test_fetch_style_request_still_reaches_the_api` (currently L104–112) with the two tests below. The old test asserted the API wins at bare `/history`; post-namespacing the API lives only at `/api/history`, so a bare path returns the shell for ANY `Accept`, and the gated API answers under `/api`.
+
+```python
+@pytest.mark.parametrize("path", ["/history", "/recommendations", "/analysis"])
+def test_bare_api_path_now_serves_the_shell(tmp_path, monkeypatch, path):
+    # Post-#151: user-facing routes live under /api/*, so an un-prefixed path can never
+    # be an API route — it falls through to the SPA catch-all shell regardless of Accept.
+    # This is the structural cure: no client route can collide with an API path anymore.
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path, headers={"Accept": "*/*"})
+    assert r.status_code == 200
+    assert 'id="root"' in r.text
+
+
+@pytest.mark.parametrize("path", ["/api/history", "/api/recommendations", "/api/analysis"])
+def test_prefixed_api_path_is_gated(tmp_path, monkeypatch, path):
+    # The API moved under /api and is still auth-gated (401 without a token, not the shell).
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path, headers={"Accept": "*/*"})
+    assert r.status_code == 401
+    assert r.json() == {"detail": "Missing bearer token."}
+```
+
+The parametrized `test_browser_navigation_to_spa_route_serves_shell` (L91–101) stays as-is — those paths still serve the shell (now via the catch-all rather than the rewrite). Update the two module comments at L1–3 and L84–88 to describe the namespace design instead of the Accept discriminator.
+
+- [ ] **Step 2: Run the new tests — verify they FAIL**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_spa_serving.py -v`
+Expected: `test_prefixed_api_path_is_gated` FAILS (no `/api/history` route yet → catch-all shell 200, not 401). `test_bare_api_path_now_serves_the_shell` currently FAILS too (bare `/history` with `*/*` still hits the API → 401).
+
+- [ ] **Step 3: Update `test_api_requires_auth.py` to the prefixed paths**
+
+In `test/unit/test_api_requires_auth.py`, change the two data-route tests to the `/api` paths (leave `test_health_stays_open` and `test_health_db_requires_auth` untouched — health stays at root):
+
+```python
+def test_history_requires_auth():
+    assert client.get("/api/history").status_code == 401
+
+
+def test_works_requires_auth():
+    assert client.get("/api/works").status_code == 401
+```
+
+- [ ] **Step 4: Add `APIRouter` import and build the parent router in `main.py`**
+
+In `src/agentic_librarian/api/main.py`, add `APIRouter` to the FastAPI import (L9):
+
+```python
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query, Request
+```
+
+Replace the user-facing `app.include_router(...)` block (currently L109–116) with a parent router; keep the two machine-only routers at root:
+
+```python
+# User-facing data routes live under /api/* so they can never collide with an SPA client
+# route (#151, follow-up to #150). The prefix lives in exactly one place.
+api_router = APIRouter(prefix="/api")
+api_router.include_router(recommendations_router)
+api_router.include_router(analysis_router)
+api_router.include_router(availability_router)
+api_router.include_router(books_router)
+api_router.include_router(imports_router)
+api_router.include_router(libraries_router)
+
+# Machine-only routers stay at root — never SPA-route collisions, and moving them would
+# break fixed contracts (Firebase /__/auth/*) or Cloud Tasks target URLs (/internal/*).
+app.include_router(firebase_auth_proxy_router)
+app.include_router(internal_router)
+```
+
+Note: `firebase_auth_proxy_router` was previously included first (L109); registration order among these disjoint-path routers does not matter, only that all are registered before the greedy catch-all.
+
+- [ ] **Step 5: Switch the inline user-facing routes from `@app` to `@api_router`**
+
+In `main.py`, change ONLY these decorators (paths stay identical; the `/api` prefix is applied by `api_router`):
+
+- L175 `@app.get("/history")` → `@api_router.get("/history")`
+- L244 `@app.delete("/history/{entry_id}")` → `@api_router.delete("/history/{entry_id}")`
+- L259 `@app.patch("/history/{entry_id}")` → `@api_router.patch("/history/{entry_id}")`
+- L376 `@app.get("/works")` → `@api_router.get("/works")`
+- L453 `@app.get("/conversations/current")` → `@api_router.get("/conversations/current")`
+- L460 `@app.post("/conversations")` → `@api_router.post("/conversations")`
+- L467 `@app.post("/chat")` → `@api_router.post("/chat")`
+
+Leave `@app.get("/health")` (L119), `@app.get("/health/db")` (L124), `@app.get("/")` (L534), and `@app.get("/{full_path:path}")` (L539) on `@app`.
+
+- [ ] **Step 6: Register the parent router before the SPA section**
+
+In `main.py`, immediately before the `# SPA static serving` comment block (currently ~L483, after the `/chat` endpoint), add:
+
+```python
+# Registered after all @api_router routes are declared and before the SPA catch-all so
+# every /api/* route takes precedence over the greedy /{full_path:path} fallback.
+app.include_router(api_router)
+```
+
+- [ ] **Step 7: Delete the navigation-rewrite middleware branch, keep the no-store stamping**
+
+In `main.py`, remove the `_SPA_CLIENT_ROUTES` constant (L514) and its explanatory comment (L506–513). Replace the middleware (L517–531) with a stamping-only version:
+
+```python
+# Private authed API JSON must never sit in a browser/proxy cache. The SPA shell and
+# static assets set their own Cache-Control (below), so this only stamps responses that
+# declared none — i.e. all API JSON. (The #150 Accept-sniffing navigation rewrite is gone:
+# with data routes under /api/*, a bare /history is not an API route and reaches the SPA
+# catch-all naturally — #151.)
+@app.middleware("http")
+async def _api_no_store_cache(request: Request, call_next):
+    response = await call_next(request)
+    if "cache-control" not in response.headers:
+        response.headers["cache-control"] = "no-store"
+    return response
+```
+
+- [ ] **Step 8: Run the SPA-serving + auth suites — verify they PASS**
+
+Run: `.venv/Scripts/python -m pytest test/unit/test_spa_serving.py test/unit/test_api_requires_auth.py -v`
+Expected: PASS (including both new tests from Step 1 and the updated auth tests). `test_api_json_responses_are_no_store` and the navigation/traversal tests still pass unchanged.
+
+- [ ] **Step 9: Update the remaining local unit test paths**
+
+Prefix `/api` on the user-facing paths in these files (each file's paths, verbatim rule below). Do NOT touch `/internal/*`, `/health`, or `/__/auth`.
+
+- `test/unit/test_api_history.py`: `/history` and `/history/{...}` → `/api/history...`
+- `test/unit/test_api_works.py`: `/works` → `/api/works`
+- `test/unit/test_api_import_preview.py`: `/import/preview` → `/api/import/preview`
+- `test/unit/test_api_import_commit.py`: `/import/commit` → `/api/import/commit`
+- `test/unit/test_api_import_routes_wired.py`: `/import/...` → `/api/import/...` (verify it does not assert on `/internal/import-row`; if it does, leave that line unchanged)
+
+- [ ] **Step 10: Run the full local unit suite — verify green**
+
+Run: `.venv/Scripts/python -m pytest test/unit -q`
+Expected: PASS (all collected unit tests; `db_integration`-marked tests are deselected locally). If any unit test still references a bare user-facing path, fix it to `/api/*`.
+
+- [ ] **Step 11: Update the CI-only integration test paths (by inspection)**
+
+Prefix `/api` on user-facing paths in each integration file. These execute in CI (Postgres), not locally, so read each edit carefully.
+
+- `test/integration/test_api_history_db.py`: `/history`, `/history/{id}` → `/api/history...` (~36 refs — check every one)
+- `test/integration/test_api_works_db.py`: `/works` → `/api/works`
+- `test/integration/test_analysis_api.py`: `/analysis` → `/api/analysis`
+- `test/integration/test_availability_api.py`: `/availability` → `/api/availability`
+- `test/integration/test_books_api.py`: `/books` → `/api/books`
+- `test/integration/test_chat_api.py`: `/chat`, `/conversations...` → `/api/chat`, `/api/conversations...`
+- `test/integration/test_libraries_api.py`: `/libraries/search`, `/me/libraries` → `/api/libraries/search`, `/api/me/libraries`
+- `test/integration/test_recommendations_api.py`: `/recommendations`, `/recommendations/{id}/status` → `/api/recommendations...`
+- `test/integration/test_recommendations_read_status.py`: `/recommendations...` → `/api/recommendations...`
+- `test/integration/test_api_import_status.py`: `/import/{job_id}...` → `/api/import/{job_id}...` (verify none are `/internal/import-row`; leave those)
+
+- [ ] **Step 12: Sanity-grep for any missed bare user-facing paths in tests**
+
+Run:
+```bash
+grep -rnE "(get|post|put|patch|delete)\(\s*f?[\"']/(history|works|recommendations|analysis|availability|books|import/|import\"|libraries|me/|conversations|chat)" test/ | grep -v "/api/"
+```
+Expected: no output. Any hit is a missed path — prefix it (unless it is genuinely `/internal/...`, which won't match this pattern).
+
+- [ ] **Step 13: Update the deploy live-smoke auth probe**
+
+In `.github/workflows/deploy.yml`, the live-smoke step (~L173–182) curls `"${URL}/history"` expecting 401. Change that path to `/api/history` (post-refactor bare `/history` returns the SPA shell 200, so the probe must target the prefixed path to exercise auth). Update the adjacent comment referencing `/history` to `/api/history`. Leave the `/health` and `/` smoke checks unchanged.
+
+```yaml
+          code=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "X-Serverless-Authorization: Bearer ${TOKEN}" "${URL}/api/history")
+```
+
+- [ ] **Step 14: Lint, format, and commit**
+
+Run:
+```bash
+uvx ruff check src/agentic_librarian/api/main.py test/
+uvx ruff format src/agentic_librarian/api/main.py test/
+.venv/Scripts/python -m pytest test/unit -q
+```
+Expected: clean lint/format, green unit suite. Then commit:
+```bash
+git add src/agentic_librarian/api/main.py test/ .github/workflows/deploy.yml
+git commit -m "refactor(api): namespace user-facing routes under /api/* (#151)"
+```
+(Full trailer per Global Constraints.)
+
+---
+
+### Task 2: Frontend — route all API calls through the `/api` prefix
+
+**Files:**
+- Modify: `frontend/src/api/client.ts` (the `authedFetchRaw` choke point, ~L117–121)
+- Modify (if present): the client's test file asserting fetched URLs (locate in Step 1)
+
+**Interfaces:**
+- Consumes: backend serves user-facing routes at `/api/*` (Task 1).
+- Produces: every `client.ts` call hits `/api/<path>`; the app works end-to-end.
+
+- [ ] **Step 1: Locate any frontend test that asserts fetched URLs**
+
+Run:
+```bash
+grep -rnE "'/(history|works|recommendations|analysis|availability|books|import|libraries|me|conversations|chat)|toHaveBeenCalledWith" frontend/src --include="*.test.ts" --include="*.test.tsx"
+```
+Note which test files assert on the un-prefixed path so Step 4 can update them. (If none, Step 4 is a no-op.)
+
+- [ ] **Step 2: Add the `/api` prefix in the fetch choke point**
+
+In `frontend/src/api/client.ts`, add a module-level constant near the top (after imports):
+
+```typescript
+// All user-facing API routes are served under /api/* (#151) so they can never collide
+// with an SPA client route. This is the single place the prefix is applied — every call
+// site keeps its bare literal path (e.g. '/history').
+const API_PREFIX = '/api'
+```
+
+Change `authedFetchRaw` (~L117–121) to prepend it:
+
+```typescript
+async function authedFetchRaw(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = await getIdToken()
+  const headers = new Headers(init.headers)
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  return fetch(`${API_PREFIX}${path}`, { ...init, headers })
+}
+```
+
+(Preserve the existing body of `authedFetchRaw` exactly — only the `fetch(...)` URL argument changes. `getJson` calls through `authedFetchRaw`, so it is covered automatically. The Firebase SDK's `/__/auth/*` requests do not go through `client.ts` and are unaffected.)
+
+- [ ] **Step 3: Run the frontend build/type-check and tests**
+
+Run (from `frontend/`): `npm run test` (or the repo's configured vitest command).
+Expected: PASS, except any URL-asserting tests found in Step 1, which now expect the un-prefixed URL — those FAIL and are fixed in Step 4.
+
+- [ ] **Step 4: Update URL-asserting frontend tests (if any)**
+
+For each test found in Step 1 that asserts a fetch URL, change the expected URL from `'/history'` to `'/api/history'` (etc.). Re-run `npm run test`.
+Expected: PASS.
+
+- [ ] **Step 5: Lint, format, and commit**
+
+Run the frontend lint/format (e.g. `npm run lint` / prettier per repo config), then:
+```bash
+git add frontend/src/api/client.ts frontend/src
+git commit -m "refactor(frontend): call the API under /api/* (#151)"
+```
+(Full trailer per Global Constraints.)
+
+---
+
+## Post-implementation verification (before opening the PR)
+
+- [ ] Full local unit suite green: `.venv/Scripts/python -m pytest test/unit -q`
+- [ ] Frontend tests green.
+- [ ] Drive the app end-to-end (superpowers/verify): history loads, chat streams, recommendations, analysis, import preview/commit, availability/libraries — all via `/api/*`; a browser refresh on `/history` renders the app (not JSON). Confirm `/health` still returns `{"status":"ok"}` and a bare `/history` fetch returns the shell.
+- [ ] Open PR to `main`; the CI `db_integration` run is the real merge gate for the integration path updates (Step 11) — treat its first run as the gate.
+
+## Self-review notes (coverage against spec)
+
+- Spec "Prefixed → /api/*" table → Task 1 Steps 4–6 (routing) + Steps 9,11 (tests). ✓
+- Spec "Stays at root" → Task 1 Step 4 keeps `internal`/`firebase_auth_proxy` at root; Steps 5 keeps `/health*`, `/`, catch-all on `@app`. ✓
+- Spec "Middleware cleanup" → Task 1 Step 7 (delete `_SPA_CLIENT_ROUTES` + rewrite, keep no-store, rename). ✓
+- Spec "Frontend" → Task 2 Step 2. ✓
+- Spec "Tests" (path updates + bare-path regression) → Task 1 Steps 1,3,9,11,12. ✓
+- Spec "Deploy" → Task 1 Step 13. ✓
+- Spec "Non-goals" (no Cloud Tasks/OIDC/health changes) → Global Constraints + do-not-touch lists. ✓

--- a/docs/superpowers/specs/2026-07-25-api-namespacing-design.md
+++ b/docs/superpowers/specs/2026-07-25-api-namespacing-design.md
@@ -1,0 +1,128 @@
+# Design: Namespace the API under `/api/*` (#151)
+
+**Date:** 2026-07-25
+**Issue:** #151 — "Namespace the API under /api/* to make SPA/API route collisions impossible"
+**Follow-up to:** #150 (refresh-on-a-tab rendered `{"detail":"Missing bearer token."}` as the page)
+**Type:** Deliberate refactor, single PR, no data/schema/infra changes.
+
+## Problem
+
+The SPA and the API are served same-origin from one container. Several browser client
+routes (`/history`, `/recommendations`, `/analysis`) are *also* authed API GET paths, and
+the API router wins — so a browser refresh on a tab rendered raw API JSON as the page.
+#150 patched this with an `Accept`-header-sniffing middleware that rewrites HTML
+navigations to the shell. That covers today's surface but is a band-aid: any new API path
+that happens to match a future client route re-opens the hole.
+
+The structural cure is to prefix every **user-facing** API route with `/api/`, so client
+routes and API paths live in disjoint namespaces and can never collide.
+
+## Scope decision: purpose-scoped, not fully uniform
+
+A collision can only occur between an API path and a **browser client route** (the SPA tab
+routes: `/history`, `/recommendations`, `/analysis`, `/add`, `/import`, `/settings`).
+Machine-only endpoints can never be SPA routes, so prefixing them buys zero collision
+safety while adding real transition hazard. Therefore:
+
+**Prefixed → `/api/*`** (all user-facing data routes):
+
+| Location | Routes |
+|---|---|
+| `main.py` inline | `/history`, `/history/{entry_id}` (DELETE + PATCH), `/works`, `/conversations/current`, `/conversations`, `/chat` |
+| `recommendations.py` | `/recommendations`, `/recommendations/{suggestion_id}/status` |
+| `analysis.py` | `/analysis` |
+| `availability.py` | `/availability` |
+| `books.py` | `/books` |
+| `imports.py` | `/import/preview`, `/import/commit`, `/import/{job_id}`, `/import/{job_id}/retry` |
+| `libraries.py` | `/libraries/search`, `/me/libraries` (GET + PUT) |
+
+**Stays at root** (machine-only — deliberately un-prefixed):
+
+- `/health`, `/health/db` — Cloud Run probes + deploy smoke checks key on these.
+- `/internal/*` (`internal.py`) — Cloud Tasks targets. Their URLs **and OIDC audience** are
+  composed in `enrichment/tasks.py` from `ENRICH_TARGET_BASE_URL`; moving them would force
+  a URL + audience change and a compat window for in-flight tasks, for no collision benefit.
+- `/__/auth/*` (`firebase_auth_proxy.py`) — a **fixed** Firebase contract path; the Firebase
+  SDK loads its sign-in handler from exactly this path and it must not move.
+- `/` and the SPA catch-all `/{full_path:path}`.
+
+## Backend mechanism (chosen: single parent router)
+
+In `main.py`, introduce one `api_router = APIRouter(prefix="/api")`:
+
+1. `api_router.include_router(...)` for each user-facing sub-router (recommendations,
+   analysis, availability, books, imports, libraries).
+2. Change the inline user-facing routes from `@app.<verb>("/history")` to
+   `@api_router.<verb>("/history")` — **the decorator path strings stay literally the
+   same**; only the object changes and the single `prefix="/api"` prepends `/api`.
+3. `app.include_router(api_router)` **after** all `@api_router` decorations and **before**
+   the SPA root/catch-all (which must remain registered last).
+4. `firebase_auth_proxy_router` and `internal_router` keep `app.include_router(...)` at
+   root. `/health`, `/health/db`, `/`, and the catch-all keep `@app`.
+
+The prefix lives in exactly one place, mirroring the frontend's single choke point.
+
+**Rejected alternatives:** (B) `prefix="/api"` on each `include_router` + rewriting each
+inline decorator — repeats `/api` ~17 times, easy to miss one. (C) mounting a sub-app at
+`/api` — separate middleware/exception/lifespan scope, overkill.
+
+## Middleware cleanup (`main.py`, currently ~L506–531)
+
+Once data routes live under `/api/*`, a browser navigation to `/history` no longer matches
+any API route — it falls straight through to the SPA catch-all, which already serves the
+shell. So:
+
+- **Delete** the `_SPA_CLIENT_ROUTES` allowlist and the navigation-rewrite branch of
+  `_spa_navigation_and_api_cache` (the `scope["path"]` rewrite).
+- **Keep** the `no-store` stamping on responses that set no cache policy of their own —
+  private authed API JSON must never be cacheable. The middleware is retained solely for
+  this; if reduced to only the stamping, rename it accordingly (e.g. `_api_no_store_cache`).
+
+## Frontend (`frontend/src/api/client.ts`)
+
+Single change in the choke point `authedFetchRaw` (~L117): prepend an `API_PREFIX = '/api'`
+constant to `path` before `fetch`. All ~15 call sites keep their literal relative paths
+(`/history`, `/recommendations`, …). `getJson` routes through `authedFetchRaw`, so it is
+covered. The Firebase SDK's `/__/auth/*` requests are issued by the SDK, not `client.ts`,
+so they are unaffected.
+
+## Tests
+
+- Update all API test paths (unit + integration) from `/x` to `/api/x`. `test_firebase_auth_proxy`
+  stays at `/__/auth`. Internal-endpoint tests stay at `/internal/*`. Health tests stay at
+  `/health`.
+- Add a regression test asserting a bare `GET /history` (no `/api` prefix) now returns the
+  **SPA shell** (200, HTML containing `id="root"`) rather than API JSON — proving the
+  collision is structurally impossible, and locking in the deleted middleware's former job.
+- Follow the repo test convention: parametrized cases, no loops inside a single test body.
+
+## Deploy (`.github/workflows/deploy.yml`)
+
+- Container smoke (`/health`, `/` → shell): **unchanged**.
+- Live smoke auth probe (~L177): `curl … "${URL}/history"` expecting 401 → change to
+  `"${URL}/api/history"`. Post-refactor, un-prefixed `/history` returns the SPA shell (200),
+  so the probe must target the prefixed path to still exercise auth enforcement.
+
+## Deploy behavior (no compat shim)
+
+A browser tab open across the deploy runs old JS calling old un-prefixed paths; after
+deploy those return the SPA shell (200 HTML) instead of JSON, breaking in-flight fetches
+until the user refreshes, which self-heals. Accepted: small user base, infrequent deploys,
+and the app already tolerates cold-start hiccups. Old un-prefixed paths are simply gone.
+
+## Non-goals
+
+- No Cloud Tasks / OIDC / `enrichment/tasks.py` changes (internal routes stay at root).
+- No health-probe or `/health` shim.
+- No API versioning (`/api/v1`) — out of scope; `/api` is the namespace boundary.
+- No route logic, payload, or auth changes — paths only.
+
+## Acceptance criteria
+
+1. Every user-facing route responds under `/api/*`; the same paths without `/api` fall
+   through to the SPA shell.
+2. `/health`, `/health/db`, `/internal/*`, `/__/auth/*` unchanged.
+3. Frontend reaches the API through `/api/*` via the single `client.ts` change; the app
+   works end-to-end (history loads, chat streams, import, recommendations, analysis).
+4. The `_SPA_CLIENT_ROUTES` navigation-rewrite is gone; `no-store` stamping remains.
+5. Full unit suite green; `deploy.yml` live smoke updated to `/api/history`.

--- a/frontend/src/api/client.import.test.ts
+++ b/frontend/src/api/client.import.test.ts
@@ -20,7 +20,7 @@ describe('import client', () => {
     const res = await previewImport(file)
     expect(res.source).toBe('goodreads')
     const [path, init] = f.mock.calls[0]
-    expect(path).toBe('/import/preview')
+    expect(path).toBe('/api/import/preview')
     expect((init as RequestInit).method).toBe('POST')
     expect((init as RequestInit).body).toBeInstanceOf(FormData)
   })
@@ -44,6 +44,6 @@ describe('import client', () => {
   it('retryImport posts to the retry route', async () => {
     const f = mockFetch({ retried: 2 })
     await retryImport('j1')
-    expect(f.mock.calls[0][0]).toBe('/import/j1/retry')
+    expect(f.mock.calls[0][0]).toBe('/api/import/j1/retry')
   })
 })

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -89,7 +89,7 @@ describe('addBook', () => {
 
     expect(result).toEqual(body)
     const [path, init] = fetchMock.mock.calls[0]
-    expect(path).toBe('/books')
+    expect(path).toBe('/api/books')
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body)).toMatchObject({ title: 'Project Hail Mary', author: 'Andy Weir' })
   })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,11 @@
 import { getIdToken } from '../auth/firebase'
 import type { ActivityStep } from './activityLabels'
 
+// All user-facing API routes are served under /api/* (#151) so they can never collide
+// with an SPA client route. This is the single place the prefix is applied — every call
+// site keeps its bare literal path (e.g. '/history').
+const API_PREFIX = '/api'
+
 export class ApiError extends Error {
   // Explicit fields, not constructor parameter properties: the build runs tsc with
   // erasableSyntaxOnly, which rejects TS-only runtime syntax (TS1294).
@@ -118,7 +123,7 @@ async function authedFetchRaw(path: string, init: RequestInit = {}): Promise<Res
   const token = await getIdToken()
   const headers = new Headers(init.headers)
   if (token) headers.set('Authorization', `Bearer ${token}`)
-  return fetch(path, { ...init, headers })
+  return fetch(`${API_PREFIX}${path}`, { ...init, headers })
 }
 
 async function getJson<T>(path: string): Promise<T> {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,11 @@ pythonpath = [
 python_files = [
     "test_*.py"
 ]
+# Local `pytest` matches the CI gate (deploy.yml / lint.yml run the same -m filter):
+# live/key-dependent and slow tests are deselected by default so a bare local run is green
+# and there is nothing to stash-verify (ADR-063). CI passes its own identical -m on the CLI
+# (which overrides this); to run the live tests locally, override with e.g. `-m api_dependent`.
+addopts = "-m 'not api_dependent and not slow and not live'"
 markers = [
     "api_dependent: tests that require an external API key and should be skipped in pre-commit",
     "slow: tests that are slow to run and should be skipped for fast feedback loops",

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -6,7 +6,7 @@ import os
 from datetime import date
 from uuid import UUID
 
-from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func, text
@@ -106,14 +106,21 @@ async def lifespan(app: FastAPI):
 # auto-docs so the full API schema isn't exposed unauthenticated. (GET /docs etc. now fall
 # through to the SPA catch-all, which is harmless.)
 app = FastAPI(title="Agentic Librarian API", lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
+
+# User-facing data routes live under /api/* so they can never collide with an SPA client
+# route (#151, follow-up to #150). The prefix lives in exactly one place.
+api_router = APIRouter(prefix="/api")
+api_router.include_router(recommendations_router)
+api_router.include_router(analysis_router)
+api_router.include_router(availability_router)
+api_router.include_router(books_router)
+api_router.include_router(imports_router)
+api_router.include_router(libraries_router)
+
+# Machine-only routers stay at root — never SPA-route collisions, and moving them would
+# break fixed contracts (Firebase /__/auth/*) or Cloud Tasks target URLs (/internal/*).
 app.include_router(firebase_auth_proxy_router)
-app.include_router(recommendations_router)
-app.include_router(analysis_router)
-app.include_router(availability_router)
-app.include_router(books_router)
-app.include_router(imports_router)
 app.include_router(internal_router)
-app.include_router(libraries_router)
 
 
 @app.get("/health")
@@ -172,7 +179,7 @@ def _history_options():
     ]
 
 
-@app.get("/history")
+@api_router.get("/history")
 def get_history(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -241,7 +248,7 @@ class HistoryUpdate(BaseModel):
         return normalized
 
 
-@app.delete("/history/{entry_id}")
+@api_router.delete("/history/{entry_id}")
 def delete_history(entry_id: UUID, user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
     with db_manager.get_session() as session:
         row = (
@@ -256,7 +263,7 @@ def delete_history(entry_id: UUID, user: AuthenticatedUser = Depends(get_current
     return {"id": str(entry_id), "deleted": True}
 
 
-@app.patch("/history/{entry_id}")
+@api_router.patch("/history/{entry_id}")
 def update_history(
     entry_id: UUID,
     req: HistoryUpdate,
@@ -373,7 +380,7 @@ def update_history(
     return payload
 
 
-@app.get("/works")
+@api_router.get("/works")
 def get_works(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -450,21 +457,21 @@ class _SyncOpener:
             self._conv.close()
 
 
-@app.get("/conversations/current")
+@api_router.get("/conversations/current")
 def get_current_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
     with as_user(user.id):
         ctx = transcript.get_or_create_active_conversation()
     return {"id": str(ctx.conversation_id), "messages": ctx.history}
 
 
-@app.post("/conversations")
+@api_router.post("/conversations")
 def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
     with as_user(user.id):
         ctx = transcript.start_new_conversation()
     return {"id": str(ctx.conversation_id), "messages": ctx.history}
 
 
-@app.post("/chat")
+@api_router.post("/chat")
 def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
     with as_user(user.id):
         ctx = transcript.get_or_create_active_conversation()
@@ -478,6 +485,11 @@ def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Bod
         ),
         media_type="text/event-stream",
     )
+
+
+# Registered after all @api_router routes are declared and before the SPA catch-all so
+# every /api/* route takes precedence over the greedy /{full_path:path} fallback.
+app.include_router(api_router)
 
 
 # ---------------------------------------------------------------------------
@@ -503,28 +515,13 @@ def _spa_index() -> FileResponse:
     return FileResponse(os.path.join(_spa_dir(), "index.html"), headers={"Cache-Control": _SHELL_CACHE})
 
 
-# Refresh-on-a-tab fix (2026-07-19): /history, /recommendations, /analysis are BOTH SPA
-# client routes and authed API GETs, and API routes win the router — so a browser refresh
-# on a tab rendered {"detail":"Missing bearer token."} as the page. A document NAVIGATION
-# is distinguished by its Accept header (browsers send text/html first; the SPA's fetch()
-# calls send */*): GET navigations to client routes serve the shell, fetches keep reaching
-# the API. The same middleware stamps Cache-Control: no-store on every response that set
-# no policy of its own (i.e. all API JSON) — private payloads must never be cacheable
-# (a heuristically-cached authed /history body could previously render as a page).
-_SPA_CLIENT_ROUTES = ("history", "recommendations", "analysis", "add", "import", "settings")
-
-
+# Private authed API JSON must never sit in a browser/proxy cache. The SPA shell and
+# static assets set their own Cache-Control (below), so this only stamps responses that
+# declared none — i.e. all API JSON. (The #150 Accept-sniffing navigation rewrite is gone:
+# with data routes under /api/*, a bare /history is not an API route and reaches the SPA
+# catch-all naturally — #151.)
 @app.middleware("http")
-async def _spa_navigation_and_api_cache(request: Request, call_next):
-    if request.method == "GET" and "text/html" in request.headers.get("accept", ""):
-        first_segment = request.url.path.strip("/").split("/", 1)[0]
-        if first_segment in _SPA_CLIENT_ROUTES:
-            # Internal rewrite to the shell route rather than returning a FileResponse
-            # from the middleware itself (BaseHTTPMiddleware + a directly-returned file
-            # response is a known footgun: fd lifetime, skipped inner middleware). The
-            # router then serves the shell exactly like a "/" request.
-            request.scope["path"] = "/"
-            request.scope["raw_path"] = b"/"
+async def _api_no_store_cache(request: Request, call_next):
     response = await call_next(request)
     if "cache-control" not in response.headers:
         response.headers["cache-control"] = "no-store"

--- a/test/integration/test_analysis_api.py
+++ b/test/integration/test_analysis_api.py
@@ -128,7 +128,7 @@ def test_analysis_aggregates_the_users_reading(client, db_url):
         rating=3,
     )
 
-    body = client.get("/analysis").json()
+    body = client.get("/api/analysis").json()
 
     snap = body["snapshot"]
     assert snap["total_read"] == 2
@@ -143,7 +143,7 @@ def test_analysis_aggregates_the_users_reading(client, db_url):
 
 
 def test_analysis_empty_for_user_with_no_reading(client):
-    body = client.get("/analysis").json()
+    body = client.get("/api/analysis").json()
     assert body["snapshot"] == {
         "total_read": 0,
         "read_this_year": 0,
@@ -174,7 +174,7 @@ def test_analysis_excludes_other_users(client, db_url):
         tropes=["haunting"],
     )
 
-    body = client.get("/analysis").json()
+    body = client.get("/api/analysis").json()
     assert body["snapshot"]["total_read"] == 0  # other user's reading is invisible
 
 
@@ -194,7 +194,7 @@ def test_analysis_includes_style_radar_and_cloud_keys(client, db_url):
             "perspective": ("third person omniscient", "Work"),
         },
     )
-    body = client.get("/analysis").json()
+    body = client.get("/api/analysis").json()
 
     assert set(body["style_radar"].keys()) == {
         "pace",
@@ -211,6 +211,6 @@ def test_analysis_includes_style_radar_and_cloud_keys(client, db_url):
 
 
 def test_analysis_empty_user_has_empty_style_fields(client):
-    body = client.get("/analysis").json()
+    body = client.get("/api/analysis").json()
     assert body["style_cloud"] == []
     assert all(v is None for v in body["style_radar"].values())

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -219,7 +219,7 @@ def _db(db_url):
 
 def _my_entry(client, fmt="ebook"):
     """The fixture's seeded read, selected by title AND format: several tests seed a second
-    'Shared Book' read at the SAME date_completed, and /history tie-breaks equal dates by
+    'Shared Book' read at the SAME date_completed, and /api/history tie-breaks equal dates by
     ReadingHistory.id — a random UUID — so title alone is a coin flip (the CI-only flake:
     the collision test grabbed the audiobook row and its PATCH became a same-format 200)."""
     return next(h for h in client.get("/api/history").json() if h["title"] == "Shared Book" and h["format"] == fmt)

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -1,4 +1,4 @@
-"""/history returns ONLY the authenticated user's read events (Lift 1, ADR-048)."""
+"""/api/history returns ONLY the authenticated user's read events (Lift 1, ADR-048)."""
 
 from datetime import date
 from uuid import UUID
@@ -42,9 +42,9 @@ def two_user_client(db_url, monkeypatch):
 
 
 def test_history_is_scoped_to_the_caller(two_user_client):
-    mine = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    mine = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/api/history").json()
     assert [h["date_completed"] for h in mine] == ["2021-01-01"]
-    theirs = two_user_client(FRIEND_ID, "friend@example.com").get("/history").json()
+    theirs = two_user_client(FRIEND_ID, "friend@example.com").get("/api/history").json()
     assert [h["date_completed"] for h in theirs] == ["2022-02-02"]
 
 
@@ -67,14 +67,14 @@ def test_history_pagination_correct_with_multi_contributor_work(two_user_client,
         session.flush()
 
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
-    page = client.get("/history?limit=3&offset=0").json()
+    page = client.get("/api/history?limit=3&offset=0").json()
     # 3 newest reads (all on the co-authored work) must come back as 3 DISTINCT history rows,
     # each listing both authors — not collapsed by row multiplication.
     assert [h["date_completed"] for h in page] == ["2025-05-05", "2024-04-04", "2023-03-03"]
     assert all(set(h["authors"]) == {"First Author", "Second Author"} for h in page)
     # The boundary Gemini's review worried about: limit < read-count must return exactly `limit`
     # distinct ReadingHistory rows (not fewer because the join multiplied by 2 contributors).
-    page2 = client.get("/history?limit=2&offset=0").json()
+    page2 = client.get("/api/history?limit=2&offset=0").json()
     assert [h["date_completed"] for h in page2] == ["2025-05-05", "2024-04-04"]
 
 
@@ -88,8 +88,8 @@ def test_history_paginates_newest_first(two_user_client, db_url):
         session.flush()
 
     c = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
-    page1 = c.get("/history?limit=2&offset=0").json()
-    page2 = c.get("/history?limit=2&offset=2").json()
+    page1 = c.get("/api/history?limit=2&offset=0").json()
+    page2 = c.get("/api/history?limit=2&offset=2").json()
     assert [h["date_completed"] for h in page1] == ["2025-05-05", "2024-04-04"]  # newest first
     assert [h["date_completed"] for h in page2] == ["2023-03-03", "2021-01-01"]  # next page, no overlap
 
@@ -116,7 +116,7 @@ def test_history_includes_genre_and_top_three_tropes(two_user_client, db_url):
         session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2026, 1, 2)))
         session.flush()
 
-    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/api/history").json()
     row = next(r for r in rows if r["title"] == "Tropey Book")
     assert row["genre"] == "Fantasy"
     assert row["tropes"] == ["Antihero", "Found Family", "Heist"]  # top 3, score desc; "Low Score" dropped
@@ -154,14 +154,14 @@ def test_history_top_tropes_prefer_justified_over_slug_fallbacks(two_user_client
         session.add(ReadingHistory(edition_id=edition.id, user_id=DEFAULT_USER_ID, date_completed=date(2026, 1, 3)))
         session.flush()
 
-    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/api/history").json()
     row = next(r for r in rows if r["title"] == "Slugged Book")
     # Both justified tropes lead (relevance desc) despite lower scores; ONE slug fills slot 3.
     assert row["tropes"] == ["Reluctant Mentor", "Heist Gone Wrong", "Dark"]
 
 
 def test_history_no_tropes_returns_empty_list(two_user_client):
-    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/history").json()
+    rows = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").get("/api/history").json()
     shared = next(r for r in rows if r["title"] == "Shared Book")
     assert shared["tropes"] == []
     assert shared["genre"] is None
@@ -169,27 +169,31 @@ def test_history_no_tropes_returns_empty_list(two_user_client):
 
 def test_delete_history_removes_only_callers_row(two_user_client):
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
-    entry_id = client.get("/history").json()[0]["id"]
-    assert client.delete(f"/history/{entry_id}").status_code == 200
-    assert entry_id not in [h["id"] for h in client.get("/history").json()]
+    entry_id = client.get("/api/history").json()[0]["id"]
+    assert client.delete(f"/api/history/{entry_id}").status_code == 200
+    assert entry_id not in [h["id"] for h in client.get("/api/history").json()]
 
 
 def test_delete_history_other_users_row_is_404(two_user_client, db_url):
     manager = DatabaseManager(db_url)
     with manager.get_session() as session:
         friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
-    assert two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").delete(f"/history/{friend_id}").status_code == 404
+    assert (
+        two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com").delete(f"/api/history/{friend_id}").status_code == 404
+    )
     with manager.get_session() as session:
         assert session.get(ReadingHistory, UUID(friend_id)) is not None
 
 
 def test_patch_history_updates_rating_date_notes(two_user_client):
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
-    entry_id = client.get("/history").json()[0]["id"]
-    resp = client.patch(f"/history/{entry_id}", json={"rating": 5, "date_completed": "2020-12-31", "notes": "loved it"})
+    entry_id = client.get("/api/history").json()[0]["id"]
+    resp = client.patch(
+        f"/api/history/{entry_id}", json={"rating": 5, "date_completed": "2020-12-31", "notes": "loved it"}
+    )
     assert resp.status_code == 200
     assert resp.json()["rating"] == 5 and resp.json()["date_completed"] == "2020-12-31"
-    row = next(h for h in client.get("/history").json() if h["id"] == entry_id)
+    row = next(h for h in client.get("/api/history").json() if h["id"] == entry_id)
     assert row["rating"] == 5 and row["date_completed"] == "2020-12-31" and row["notes"] == "loved it"
 
 
@@ -197,16 +201,16 @@ def test_patch_history_rejects_bad_input_and_other_users(two_user_client, db_url
     from datetime import timedelta
 
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
-    entry_id = client.get("/history").json()[0]["id"]
-    assert client.patch(f"/history/{entry_id}", json={"rating": True}).status_code == 422
-    assert client.patch(f"/history/{entry_id}", json={"rating": 9}).status_code == 422
+    entry_id = client.get("/api/history").json()[0]["id"]
+    assert client.patch(f"/api/history/{entry_id}", json={"rating": True}).status_code == 422
+    assert client.patch(f"/api/history/{entry_id}", json={"rating": 9}).status_code == 422
     future = (date.today() + timedelta(days=3)).isoformat()
-    assert client.patch(f"/history/{entry_id}", json={"date_completed": future}).status_code == 422
-    assert client.patch(f"/history/{entry_id}", json={"date_completed": None}).status_code == 422
+    assert client.patch(f"/api/history/{entry_id}", json={"date_completed": future}).status_code == 422
+    assert client.patch(f"/api/history/{entry_id}", json={"date_completed": None}).status_code == 422
     manager = DatabaseManager(db_url)
     with manager.get_session() as session:
         friend_id = str(session.query(ReadingHistory).filter(ReadingHistory.user_id == FRIEND_ID).first().id)
-    assert client.patch(f"/history/{friend_id}", json={"rating": 3}).status_code == 404
+    assert client.patch(f"/api/history/{friend_id}", json={"rating": 3}).status_code == 404
 
 
 def _db(db_url):
@@ -218,15 +222,15 @@ def _my_entry(client, fmt="ebook"):
     'Shared Book' read at the SAME date_completed, and /history tie-breaks equal dates by
     ReadingHistory.id — a random UUID — so title alone is a coin flip (the CI-only flake:
     the collision test grabbed the audiobook row and its PATCH became a same-format 200)."""
-    return next(h for h in client.get("/history").json() if h["title"] == "Shared Book" and h["format"] == fmt)
+    return next(h for h in client.get("/api/history").json() if h["title"] == "Shared Book" and h["format"] == fmt)
 
 
 def test_patch_format_creates_sibling_edition_and_repoints(two_user_client, db_url):
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     # Seed rating + notes first so the repoint has non-null scalars to preserve (#96 lens).
-    assert client.patch(f"/history/{entry['id']}", json={"rating": 4, "notes": "keep me"}).status_code == 200
-    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    assert client.patch(f"/api/history/{entry['id']}", json={"rating": 4, "notes": "keep me"}).status_code == 200
+    resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["format"] == "audiobook"
     assert resp.json()["enrichment_enqueued"] is False  # no Cloud Tasks in tests
@@ -257,7 +261,7 @@ def test_patch_combined_date_and_format_valid_at_final_state_succeeds(two_user_c
         s.flush()
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)  # the 2021-01-01 read
-    resp = client.patch(f"/history/{entry['id']}", json={"date_completed": "2020-06-06", "format": "audiobook"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"date_completed": "2020-06-06", "format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["format"] == "audiobook"
     assert resp.json()["date_completed"] == "2020-06-06"
@@ -270,7 +274,7 @@ def test_patch_format_reuses_existing_sibling_edition(two_user_client, db_url):
         s.flush()
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    assert client.patch(f"/history/{entry['id']}", json={"format": "audiobook"}).status_code == 200
+    assert client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"}).status_code == 200
     with _db(db_url).get_session() as s:
         assert s.query(Edition).filter(Edition.work_id == work_id).count() == 2  # reused, not duplicated
         row = s.get(ReadingHistory, UUID(entry["id"]))
@@ -280,7 +284,7 @@ def test_patch_format_reuses_existing_sibling_edition(two_user_client, db_url):
 def test_patch_same_format_is_a_noop(two_user_client, db_url):
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    assert client.patch(f"/history/{entry['id']}", json={"format": "ebook"}).status_code == 200
+    assert client.patch(f"/api/history/{entry['id']}", json={"format": "ebook"}).status_code == 200
     with _db(db_url).get_session() as s:
         work_id = s.get(ReadingHistory, UUID(entry["id"])).edition.work_id
         assert s.query(Edition).filter(Edition.work_id == work_id).count() == 1  # nothing minted
@@ -297,7 +301,7 @@ def test_patch_format_collision_is_409_and_rolls_back(two_user_client, db_url):
         s.flush()
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook", "notes": "should not stick"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook", "notes": "should not stick"})
     assert resp.status_code == 409
     assert "already logged" in resp.json()["detail"]
     with _db(db_url).get_session() as s:
@@ -315,7 +319,7 @@ def test_patch_date_collision_is_409_not_500(two_user_client, db_url):
         s.flush()
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)  # the 2021-01-01 read
-    assert client.patch(f"/history/{entry['id']}", json={"date_completed": "2020-06-06"}).status_code == 409
+    assert client.patch(f"/api/history/{entry['id']}", json={"date_completed": "2020-06-06"}).status_code == 409
 
 
 def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, monkeypatch):
@@ -323,7 +327,7 @@ def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, mon
     monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append((wid, fmt)) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is True
     assert len(calls) == 1 and calls[0][1] == "audiobook"
@@ -336,7 +340,7 @@ def test_patch_format_enqueue_failure_never_fails_the_edit(two_user_client, monk
     monkeypatch.setattr(api_main, "enqueue_edition_completion", _boom)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["format"] == "audiobook"  # the edit stuck
     assert resp.json()["enrichment_enqueued"] is False
@@ -355,7 +359,7 @@ def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_ur
     monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    resp = client.patch(f"/history/{entry['id']}", json={"format": "audiobook"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is False
     assert calls == []  # already complete — no paid pass
@@ -366,7 +370,7 @@ def test_patch_notes_only_never_enqueues(two_user_client, monkeypatch):
     monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
-    resp = client.patch(f"/history/{entry['id']}", json={"notes": "just notes"})
+    resp = client.patch(f"/api/history/{entry['id']}", json={"notes": "just notes"})
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is False
     assert calls == []

--- a/test/integration/test_api_import_status.py
+++ b/test/integration/test_api_import_status.py
@@ -21,7 +21,7 @@ def client(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(imports_mod, "db_manager", manager)
     app = FastAPI()
-    app.include_router(router)
+    app.include_router(router, prefix="/api")
     app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
     return TestClient(app), manager
 
@@ -67,7 +67,7 @@ def _seed_row(manager, status, minutes_old):
 def test_progress_is_derived_from_rows(client):
     c, manager = client
     job_id = _seed_job(manager, ["done", "done", "failed", "pending"])
-    body = c.get(f"/import/{job_id}").json()
+    body = c.get(f"/api/import/{job_id}").json()
     assert body["total_rows"] == 4
     assert body["counts"]["done"] == 2
     assert body["counts"]["failed"] == 1
@@ -80,10 +80,10 @@ def test_retry_re_enqueues_failed_rows(client, monkeypatch):
     job_id = _seed_job(manager, ["failed", "done"])
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda rid: enq.append(rid) or True)
-    r = c.post(f"/import/{job_id}/retry")
+    r = c.post(f"/api/import/{job_id}/retry")
     assert r.status_code == 200
     assert len(enq) == 1  # only the failed row
-    body = c.get(f"/import/{job_id}").json()
+    body = c.get(f"/api/import/{job_id}").json()
     assert body["counts"].get("failed", 0) == 0
     assert body["counts"]["pending"] == 1
 
@@ -91,7 +91,7 @@ def test_retry_re_enqueues_failed_rows(client, monkeypatch):
 def test_report_lists_skipped_rows(client):
     c, manager = client
     job_id = _seed_job(manager, ["skipped", "done"])
-    body = c.get(f"/import/{job_id}").json()
+    body = c.get(f"/api/import/{job_id}").json()
     assert body["counts"]["skipped"] == 1
     assert any(item["status"] == "skipped" for item in body["report"])
 
@@ -114,7 +114,7 @@ def test_stalled_processing_rows_are_counted(client):
         )
         s.flush()
         job_id = job.id
-    body = c.get(f"/import/{job_id}").json()
+    body = c.get(f"/api/import/{job_id}").json()
     assert body["stalled"] == 1
     assert body["complete"] is False
 
@@ -125,7 +125,7 @@ def test_retry_re_enqueues_stranded_pending_rows(client, monkeypatch):
     job_id = _seed_row(manager, "pending", minutes_old=30)
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda rid: enq.append(rid) or True)
-    r = c.post(f"/import/{job_id}/retry")
+    r = c.post(f"/api/import/{job_id}/retry")
     assert r.status_code == 200
     assert r.json()["retried"] == 1
     assert len(enq) == 1
@@ -137,7 +137,7 @@ def test_retry_ignores_fresh_pending_rows(client, monkeypatch):
     job_id = _seed_row(manager, "pending", minutes_old=0)
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda rid: enq.append(rid) or True)
-    r = c.post(f"/import/{job_id}/retry")
+    r = c.post(f"/api/import/{job_id}/retry")
     assert r.json()["retried"] == 0
     assert enq == []
 
@@ -146,6 +146,6 @@ def test_stalled_counts_stale_pending_rows(client):
     """'stalled' = rows a retry will re-drive: stale processing + stale pending (#99)."""
     c, manager = client
     job_id = _seed_row(manager, "pending", minutes_old=30)
-    body = c.get(f"/import/{job_id}").json()
+    body = c.get(f"/api/import/{job_id}").json()
     assert body["stalled"] == 1
     assert body["complete"] is False

--- a/test/integration/test_api_works_db.py
+++ b/test/integration/test_api_works_db.py
@@ -1,4 +1,4 @@
-"""GET /works against the real schema in the isolated test DB (ADR-034)."""
+"""GET /api/works against the real schema in the isolated test DB (ADR-034)."""
 
 from unittest.mock import patch
 

--- a/test/integration/test_api_works_db.py
+++ b/test/integration/test_api_works_db.py
@@ -42,7 +42,7 @@ def test_get_works_end_to_end(db_url):
     # db_integration test, so leftover rows can't poison runs.
     with patch("agentic_librarian.api.main.db_manager", manager):
         client = TestClient(app)
-        data = client.get("/works", params={"limit": 200}).json()
+        data = client.get("/api/works", params={"limit": 200}).json()
         by_id = {entry["id"]: entry for entry in data}
 
         assert created["a"] in by_id and created["b"] in by_id, f"seeded works missing from {len(data)}-row response"
@@ -60,4 +60,4 @@ def test_get_works_end_to_end(db_url):
         assert ids_in_order.index(created["a"]) < ids_in_order.index(created["b"])
 
         # Pagination: limit=1 returns exactly one row
-        assert len(client.get("/works", params={"limit": 1}).json()) == 1
+        assert len(client.get("/api/works", params={"limit": 1}).json()) == 1

--- a/test/integration/test_availability_api.py
+++ b/test/integration/test_availability_api.py
@@ -68,7 +68,7 @@ def test_availability_returns_links_and_empty_libby_when_service_returns_empty(c
         lambda db_manager, libs, items: {(lib["slug"], title, author): [] for lib in libs for title, author in items},
     )
 
-    resp = client.post("/availability", json={"work_ids": [str(work_id)]})
+    resp = client.post("/api/availability", json={"work_ids": [str(work_id)]})
     assert resp.status_code == 200
 
     body = resp.json()
@@ -96,7 +96,7 @@ def test_availability_returns_200_when_service_returns_none(client, db_url, monk
         lambda db_manager, libs, items: {(lib["slug"], title, author): None for lib in libs for title, author in items},
     )
 
-    resp = client.post("/availability", json={"work_ids": [str(work_id)]})
+    resp = client.post("/api/availability", json={"work_ids": [str(work_id)]})
     assert resp.status_code == 200
 
     body = resp.json()
@@ -109,7 +109,7 @@ def test_availability_returns_200_when_service_returns_none(client, db_url, monk
 
 def test_availability_empty_work_ids_returns_empty_dict(client, db_url):
     """Empty work_ids list returns an empty dict (fast path)."""
-    resp = client.post("/availability", json={"work_ids": []})
+    resp = client.post("/api/availability", json={"work_ids": []})
     assert resp.status_code == 200
     assert resp.json() == {}
 
@@ -122,6 +122,6 @@ def test_availability_skips_unknown_work_ids(client, db_url, monkeypatch):
         lambda db_manager, libs, items: {(lib["slug"], title, author): [] for lib in libs for title, author in items},
     )
     fake_id = str(uuid4())
-    resp = client.post("/availability", json={"work_ids": [fake_id]})
+    resp = client.post("/api/availability", json={"work_ids": [fake_id]})
     assert resp.status_code == 200
     assert resp.json() == {}

--- a/test/integration/test_availability_api.py
+++ b/test/integration/test_availability_api.py
@@ -55,7 +55,7 @@ def _seed_library(manager, *, user_id, slug, name, sort_order=0):
 
 
 def test_availability_returns_links_and_empty_libby_when_service_returns_empty(client, db_url, monkeypatch):
-    """POST /availability for a seeded work returns 200 with links (including amazon)
+    """POST /api/availability for a seeded work returns 200 with links (including amazon)
     and libby==[] when service.batch_availability is patched to return an all-empty dict."""
     manager = DatabaseManager(db_url)
     work_id = _seed_work(manager, title="Dune", author_name="Frank Herbert")
@@ -83,7 +83,7 @@ def test_availability_returns_links_and_empty_libby_when_service_returns_empty(c
 
 
 def test_availability_returns_200_when_service_returns_none(client, db_url, monkeypatch):
-    """POST /availability is always 200 even when service.batch_availability returns None
+    """POST /api/availability is always 200 even when service.batch_availability returns None
     for a pair (Thunder down). libby badge is simply absent from results."""
     manager = DatabaseManager(db_url)
     work_id = _seed_work(manager, title="Foundation", author_name="Isaac Asimov")

--- a/test/integration/test_books_api.py
+++ b/test/integration/test_books_api.py
@@ -54,7 +54,7 @@ def test_add_book_persists_logs_and_enqueues(client, monkeypatch):
     )
 
     resp = client.post(
-        "/books", json={"title": "Project Hail Mary", "author": "Andy Weir", "format": "ebook", "rating": 5}
+        "/api/books", json={"title": "Project Hail Mary", "author": "Andy Weir", "format": "ebook", "rating": 5}
     )
 
     assert resp.status_code == 200
@@ -70,7 +70,7 @@ def test_add_book_not_found_returns_404(client, monkeypatch):
     monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
     _stub_fast(monkeypatch, {})  # scouts find nothing
 
-    resp = client.post("/books", json={"title": "Nope", "author": "Nobody"})
+    resp = client.post("/api/books", json={"title": "Nope", "author": "Nobody"})
     assert resp.status_code == 404
 
 
@@ -91,7 +91,8 @@ def test_add_book_rereads_do_not_reenqueue(client, db_url, monkeypatch):
     _stub_fast(monkeypatch, {"title": "Dune", "contributors": [{"name": "Frank Herbert", "role": "Author"}]})
 
     resp = client.post(
-        "/books", json={"title": "Dune", "author": "Frank Herbert", "format": "ebook", "date_completed": "2020-01-01"}
+        "/api/books",
+        json={"title": "Dune", "author": "Frank Herbert", "format": "ebook", "date_completed": "2020-01-01"},
     )
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is False  # de-dup hit → no re-enqueue
@@ -102,12 +103,12 @@ def test_add_book_rejects_future_date(client, monkeypatch):
     monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
-    resp = client.post("/books", json={"title": "X", "author": "Y", "date_completed": tomorrow})
+    resp = client.post("/api/books", json={"title": "X", "author": "Y", "date_completed": tomorrow})
     assert resp.status_code == 422
 
 
 def test_add_book_rejects_blank_title(client):
-    resp = client.post("/books", json={"title": "   ", "author": "Y"})
+    resp = client.post("/api/books", json={"title": "   ", "author": "Y"})
     assert resp.status_code == 422
 
 
@@ -121,7 +122,7 @@ def test_add_book_is_user_scoped(client, db_url, monkeypatch):
         s.flush()
     _stub_fast(monkeypatch, {"title": "Hyperion", "contributors": [{"name": "Dan Simmons", "role": "Author"}]})
 
-    client.post("/books", json={"title": "Hyperion", "author": "Dan Simmons"})
+    client.post("/api/books", json={"title": "Hyperion", "author": "Dan Simmons"})
     with manager.get_session() as s:
         rows = s.query(ReadingHistory).filter(ReadingHistory.user_id == other).all()
         assert rows == []  # nothing logged to the other user
@@ -132,7 +133,7 @@ def test_add_book_is_user_scoped(client, db_url, monkeypatch):
 def test_add_book_rejects_boolean_rating(client, monkeypatch):
     monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
-    resp = client.post("/books", json={"title": "X", "author": "Y", "rating": True})
+    resp = client.post("/api/books", json={"title": "X", "author": "Y", "rating": True})
     assert resp.status_code == 422
 
 
@@ -144,8 +145,8 @@ def test_add_book_same_date_reports_already_logged(client, monkeypatch):
     )
     payload = {"title": "Solaris", "author": "Stanislaw Lem", "format": "ebook", "date_completed": "2021-05-01"}
 
-    first = client.post("/books", json=payload).json()
-    second = client.post("/books", json=payload).json()
+    first = client.post("/api/books", json=payload).json()
+    second = client.post("/api/books", json=payload).json()
 
     assert first["already_logged"] is False and first["read_number"] == 1
     assert second["already_logged"] is True  # same work + same date = no new read-event
@@ -162,7 +163,7 @@ def test_add_book_survives_enqueue_failure(client, monkeypatch):
         {"title": "Blindsight", "contributors": [{"name": "Peter Watts", "role": "Author"}], "genres": [], "moods": []},
     )
 
-    resp = client.post("/books", json={"title": "Blindsight", "author": "Peter Watts"})
+    resp = client.post("/api/books", json={"title": "Blindsight", "author": "Peter Watts"})
     assert resp.status_code == 200  # the book is saved even though enqueue raised
     assert resp.json()["enrichment_enqueued"] is False
 
@@ -192,7 +193,7 @@ def test_add_book_resolves_active_pick(client, db_url, monkeypatch):
         monkeypatch, {"title": "The Fifth Season", "contributors": [{"name": "N. K. Jemisin", "role": "Author"}]}
     )
 
-    resp = client.post("/books", json={"title": "The Fifth Season", "author": "N. K. Jemisin", "format": "ebook"})
+    resp = client.post("/api/books", json={"title": "The Fifth Season", "author": "N. K. Jemisin", "format": "ebook"})
 
     assert resp.status_code == 200
     body = resp.json()
@@ -208,7 +209,7 @@ def test_add_book_without_pick_reports_not_resolved(client, monkeypatch):
     monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
     _stub_fast(monkeypatch, {"title": "Piranesi", "contributors": [{"name": "Susanna Clarke", "role": "Author"}]})
 
-    resp = client.post("/books", json={"title": "Piranesi", "author": "Susanna Clarke"})
+    resp = client.post("/api/books", json={"title": "Piranesi", "author": "Susanna Clarke"})
     assert resp.status_code == 200
     assert resp.json()["pick_resolved"] is False
 
@@ -228,7 +229,7 @@ def test_add_book_duplicate_still_resolves_pick(client, db_url, monkeypatch):
     _stub_fast(monkeypatch, {"title": "Annihilation", "contributors": [{"name": "Jeff VanderMeer", "role": "Author"}]})
 
     resp = client.post(
-        "/books",
+        "/api/books",
         json={"title": "Annihilation", "author": "Jeff VanderMeer", "format": "ebook", "date_completed": "2021-05-01"},
     )
 
@@ -246,7 +247,7 @@ def test_add_book_leaves_dismissed_pick_untouched(client, db_url, monkeypatch):
     _work_id, sug_id = _seed_picked_work(db_url, title="Uprooted", author="Naomi Novik", status="Dismissed")
     _stub_fast(monkeypatch, {"title": "Uprooted", "contributors": [{"name": "Naomi Novik", "role": "Author"}]})
 
-    resp = client.post("/books", json={"title": "Uprooted", "author": "Naomi Novik"})
+    resp = client.post("/api/books", json={"title": "Uprooted", "author": "Naomi Novik"})
 
     assert resp.status_code == 200
     assert resp.json()["pick_resolved"] is False
@@ -264,7 +265,7 @@ def test_add_book_leaves_other_users_pick_untouched(client, db_url, monkeypatch)
     _work_id, sug_id = _seed_picked_work(db_url, title="Circe", author="Madeline Miller", user_id=other)
     _stub_fast(monkeypatch, {"title": "Circe", "contributors": [{"name": "Madeline Miller", "role": "Author"}]})
 
-    resp = client.post("/books", json={"title": "Circe", "author": "Madeline Miller"})
+    resp = client.post("/api/books", json={"title": "Circe", "author": "Madeline Miller"})
 
     assert resp.status_code == 200
     assert resp.json()["pick_resolved"] is False

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -38,16 +38,16 @@ def client(db_url, monkeypatch):
 
 
 def test_current_conversation_then_chat_then_resume(client):
-    current = client.get("/conversations/current").json()
+    current = client.get("/api/conversations/current").json()
     assert current["messages"] == []
     cid = current["id"]
 
-    with client.stream("POST", "/chat", json={"message": "hi"}) as r:
+    with client.stream("POST", "/api/chat", json={"message": "hi"}) as r:
         body = "".join(r.iter_text())
     assert "echo:hi" in body
     assert body.rstrip().endswith("event: done\ndata: {}")
 
-    resumed = client.get("/conversations/current").json()
+    resumed = client.get("/api/conversations/current").json()
     assert resumed["id"] == cid
     assert resumed["messages"] == [
         {"role": "user", "content": "hi"},
@@ -56,8 +56,8 @@ def test_current_conversation_then_chat_then_resume(client):
 
 
 def test_new_conversation_starts_empty(client):
-    current = client.get("/conversations/current").json()
-    fresh = client.post("/conversations").json()
+    current = client.get("/api/conversations/current").json()
+    fresh = client.post("/api/conversations").json()
     assert fresh["messages"] == []
     assert fresh["id"] != current["id"]  # New chat is a distinct conversation
 
@@ -69,7 +69,7 @@ def test_usage_rows_reference_the_conversation(client, db_url, monkeypatch):
     from agentic_librarian.db.models import Usage
     from agentic_librarian.db.session import DatabaseManager
 
-    current = client.get("/conversations/current").json()
+    current = client.get("/api/conversations/current").json()
     cid = UUID(current["id"])
 
     class _UsingConv:
@@ -85,7 +85,7 @@ def test_usage_rows_reference_the_conversation(client, db_url, monkeypatch):
 
     monkeypatch.setattr(api_main, "_open_conversation", _using_open)
 
-    with client.stream("POST", "/chat", json={"message": "go"}) as r:
+    with client.stream("POST", "/api/chat", json={"message": "go"}) as r:
         "".join(r.iter_text())
 
     with DatabaseManager(db_url).get_session() as s:

--- a/test/integration/test_libraries_api.py
+++ b/test/integration/test_libraries_api.py
@@ -25,7 +25,7 @@ def client(db_url, monkeypatch):
 
 
 def test_search_libraries_filters_directory_snapshot(client, monkeypatch):
-    """GET /libraries/search?q=king returns matches from the directory snapshot."""
+    """GET /api/libraries/search?q=king returns matches from the directory snapshot."""
     fake_results = [{"slug": "kcls", "name": "King County Library System"}]
     monkeypatch.setattr(directory, "search", lambda q, **kw: fake_results)
 
@@ -35,7 +35,7 @@ def test_search_libraries_filters_directory_snapshot(client, monkeypatch):
 
 
 def test_put_then_get_libraries_round_trips_in_order(client, db_url):
-    """PUT /me/libraries then GET /me/libraries preserves the full list in order."""
+    """PUT /api/me/libraries then GET /api/me/libraries preserves the full list in order."""
     payload = {
         "libraries": [
             {"slug": "seattle", "name": "Seattle Public Library"},
@@ -67,14 +67,14 @@ def test_put_libraries_replaces_previous_set(client, db_url):
 
 
 def test_get_libraries_empty_when_none_saved(client, db_url):
-    """GET /me/libraries returns an empty list when the user has no saved libraries."""
+    """GET /api/me/libraries returns an empty list when the user has no saved libraries."""
     resp = client.get("/api/me/libraries")
     assert resp.status_code == 200
     assert resp.json() == {"libraries": []}
 
 
 def test_put_libraries_422_on_duplicate_slugs(client):
-    """PUT /me/libraries returns 422 when the request body contains duplicate slugs."""
+    """PUT /api/me/libraries returns 422 when the request body contains duplicate slugs."""
     payload = {
         "libraries": [
             {"slug": "seattle", "name": "Seattle Public Library"},

--- a/test/integration/test_libraries_api.py
+++ b/test/integration/test_libraries_api.py
@@ -29,7 +29,7 @@ def test_search_libraries_filters_directory_snapshot(client, monkeypatch):
     fake_results = [{"slug": "kcls", "name": "King County Library System"}]
     monkeypatch.setattr(directory, "search", lambda q, **kw: fake_results)
 
-    resp = client.get("/libraries/search?q=king")
+    resp = client.get("/api/libraries/search?q=king")
     assert resp.status_code == 200
     assert resp.json() == fake_results
 
@@ -42,11 +42,11 @@ def test_put_then_get_libraries_round_trips_in_order(client, db_url):
             {"slug": "nypl", "name": "New York Public Library"},
         ]
     }
-    put_resp = client.put("/me/libraries", json=payload)
+    put_resp = client.put("/api/me/libraries", json=payload)
     assert put_resp.status_code == 200
     assert put_resp.json() == payload
 
-    get_resp = client.get("/me/libraries")
+    get_resp = client.get("/api/me/libraries")
     assert get_resp.status_code == 200
     assert get_resp.json() == payload
 
@@ -54,21 +54,21 @@ def test_put_then_get_libraries_round_trips_in_order(client, db_url):
 def test_put_libraries_replaces_previous_set(client, db_url):
     """A second PUT fully replaces the previous set (no stale rows remain)."""
     client.put(
-        "/me/libraries",
+        "/api/me/libraries",
         json={"libraries": [{"slug": "old-lib", "name": "Old Library"}]},
     )
 
     new_payload = {"libraries": [{"slug": "new-lib", "name": "New Library"}]}
-    client.put("/me/libraries", json=new_payload)
+    client.put("/api/me/libraries", json=new_payload)
 
-    get_resp = client.get("/me/libraries")
+    get_resp = client.get("/api/me/libraries")
     assert get_resp.status_code == 200
     assert get_resp.json() == new_payload
 
 
 def test_get_libraries_empty_when_none_saved(client, db_url):
     """GET /me/libraries returns an empty list when the user has no saved libraries."""
-    resp = client.get("/me/libraries")
+    resp = client.get("/api/me/libraries")
     assert resp.status_code == 200
     assert resp.json() == {"libraries": []}
 
@@ -81,5 +81,5 @@ def test_put_libraries_422_on_duplicate_slugs(client):
             {"slug": "seattle", "name": "Seattle Public Library (duplicate)"},
         ]
     }
-    resp = client.put("/me/libraries", json=payload)
+    resp = client.put("/api/me/libraries", json=payload)
     assert resp.status_code == 422

--- a/test/integration/test_recommendations_api.py
+++ b/test/integration/test_recommendations_api.py
@@ -48,7 +48,7 @@ def test_lists_only_active_suggestions_for_the_user(client, db_url):
     )
     _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Old Pick", author="X", status="Dismissed")
 
-    body = client.get("/recommendations").json()
+    body = client.get("/api/recommendations").json()
 
     assert [r["title"] for r in body] == ["Dune"]  # Dismissed one excluded
     row = body[0]
@@ -68,7 +68,7 @@ def test_does_not_leak_another_users_suggestions(client, db_url):
         s.flush()
     _seed_suggestion(manager, user_id=other_id, title="Secret", author="Nobody")
 
-    body = client.get("/recommendations").json()
+    body = client.get("/api/recommendations").json()
 
     assert body == []  # the default user sees none of the other user's suggestions
 
@@ -77,18 +77,18 @@ def test_dismiss_marks_status_and_removes_from_list(client, db_url):
     manager = DatabaseManager(db_url)
     sid, _ = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Meh", author="Z")
 
-    resp = client.post(f"/recommendations/{sid}/status", json={"status": "Dismissed"})
+    resp = client.post(f"/api/recommendations/{sid}/status", json={"status": "Dismissed"})
     assert resp.status_code == 200
     assert resp.json() == {"id": str(sid), "status": "Dismissed"}
 
-    assert client.get("/recommendations").json() == []  # no longer active
+    assert client.get("/api/recommendations").json() == []  # no longer active
 
 
 def test_rejects_unknown_status(client, db_url):
     manager = DatabaseManager(db_url)
     sid, _ = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Meh", author="Z")
 
-    resp = client.post(f"/recommendations/{sid}/status", json={"status": "Banished"})
+    resp = client.post(f"/api/recommendations/{sid}/status", json={"status": "Banished"})
     assert resp.status_code == 422
 
 
@@ -100,7 +100,7 @@ def test_cannot_dismiss_another_users_suggestion(client, db_url):
         s.flush()
     sid, _ = _seed_suggestion(manager, user_id=other_id, title="Secret", author="Nobody")
 
-    resp = client.post(f"/recommendations/{sid}/status", json={"status": "Dismissed"})
+    resp = client.post(f"/api/recommendations/{sid}/status", json={"status": "Dismissed"})
     assert resp.status_code == 404  # scoping: not the caller's suggestion
 
 
@@ -108,10 +108,10 @@ def test_mark_read_removes_from_active_list(client, db_url):
     manager = DatabaseManager(db_url)
     sid, _ = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Read It", author="Q")
 
-    resp = client.post(f"/recommendations/{sid}/status", json={"status": "Read"})
+    resp = client.post(f"/api/recommendations/{sid}/status", json={"status": "Read"})
     assert resp.status_code == 200
     assert resp.json() == {"id": str(sid), "status": "Read"}
-    assert client.get("/recommendations").json() == []  # no longer "Suggested"
+    assert client.get("/api/recommendations").json() == []  # no longer "Suggested"
 
 
 def test_genres_defaults_to_empty_list_when_not_set(client, db_url):
@@ -119,7 +119,7 @@ def test_genres_defaults_to_empty_list_when_not_set(client, db_url):
     manager = DatabaseManager(db_url)
     _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Genreless", author="Anon")
 
-    body = client.get("/recommendations").json()
+    body = client.get("/api/recommendations").json()
 
     assert len(body) == 1
     assert body[0]["genres"] == []
@@ -130,7 +130,7 @@ def test_status_endpoint_accepts_each_allowed_value(client, db_url, status):
     manager = DatabaseManager(db_url)
     sug_id, _work_id = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title=f"Allowed {status}", author="A. Uthor")
 
-    resp = client.post(f"/recommendations/{sug_id}/status", json={"status": status})
+    resp = client.post(f"/api/recommendations/{sug_id}/status", json={"status": status})
 
     assert resp.status_code == 200
     assert resp.json() == {"id": str(sug_id), "status": status}
@@ -145,7 +145,7 @@ def test_status_endpoint_rejects_bad_vocab(client, db_url, bad):
     manager = DatabaseManager(db_url)
     sug_id, _work_id = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title=f"Bad {bad!r}", author="A. Uthor")
 
-    resp = client.post(f"/recommendations/{sug_id}/status", json={"status": bad})
+    resp = client.post(f"/api/recommendations/{sug_id}/status", json={"status": bad})
 
     assert resp.status_code == 422
     with manager.get_session() as s:
@@ -158,10 +158,10 @@ def test_remove_marks_status_and_removes_from_list(client, db_url):
     manager = DatabaseManager(db_url)
     sug_id, _work_id = _seed_suggestion(manager, user_id=DEFAULT_USER_ID, title="Neutral Exit", author="A. Uthor")
 
-    resp = client.post(f"/recommendations/{sug_id}/status", json={"status": "Removed"})
+    resp = client.post(f"/api/recommendations/{sug_id}/status", json={"status": "Removed"})
     assert resp.status_code == 200
 
-    listed = client.get("/recommendations").json()
+    listed = client.get("/api/recommendations").json()
     assert all(item["id"] != str(sug_id) for item in listed)
     with manager.get_session() as s:
         assert s.get(Suggestions, sug_id).status == "Removed"  # row kept, not deleted

--- a/test/integration/test_recommendations_read_status.py
+++ b/test/integration/test_recommendations_read_status.py
@@ -1,4 +1,4 @@
-"""/recommendations payload carries read_status/last_read/rating (A3)."""
+"""/api/recommendations payload carries read_status/last_read/rating (A3)."""
 
 from datetime import UTC, date, datetime
 
@@ -66,7 +66,7 @@ def recs_client(db_url):
 
 
 def test_recommendations_payload_carries_read_status(recs_client):
-    resp = recs_client.get("/recommendations")
+    resp = recs_client.get("/api/recommendations")
     assert resp.status_code == 200
     by_title = {r["title"]: r for r in resp.json()}
 

--- a/test/unit/test_api_history.py
+++ b/test/unit/test_api_history.py
@@ -35,7 +35,7 @@ def test_get_history_empty():
         mock_query.limit.return_value = mock_query
         mock_query.all.return_value = []
 
-        response = client.get("/history")
+        response = client.get("/api/history")
         assert response.status_code == 200
         assert response.json() == []
 
@@ -67,7 +67,7 @@ def test_get_history_with_data():
         mock_query.limit.return_value = mock_query
         mock_query.all.return_value = [mock_history]
 
-        response = client.get("/history")
+        response = client.get("/api/history")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
@@ -104,7 +104,7 @@ def test_get_history_no_date():
         mock_query.limit.return_value = mock_query
         mock_query.all.return_value = [mock_history]
 
-        response = client.get("/history")
+        response = client.get("/api/history")
         assert response.status_code == 200
         data = response.json()
         assert data[0]["date_completed"] is None
@@ -129,16 +129,16 @@ def test_get_history_pagination_params_forwarded():
         mock_db.get_session.return_value.__enter__.return_value = mock_session
         mock_query = _history_chain(mock_session, [])
 
-        response = client.get("/history?limit=10&offset=20")
+        response = client.get("/api/history?limit=10&offset=20")
         assert response.status_code == 200
         mock_query.offset.assert_called_once_with(20)
         mock_query.limit.assert_called_once_with(10)
 
 
 def test_get_history_limit_cap_enforced():
-    assert client.get("/history?limit=500").status_code == 422
-    assert client.get("/history?limit=0").status_code == 422
-    assert client.get("/history?offset=-1").status_code == 422
+    assert client.get("/api/history?limit=500").status_code == 422
+    assert client.get("/api/history?limit=0").status_code == 422
+    assert client.get("/api/history?offset=-1").status_code == 422
 
 
 def _mock_work_trope(name, *, relevance, justification):
@@ -192,7 +192,7 @@ def test_get_history_tropes_prefer_real_over_slugs(tropes, expected_names):
 
         _history_chain(mock_session, [mock_history])
 
-        response = client.get("/history")
+        response = client.get("/api/history")
         assert response.status_code == 200
         data = response.json()
         assert data[0]["tropes"] == expected_names
@@ -204,7 +204,7 @@ def _patch_with_mock_row(json_body):
         mock_session = MagicMock()
         mock_db.get_session.return_value.__enter__.return_value = mock_session
         _history_chain(mock_session, [])
-        return client.patch("/history/00000000-0000-4000-8000-00000000abcd", json=json_body)
+        return client.patch("/api/history/00000000-0000-4000-8000-00000000abcd", json=json_body)
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_api_import_commit.py
+++ b/test/unit/test_api_import_commit.py
@@ -10,7 +10,7 @@ from agentic_librarian.api.imports import router
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
 
 app = FastAPI()
-app.include_router(router)
+app.include_router(router, prefix="/api")
 app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
 client = TestClient(app)
 
@@ -72,7 +72,7 @@ def _commit(monkeypatch, *, to_read=True):
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda row_id: enq.append(row_id) or True)
     r = client.post(
-        "/import/commit",
+        "/api/import/commit",
         files={"file": ("export.csv", io.BytesIO(CSV.encode()), "text/csv")},
         data={
             "mapping": json.dumps(_GOODREADS_MAP),
@@ -104,7 +104,7 @@ def test_commit_422_when_required_mapping_missing(monkeypatch):
     monkeypatch.setattr(imports_mod, "db_manager", _fake_manager(_Recorder()))
     bad = dict(_GOODREADS_MAP, date_completed=None)
     r = client.post(
-        "/import/commit",
+        "/api/import/commit",
         files={"file": ("export.csv", io.BytesIO(CSV.encode()), "text/csv")},
         data={"mapping": json.dumps(bad), "import_to_read": "true", "import_currently_reading": "true"},
     )

--- a/test/unit/test_api_import_preview.py
+++ b/test/unit/test_api_import_preview.py
@@ -9,7 +9,7 @@ from agentic_librarian.api.imports import MAX_ROWS, router
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
 
 app = FastAPI()
-app.include_router(router)
+app.include_router(router, prefix="/api")
 app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
 client = TestClient(app)
 
@@ -23,7 +23,7 @@ GOODREADS_CSV = (
 def _upload(csv_text, mapping=None):
     data = {"mapping": json.dumps(mapping)} if mapping else {}
     return client.post(
-        "/import/preview",
+        "/api/import/preview",
         files={"file": ("export.csv", io.BytesIO(csv_text.encode()), "text/csv")},
         data=data,
     )

--- a/test/unit/test_api_import_routes_wired.py
+++ b/test/unit/test_api_import_routes_wired.py
@@ -1,22 +1,49 @@
+"""#151: user-facing import routes live under /api/*; the Cloud Tasks endpoint
+/internal/import-row stays at root.
+
+Asserted by route RESOLUTION (behavior) rather than by walking app.routes internals. The
+previous `_all_paths` helper traversed a FastAPI `original_router` attribute whose shape
+differs across FastAPI versions — it passed on the pinned local FastAPI but failed in CI
+(freshly resolved from pyproject) even though runtime routing was correct there (the
+`/api/import/*` integration tests pass in the same CI run). Resolution-based checks are
+version-robust and also auth-state-robust (they assert a route exists / is gone, not a
+specific auth code that a leaked dependency override could change).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
 from agentic_librarian.api.main import app
 
-
-def _all_paths(routes) -> set[str]:
-    """Recursively collect route paths from the app route tree (FastAPI wraps
-    sub-routers in _IncludedRouter objects whose individual routes live on
-    original_router.routes, not directly on app.routes)."""
-    paths: set[str] = set()
-    for route in routes:
-        if hasattr(route, "path"):
-            paths.add(route.path)
-        if hasattr(route, "original_router"):
-            paths |= _all_paths(route.original_router.routes)
-    return paths
+client = TestClient(app)
 
 
-def test_import_routes_are_registered():
-    paths = _all_paths(app.routes)
-    assert "/api/import/preview" in paths
-    assert "/api/import/commit" in paths
-    assert "/api/import/{job_id}" in paths
-    assert "/internal/import-row/{row_id}" in paths
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("post", "/api/import/preview"),
+        ("post", "/api/import/commit"),
+        ("get", "/api/import/any-job-id"),
+        ("post", "/api/import/any-job-id/retry"),
+    ],
+)
+def test_user_facing_import_routes_registered_under_api(method, path):
+    # A route IS registered at this /api path+method: the request reaches the import router
+    # (auth/validation response), never the GET-only SPA catch-all (which 405s a POST) and
+    # never a 404. We assert only that a route exists here (not the SPA shell), so the check
+    # is independent of both the exact auth code and the FastAPI version.
+    resp = client.request(method, path)
+    assert resp.status_code not in (404, 405)
+
+
+@pytest.mark.parametrize("path", ["/import/preview", "/import/commit"])
+def test_bare_import_paths_are_no_longer_api_routes(path):
+    # #151 structural cure: the un-prefixed /import/* paths are gone. A POST matches only the
+    # GET-only SPA catch-all (405/404), so it can never reach the import handler.
+    assert client.post(path).status_code in (404, 405)
+
+
+def test_internal_import_row_stays_at_root():
+    # The Cloud Tasks target is deliberately NOT under /api; a POST reaches its handler at the
+    # root path (registered -> not 404/405), unlike the user-facing import routes above.
+    assert client.post("/internal/import-row/not-a-uuid").status_code not in (404, 405)

--- a/test/unit/test_api_import_routes_wired.py
+++ b/test/unit/test_api_import_routes_wired.py
@@ -16,7 +16,7 @@ def _all_paths(routes) -> set[str]:
 
 def test_import_routes_are_registered():
     paths = _all_paths(app.routes)
-    assert "/import/preview" in paths
-    assert "/import/commit" in paths
-    assert "/import/{job_id}" in paths
+    assert "/api/import/preview" in paths
+    assert "/api/import/commit" in paths
+    assert "/api/import/{job_id}" in paths
     assert "/internal/import-row/{row_id}" in paths

--- a/test/unit/test_api_requires_auth.py
+++ b/test/unit/test_api_requires_auth.py
@@ -16,8 +16,8 @@ def test_health_db_requires_auth():
 
 
 def test_history_requires_auth():
-    assert client.get("/history").status_code == 401
+    assert client.get("/api/history").status_code == 401
 
 
 def test_works_requires_auth():
-    assert client.get("/works").status_code == 401
+    assert client.get("/api/works").status_code == 401

--- a/test/unit/test_api_works.py
+++ b/test/unit/test_api_works.py
@@ -58,7 +58,7 @@ def test_get_works_empty():
         mock_db.get_session.return_value.__enter__.return_value = mock_session
         _mock_chain(mock_session, [])
 
-        response = client.get("/works")
+        response = client.get("/api/works")
         assert response.status_code == 200
         assert response.json() == []
 
@@ -70,7 +70,7 @@ def test_get_works_shape():
         work = _mock_work()
         _mock_chain(mock_session, [work])
 
-        response = client.get("/works")
+        response = client.get("/api/works")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
@@ -94,7 +94,7 @@ def test_get_works_null_arrays_become_empty_lists():
         work.moods = None
         _mock_chain(mock_session, [work])
 
-        response = client.get("/works")
+        response = client.get("/api/works")
         entry = response.json()[0]
         assert entry["genres"] == []
         assert entry["moods"] == []
@@ -107,7 +107,7 @@ def test_get_works_pagination_params_forwarded():
         mock_db.get_session.return_value.__enter__.return_value = mock_session
         mock_query = _mock_chain(mock_session, [])
 
-        response = client.get("/works?limit=10&offset=20")
+        response = client.get("/api/works?limit=10&offset=20")
         assert response.status_code == 200
         mock_query.offset.assert_called_once_with(20)
         mock_query.limit.assert_called_once_with(10)
@@ -115,9 +115,9 @@ def test_get_works_pagination_params_forwarded():
 
 def test_get_works_limit_cap_enforced():
     # limit above 200 and below 1, and negative offset, are rejected by validation
-    assert client.get("/works?limit=500").status_code == 422
-    assert client.get("/works?limit=0").status_code == 422
-    assert client.get("/works?offset=-1").status_code == 422
+    assert client.get("/api/works?limit=500").status_code == 422
+    assert client.get("/api/works?limit=0").status_code == 422
+    assert client.get("/api/works?offset=-1").status_code == 422
 
 
 def _mock_work_trope(name, *, relevance, justification):
@@ -141,7 +141,7 @@ def test_get_works_tropes_ordered_justified_first():
         ]
         _mock_chain(mock_session, [work])
 
-        response = client.get("/works")
+        response = client.get("/api/works")
         assert response.status_code == 200
         entry = response.json()[0]
         assert entry["tropes"] == ["Slow Burn", "Found Family", "Dark", "Fantasy"]

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -136,7 +136,7 @@ def test_navigation_to_a_real_static_file_is_not_hijacked(tmp_path, monkeypatch)
 
 def test_api_json_responses_are_no_store(tmp_path, monkeypatch):
     # Private API JSON must never sit in a browser/proxy cache — this is also what let a
-    # stale authed /history body render as a page after the route collision.
+    # stale authed /api/history body render as a page after the route collision.
     dist = _build_dist(tmp_path)
     monkeypatch.setenv("SPA_DIST_DIR", str(dist))
     r = TestClient(app).get("/health")

--- a/test/unit/test_spa_serving.py
+++ b/test/unit/test_spa_serving.py
@@ -1,6 +1,7 @@
 """Lift 2 Stage 4: FastAPI serves the built SPA same-origin, with an index.html fallback
-for client-side routes, real built files served as-is, API routes taking precedence, and a
-path-traversal guard on the catch-all."""
+for client-side routes, real built files served as-is, and a path-traversal guard on the
+catch-all. Post-#151, all user-facing API routes live under /api/*, so bare client routes
+can never collide with an API path — the catch-all serves the shell for any Accept."""
 
 import pytest
 from fastapi.testclient import TestClient
@@ -81,10 +82,10 @@ def test_api_route_wins_over_spa_catch_all(tmp_path, monkeypatch):
     assert r.json() == {"status": "ok"}
 
 
-# Refresh-on-a-tab collision (2026-07-19): /history, /recommendations, /analysis are BOTH
-# SPA client routes and authed API GETs. A browser NAVIGATION (refresh, bookmark, typed
-# URL — Accept prefers text/html) must get the shell; the SPA's fetch() calls
-# (Accept: */*) must keep reaching the API. The Accept header is the discriminator.
+# Refresh-on-a-tab collision (2026-07-19), structurally cured by #151: /history,
+# /recommendations, /analysis are SPA client routes; the same-named API GETs now live only
+# under /api/*, so a bare path is never an API route regardless of Accept — it always falls
+# through to the catch-all shell. The Accept header no longer needs to discriminate.
 _NAV_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
 
 
@@ -102,9 +103,20 @@ def test_browser_navigation_to_spa_route_serves_shell(tmp_path, monkeypatch, pat
 
 
 @pytest.mark.parametrize("path", ["/history", "/recommendations", "/analysis"])
-def test_fetch_style_request_still_reaches_the_api(tmp_path, monkeypatch, path):
-    # fetch() sends Accept: */* — the API route must still win (401 without a token,
-    # NOT the shell).
+def test_bare_api_path_now_serves_the_shell(tmp_path, monkeypatch, path):
+    # Post-#151: user-facing routes live under /api/*, so an un-prefixed path can never
+    # be an API route — it falls through to the SPA catch-all shell regardless of Accept.
+    # This is the structural cure: no client route can collide with an API path anymore.
+    dist = _build_dist(tmp_path)
+    monkeypatch.setenv("SPA_DIST_DIR", str(dist))
+    r = TestClient(app).get(path, headers={"Accept": "*/*"})
+    assert r.status_code == 200
+    assert 'id="root"' in r.text
+
+
+@pytest.mark.parametrize("path", ["/api/history", "/api/recommendations", "/api/analysis"])
+def test_prefixed_api_path_is_gated(tmp_path, monkeypatch, path):
+    # The API moved under /api and is still auth-gated (401 without a token, not the shell).
     dist = _build_dist(tmp_path)
     monkeypatch.setenv("SPA_DIST_DIR", str(dist))
     r = TestClient(app).get(path, headers={"Accept": "*/*"})

--- a/test/unit/test_usage_recording_backends.py
+++ b/test/unit/test_usage_recording_backends.py
@@ -7,6 +7,8 @@ context propagation through run_coroutine_threadsafe)."""
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
+
 from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user, get_required_user_id
 
 
@@ -43,6 +45,7 @@ def test_adk_conversation_records_usage(monkeypatch):
 
 
 def test_claude_conversation_records_usage(monkeypatch):
+    pytest.importorskip("claude_agent_sdk")  # the `claude` optional extra; skip if not installed
     calls = []
     monkeypatch.setattr("agentic_librarian.agents.backends.claude.record_llm_call", lambda **kw: calls.append(kw))
 
@@ -89,6 +92,7 @@ def test_claude_loop_thread_sees_the_user_context():
     The ambient context during the send is a DIFFERENT uuid so that if the
     explicit capture is removed the assertion fails (seen gets the wrong uuid, not
     DEFAULT_USER_ID)."""
+    pytest.importorskip("claude_agent_sdk")  # the `claude` optional extra; skip if not installed
     seen = []
 
     class FakeClient:


### PR DESCRIPTION
Closes #151. Structural cure for the SPA/API route collision patched in #150: a browser refresh on a tab (`/history`, `/recommendations`, `/analysis`) used to render raw API JSON because those paths were *both* SPA client routes and API GETs, and the API router won.

## What changed

**Backend (`4e615f9`)** — all user-facing routes moved under `/api/*` via a single parent `APIRouter(prefix="/api")` in `main.py`. Machine-only endpoints deliberately stay at root (they can't collide with SPA routes): `/health`, `/health/db`, `/internal/*` (Cloud Tasks + OIDC untouched), `/__/auth/*` (fixed Firebase contract), `/`, and the SPA catch-all. The `_SPA_CLIENT_ROUTES` Accept-sniffing navigation-rewrite middleware is deleted — a bare `/history` now falls through to the catch-all shell naturally; the `no-store` stamping on API JSON is kept.

**Frontend (`e089103`)** — one `/api` prefix added in the `authedFetchRaw` choke point in `client.ts`; all ~15 call sites keep their literal paths. Verified there is exactly one `fetch()` in the frontend (the SSE chat path routes through it too), so no double-prefix and no bypass.

**Deploy** — live-smoke auth probe retargeted `/history` → `/api/history`.

## Bundled: local test suite green by default (ADR-063, `ed0161a`)

Injected mid-refactor to stop the recurring "stash-and-rerun to confirm baseline failures" dance. `pytest` `addopts` now carries CI's exact `-m "not api_dependent and not slow and not live"` filter, and two unguarded `claude_agent_sdk` tests got `importorskip`. Coverage-neutral (CI already passes the same `-m` and installs `.[dev,claude]`). Result: `test/unit` = 835 passed, 5 skipped, 5 deselected, **0 failed**.

## Verification

- Unit: 835 passed / 5 skipped / 5 deselected / 0 failed.
- Frontend: 143/143 vitest + build + eslint clean.
- Runtime smoke (real uvicorn, no DB): `/api/history` → 401, `/history` → SPA shell 200, `POST /api/chat` → 401, `/api/works` & `/api/recommendations` → 401, `/api/health` → shell (correctly not namespaced), `/health` → `{"status":"ok"}`.
- Integration path updates (`db_integration`) execute for the first time in **CI** — that first run is the real gate for the ~120 path edits (per project gate #5).

Design spec + plan: `docs/superpowers/specs/2026-07-25-api-namespacing-design.md`, `docs/superpowers/plans/2026-07-25-api-namespacing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)