### PR TITLE
feat: LLM metering, tiers, and per-user budgets (#100) — monetization arc 1/3

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py
+++ b/alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py
@@ -1,0 +1,30 @@
+"""users_subscriber_until — GH #100 monetization arc: Ko-fi entitlement horizon column
+
+Revision ID: a1b2c3d4e5f6
+Revises: f871fd59415e
+Create Date: 2026-07-25 00:00:00.000000
+
+Rule 11 note: this migration only ADDS a nullable column to users; it alters nothing
+existing, so the pre-migration-schema rehearsal pressure that applies to
+migration-gating tools (dedup, requeue) is nil here — no query against an existing
+model changes shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "f871fd59415e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("subscriber_until", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "subscriber_until")

--- a/docs/superpowers/plans/2026-07-25-metering-tiers-budgets.md
+++ b/docs/superpowers/plans/2026-07-25-metering-tiers-budgets.md
@@ -1,0 +1,827 @@
+# Metering, Tiers & Budgets Implementation Plan (#100 — monetization arc 1/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every LLM/embedding call writes an attributed `usage` row; per-tier budgets (free/supporter/byok) are enforced at the chat, import, and enrichment chokepoints; over-budget background enrichment defers to the next UTC day via Cloud Tasks `schedule_time`.
+
+**Architecture:** New `core/tiers.py` (tier decision + env-tunable knobs) and `core/budgets.py` (counting queries + allow/defer decisions, own `db_manager` + `set_db_manager` seam like `core/usage.py`). Metering wires the existing `record_llm_call` into the grounded scouts and the embedding cache-miss path; user attribution reaches background tasks by threading `user_id` through the Cloud Tasks payload into `as_user(...)` in the handlers. Enforcement returns 429/413/409 with `{"code", "message"}` details interactively and re-enqueues with `schedule_time` in the queue handlers.
+
+**Tech Stack:** Python 3.14, FastAPI, SQLAlchemy (Postgres-only models), Alembic, google-genai, Cloud Tasks, React/TS (vitest).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md` — its budget table is normative: defaults 20/200 chat turns per day, 4000 chars, 300/2000 import rows, 300/1500 grounded calls per day, 1400 global; byok = supporter × 10 for chat/import/grounded.
+- Env knobs are read **per call** (never at import time); invalid or non-positive values fall back to the default (the `_seed_limit()` pattern from `chat/transcript.py`).
+- Metering is best-effort and NEVER blocks or breaks the user path; enforcement checks fail OPEN with a logged warning.
+- Meter at the **response object** (SDK-level HTTP retries must not double-count); scout-level retries are genuinely separate billable calls and record separately.
+- Budget windows are UTC days (`created_at >= UTC midnight today`).
+- Pre-deploy Cloud Tasks (no `user_id` in URL) MUST still work: handlers treat `user_id` as optional everywhere.
+- Deferral must NOT burn the #97 give-up retry count: defer = re-enqueue a NEW task with `schedule_time`, return 200.
+- Postgres-only models: DB-backed tests are `db_integration` (CI-gated); DB-free logic gets local unit tests. All tests parametrized — never loops inside a test body.
+- DB cap/count tests insert rows with EXPLICIT distinct `created_at` values (the #147 same-timestamp flake lesson).
+- Tests run via `.venv/Scripts/python -m pytest ...` from repo root; local `test/unit` is green-by-default (ADR-063) — any failure is real.
+- Before each commit: `uvx ruff check <files>` AND `uvx ruff format <files>`. No `[skip ci]`.
+- Commit trailer — end every commit message with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`
+
+## File Structure
+
+- `alembic/versions/<gen>_users_subscriber_until.py` — new migration (down_revision `f871fd59415e`)
+- `src/agentic_librarian/db/models.py` — `User.subscriber_until`
+- `src/agentic_librarian/core/tiers.py` — NEW: `Tier`, `tier_for`, `effective_tier`, knob accessors
+- `src/agentic_librarian/core/budgets.py` — NEW: counting queries + decisions + deferral time
+- `src/agentic_librarian/scouts/grounded_llm.py` — meter both providers
+- `src/agentic_librarian/scouts/utils.py` — meter embed cache misses
+- `src/agentic_librarian/enrichment/tasks.py` — `user_id` + `schedule_time` on both enqueue helpers
+- `src/agentic_librarian/api/internal.py` — `as_user` wrap + budget check + deferral
+- `src/agentic_librarian/imports/worker.py` — widen `as_user` scope; pass user to deep enqueue
+- `src/agentic_librarian/api/books.py`, `src/agentic_librarian/api/main.py` — pass user to enqueues; chat enforcement
+- `src/agentic_librarian/api/imports.py` — per-tier rows cap + one-in-flight rule
+- `frontend/src/api/client.ts`, `frontend/src/views/ChatView.tsx` (only if needed) — 429/422 detail surfacing
+
+---
+
+### Task 1: Tier model, budget knobs, counting queries, migration
+
+**Files:**
+- Create: `src/agentic_librarian/core/tiers.py`
+- Create: `src/agentic_librarian/core/budgets.py`
+- Modify: `src/agentic_librarian/db/models.py` (User, after `display_name`)
+- Create: `alembic/versions/<gen>_users_subscriber_until.py`
+- Create: `test/unit/test_tiers.py`
+- Create: `test/integration/test_budgets_db.py`
+
+**Interfaces (later tasks rely on these exact names):**
+- `tiers.Tier = Literal["free", "supporter", "byok"]`
+- `tiers.tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier` (pure)
+- `tiers.effective_tier(session, user_id: UUID) -> Tier` (DB wrapper)
+- `tiers.chat_turns_per_day(tier) -> int`, `tiers.chat_message_max_chars() -> int`, `tiers.import_max_rows(tier) -> int`, `tiers.grounded_calls_per_day(tier) -> int`, `tiers.grounded_calls_per_day_global() -> int`, `tiers.grounding_model_name() -> str`
+- `budgets.set_db_manager(m)`, `budgets.chat_turn_allowed(user_id) -> tuple[bool, str]`, `budgets.enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]`, `budgets.next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime`
+
+- [ ] **Step 1: Failing unit tests for the pure tier/knob logic**
+
+Create `test/unit/test_tiers.py`:
+
+```python
+"""#100: tier decision + env-tunable budget knobs are DB-free and unit-testable
+(the un-gate-DB-free-paths lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentic_librarian.core import tiers
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "subscriber_until,has_cred,expected",
+    [
+        (None, False, "free"),
+        (NOW - timedelta(days=1), False, "free"),          # lapsed
+        (NOW + timedelta(days=1), False, "supporter"),
+        (None, True, "byok"),
+        (NOW + timedelta(days=1), True, "byok"),           # byok wins over supporter
+    ],
+)
+def test_tier_for(subscriber_until, has_cred, expected):
+    assert tiers.tier_for(subscriber_until, has_cred, now=NOW) == expected
+
+
+@pytest.mark.parametrize(
+    "fn,tier,expected",
+    [
+        (tiers.chat_turns_per_day, "free", 20),
+        (tiers.chat_turns_per_day, "supporter", 200),
+        (tiers.chat_turns_per_day, "byok", 2000),
+        (tiers.import_max_rows, "free", 300),
+        (tiers.import_max_rows, "supporter", 2000),
+        (tiers.grounded_calls_per_day, "free", 300),
+        (tiers.grounded_calls_per_day, "supporter", 1500),
+        (tiers.grounded_calls_per_day, "byok", 15000),
+    ],
+)
+def test_default_budgets(monkeypatch, fn, tier, expected):
+    for var in tiers._DEFAULTS:
+        monkeypatch.delenv(var, raising=False)
+    assert fn(tier) == expected
+
+
+def test_global_governor_default(monkeypatch):
+    monkeypatch.delenv("GROUNDED_CALLS_PER_DAY_GLOBAL", raising=False)
+    assert tiers.grounded_calls_per_day_global() == 1400
+
+
+@pytest.mark.parametrize("raw,expected", [("50", 50), ("abc", 20), ("", 20), ("-5", 20), ("0", 20)])
+def test_env_override_and_fallback(monkeypatch, raw, expected):
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", raw)
+    assert tiers.chat_turns_per_day("free") == expected
+
+
+def test_chat_message_max_chars_default(monkeypatch):
+    monkeypatch.delenv("CHAT_MESSAGE_MAX_CHARS", raising=False)
+    assert tiers.chat_message_max_chars() == 4000
+
+
+def test_grounding_model_name_default(monkeypatch):
+    monkeypatch.delenv("GROUNDING_MODEL", raising=False)
+    monkeypatch.delenv("EXPLORER_MODEL", raising=False)
+    assert tiers.grounding_model_name() == "gemini-2.5-flash"
+```
+
+Also add (same file) the deferral-time tests:
+
+```python
+def test_next_utc_day_start_is_next_midnight_plus_jitter():
+    from agentic_librarian.core import budgets
+
+    now = datetime(2026, 7, 25, 23, 50, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now, jitter_seconds=600)
+    assert when == datetime(2026, 7, 26, 0, 10, tzinfo=UTC)
+
+
+def test_next_utc_day_start_jitter_bounds():
+    now = datetime(2026, 7, 25, 3, 0, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now)
+    midnight = datetime(2026, 7, 26, tzinfo=UTC)
+    assert midnight <= when <= midnight + timedelta(seconds=1800)
+```
+
+(import `budgets` at module top with `tiers`.)
+
+- [ ] **Step 2: Run — verify FAIL** (`cannot import name 'tiers'`):
+`.venv/Scripts/python -m pytest test/unit/test_tiers.py -v`
+
+- [ ] **Step 3: Implement `core/tiers.py`**
+
+```python
+"""Effective tier + env-tunable budget knobs (#100, monetization arc 1/3; spec
+2026-07-25-metering-tiers-budgets-design.md).
+
+Tier semantics: 'byok' requires a user_credentials row for vendor 'gemini' — that table
+has NO writers until arc PR3 lands, so today the branch is inert but the enum is stable
+across the arc. 'supporter' = subscriber_until in the future (Ko-fi entitlements are
+PR2). Knobs are read per call (prod-tunable without redeploy); invalid or non-positive
+values fall back to the defaults below."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+Tier = Literal["free", "supporter", "byok"]
+
+_DEFAULTS = {
+    "CHAT_TURNS_PER_DAY_FREE": 20,
+    "CHAT_TURNS_PER_DAY_SUPPORTER": 200,
+    "CHAT_MESSAGE_MAX_CHARS": 4000,
+    "IMPORT_MAX_ROWS_FREE": 300,
+    "IMPORT_MAX_ROWS_SUPPORTER": 2000,
+    "GROUNDED_CALLS_PER_DAY_FREE": 300,
+    "GROUNDED_CALLS_PER_DAY_SUPPORTER": 1500,
+    "GROUNDED_CALLS_PER_DAY_GLOBAL": 1400,
+}
+
+# byok budgets are structural sanity bounds, not cost protection (their key, their bill).
+_BYOK_MULTIPLIER = 10
+
+
+def _env_int(name: str) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULTS[name]
+    return value if value > 0 else _DEFAULTS[name]
+
+
+def tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier:
+    if has_byok_credential:
+        return "byok"
+    now = now or datetime.now(UTC)
+    if subscriber_until is not None and subscriber_until > now:
+        return "supporter"
+    return "free"
+
+
+def effective_tier(session, user_id: UUID) -> Tier:
+    from agentic_librarian.db.models import User, UserCredential
+
+    user = session.get(User, user_id)
+    has_cred = (
+        session.query(UserCredential.user_id)
+        .filter(UserCredential.user_id == user_id, UserCredential.vendor == "gemini")
+        .first()
+        is not None
+    )
+    return tier_for(user.subscriber_until if user else None, has_cred)
+
+
+def _tiered(free_var: str, supporter_var: str, tier: Tier) -> int:
+    if tier == "free":
+        return _env_int(free_var)
+    supporter = _env_int(supporter_var)
+    return supporter * _BYOK_MULTIPLIER if tier == "byok" else supporter
+
+
+def chat_turns_per_day(tier: Tier) -> int:
+    return _tiered("CHAT_TURNS_PER_DAY_FREE", "CHAT_TURNS_PER_DAY_SUPPORTER", tier)
+
+
+def chat_message_max_chars() -> int:
+    return _env_int("CHAT_MESSAGE_MAX_CHARS")
+
+
+def import_max_rows(tier: Tier) -> int:
+    return _tiered("IMPORT_MAX_ROWS_FREE", "IMPORT_MAX_ROWS_SUPPORTER", tier)
+
+
+def grounded_calls_per_day(tier: Tier) -> int:
+    return _tiered("GROUNDED_CALLS_PER_DAY_FREE", "GROUNDED_CALLS_PER_DAY_SUPPORTER", tier)
+
+
+def grounded_calls_per_day_global() -> int:
+    return _env_int("GROUNDED_CALLS_PER_DAY_GLOBAL")
+
+
+def grounding_model_name() -> str:
+    """Single source of truth for the grounded-scout model id — budgets count usage rows
+    by this name, and scouts/grounded_llm.py resolves its model from it."""
+    return os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
+```
+
+- [ ] **Step 4: Implement `core/budgets.py`**
+
+```python
+"""Budget decisions for #100 — counting queries over existing tables (messages, usage);
+no new counters, no Redis. Checks FAIL OPEN: a broken budget query logs and allows (the
+budget protects cost, not correctness). Module-level db_manager + set_db_manager seam
+mirrors core/usage.py."""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import UTC, datetime, time, timedelta
+from uuid import UUID
+
+from agentic_librarian.core import tiers
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+db_manager = DatabaseManager()
+
+_DEFER_JITTER_MAX_SECONDS = 1800  # spread the next-midnight thundering herd over 30 min
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+def _utc_day_start(now: datetime | None = None) -> datetime:
+    now = now or datetime.now(UTC)
+    return datetime.combine(now.date(), time.min, tzinfo=UTC)
+
+
+def chat_turns_today(session, user_id: UUID) -> int:
+    from agentic_librarian.db.models import Conversation, Message
+
+    return (
+        session.query(Message.id)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .filter(
+            Conversation.user_id == user_id,
+            Message.role == "user",
+            Message.created_at >= _utc_day_start(),
+        )
+        .count()
+    )
+
+
+def grounded_calls_today(session, user_id: UUID | None) -> int:
+    """App-key grounded-model usage rows today — per-user, or global when user_id is None."""
+    from agentic_librarian.db.models import Usage
+
+    q = session.query(Usage.id).filter(
+        Usage.model == tiers.grounding_model_name(),
+        Usage.key_source == "app",
+        Usage.created_at >= _utc_day_start(),
+    )
+    if user_id is not None:
+        q = q.filter(Usage.user_id == user_id)
+    return q.count()
+
+
+def chat_turn_allowed(user_id: UUID) -> tuple[bool, str]:
+    """(allowed, human_message). Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            tier = tiers.effective_tier(session, user_id)
+            limit = tiers.chat_turns_per_day(tier)
+            used = chat_turns_today(session, user_id)
+        if used >= limit:
+            return False, (
+                f"You've reached today's chat limit ({limit} messages). "
+                "It resets at midnight UTC — or support Shelfwright for a higher limit."
+            )
+        return True, ""
+    except Exception:
+        logger.warning("chat budget check failed open", exc_info=True)
+        return True, ""
+
+
+def enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]:
+    """Per-user grounded budget (when attributed) AND the global governor. Un-attributed
+    (pre-deploy) tasks check only the governor. Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            if grounded_calls_today(session, None) >= tiers.grounded_calls_per_day_global():
+                return False, "global grounded-call governor reached"
+            if user_id is not None:
+                tier = tiers.effective_tier(session, user_id)
+                if grounded_calls_today(session, user_id) >= tiers.grounded_calls_per_day(tier):
+                    return False, f"per-user grounded budget reached (tier {tier})"
+        return True, ""
+    except Exception:
+        logger.warning("enrichment budget check failed open", exc_info=True)
+        return True, ""
+
+
+def next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime:
+    if jitter_seconds is None:
+        jitter_seconds = random.randint(0, _DEFER_JITTER_MAX_SECONDS)
+    return _utc_day_start(now) + timedelta(days=1, seconds=jitter_seconds)
+```
+
+NOTE for the implementer: check the actual `conversations` model class name and its
+user column in `db/models.py` (~line 266) and adjust the import/filters if the names
+differ from `Conversation.user_id` — the QUERY SEMANTICS in the spec are normative, the
+names here are best-effort.
+
+- [ ] **Step 5: Model + migration**
+
+In `db/models.py`, add to `User` after `display_name`:
+
+```python
+    # #100 monetization: Ko-fi entitlement horizon (PR2 writes it; NULL/past = free tier).
+    subscriber_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+```
+
+Generate the migration file manually (do NOT run `alembic revision --autogenerate` — no
+local Postgres). Create `alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py`
+following the style of `f871fd59415e_detected_duplicates.py` (read it first):
+`revision = "a1b2c3d4e5f6"`, `down_revision = "f871fd59415e"`, upgrade =
+`op.add_column("users", sa.Column("subscriber_until", sa.DateTime(timezone=True), nullable=True))`,
+downgrade = `op.drop_column("users", "subscriber_until")`.
+
+- [ ] **Step 6: Run unit tests — verify PASS**
+`.venv/Scripts/python -m pytest test/unit/test_tiers.py -v`
+
+- [ ] **Step 7: db_integration tests (CI-only — write by inspection)**
+
+Create `test/integration/test_budgets_db.py` marked `@pytest.mark.db_integration`
+(follow the fixture pattern of an existing integration DB test file, e.g.
+`test/integration/test_transcript_store.py`). Cover, all parametrized, all rows with
+EXPLICIT distinct `created_at`:
+
+- `chat_turns_today`: user messages today count; yesterday's rows and OTHER users'
+  conversations excluded; assistant-role rows excluded.
+- `grounded_calls_today`: counts only rows with the grounding model name +
+  `key_source='app'` + today; per-user filter vs global (None) behavior.
+- `effective_tier` DB wrapper: user with future `subscriber_until` → supporter; with a
+  `user_credentials` row (vendor gemini) → byok; plain → free.
+
+- [ ] **Step 8: Full local unit suite, lint, format, commit**
+
+```bash
+.venv/Scripts/python -m pytest test/unit -q
+uvx ruff check src/agentic_librarian/core/tiers.py src/agentic_librarian/core/budgets.py src/agentic_librarian/db/models.py alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py test/unit/test_tiers.py test/integration/test_budgets_db.py
+uvx ruff format <same files>
+git add <same files>
+git commit -m "feat(core): tier model, budget knobs, counting queries + subscriber_until migration (#100)"
+```
+
+---
+
+### Task 2: Meter scouts + embeddings; thread user attribution into background tasks
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/grounded_llm.py`
+- Modify: `src/agentic_librarian/scouts/utils.py`
+- Modify: `src/agentic_librarian/enrichment/tasks.py`
+- Modify: `src/agentic_librarian/api/internal.py`
+- Modify: `src/agentic_librarian/imports/worker.py`
+- Modify: `src/agentic_librarian/api/books.py` (enqueue call ~line 75)
+- Modify: `src/agentic_librarian/api/main.py` (PATCH /history enqueue call ~line 376)
+- Create: `test/unit/test_scout_metering.py`
+- Modify: `test/integration/` (extend the existing internal-endpoint/import-worker test files you find via `grep -rl "internal/enrich\|process_import_row" test/`)
+
+**Interfaces:**
+- Consumes: `record_llm_call` (core/usage.py), `as_user` (core/user_context.py), `tiers.grounding_model_name()`.
+- Produces: `enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool` and `enqueue_edition_completion(work_id: str, fmt: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool` (schedule_time is USED in Task 4 but added here so tasks.py is touched once). `/internal/enrich/{work_id}` and `/internal/complete-edition/{work_id}` accept optional `user_id` query param.
+
+- [ ] **Step 1: Failing unit tests for metering capture**
+
+Create `test/unit/test_scout_metering.py`:
+
+```python
+"""#100: grounded-scout + embedding metering. Fake response objects — no network, no DB
+(record_llm_call is monkeypatched to a recorder)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentic_librarian.scouts import grounded_llm
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None):
+        self.calls.append((vendor, model, input_tokens, output_tokens))
+
+
+@pytest.mark.parametrize(
+    "usage,expected",
+    [
+        (SimpleNamespace(prompt_token_count=120, candidates_token_count=45), [("gemini", "gemini-2.5-flash", 120, 45)]),
+        (SimpleNamespace(prompt_token_count=None, candidates_token_count=None), [("gemini", "gemini-2.5-flash", 0, 0)]),
+        (None, []),  # no usage_metadata -> no row, no crash
+    ],
+)
+def test_record_gemini_usage(monkeypatch, usage, expected):
+    rec = _Recorder()
+    monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
+    response = SimpleNamespace(text="ok", usage_metadata=usage)
+    grounded_llm._record_gemini_usage("gemini-2.5-flash", response)
+    assert rec.calls == expected
+```
+
+And the embed-metering test (same file):
+
+```python
+def test_embed_metering_records_only_on_cache_miss(monkeypatch):
+    from agentic_librarian.scouts import utils
+
+    rec = _Recorder()
+    monkeypatch.setattr(utils, "record_llm_call", rec)
+
+    fake_resp = SimpleNamespace(embeddings=[SimpleNamespace(values=[0.0] * 4)])
+    client = SimpleNamespace(models=SimpleNamespace(embed_content=lambda **kw: fake_resp))
+    monkeypatch.setattr(utils, "get_shared_genai_client", lambda: client)
+
+    utils.get_cached_embedding.cache_clear()
+    utils.get_cached_embedding("m", "some tag text!!")  # miss -> one row
+    utils.get_cached_embedding("m", "some tag text!!")  # hit -> no new row
+    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0)]
+```
+
+- [ ] **Step 2: Run — verify FAIL** (`no attribute '_record_gemini_usage'` / no `record_llm_call` in utils):
+`.venv/Scripts/python -m pytest test/unit/test_scout_metering.py -v`
+
+- [ ] **Step 3: Implement metering in `grounded_llm.py`**
+
+Add imports: `from agentic_librarian.core.usage import record_llm_call` and
+`from agentic_librarian.core.tiers import grounding_model_name`. Replace the
+`GeminiGroundedLLM.__init__` model resolution `os.environ.get("GROUNDING_MODEL") or
+os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"` with `grounding_model_name()`
+(single source of truth — budgets count by this name). Add:
+
+```python
+def _record_gemini_usage(model_name: str, response) -> None:
+    """Meter at the RESPONSE object (#100): the SDK's HTTP-level 429/5xx retry must not
+    double-count; scout-level retries are genuinely separate billable calls and each
+    records via its own response. record_llm_call never raises (warns + drops when no
+    user is in context, e.g. pre-#100 queued tasks)."""
+    um = getattr(response, "usage_metadata", None)
+    if um is None:
+        return
+    record_llm_call(
+        "gemini",
+        model_name,
+        int(getattr(um, "prompt_token_count", 0) or 0),
+        int(getattr(um, "candidates_token_count", 0) or 0),
+    )
+```
+
+In `GeminiGroundedLLM.generate`, between the `generate_content` call and the return:
+`_record_gemini_usage(self.model_name, response)`.
+
+In `ClaudeGroundedLLM._agenerate`, extend the message loop (mirrors
+`agents/backends/claude.py` — read its usage-recording lines first and match the
+attribute access it uses):
+
+```python
+        async for message in query(prompt=prompt, options=options):
+            result_val = getattr(message, "result", None)
+            if result_val and isinstance(result_val, str):
+                text = result_val
+            usage = getattr(message, "usage", None)
+            if usage:
+                record_llm_call(
+                    "anthropic",
+                    self.model,
+                    int(usage.get("input_tokens", 0) or 0),
+                    int(usage.get("output_tokens", 0) or 0),
+                )
+```
+
+(Known limit, do not fix: the ThreadPoolExecutor fallback path in `generate` does not
+propagate ContextVars, so metering warns+drops there — that path only runs under async
+test runners, never in the scout worker. Note this in the docstring.)
+
+- [ ] **Step 4: Implement embed metering in `scouts/utils.py`**
+
+Import `from agentic_librarian.core.usage import record_llm_call` (no import cycle:
+core.usage pulls only db + user_context). In `get_cached_embedding`, after the
+`if not response or not response.embeddings: raise` guard, before the return:
+
+```python
+    # #100: embed responses expose no token counts and lru_cache means only MISSES reach
+    # here — record per network call with a documented chars//4 estimate (visibility, not
+    # billing-grade; embeddings are $0.15/M).
+    record_llm_call("gemini", model_name, len(text) // 4, 0)
+    return response.embeddings[0].values
+```
+
+- [ ] **Step 5: Thread `user_id` through the enqueue helpers**
+
+In `enrichment/tasks.py`, change both signatures and URLs (audience handling UNCHANGED —
+it already deliberately excludes query strings; extend that comment to cover user_id):
+
+```python
+def enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool:
+```
+URL: `url = f"{base.rstrip('/')}/internal/enrich/{work_id}"`, then
+`if user_id: url += f"?user_id={quote(user_id)}"`; audience stays the PATH url (bind it
+to a variable before appending the query). After building `task`, add:
+
+```python
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
+```
+
+Same for `enqueue_edition_completion` (its URL already has `?format=`, so append
+`&user_id=` there), same schedule_time block. Add `from datetime import datetime` import.
+
+- [ ] **Step 6: Accept + use `user_id` in the internal handlers**
+
+In `api/internal.py`: add `import contextlib` and
+`from agentic_librarian.core.user_context import as_user`. In `enrich(...)` add parameter
+`user_id: UUID | None = Query(None)` and wrap the work:
+
+```python
+    _require_queue_caller(authorization)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
+    # skips; nothing crashes). Attributed tasks bill the requesting user.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.enrich_deep(work_id)
+```
+
+Same pattern in `complete_edition` around `two_phase.complete_edition(work_id, format)`.
+
+- [ ] **Step 7: Attribute the import worker + caller enqueues**
+
+In `imports/worker.py process_import_row`: lift the `as_user(...)` so steps 2–4 (the
+`enrich_fast` call through `enqueue_enrichment`) all run inside
+`with as_user(data["user_id"]):` — remove the now-nested inner `with as_user(...)` in the
+history branch (it would just re-set the same ContextVar). Change the enqueue to
+`enqueue_enrichment(str(work_id), user_id=str(data["user_id"]))`.
+
+In `api/books.py` (~line 75): `enqueue_enrichment(str(work_id), user_id=str(user.id))`.
+In `api/main.py` PATCH /history (~line 376): pass `user_id=str(user.id)` to
+`enqueue_edition_completion` (match the actual local variable names at the call site).
+
+- [ ] **Step 8: Run unit tests — verify PASS**; also run any existing unit tests
+covering these modules:
+`.venv/Scripts/python -m pytest test/unit/test_scout_metering.py test/unit -q`
+
+- [ ] **Step 9: Extend integration tests (CI-only — by inspection)**
+
+Find the existing files: `grep -rl "internal/enrich\|process_import_row\|enqueue_enrichment" test/`.
+Add parametrized cases:
+- `/internal/enrich/{id}?user_id=<uuid>` runs `enrich_deep` with the user set — assert
+  by monkeypatching a probe inside the handler's scope (e.g. patch `two_phase.enrich_deep`
+  to capture `get_required_user_id()`); and WITHOUT the param it still succeeds with no
+  user in context (pre-deploy task shape — the back-compat guarantee).
+- `process_import_row` calls `enqueue_enrichment` with `user_id=str(row.user_id)`
+  (patch the enqueue seam the existing tests already patch — they exist per the old-seam
+  CI lesson: search for patches of `enqueue_enrichment` and update ALL of them to the
+  new signature expectation).
+- Any existing test that patches/asserts `enqueue_enrichment(str(work_id))` (books flow)
+  must be updated for the new kwargs — grep the integration suites for the OLD seam
+  (CLAUDE.md gate #5).
+
+- [ ] **Step 10: Full unit suite, lint, format, commit**
+(as Task 1 Step 8, listing this task's files)
+`git commit -m "feat(metering): record scout + embedding usage with task-context user attribution (#100)"`
+
+---
+
+### Task 3: Chat enforcement (length cap, daily turn budget, 429) + frontend surfacing
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py` (the `/chat` handler, ~line 474)
+- Modify: `frontend/src/api/client.ts` (`streamChat`, ~line 246)
+- Modify: `test/integration/test_chat_api.py` (or the file that tests POST /api/chat — grep)
+- Modify: `frontend/src/api/client.test.ts` (or wherever streamChat is tested — grep `streamChat`)
+
+**Interfaces:**
+- Consumes: `tiers.chat_message_max_chars()`, `budgets.chat_turn_allowed(user_id)`.
+- Produces: POST /api/chat → 422 `{"detail": {"code": "message_too_long", "message": ...}}` when over-length; 429 `{"detail": {"code": "chat_quota", "message": ...}}` when over budget. SSE contract unchanged otherwise.
+
+- [ ] **Step 1: Write failing API tests** (extend the chat API integration file; follow
+its fixture pattern; parametrized):
+- over-length message (len = cap+1, monkeypatch `CHAT_MESSAGE_MAX_CHARS=50` for cheap
+  strings) → 422 with `code == "message_too_long"`.
+- budget: monkeypatch `CHAT_TURNS_PER_DAY_FREE=2`, seed 2 user messages TODAY (explicit
+  created_at, #147 lesson), POST /api/chat → 429 with `code == "chat_quota"`; with only
+  1 seeded → not 429.
+- If this file is `db_integration`/CI-only, write by inspection and verify collection:
+  `--collect-only -q`.
+
+- [ ] **Step 2: Implement in the chat handler**
+
+Add imports `from agentic_librarian.core import budgets, tiers` in main.py. New handler body
+(before the existing `with as_user(...)` block):
+
+```python
+@api_router.post("/chat")
+def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    max_chars = tiers.chat_message_max_chars()
+    if len(message) > max_chars:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "message_too_long", "message": f"Message too long (max {max_chars} characters)."},
+        )
+    allowed, why = budgets.chat_turn_allowed(user.id)
+    if not allowed:
+        # Must reject BEFORE the StreamingResponse exists — SSE cannot carry an HTTP 429.
+        raise HTTPException(status_code=429, detail={"code": "chat_quota", "message": why})
+    ...existing body unchanged...
+```
+
+- [ ] **Step 3: Frontend — surface the 429/422 detail**
+
+In `client.ts` `streamChat`, replace the `if (!res.ok || !res.body)` block:
+
+```ts
+  if (!res.ok || !res.body) {
+    if (res.status === 429 || res.status === 422) {
+      let message = ''
+      try {
+        const body = await res.json()
+        message = body?.detail?.message ?? ''
+      } catch {
+        // fall through to the generic copy
+      }
+      handlers.onError(message || GENERIC_CHAT_ERROR)
+      return
+    }
+    handlers.onError(GENERIC_CHAT_ERROR)
+    return
+  }
+```
+
+- [ ] **Step 4: Frontend test** (extend the existing streamChat/vitest suite; use
+`...Once` mock variants — the vitest#1692 lesson): a 429 response with
+`{"detail": {"code": "chat_quota", "message": "Daily limit reached."}}` → `onError`
+receives `"Daily limit reached."`; a 500 → generic copy unchanged.
+Run: `npm test -- --run` from `frontend/` (match the repo's script).
+
+- [ ] **Step 5: Local suites, lint, format, commit**
+Backend: `.venv/Scripts/python -m pytest test/unit -q` (+ `--collect-only` on touched
+integration files). Frontend: the repo's vitest command.
+`git commit -m "feat(chat): per-tier daily turn budget + message length cap, 429 surfaced in UI (#100)"`
+
+---
+
+### Task 4: Import caps + enrichment budget deferral
+
+**Files:**
+- Modify: `src/agentic_librarian/api/imports.py` (preview/commit, MAX_ROWS at line 27)
+- Modify: `src/agentic_librarian/api/internal.py` (enrich + complete_edition budget gate)
+- Modify: `frontend/src/api/client.ts` (import commit error detail — only if the current
+  generic `Error` hides the server message; follow the `updateHistory` ApiError pattern)
+- Modify: the imports API integration test file + internal-endpoint test file (grep as in Task 2)
+- Create/extend: `test/unit/` for any new pure helpers
+
+**Interfaces:**
+- Consumes: `tiers.import_max_rows`, `tiers.effective_tier`, `budgets.enrichment_allowed`, `budgets.next_utc_day_start_with_jitter`, `enqueue_enrichment(..., user_id=, schedule_time=)`.
+- Produces: import commit → 413 `{"code": "import_rows_limit", ...}` over tier cap; 409 `{"code": "import_in_flight", ...}` when the user already has a pending/processing import. `/internal/enrich` responds `{"status": "deferred"}` (HTTP 200) when over budget.
+
+- [ ] **Step 1: Failing tests for import caps** (extend the imports API test file;
+parametrized): free-tier user commits 301 rows → 413 with `code == "import_rows_limit"`
+(monkeypatch `IMPORT_MAX_ROWS_FREE` small, e.g. 5, and build a 6-row CSV to keep the
+test cheap); supporter (seed `subscriber_until` future) passes the same file; a second
+commit while rows from the first are still `pending` → 409 `import_in_flight`; after
+all rows reach a terminal status → commit allowed again.
+
+- [ ] **Step 2: Implement import caps** in `api/imports.py`: in `commit` (and `preview`
+if it validates row counts — mirror wherever `MAX_ROWS` is enforced today, line ~49):
+
+```python
+    with db_manager.get_session() as session:
+        tier = tiers.effective_tier(session, user.id)
+    limit = min(MAX_ROWS, tiers.import_max_rows(tier))
+    if row_count > limit:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "code": "import_rows_limit",
+                "message": f"This import has {row_count} rows; your current limit is {limit}. "
+                "Split the file — or support Shelfwright for the full 2,000-row limit.",
+            },
+        )
+```
+
+(match the function's actual local names/session handling — read the file first). In-flight
+check in `commit` before writing the new job:
+
+```python
+    in_flight = (
+        session.query(ImportRow.id)
+        .join(ImportJob, ImportJob.id == ImportRow.job_id)
+        .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+        .first()
+    )
+    if in_flight is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "import_in_flight", "message": "Your previous import is still running — wait for it to finish before starting another."},
+        )
+```
+
+(verify the actual status strings + model/column names against `db/models.py` and the worker.)
+
+- [ ] **Step 3: Failing tests for deferral** (internal-endpoint test file): monkeypatch
+`budgets.enrichment_allowed` → `(False, "global grounded-call governor reached")`, patch the
+enqueue seam, POST `/internal/enrich/{id}?user_id=...` → 200 with `status == "deferred"`,
+enqueue called once with same work_id/user_id and a `schedule_time` strictly after now;
+`enrichment_allowed` → `(True, "")` → normal path unchanged. Same shape for
+`/internal/complete-edition`. And: deferral with enqueue returning False → 200
+`status == "deferred_enqueue_failed"` (the requeue sweep is the backstop — no retry storm).
+
+- [ ] **Step 4: Implement the budget gate** in `api/internal.py` — in `enrich(...)`,
+after `_require_queue_caller`, before `enrich_deep`:
+
+```python
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_enrichment(str(work_id), user_id=str(user_id) if user_id else None, schedule_time=when)
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s", work_id)
+            requeued = False
+        if not requeued:
+            logger.warning("over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why)
+            return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+        logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
+        # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
+        # so the #97 give-up retry count does not accumulate across days.
+        return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
+```
+
+Mirror in `complete_edition` with `enqueue_edition_completion(str(work_id), format, user_id=..., schedule_time=when)`.
+Add the needed imports (`budgets`, the enqueue helpers).
+
+- [ ] **Step 5: Frontend import-error check**: read how the import view surfaces commit
+errors today; if the 413/409 `detail.message` doesn't reach the user (client.ts throws
+generic `Error`), extend `commitImport` to raise `ApiError` (the existing class,
+`updateHistory` pattern) and render `.detail.message` in the view's error slot. If it
+already surfaces server detail, skip this step and say so in the report.
+
+- [ ] **Step 6: Suites, lint, format, commit**
+`git commit -m "feat(budgets): per-tier import caps + enrichment budget deferral via schedule_time (#100)"`
+
+---
+
+## Post-implementation verification
+
+- [ ] Full local unit suite green; frontend vitest green.
+- [ ] `--collect-only` clean on every touched integration file.
+- [ ] CI green on the PR (db_integration executes there FIRST — gate #5); grep confirmed
+      no stale patches of the old `enqueue_enrichment(work_id)` seam remain.
+- [ ] Optional runtime sanity (no DB): uvicorn boots; POST /api/chat with an over-length
+      body → 422 JSON.
+
+## Self-review notes (coverage against spec)
+
+- Spec §1 tier model/migration → Task 1. §2 metering incl. Claude scout + embed
+  estimate + attribution threading/back-compat → Task 2. §3 chat → Task 3; imports +
+  governor/deferral → Task 4. ✓
+- Spec error posture (meter best-effort, enforce fail-open, 429 bodies with code+message)
+  → budgets.py design + handler code. ✓
+- Spec non-goals (Ko-fi, BYOK, queue fairness) → no task touches them. ✓
+- Names consistent across tasks (checked: `chat_turn_allowed`, `enrichment_allowed`,
+  `next_utc_day_start_with_jitter`, enqueue kwargs). ✓

--- a/docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md
+++ b/docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md
@@ -1,0 +1,210 @@
+# Design: Metering, tiers, and budgets (#100 — sub-project 1 of the monetization arc)
+
+**Date:** 2026-07-25
+**Issue:** #100 — per-user quotas, rate limiting, and enrichment metering
+**Arc:** Monetization (1 of 3: this → Ko-fi subscriber tracking → BYOK)
+**Branch:** `feat/metering-tiers-100` (PRs stack; user merges in order at end of arc)
+
+## Product decisions (user, 2026-07-25)
+
+- Scope: meter everything + per-tier budgets; the shared Gemini key flips to **paid tier**
+  at rollout (operator step). Pricing data measured for a month before any price tuning.
+- Tiers: **free** = trial quotas (~20 chat turns/day, ~300-row import); **supporter**
+  (Ko-fi $3/mo / $25/yr, PR2) = generous env-tunable safety budgets, not unlimited;
+  **byok** (PR3) = own key, bypasses app-key budgets.
+- Cost model measured from prod: chat turn ≈ 0.7¢; deep-enrich ≈ 2¢/work under the paid
+  tier's free 1,500 grounded-prompts/day, ≈ 13¢ past it ($35/1k). The **global grounding
+  governor** below is what keeps the worst-case bill at "fixed floor + tokens".
+
+## Problem
+
+`record_llm_call` is wired into the chat mesh backends only. The most expensive path —
+grounded scouts + embeddings (every one of prod's 1,127 works) — writes zero usage rows,
+and nothing anywhere is enforced: no chat rate limit, no message length cap, no per-user
+import/enrichment budget. One 2,000-row import ≈ 6k grounded calls, unmetered.
+
+## Architecture
+
+Three layers, all in this PR:
+
+1. **Tier model** — schema + one pure function.
+2. **Metering** — every Gemini/Claude call site records a `usage` row, including
+   background tasks (requires threading `user_id` into task payloads).
+3. **Enforcement** — pre-LLM chokepoint checks against the `usage`/domain tables
+   (no Redis), returning 429 to interactive callers and *deferring* background work
+   via Cloud Tasks `schedule_time`.
+
+### 1. Tier model
+
+- Migration: `users.subscriber_until` (timestamptz, nullable). Comps = far-future value
+  (CLI to set it lands in PR2; until then operator SQL or nothing — acceptable, merge
+  order is 1→2→3).
+- New `core/tiers.py`:
+  - `effective_tier(session, user_id) -> Literal["free", "supporter", "byok"]`:
+    `byok` if a `user_credentials` row exists for vendor `gemini` (table has NO writers
+    until PR3, so this branch is inert but the enum is stable across the arc);
+    else `supporter` if `subscriber_until` is set and `> now()`; else `free`.
+  - Budget lookups, all env-tunable with defaults (the `_seed_limit()` parse pattern —
+    invalid/non-positive → default, read per call):
+
+    | Env var | Default | Meaning |
+    |---|---|---|
+    | `CHAT_TURNS_PER_DAY_FREE` | 20 | user messages / UTC day |
+    | `CHAT_TURNS_PER_DAY_SUPPORTER` | 200 | |
+    | `CHAT_MESSAGE_MAX_CHARS` | 4000 | all tiers (structural) |
+    | `IMPORT_MAX_ROWS_FREE` | 300 | per import file |
+    | `IMPORT_MAX_ROWS_SUPPORTER` | 2000 | = existing absolute `MAX_ROWS` |
+    | `GROUNDED_CALLS_PER_DAY_FREE` | 300 | ≈100 works/day |
+    | `GROUNDED_CALLS_PER_DAY_SUPPORTER` | 1500 | can consume the whole free allowance |
+    | `GROUNDED_CALLS_PER_DAY_GLOBAL` | 1400 | governor: all users, headroom under Google's free 1,500/day |
+
+  - `byok` tier: chat/import budgets use the supporter values ×10 (structural sanity,
+    not cost protection); grounded budgets don't apply once PR3 routes to their key —
+    in THIS PR byok cannot occur (no credential writers), so no special-casing beyond
+    the enum.
+- Budget *counting* queries the existing tables — no new counters to keep consistent:
+  - chat turns today = `messages` rows with `role='user'`, joined via `conversations.user_id`, `created_at >= UTC midnight`.
+  - grounded calls today (per-user / global) = `usage` rows with `model = <grounding model>`, `key_source='app'`, same window.
+
+### 2. Metering
+
+- **Gemini grounded scout** (`scouts/grounded_llm.py` `GeminiGroundedLLM.generate`):
+  the response already carries `usage_metadata` (prompt/candidates token counts) and
+  `_extract_text` discards it. Capture it and call `record_llm_call("gemini", model,
+  prompt_tokens, candidates_tokens)`. Meter **at the response object** — the SDK-level
+  429/5xx retry (`genai_http_options`) must not double-count; scout-level retries are
+  genuinely second billable calls and record again (correct).
+- **Claude grounded scout** (`ClaudeGroundedLLM._agenerate`): read the SDK
+  `ResultMessage.usage` the same way `agents/backends/claude.py` already does; record
+  with vendor `anthropic`.
+- **Embeddings** (`scouts/utils.py get_cached_embedding`): embed responses expose no
+  token counts, and the `@lru_cache` means only cache misses hit the network. Record
+  **inside the cached function body** (misses only), `input_tokens = len(text) // 4`
+  (documented estimate — embeddings are $0.15/M, this is visibility, not billing-grade),
+  `output_tokens = 0`, model `gemini-embedding-001`. This transparently covers all
+  callers (trope/style managers, MCP warming, two-phase warming, analysis_style).
+- **Failure posture unchanged:** `record_llm_call` never raises; a metering failure
+  logs and the call proceeds (ADR-048 best-effort stands until billing-grade is needed).
+
+#### User attribution in background tasks (the prerequisite)
+
+`record_llm_call` → `get_required_user_id()` fails closed, and today the enrichment
+handlers have **no user in context**, so metering there would silently drop every row:
+
+- `enqueue_enrichment(work_id)` and `enqueue_edition_completion(work_id, fmt)` gain a
+  `user_id: str | None = None` parameter, appended to the task URL as a query parameter.
+  Callers pass the acting user: `books.py` add-book and `main.py` PATCH /history (current
+  user), `imports/worker.py` (the row's `user_id`).
+- `/internal/enrich/{work_id}`, `/internal/complete-edition/{work_id}` accept the
+  optional `user_id` query param and wrap their work in `as_user(user_id)` when present.
+  **Tasks enqueued before this deploy carry no user_id — handlers must tolerate its
+  absence** (run un-attributed exactly as today; metering skips, nothing crashes).
+- `imports/worker.py process_import_row`: the `as_user(...)` block moves up to also
+  cover `enrich_fast(...)` (today it covers only the history/suggestion writes), so
+  import-triggered fast-scout calls are attributed.
+- Enrichment for a shared work bills to whoever requested it (catalog sharing means
+  later users of the same work pay nothing — by design).
+
+### 3. Enforcement
+
+**Chat** (`api/main.py /chat`):
+- Length cap as an explicit handler check (`len(message) > chat_message_max_chars()`),
+  NOT a Pydantic `max_length` constant — the env value must be tunable without redeploy
+  and read per call. Over-length → 422 with a clear detail.
+- After `get_current_user`, before the `StreamingResponse` is created (the map confirms
+  429 is impossible once streaming starts): count today's user messages; at/over the
+  tier budget → `HTTPException(429, detail={"code": "chat_quota", "message": ..., "tier": ...})`.
+- Frontend `streamChat` (client.ts): today any non-OK collapses to a generic error.
+  Add: `res.status === 429` → parse detail → show its message (friendly copy: daily
+  limit reached — support Shelfwright or bring your own key soon). No toast system is
+  built (none exists; per-view error slots are the house pattern).
+
+**Imports** (`api/imports.py`):
+- Per-tier rows/import: preview/commit reject files over the tier's `IMPORT_MAX_ROWS_*`
+  (existing absolute `MAX_ROWS=2000` stays as the ceiling). 413/422-style JSON detail the
+  ImportView already renders; include the tier and the limit in the message.
+- **One in-flight import per user** (any tier): commit refuses (409) while the user has
+  a job with pending/running rows (query `import_jobs` + `import_rows` status; no new
+  columns).
+
+**Enrichment budget + global governor** (`api/internal.py` enrich / complete-edition):
+- At task execution, BEFORE running scouts: if the acting user's grounded calls today
+  ≥ tier budget, OR the global count ≥ `GROUNDED_CALLS_PER_DAY_GLOBAL`, **defer**: the
+  handler re-enqueues the same task with `schedule_time` = next UTC midnight + jitter
+  (0–30 min, spreads the morning thundering herd) and returns 200 (task consumed —
+  deferral must NOT burn the #97 give-up retry count).
+- Un-attributed tasks (pre-deploy backlog, no user_id) check only the global governor.
+- `enrichment/tasks.py` + `imports/tasks.py` gain optional `schedule_time` support on
+  the Task dict (protobuf timestamp) — the missing knob the map identified.
+- `/books` gets no separate in-flight cap: the daily grounded budget bounds the same
+  cost (the issue's suggestion is subsumed).
+
+**Queue fairness** (issue item 4): NOT in this PR. The governor + per-user budgets bound
+the cost; FIFO fairness between a bulk import and an interactive add remains a 6.5/6.6
+follow-up. Noted here so the deferral is deliberate.
+
+## Data flow (enforcement read path)
+
+Every check is one indexed COUNT against existing tables (`messages`, `usage`,
+`import_rows`) scoped to a UTC day — no new state, no Redis, consistent-enough (a
+racing pair of requests can each pass at N-1; budgets are safety nets, not invoicing).
+`usage.created_at` has no index today; `usage(user_id)` is indexed — the per-day scan
+per user is trivial at this scale. Add a composite index only if CI's query plans say so
+(YAGNI now).
+
+## Error handling
+
+- Metering: best-effort, never blocks the user path (unchanged posture).
+- Enforcement failures fail OPEN with a logged warning (a broken budget query must not
+  take chat down — the budget protects cost, not correctness).
+- 429 bodies always carry `{"code", "message"}` so the frontend renders a human
+  sentence, never a bare status.
+
+## Testing
+
+Per house rules: parametrized cases only; Postgres-only models → counting/attribution
+tests are `db_integration` (CI-first gate); DB-free logic (env parsing, tier decision
+with injected rows, usage-capture with fake response objects) unit-tests locally.
+
+- Unit: `effective_tier` matrix (subscriber_until past/future/null × credential
+  present/absent); budget env parsing (valid/invalid/non-positive); Gemini scout
+  metering captures usage_metadata off a fake response (and records once despite
+  `_extract_text` retry paths); embed metering records only on cache miss with the
+  documented estimate; deferral schedule_time computation (next-UTC-midnight + jitter
+  bounds).
+- db_integration: chat-turn counting query (today vs yesterday rows, other users'
+  rows excluded); grounded-call counting (per-user and global, key_source filter);
+  worker attribution — `process_import_row` writes usage rows with the row's user_id;
+  enrich handler defers (returns 200, re-enqueues with schedule_time) when over budget
+  — enqueue helper faked, assert the schedule_time argument.
+- API integration: /chat 429 at the budget boundary (seed N user messages today, N+1th
+  turn refused; under-budget passes); over-length message 422; import commit 409 with
+  an in-flight job; per-tier rows/import rejection.
+- Frontend (vitest): streamChat surfaces the 429 detail message; generic errors
+  unchanged.
+
+## Acceptance criteria
+
+1. Every Gemini/Claude LLM call and every embedding cache-miss writes a `usage` row
+   with correct user attribution, including Cloud-Tasks-driven enrichment.
+2. Free tier: 21st chat turn of the day → 429 with human-readable detail; 301-row
+   import rejected; supporter limits are the higher numbers; all env-tunable.
+3. Over-budget/over-governor enrichment tasks defer to next UTC day via
+   `schedule_time` without burning give-up retries; pre-deploy tasks (no user_id)
+   still complete.
+4. Frontend shows the quota message on chat 429 (not the generic error).
+5. Full local unit suite green; db_integration/API additions green in CI; no frontend
+   regression.
+
+## Non-goals (deferred within the arc or later)
+
+- Ko-fi webhook, payments table, subscribe CLI, avatar-dropdown UI → PR2.
+- BYOK storage/routing/walkthrough → PR3.
+- Queue fairness (bulk vs interactive), summarizing old chat context, billing-grade
+  metering, `usage` table rotation → later phases.
+
+## Ops at rollout (operator, with sub-project 1's deploy)
+
+Flip the shared Gemini key's project to the paid tier (billing on). Until then the
+governor still helps (free tier's 500 grounded RPD << 1,500) — set
+`GROUNDED_CALLS_PER_DAY_GLOBAL=450` in the interim if the flip lags the deploy.

--- a/frontend/src/api/client.import.test.ts
+++ b/frontend/src/api/client.import.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { commitImport, getImportJob, previewImport, retryImport } from './client'
+import { ApiError, commitImport, getImportJob, previewImport, retryImport } from './client'
 
 vi.mock('../auth/firebase', () => ({ getIdToken: async () => 'tok' }))
 
@@ -33,6 +33,49 @@ describe('import client', () => {
     const body = (f.mock.calls[0][1] as RequestInit).body as FormData
     expect(body.get('import_to_read')).toBe('true')
     expect(body.get('import_currently_reading')).toBe('false')
+  })
+
+  it('commitImport surfaces the server detail.message on 413 as an ApiError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({
+        detail: {
+          code: 'import_rows_limit',
+          message: 'This import has 301 rows; your current limit is 300. Split the file.',
+        },
+      }),
+    } as Response)
+    const file = new File(['x'], 'export.csv', { type: 'text/csv' })
+    let caught: unknown
+    try {
+      await commitImport(file, { title: 'Title' }, { importToRead: true, importCurrentlyReading: false })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ApiError)
+    expect((caught as InstanceType<typeof ApiError>).status).toBe(413)
+    expect((caught as InstanceType<typeof ApiError>).detail).toContain('current limit is 300')
+  })
+
+  it('commitImport surfaces the server detail.message on 409 as an ApiError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        detail: { code: 'import_in_flight', message: 'Your previous import is still running.' },
+      }),
+    } as Response)
+    const file = new File(['x'], 'export.csv', { type: 'text/csv' })
+    let caught: unknown
+    try {
+      await commitImport(file, { title: 'Title' }, { importToRead: true, importCurrentlyReading: false })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ApiError)
+    expect((caught as InstanceType<typeof ApiError>).status).toBe(409)
+    expect((caught as InstanceType<typeof ApiError>).detail).toBe('Your previous import is still running.')
   })
 
   it('getImportJob fetches status', async () => {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -67,6 +67,35 @@ describe('api client', () => {
     await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
     expect(detail).toBe('boom')
   })
+
+  it('streamChat surfaces the 429 quota detail message', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { code: 'chat_quota', message: 'Daily limit reached.' } }), {
+        status: 429,
+      }),
+    )
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('Daily limit reached.')
+  })
+
+  it('streamChat surfaces the 422 message-too-long detail message', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { code: 'message_too_long', message: 'Message too long.' } }), {
+        status: 422,
+      }),
+    )
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('Message too long.')
+  })
+
+  it('streamChat falls back to the generic copy on a 500', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('boom', { status: 500 }))
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('The Librarian hit a problem. Please try again.')
+  })
 })
 
 describe('addBook', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -257,6 +257,17 @@ export async function streamChat(message: string, handlers: ChatHandlers): Promi
     return
   }
   if (!res.ok || !res.body) {
+    if (res.status === 429 || res.status === 422) {
+      let message = ''
+      try {
+        const body = await res.json()
+        message = body?.detail?.message ?? ''
+      } catch {
+        // fall through to the generic copy
+      }
+      handlers.onError(message || GENERIC_CHAT_ERROR)
+      return
+    }
     handlers.onError(GENERIC_CHAT_ERROR)
     return
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -356,7 +356,20 @@ export async function commitImport(
   form.set('import_currently_reading', String(opts.importCurrentlyReading))
   form.set('original_filename', file.name)
   const res = await authedFetchRaw('/import/commit', { method: 'POST', body: form })
-  if (!res.ok) throw new Error(`commit import → ${res.status}`)
+  if (!res.ok) {
+    // #100: 413 import_rows_limit / 409 import_in_flight carry a human message in
+    // detail.message (updateHistory's ApiError pattern, adapted for the object-shaped
+    // detail the chat 429 path also uses — see streamChat above).
+    let detail = `commit import → ${res.status}`
+    try {
+      const parsed = await res.json()
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+      else if (typeof parsed?.detail?.message === 'string') detail = parsed.detail.message
+    } catch {
+      // non-JSON error body — keep the generic detail
+    }
+    throw new ApiError(res.status, detail)
+  }
   return res.json() as Promise<ImportCommitResult>
 }
 

--- a/frontend/src/views/ImportView.test.tsx
+++ b/frontend/src/views/ImportView.test.tsx
@@ -6,6 +6,7 @@ vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null)
 
 import ImportView from './ImportView'
 import * as client from '../api/client'
+import { ApiError } from '../api/client'
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -112,6 +113,21 @@ describe('ImportView', () => {
     fireEvent.click(screen.getByRole('button', { name: /continue/i }))     // map → review
     fireEvent.click(screen.getByRole('button', { name: /start import/i })) // review → progress
     await waitFor(() => expect(screen.getByText(/2 \/ 2/)).toBeInTheDocument())
+  })
+
+  it('surfaces the server detail.message when commit is rejected over the row cap (#100)', async () => {
+    vi.spyOn(client, 'previewImport').mockResolvedValue(PREVIEW)
+    // #100: a persistent mockRejectedValue overrides EVERY call (vitest#1692) and would fail
+    // as an "unhandled error" outside the awaited assertion — use ...Once (frontend-test-pitfalls).
+    vi.spyOn(client, 'commitImport').mockRejectedValueOnce(
+      new ApiError(413, 'This import has 301 rows; your current limit is 300. Split the file.'),
+    )
+    render(<ImportView />)
+    uploadFile()
+    await screen.findByText(/Detected: goodreads/i)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))     // map → review
+    fireEvent.click(screen.getByRole('button', { name: /start import/i })) // review → progress
+    await screen.findByText(/your current limit is 300/i)
   })
 
   it('offers retry when rows are stalled (not yet complete)', async () => {

--- a/frontend/src/views/ImportView.tsx
+++ b/frontend/src/views/ImportView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import {
-  commitImport, getImportJob, previewImport, retryImport,
+  ApiError, commitImport, getImportJob, previewImport, retryImport,
   type ColumnMapping, type ImportPreview, type ImportStatus,
 } from '../api/client'
 import './ImportView.css'
@@ -77,8 +77,10 @@ export default function ImportView() {
       const res = await commitImport(file, mapping, { importToRead: toRead, importCurrentlyReading: currently })
       setJobId(res.import_job_id)
       setStep('progress')
-    } catch {
-      setError('Import could not start. Please try again.')
+    } catch (e) {
+      // #100: 413 import_rows_limit / 409 import_in_flight carry a human message worth
+      // showing verbatim; anything else falls back to the generic copy.
+      setError(e instanceof ApiError ? e.detail : 'Import could not start. Please try again.')
     } finally {
       setBusy(false)
     }

--- a/src/agentic_librarian/api/books.py
+++ b/src/agentic_librarian/api/books.py
@@ -55,7 +55,10 @@ class AddBookRequest(BaseModel):
 
 @router.post("/books")
 def add_book(req: AddBookRequest, user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
-    fast = two_phase.enrich_fast(req.title, req.author, req.format)
+    # as_user covers the fast pass so its embed cache-miss metering attributes to the
+    # requester (#100 AC#1) — fast scouts make no grounded calls, so no budget effect.
+    with as_user(user.id):
+        fast = two_phase.enrich_fast(req.title, req.author, req.format)
     if fast is None:
         raise HTTPException(
             status_code=404,

--- a/src/agentic_librarian/api/books.py
+++ b/src/agentic_librarian/api/books.py
@@ -72,7 +72,7 @@ def add_book(req: AddBookRequest, user: AuthenticatedUser = Depends(get_current_
     if created:
         # A failed enqueue must not fail the add — the book is already saved.
         try:
-            enqueued = enqueue_enrichment(str(work_id))
+            enqueued = enqueue_enrichment(str(work_id), user_id=str(user.id))
         except Exception:  # noqa: BLE001 - enqueue is best-effort; deep pass can be retried later
             logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 

--- a/src/agentic_librarian/api/imports.py
+++ b/src/agentic_librarian/api/imports.py
@@ -16,6 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.core import tiers
 from agentic_librarian.db.models import ImportJob, ImportRow
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.imports import bucketing, parsing
@@ -139,6 +140,38 @@ async def commit(
 
     enqueue_ids: list[str] = []
     with db_manager.get_session() as session:
+        # Per-tier row cap (#100): the hard MAX_ROWS ceiling above is absolute (protects
+        # the parser/DB regardless of tier); this is the tighter, tier-aware limit.
+        tier = tiers.effective_tier(session, user.id)
+        limit = min(MAX_ROWS, tiers.import_max_rows(tier))
+        row_count = len(parsed)
+        if row_count > limit:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "code": "import_rows_limit",
+                    "message": f"This import has {row_count} rows; your current limit is {limit}. "
+                    "Split the file — or support Shelfwright for the full 2,000-row limit.",
+                },
+            )
+
+        # One in-flight import at a time (#100): a prior commit's rows still pending/processing
+        # blocks a new commit — avoids two jobs' Cloud Tasks racing on the same user's history.
+        in_flight = (
+            session.query(ImportRow.id)
+            .join(ImportJob, ImportJob.id == ImportRow.import_job_id)
+            .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+            .first()
+        )
+        if in_flight is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "import_in_flight",
+                    "message": "Your previous import is still running — wait for it to finish before starting another.",
+                },
+            )
+
         job = ImportJob(user_id=user.id, source=source, original_filename=original_filename, total_rows=len(parsed))
         session.add(job)
         session.flush()  # populate job.id for the ImportRow FK

--- a/src/agentic_librarian/api/imports.py
+++ b/src/agentic_librarian/api/imports.py
@@ -27,6 +27,13 @@ router = APIRouter()
 
 MAX_ROWS = 2000
 STALLED_AFTER = timedelta(minutes=15)
+# #100 review fix: bounds the in-flight-import lockout. An import-row task has no give-up
+# retry bound (unlike /internal/enrich's GIVE_UP_AFTER_RETRIES), and job recovery UI lives
+# only in React state — so a row wedged in 'processing' forever would otherwise block every
+# future commit for that user permanently. Invariant: a wedged job stops counting as
+# in-flight once it's older than this window; the daily enrichment budget still bounds the
+# cost of any rows from an overlapping "second" import that slips through afterward.
+IN_FLIGHT_WINDOW = timedelta(hours=24)
 
 db_manager = DatabaseManager()
 
@@ -146,21 +153,33 @@ async def commit(
         limit = min(MAX_ROWS, tiers.import_max_rows(tier))
         row_count = len(parsed)
         if row_count > limit:
+            # Un-hardcode the upsell figure (env-tunable, #100 review fix) and only pitch
+            # it to a free-tier user — a supporter already at their ceiling shouldn't be
+            # told to "support" for a limit they already have.
+            supporter_limit = min(MAX_ROWS, tiers.import_max_rows("supporter"))
+            message = f"This import has {row_count} rows; your current limit is {limit}. Split the file"
+            message += (
+                f" — or support Shelfwright for the full {supporter_limit:,}-row limit." if tier == "free" else "."
+            )
             raise HTTPException(
                 status_code=413,
-                detail={
-                    "code": "import_rows_limit",
-                    "message": f"This import has {row_count} rows; your current limit is {limit}. "
-                    "Split the file — or support Shelfwright for the full 2,000-row limit.",
-                },
+                detail={"code": "import_rows_limit", "message": message},
             )
 
         # One in-flight import at a time (#100): a prior commit's rows still pending/processing
-        # blocks a new commit — avoids two jobs' Cloud Tasks racing on the same user's history.
+        # on a RECENT job (#100 review fix, see IN_FLIGHT_WINDOW) blocks a new commit — avoids
+        # two jobs' Cloud Tasks racing on the same user's history. Two concurrent commits can
+        # both pass this check before either writes its job (query-then-insert race) — accepted:
+        # the worst case is two jobs' worth of duplicate rows, never corruption, and the daily
+        # enrichment budget still bounds the cost.
         in_flight = (
             session.query(ImportRow.id)
             .join(ImportJob, ImportJob.id == ImportRow.import_job_id)
-            .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+            .filter(
+                ImportJob.user_id == user.id,
+                ImportRow.status.in_(("pending", "processing")),
+                ImportJob.created_at >= datetime.now(UTC) - IN_FLIGHT_WINDOW,
+            )
             .first()
         )
         if in_flight is not None:

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -7,12 +7,14 @@ Idempotent: Cloud Tasks may redeliver, and two_phase.enrich_deep is retry-safe."
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, Query
 
+from agentic_librarian.core.user_context import as_user
 from agentic_librarian.enrichment import two_phase
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
@@ -88,9 +90,14 @@ def enrich(
     work_id: UUID,
     authorization: str | None = Header(None),  # noqa: B008
     x_cloudtasks_taskretrycount: str | None = Header(None),  # noqa: B008
+    user_id: UUID | None = Query(None),  # noqa: B008
 ):
     _require_queue_caller(authorization)
-    result = two_phase.enrich_deep(work_id)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
+    # skips; nothing crashes). Attributed tasks bill the requesting user.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.enrich_deep(work_id)
     if result == "missing":
         # Non-retryable: the work no longer exists. 404 stops Cloud Tasks from retrying.
         raise HTTPException(status_code=404, detail="work not found")
@@ -128,6 +135,7 @@ def complete_edition(
     work_id: UUID,
     format: str = Query(..., max_length=50),  # noqa: B008
     authorization: str | None = Header(None),  # noqa: B008
+    user_id: UUID | None = Query(None),  # noqa: B008
 ):
     """Format-completion pass target (history-format-edit spec). Same OIDC gate as
     /internal/enrich. 'missing' → 404 (non-retryable: work/edition gone); 'empty' and
@@ -140,7 +148,10 @@ def complete_edition(
     A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
     (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
-    result = two_phase.complete_edition(work_id, format)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.complete_edition(work_id, format)
     if result == "missing":
         raise HTTPException(status_code=404, detail="work or edition not found")
     return {"work_id": str(work_id), "format": format, "status": result}

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -14,8 +14,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, Query
 
+from agentic_librarian.core import budgets
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.enrichment import two_phase
+from agentic_librarian.enrichment.tasks import enqueue_edition_completion, enqueue_enrichment
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
 logger = logging.getLogger(__name__)
@@ -93,6 +95,23 @@ def enrich(
     user_id: UUID | None = Query(None),  # noqa: B008
 ):
     _require_queue_caller(authorization)
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_enrichment(
+                str(work_id), user_id=str(user_id) if user_id is not None else None, schedule_time=when
+            )
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s", work_id)
+            requeued = False
+        if not requeued:
+            logger.warning("over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why)
+            return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+        logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
+        # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
+        # so the #97 give-up retry count does not accumulate across days.
+        return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
     # skips; nothing crashes). Attributed tasks bill the requesting user.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
@@ -148,6 +167,28 @@ def complete_edition(
     A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
     (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_edition_completion(
+                str(work_id), format, user_id=str(user_id) if user_id is not None else None, schedule_time=when
+            )
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s format %s", work_id, format)
+            requeued = False
+        if not requeued:
+            logger.warning(
+                "over budget and could not defer completion of work %s format %s (%s) — dropping to the requeue sweep",
+                work_id,
+                format,
+                why,
+            )
+            return {"work_id": str(work_id), "format": format, "status": "deferred_enqueue_failed"}
+        logger.info(
+            "deferred edition completion of work %s format %s to %s (%s)", work_id, format, when.isoformat(), why
+        )
+        return {"work_id": str(work_id), "format": format, "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
     with ctx:

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -98,6 +98,7 @@ async def lifespan(app: FastAPI):
     mcp_server.set_db_manager(shared)
     two_phase.set_db_manager(shared)
     imports_worker.set_db_manager(shared)
+    budgets.set_db_manager(shared)
     yield
 
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -28,7 +28,7 @@ from agentic_librarian.api.internal import router as internal_router
 from agentic_librarian.api.libraries import router as libraries_router
 from agentic_librarian.api.recommendations import router as recommendations_router
 from agentic_librarian.chat import stream, transcript
-from agentic_librarian.core import usage
+from agentic_librarian.core import budgets, tiers, usage
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.migration_guard import check_migrations
@@ -473,6 +473,16 @@ def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # no
 
 @api_router.post("/chat")
 def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    max_chars = tiers.chat_message_max_chars()
+    if len(message) > max_chars:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "message_too_long", "message": f"Message too long (max {max_chars} characters)."},
+        )
+    allowed, why = budgets.chat_turn_allowed(user.id)
+    if not allowed:
+        # Must reject BEFORE the StreamingResponse exists — SSE cannot carry an HTTP 429.
+        raise HTTPException(status_code=429, detail={"code": "chat_quota", "message": why})
     with as_user(user.id):
         ctx = transcript.get_or_create_active_conversation()
     adk_user_id = str(user.id)

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -373,7 +373,7 @@ def update_history(
     enqueued = False
     if needs_completion:
         try:
-            enqueued = enqueue_edition_completion(work_id_str, fmt_str)
+            enqueued = enqueue_edition_completion(work_id_str, fmt_str, user_id=str(user.id))
         except Exception:  # noqa: BLE001 - enqueue is best-effort
             logger.exception("edition-completion enqueue failed for work %s", work_id_str)
     payload["enrichment_enqueued"] = enqueued

--- a/src/agentic_librarian/core/budgets.py
+++ b/src/agentic_librarian/core/budgets.py
@@ -1,0 +1,100 @@
+"""Budget decisions for #100 — counting queries over existing tables (messages, usage);
+no new counters, no Redis. Checks FAIL OPEN: a broken budget query logs and allows (the
+budget protects cost, not correctness). Module-level db_manager + set_db_manager seam
+mirrors core/usage.py."""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import UTC, datetime, time, timedelta
+from uuid import UUID
+
+from agentic_librarian.core import tiers
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+db_manager = DatabaseManager()
+
+_DEFER_JITTER_MAX_SECONDS = 1800  # spread the next-midnight thundering herd over 30 min
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+def _utc_day_start(now: datetime | None = None) -> datetime:
+    now = now or datetime.now(UTC)
+    return datetime.combine(now.date(), time.min, tzinfo=UTC)
+
+
+def chat_turns_today(session, user_id: UUID) -> int:
+    from agentic_librarian.db.models import Conversation, Message
+
+    return (
+        session.query(Message.id)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .filter(
+            Conversation.user_id == user_id,
+            Message.role == "user",
+            Message.created_at >= _utc_day_start(),
+        )
+        .count()
+    )
+
+
+def grounded_calls_today(session, user_id: UUID | None) -> int:
+    """App-key grounded-model usage rows today — per-user, or global when user_id is None."""
+    from agentic_librarian.db.models import Usage
+
+    q = session.query(Usage.id).filter(
+        Usage.model == tiers.grounding_model_name(),
+        Usage.key_source == "app",
+        Usage.created_at >= _utc_day_start(),
+    )
+    if user_id is not None:
+        q = q.filter(Usage.user_id == user_id)
+    return q.count()
+
+
+def chat_turn_allowed(user_id: UUID) -> tuple[bool, str]:
+    """(allowed, human_message). Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            tier = tiers.effective_tier(session, user_id)
+            limit = tiers.chat_turns_per_day(tier)
+            used = chat_turns_today(session, user_id)
+        if used >= limit:
+            return False, (
+                f"You've reached today's chat limit ({limit} messages). "
+                "It resets at midnight UTC — or support Shelfwright for a higher limit."
+            )
+        return True, ""
+    except Exception:
+        logger.warning("chat budget check failed open", exc_info=True)
+        return True, ""
+
+
+def enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]:
+    """Per-user grounded budget (when attributed) AND the global governor. Un-attributed
+    (pre-deploy) tasks check only the governor. Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            if grounded_calls_today(session, None) >= tiers.grounded_calls_per_day_global():
+                return False, "global grounded-call governor reached"
+            if user_id is not None:
+                tier = tiers.effective_tier(session, user_id)
+                if grounded_calls_today(session, user_id) >= tiers.grounded_calls_per_day(tier):
+                    return False, f"per-user grounded budget reached (tier {tier})"
+        return True, ""
+    except Exception:
+        logger.warning("enrichment budget check failed open", exc_info=True)
+        return True, ""
+
+
+def next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime:
+    if jitter_seconds is None:
+        jitter_seconds = random.randint(0, _DEFER_JITTER_MAX_SECONDS)
+    return _utc_day_start(now) + timedelta(days=1, seconds=jitter_seconds)

--- a/src/agentic_librarian/core/tiers.py
+++ b/src/agentic_librarian/core/tiers.py
@@ -1,0 +1,95 @@
+"""Effective tier + env-tunable budget knobs (#100, monetization arc 1/3; spec
+2026-07-25-metering-tiers-budgets-design.md).
+
+Tier semantics: 'byok' requires a user_credentials row for vendor 'gemini' — that table
+has NO writers until arc PR3 lands, so today the branch is inert but the enum is stable
+across the arc. 'supporter' = subscriber_until in the future (Ko-fi entitlements are
+PR2). Knobs are read per call (prod-tunable without redeploy); invalid or non-positive
+values fall back to the defaults below."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+Tier = Literal["free", "supporter", "byok"]
+
+_DEFAULTS = {
+    "CHAT_TURNS_PER_DAY_FREE": 20,
+    "CHAT_TURNS_PER_DAY_SUPPORTER": 200,
+    "CHAT_MESSAGE_MAX_CHARS": 4000,
+    "IMPORT_MAX_ROWS_FREE": 300,
+    "IMPORT_MAX_ROWS_SUPPORTER": 2000,
+    "GROUNDED_CALLS_PER_DAY_FREE": 300,
+    "GROUNDED_CALLS_PER_DAY_SUPPORTER": 1500,
+    "GROUNDED_CALLS_PER_DAY_GLOBAL": 1400,
+}
+
+# byok budgets are structural sanity bounds, not cost protection (their key, their bill).
+_BYOK_MULTIPLIER = 10
+
+
+def _env_int(name: str) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULTS[name]
+    return value if value > 0 else _DEFAULTS[name]
+
+
+def tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier:
+    if has_byok_credential:
+        return "byok"
+    now = now or datetime.now(UTC)
+    if subscriber_until is not None and subscriber_until > now:
+        return "supporter"
+    return "free"
+
+
+def effective_tier(session, user_id: UUID) -> Tier:
+    from agentic_librarian.db.models import User, UserCredential
+
+    user = session.get(User, user_id)
+    has_cred = (
+        session.query(UserCredential.user_id)
+        .filter(UserCredential.user_id == user_id, UserCredential.vendor == "gemini")
+        .first()
+        is not None
+    )
+    return tier_for(user.subscriber_until if user else None, has_cred)
+
+
+def _tiered(free_var: str, supporter_var: str, tier: Tier) -> int:
+    if tier == "free":
+        return _env_int(free_var)
+    supporter = _env_int(supporter_var)
+    return supporter * _BYOK_MULTIPLIER if tier == "byok" else supporter
+
+
+def chat_turns_per_day(tier: Tier) -> int:
+    return _tiered("CHAT_TURNS_PER_DAY_FREE", "CHAT_TURNS_PER_DAY_SUPPORTER", tier)
+
+
+def chat_message_max_chars() -> int:
+    return _env_int("CHAT_MESSAGE_MAX_CHARS")
+
+
+def import_max_rows(tier: Tier) -> int:
+    return _tiered("IMPORT_MAX_ROWS_FREE", "IMPORT_MAX_ROWS_SUPPORTER", tier)
+
+
+def grounded_calls_per_day(tier: Tier) -> int:
+    return _tiered("GROUNDED_CALLS_PER_DAY_FREE", "GROUNDED_CALLS_PER_DAY_SUPPORTER", tier)
+
+
+def grounded_calls_per_day_global() -> int:
+    return _env_int("GROUNDED_CALLS_PER_DAY_GLOBAL")
+
+
+def grounding_model_name() -> str:
+    """Single source of truth for the grounded-scout model id — budgets count usage rows
+    by this name, and scouts/grounded_llm.py resolves its model from it."""
+    return os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -308,6 +308,8 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, nullable=False)  # lowercased; the invite key
     firebase_uid: Mapped[str | None] = mapped_column(String, unique=True, nullable=True)
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    # #100 monetization: Ko-fi entitlement horizon (PR2 writes it; NULL/past = free tier).
+    subscriber_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )

--- a/src/agentic_librarian/enrichment/tasks.py
+++ b/src/agentic_librarian/enrichment/tasks.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from datetime import datetime
 from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
@@ -44,10 +45,14 @@ def _client():
     return _client_cached
 
 
-def enqueue_enrichment(work_id: str) -> bool:
+def enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool:
     """Enqueue the deep-enrichment task for work_id. Returns True if enqueued, False if
     Cloud Tasks is not configured (local dev) — the caller treats a False/raised result as
-    non-fatal so the fast add still succeeds."""
+    non-fatal so the fast add still succeeds.
+
+    user_id (#100) attributes the eventual /internal/enrich metering to the requesting user;
+    omitted for pre-#100 callers, which run un-attributed exactly as before. schedule_time is
+    added here (used starting Task 4) so tasks.py is touched once for the arc."""
     queue = os.environ.get("CLOUD_TASKS_QUEUE")
     base = os.environ.get("ENRICH_TARGET_BASE_URL")
     sa = os.environ.get("ENRICH_INVOKER_SA")
@@ -55,8 +60,14 @@ def enqueue_enrichment(work_id: str) -> bool:
         logger.info("enrichment enqueue skipped — Cloud Tasks not configured (work %s)", work_id)
         return False
 
-    url = f"{base.rstrip('/')}/internal/enrich/{work_id}"
-    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or url
+    # Audience is bound to the bare PATH url on purpose — see enqueue_edition_completion's
+    # comment: a per-call query string (user_id here, format there) must never leak into the
+    # audience the receiver checks against a single fixed ENRICH_OIDC_AUDIENCE.
+    audience_url = f"{base.rstrip('/')}/internal/enrich/{work_id}"
+    url = audience_url
+    if user_id:
+        url += f"?user_id={quote(user_id)}"
+    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or audience_url
     task = {
         "http_request": {
             # String, not tasks_v2.HttpMethod.POST, on purpose: proto-plus coerces it, and
@@ -67,15 +78,22 @@ def enqueue_enrichment(work_id: str) -> bool:
             "oidc_token": {"service_account_email": sa, "audience": audience},
         }
     }
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
     _client().create_task(parent=queue, task=task)
     logger.info("enqueued deep enrichment for work %s", work_id)
     return True
 
 
-def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
+def enqueue_edition_completion(
+    work_id: str, fmt: str, user_id: str | None = None, schedule_time: datetime | None = None
+) -> bool:
     """Enqueue the format-completion pass for (work_id, fmt) — history-format-edit spec.
     Returns True if enqueued, False if Cloud Tasks is not configured (local dev); the
-    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved."""
+    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved.
+
+    user_id (#100) attributes the eventual /internal/complete-edition metering to the
+    requesting user; omitted for pre-#100 callers. schedule_time added for Task 4."""
     queue = os.environ.get("CLOUD_TASKS_QUEUE")
     base = os.environ.get("ENRICH_TARGET_BASE_URL")
     sa = os.environ.get("ENRICH_INVOKER_SA")
@@ -85,8 +103,10 @@ def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
 
     path_url = f"{base.rstrip('/')}/internal/complete-edition/{work_id}"
     url = f"{path_url}?format={quote(fmt)}"
+    if user_id:
+        url += f"&user_id={quote(user_id)}"
     # Audience deliberately excludes the query string: the receiver verifies against a
-    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format audience would never match.
+    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format/per-user audience would never match.
     audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or path_url
     task = {
         "http_request": {
@@ -95,6 +115,8 @@ def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
             "oidc_token": {"service_account_email": sa, "audience": audience},
         }
     }
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
     _client().create_task(parent=queue, task=task)
     logger.info("enqueued edition completion for work %s format %s", work_id, fmt)
     return True

--- a/src/agentic_librarian/imports/worker.py
+++ b/src/agentic_librarian/imports/worker.py
@@ -85,22 +85,24 @@ def process_import_row(row_id: UUID) -> str:
             "user_id": row.user_id,
         }
 
-    # 2. Resolve the work (de-dup, else shallow scouts) OUTSIDE our session — enrich_fast
-    #    owns its own session/pool.
-    try:
-        fast = two_phase.enrich_fast(data["title"], data["author"], data["fmt"])
-    except Exception as e:  # noqa: BLE001 - transient: record + re-raise so Cloud Tasks retries
-        _record_error(row_id, f"{type(e).__name__}: {e}")
-        raise
-    if fast is None:
-        _finish(row_id, status="failed", outcome="not_found")
-        return "not_found"
-    work_id, created = fast
+    # 2-4 all run attributed to the row's user (#100): enrich_fast's grounded/embed calls,
+    # the history/suggestion write, and the deep-enrichment enqueue all bill/attribute to
+    # this user. OUTSIDE our claim session — enrich_fast owns its own session/pool.
+    with as_user(data["user_id"]):
+        # 2. Resolve the work (de-dup, else shallow scouts).
+        try:
+            fast = two_phase.enrich_fast(data["title"], data["author"], data["fmt"])
+        except Exception as e:  # noqa: BLE001 - transient: record + re-raise so Cloud Tasks retries
+            _record_error(row_id, f"{type(e).__name__}: {e}")
+            raise
+        if fast is None:
+            _finish(row_id, status="failed", outcome="not_found")
+            return "not_found"
+        work_id, created = fast
 
-    # 3. Write to the routed destination.
-    try:
-        if data["destination"] == "history":
-            with as_user(data["user_id"]):
+        # 3. Write to the routed destination.
+        try:
+            if data["destination"] == "history":
                 event = two_phase.add_read_event(
                     work_id,
                     completed=data["completed"],
@@ -108,23 +110,23 @@ def process_import_row(row_id: UUID) -> str:
                     notes=data["notes"],
                     fmt=data["fmt"],
                 )
-            outcome = "duplicate" if event["already_logged"] else ("created" if created else "linked")
-        else:  # 'suggestion'. ('skip' rows are never enqueued — commit filters them — so they never reach here.)
-            shelf = data["shelf"]
-            context = f"imported:{shelf}" if shelf in ("to-read", "currently-reading") else "imported"
-            with db_manager.get_session() as session:
-                is_new = _upsert_suggestion(session, work_id=work_id, user_id=data["user_id"], context=context)
-            outcome = "created" if (is_new and created) else ("linked" if is_new else "duplicate")
-    except Exception as e:  # noqa: BLE001 - transient: record + re-raise for retry
-        _record_error(row_id, f"{type(e).__name__}: {e}")
-        raise
+                outcome = "duplicate" if event["already_logged"] else ("created" if created else "linked")
+            else:  # 'suggestion'. ('skip' rows are never enqueued — commit filters them — so they never reach here.)
+                shelf = data["shelf"]
+                context = f"imported:{shelf}" if shelf in ("to-read", "currently-reading") else "imported"
+                with db_manager.get_session() as session:
+                    is_new = _upsert_suggestion(session, work_id=work_id, user_id=data["user_id"], context=context)
+                outcome = "created" if (is_new and created) else ("linked" if is_new else "duplicate")
+        except Exception as e:  # noqa: BLE001 - transient: record + re-raise for retry
+            _record_error(row_id, f"{type(e).__name__}: {e}")
+            raise
 
-    # 4. Queue the deep pass only for newly-created works (best-effort).
-    if created:
-        try:
-            enqueue_enrichment(str(work_id))
-        except Exception:  # noqa: BLE001 - deep pass can be retried later; never fail the row
-            logger.exception("deep-enrichment enqueue failed for work %s", work_id)
+        # 4. Queue the deep pass only for newly-created works (best-effort).
+        if created:
+            try:
+                enqueue_enrichment(str(work_id), user_id=str(data["user_id"]))
+            except Exception:  # noqa: BLE001 - deep pass can be retried later; never fail the row
+                logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 
     _finish(row_id, status="done", outcome=outcome, work_id=work_id)
     return "done"

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -64,6 +64,17 @@ def _parse_uuid(value) -> UUID | None:
         return None
 
 
+def _current_user_id_or_none() -> str | None:
+    """Best-effort attribution for the deep-enrichment enqueue (#100): chat tools run inside
+    the turn's as_user(...) scope (chat/stream.py sets it around the driver; make_async_tool's
+    asyncio.to_thread copies contextvars), so the user is normally present here — but the
+    enqueue itself is best-effort by design, so a missing ambient user must never crash it."""
+    try:
+        return str(get_required_user_id())
+    except Exception:  # noqa: BLE001 - defensive: no ambient user is a valid state for this call
+        return None
+
+
 def _normalize_status(value, allowed: tuple[str, ...]) -> str | None:
     """Case-insensitively match an agent-supplied status to a canonical member of
     `allowed`; None if it matches nothing (SEC-002: strict enum, no coercion)."""
@@ -733,7 +744,7 @@ def add_book_to_history(
     enqueued = False
     if created:
         try:
-            enqueued = enqueue_enrichment(str(work_id))
+            enqueued = enqueue_enrichment(str(work_id), user_id=_current_user_id_or_none())
         except Exception:  # noqa: BLE001 - deep pass is best-effort
             logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 
@@ -977,7 +988,7 @@ def enrich_and_persist_work(title: str, author: str, format: str = "ebook") -> s
         work_id, created = resolved
         if created:
             try:
-                enqueue_enrichment(str(work_id))
+                enqueue_enrichment(str(work_id), user_id=_current_user_id_or_none())
             except Exception:  # noqa: BLE001 - deep pass is best-effort; fast data already persisted
                 logger.exception("deep-enrichment enqueue failed for work %s", work_id)
         return str(work_id)

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -112,7 +112,9 @@ class ClaudeGroundedLLM:
             if result_val and isinstance(result_val, str):
                 text = result_val
             usage = getattr(message, "usage", None)
-            if usage:
+            # isinstance guard matches agents/backends/claude.py: a non-dict usage on a
+            # non-Result message must not crash the scout path.
+            if isinstance(usage, dict):
                 record_llm_call(
                     "anthropic",
                     self.model,

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -11,6 +11,8 @@ from typing import Protocol, runtime_checkable
 
 from google import genai
 
+from agentic_librarian.core.tiers import grounding_model_name
+from agentic_librarian.core.usage import record_llm_call
 from agentic_librarian.llm_retry import genai_http_options
 
 
@@ -34,14 +36,28 @@ def _extract_text(response) -> str | None:
     return "".join(texts) if texts else None
 
 
+def _record_gemini_usage(model_name: str, response) -> None:
+    """Meter at the RESPONSE object (#100): the SDK's HTTP-level 429/5xx retry must not
+    double-count; scout-level retries are genuinely separate billable calls and each
+    records via its own response. record_llm_call never raises (warns + drops when no
+    user is in context, e.g. pre-#100 queued tasks)."""
+    um = getattr(response, "usage_metadata", None)
+    if um is None:
+        return
+    record_llm_call(
+        "gemini",
+        model_name,
+        int(getattr(um, "prompt_token_count", 0) or 0),
+        int(getattr(um, "candidates_token_count", 0) or 0),
+    )
+
+
 class GeminiGroundedLLM:
     """Grounded generation via Gemini's google_search tool — the prior scout behavior, relocated."""
 
     def __init__(self, api_key: str | None = None, model_name: str | None = None):
         self.api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
-        self.model_name = (
-            model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
-        )
+        self.model_name = model_name or grounding_model_name()
         self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
 
     def generate(self, prompt: str, grounded: bool = True) -> str:
@@ -51,6 +67,7 @@ class GeminiGroundedLLM:
             contents=prompt,
             config={"tools": [{"google_search": {}}] if use_grounding else []},
         )
+        _record_gemini_usage(self.model_name, response)
         return _extract_text(response) or ""
 
 
@@ -73,6 +90,9 @@ class ClaudeGroundedLLM:
             return asyncio.run(self._agenerate(prompt, grounded))
         # Called from within a running event loop (async test runner / framework): asyncio.run can't
         # run inside one, so offload to a worker thread that gets its own loop.
+        # Known limit, do not fix (#100): ThreadPoolExecutor does not propagate ContextVars, so
+        # usage metering warns+drops on this fallback path — it only runs under async test
+        # runners, never in the scout worker (which always drives the no-running-loop branch).
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
@@ -91,6 +111,14 @@ class ClaudeGroundedLLM:
             result_val = getattr(message, "result", None)
             if result_val and isinstance(result_val, str):
                 text = result_val
+            usage = getattr(message, "usage", None)
+            if usage:
+                record_llm_call(
+                    "anthropic",
+                    self.model,
+                    int(usage.get("input_tokens", 0) or 0),
+                    int(usage.get("output_tokens", 0) or 0),
+                )
         return text
 
 

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -6,6 +6,8 @@ from functools import lru_cache
 from google import genai
 from google.genai import types
 
+from agentic_librarian.core.usage import record_llm_call
+
 # Current GA Gemini embedding model — the single source of truth for the model name (managers
 # and the #123 warm-before-session callers all reference this instead of copying the string).
 EMBED_MODEL = "gemini-embedding-001"
@@ -82,4 +84,8 @@ def get_cached_embedding(model_name: str, text: str) -> list[float]:
     )
     if not response or not response.embeddings:
         raise ValueError(f"Embedding generation returned no result for text: {text!r}")
+    # #100: embed responses expose no token counts and lru_cache means only MISSES reach
+    # here — record per network call with a documented chars//4 estimate (visibility, not
+    # billing-grade; embeddings are $0.15/M).
+    record_llm_call("gemini", model_name, len(text) // 4, 0)
     return response.embeddings[0].values

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -324,17 +324,23 @@ def test_patch_date_collision_is_409_not_500(two_user_client, db_url):
 
 def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, monkeypatch):
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append((wid, fmt)) or True)
+    monkeypatch.setattr(
+        api_main,
+        "enqueue_edition_completion",
+        lambda wid, fmt, user_id=None: calls.append((wid, fmt, user_id)) or True,
+    )
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is True
-    assert len(calls) == 1 and calls[0][1] == "audiobook"
+    assert len(calls) == 1
+    assert calls[0][1] == "audiobook"
+    assert calls[0][2] == str(DEFAULT_USER_ID)  # attributed to the authenticated caller (#100)
 
 
 def test_patch_format_enqueue_failure_never_fails_the_edit(two_user_client, monkeypatch):
-    def _boom(wid, fmt):
+    def _boom(wid, fmt, user_id=None):
         raise RuntimeError("tasks down")
 
     monkeypatch.setattr(api_main, "enqueue_edition_completion", _boom)
@@ -356,7 +362,7 @@ def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_ur
         s.add(done)
         s.flush()
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt, user_id=None: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
@@ -367,7 +373,7 @@ def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_ur
 
 def test_patch_notes_only_never_enqueues(two_user_client, monkeypatch):
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt, user_id=None: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"notes": "just notes"})

--- a/test/integration/test_api_import_caps.py
+++ b/test/integration/test_api_import_caps.py
@@ -16,7 +16,7 @@ from agentic_librarian.api import imports as imports_mod
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
 from agentic_librarian.api.imports import router
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
-from agentic_librarian.db.models import ImportRow, User
+from agentic_librarian.db.models import ImportJob, ImportRow, User
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -72,12 +72,32 @@ def test_supporter_tier_same_file_passes(client, monkeypatch):
 
 
 def test_second_commit_while_first_still_pending_is_409(client):
+    """A RECENT in-flight job (created just now, by the commit above) blocks — the other
+    half of the #100 review fix's window invariant."""
     c, _manager = client
     first = _commit(c, 2)
     assert first.status_code == 200
     second = _commit(c, 2)
     assert second.status_code == 409
     assert second.json()["detail"]["code"] == "import_in_flight"
+
+
+def test_old_wedged_pending_row_does_not_block_a_new_commit(client):
+    """#100 review fix: an import-row task has no give-up retry bound and job-recovery UI
+    lives only in React state, so a row permanently wedged in 'pending'/'processing' must
+    not lock the user out of ever importing again. A job older than IN_FLIGHT_WINDOW no
+    longer counts as in-flight. #147 lesson: seed created_at explicitly, don't rely on
+    wall-clock proximity to a boundary."""
+    c, manager = client
+    stale = datetime.now(UTC) - timedelta(hours=25)  # older than the 24h IN_FLIGHT_WINDOW
+    with manager.get_session() as s:
+        job = ImportJob(user_id=DEFAULT_USER_ID, source="goodreads", total_rows=1, created_at=stale)
+        s.add(job)
+        s.flush()
+        s.add(ImportRow(import_job_id=job.id, user_id=DEFAULT_USER_ID, destination="history", status="pending"))
+
+    r = _commit(c, 2)
+    assert r.status_code == 200
 
 
 def test_commit_allowed_again_once_all_rows_reach_terminal_status(client):

--- a/test/integration/test_api_import_caps.py
+++ b/test/integration/test_api_import_caps.py
@@ -1,0 +1,94 @@
+"""#100: per-tier import row caps + the one-in-flight-import rule (api/imports.py commit),
+executed against a real Postgres (db_integration — CI-only, see test/conftest.py). The fast
+wiring-only checks (fake session, no real tier/DB behavior) live in
+test/unit/test_api_import_commit.py; this file proves the real tier resolution (including a
+future subscriber_until) and the real pending/processing-row join."""
+
+import io
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import imports as imports_mod
+from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.api.imports import router
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import ImportRow, User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+_MAPPING = {"title": "Title", "author": "Author", "date_completed": "Date Read", "shelf": "Exclusive Shelf"}
+
+
+@pytest.fixture()
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(imports_mod, "db_manager", manager)
+    # Never hit real Cloud Tasks; the enqueue call itself is covered in test_api_import_status.py.
+    monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda row_id: True)
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
+    return TestClient(app), manager
+
+
+def _csv(n_rows: int) -> bytes:
+    header = "Title,Author,Date Read,Exclusive Shelf\n"
+    body = "".join(f"Book {i},Author {i},2024/01/{(i % 27) + 1:02d},read\n" for i in range(n_rows))
+    return (header + body).encode()
+
+
+def _commit(c, n_rows):
+    return c.post(
+        "/api/import/commit",
+        files={"file": ("export.csv", io.BytesIO(_csv(n_rows)), "text/csv")},
+        data={"mapping": json.dumps(_MAPPING), "import_to_read": "false", "import_currently_reading": "false"},
+    )
+
+
+def test_free_tier_over_cap_is_413(client, monkeypatch):
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "5")
+    c, _manager = client
+    r = _commit(c, 6)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert "5" in body["message"]
+
+
+def test_supporter_tier_same_file_passes(client, monkeypatch):
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "5")
+    c, manager = client
+    with manager.get_session() as s:
+        user = s.get(User, DEFAULT_USER_ID)
+        user.subscriber_until = datetime.now(UTC) + timedelta(days=30)
+    r = _commit(c, 6)
+    assert r.status_code == 200
+    assert r.json()["total_rows"] == 6
+
+
+def test_second_commit_while_first_still_pending_is_409(client):
+    c, _manager = client
+    first = _commit(c, 2)
+    assert first.status_code == 200
+    second = _commit(c, 2)
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "import_in_flight"
+
+
+def test_commit_allowed_again_once_all_rows_reach_terminal_status(client):
+    c, manager = client
+    first = _commit(c, 2)
+    assert first.status_code == 200
+    job_id = first.json()["import_job_id"]
+    with manager.get_session() as s:
+        rows = s.query(ImportRow).filter(ImportRow.import_job_id == job_id).all()
+        for row in rows:
+            row.status = "done"
+
+    third = _commit(c, 2)
+    assert third.status_code == 200

--- a/test/integration/test_books_api.py
+++ b/test/integration/test_books_api.py
@@ -42,7 +42,11 @@ def _stub_fast(monkeypatch, result):
 
 def test_add_book_persists_logs_and_enqueues(client, monkeypatch):
     enqueued = []
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: enqueued.append(wid) or True)
+    monkeypatch.setattr(
+        books_mod,
+        "enqueue_enrichment",
+        lambda wid, user_id=None: enqueued.append((wid, user_id)) or True,
+    )
     _stub_fast(
         monkeypatch,
         {
@@ -63,11 +67,12 @@ def test_add_book_persists_logs_and_enqueues(client, monkeypatch):
     assert body["read_number"] == 1
     assert body["already_logged"] is False
     assert body["enrichment_enqueued"] is True
-    assert enqueued == [body["work_id"]]  # newly created → deep pass enqueued
+    # newly created → deep pass enqueued, attributed to the authenticated caller (#100)
+    assert enqueued == [(body["work_id"], str(DEFAULT_USER_ID))]
 
 
 def test_add_book_not_found_returns_404(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {})  # scouts find nothing
 
     resp = client.post("/api/books", json={"title": "Nope", "author": "Nobody"})
@@ -76,7 +81,7 @@ def test_add_book_not_found_returns_404(client, monkeypatch):
 
 def test_add_book_rereads_do_not_reenqueue(client, db_url, monkeypatch):
     calls = []
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: calls.append(wid) or True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: calls.append(wid) or True)
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
         work = Work(title="Dune")
@@ -100,7 +105,7 @@ def test_add_book_rereads_do_not_reenqueue(client, db_url, monkeypatch):
 
 
 def test_add_book_rejects_future_date(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     resp = client.post("/api/books", json={"title": "X", "author": "Y", "date_completed": tomorrow})
@@ -114,7 +119,7 @@ def test_add_book_rejects_blank_title(client):
 
 def test_add_book_is_user_scoped(client, db_url, monkeypatch):
     # The read-event lands on the authenticated user, not another.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     other = uuid4()
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
@@ -131,14 +136,14 @@ def test_add_book_is_user_scoped(client, db_url, monkeypatch):
 
 
 def test_add_book_rejects_boolean_rating(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
     resp = client.post("/api/books", json={"title": "X", "author": "Y", "rating": True})
     assert resp.status_code == 422
 
 
 def test_add_book_same_date_reports_already_logged(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(
         monkeypatch,
         {"title": "Solaris", "contributors": [{"name": "Stanislaw Lem", "role": "Author"}], "genres": [], "moods": []},
@@ -154,7 +159,7 @@ def test_add_book_same_date_reports_already_logged(client, monkeypatch):
 
 
 def test_add_book_survives_enqueue_failure(client, monkeypatch):
-    def _boom(wid):
+    def _boom(wid, user_id=None):
         raise RuntimeError("cloud tasks down")
 
     monkeypatch.setattr(books_mod, "enqueue_enrichment", _boom)
@@ -187,7 +192,7 @@ def _seed_picked_work(db_url, *, title, author, status="Suggested", user_id=DEFA
 
 def test_add_book_resolves_active_pick(client, db_url, monkeypatch):
     # GH #130 invariant: a book in your history is never simultaneously an active pick.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     work_id, sug_id = _seed_picked_work(db_url, title="The Fifth Season", author="N. K. Jemisin")
     _stub_fast(
         monkeypatch, {"title": "The Fifth Season", "contributors": [{"name": "N. K. Jemisin", "role": "Author"}]}
@@ -206,7 +211,7 @@ def test_add_book_resolves_active_pick(client, db_url, monkeypatch):
 
 
 def test_add_book_without_pick_reports_not_resolved(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "Piranesi", "contributors": [{"name": "Susanna Clarke", "role": "Author"}]})
 
     resp = client.post("/api/books", json={"title": "Piranesi", "author": "Susanna Clarke"})
@@ -217,7 +222,7 @@ def test_add_book_without_pick_reports_not_resolved(client, monkeypatch):
 def test_add_book_duplicate_still_resolves_pick(client, db_url, monkeypatch):
     # The already_logged early-return branch must ALSO resolve (re-adding a book
     # already in history still clears its stale pick).
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     work_id, sug_id = _seed_picked_work(db_url, title="Annihilation", author="Jeff VanderMeer")
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
@@ -243,7 +248,7 @@ def test_add_book_duplicate_still_resolves_pick(client, db_url, monkeypatch):
 
 def test_add_book_leaves_dismissed_pick_untouched(client, db_url, monkeypatch):
     # Resolution only touches 'Suggested' rows — it never rewrites resolved statuses.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _work_id, sug_id = _seed_picked_work(db_url, title="Uprooted", author="Naomi Novik", status="Dismissed")
     _stub_fast(monkeypatch, {"title": "Uprooted", "contributors": [{"name": "Naomi Novik", "role": "Author"}]})
 
@@ -256,7 +261,7 @@ def test_add_book_leaves_dismissed_pick_untouched(client, db_url, monkeypatch):
 
 
 def test_add_book_leaves_other_users_pick_untouched(client, db_url, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     other = uuid4()
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:

--- a/test/integration/test_budgets_db.py
+++ b/test/integration/test_budgets_db.py
@@ -1,0 +1,163 @@
+"""#100: budget counting queries + the effective_tier DB wrapper, executed against a
+real Postgres (db_integration — CI-only, see test/conftest.py). Rows are seeded with
+EXPLICIT, distinct created_at values (the #147 same-timestamp flake lesson)."""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+from agentic_librarian.core.user_context import DEFAULT_USER_ID
+from agentic_librarian.db.models import Conversation, Message, Usage, User, UserCredential
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+OTHER_USER = UUID("00000000-0000-4000-8000-0000000000ff")
+
+# Fixed at noon so it's always >= today's midnight regardless of the real wall-clock
+# time the suite happens to run at; _utc_day_start() has no upper bound, so a "today"
+# row need not be <= "now".
+_NOW = datetime.now(UTC)
+TODAY = _NOW.replace(hour=12, minute=0, second=0, microsecond=0)
+YESTERDAY = TODAY - timedelta(days=1)
+
+GROUNDING_MODEL = tiers.grounding_model_name()
+
+
+@pytest.fixture
+def budgets_db(db_url):
+    """Point the budgets module at the isolated test DB (test_usage_db.py pattern)."""
+    manager = DatabaseManager(db_url)
+    original = budgets.db_manager
+    budgets.set_db_manager(manager)
+    yield manager
+    budgets.set_db_manager(original)
+
+
+@pytest.mark.parametrize(
+    "role,owner,when,expected_count",
+    [
+        ("user", "self", "today", 1),
+        ("assistant", "self", "today", 0),
+        ("user", "self", "yesterday", 0),
+        ("user", "other", "today", 0),
+    ],
+    ids=[
+        "todays-user-message-counts",
+        "assistant-role-excluded",
+        "yesterdays-message-excluded",
+        "other-users-conversation-excluded",
+    ],
+)
+def test_chat_turns_today(budgets_db, role, owner, when, expected_count):
+    user_id = OTHER_USER if owner == "other" else DEFAULT_USER_ID
+    created_at = TODAY if when == "today" else YESTERDAY
+    with budgets_db.get_session() as session:
+        if owner == "other":
+            session.merge(User(id=OTHER_USER, email="other@example.com"))
+        convo = Conversation(user_id=user_id)
+        session.add(convo)
+        session.flush()
+        session.add(Message(conversation_id=convo.id, role=role, content="x", created_at=created_at))
+
+    with budgets_db.get_session() as session:
+        count = budgets.chat_turns_today(session, DEFAULT_USER_ID)
+    assert count == expected_count
+
+
+@pytest.mark.parametrize(
+    "model,key_source,when,expected_count",
+    [
+        (GROUNDING_MODEL, "app", "today", 1),
+        ("some-other-model", "app", "today", 0),
+        (GROUNDING_MODEL, "byok", "today", 0),
+        (GROUNDING_MODEL, "app", "yesterday", 0),
+    ],
+    ids=["matching-row-counts", "wrong-model-excluded", "byok-key-source-excluded", "yesterdays-row-excluded"],
+)
+def test_grounded_calls_today_filters(budgets_db, model, key_source, when, expected_count):
+    created_at = TODAY if when == "today" else YESTERDAY
+    with budgets_db.get_session() as session:
+        session.add(
+            Usage(
+                user_id=DEFAULT_USER_ID,
+                key_source=key_source,
+                vendor="gemini",
+                model=model,
+                input_tokens=1,
+                output_tokens=1,
+                created_at=created_at,
+            )
+        )
+
+    with budgets_db.get_session() as session:
+        count = budgets.grounded_calls_today(session, DEFAULT_USER_ID)
+    assert count == expected_count
+
+
+def test_grounded_calls_today_per_user_vs_global(budgets_db):
+    """user_id=None is the global governor — it must see BOTH users' rows; a specific
+    user_id must see only that user's."""
+    with budgets_db.get_session() as session:
+        session.merge(User(id=OTHER_USER, email="other@example.com"))
+        session.add_all(
+            [
+                Usage(
+                    user_id=DEFAULT_USER_ID,
+                    key_source="app",
+                    vendor="gemini",
+                    model=GROUNDING_MODEL,
+                    input_tokens=1,
+                    output_tokens=1,
+                    created_at=TODAY,
+                ),
+                Usage(
+                    user_id=OTHER_USER,
+                    key_source="app",
+                    vendor="gemini",
+                    model=GROUNDING_MODEL,
+                    input_tokens=1,
+                    output_tokens=1,
+                    created_at=TODAY + timedelta(minutes=1),
+                ),
+            ]
+        )
+
+    with budgets_db.get_session() as session:
+        mine = budgets.grounded_calls_today(session, DEFAULT_USER_ID)
+        theirs = budgets.grounded_calls_today(session, OTHER_USER)
+        everyone = budgets.grounded_calls_today(session, None)
+    assert mine == 1
+    assert theirs == 1
+    assert everyone == 2
+
+
+@pytest.mark.parametrize(
+    "days_from_now,has_cred,expected",
+    [
+        (None, False, "free"),
+        (30, False, "supporter"),
+        (None, True, "byok"),
+    ],
+    ids=["plain-user-is-free", "future-subscriber-until-is-supporter", "gemini-credential-is-byok"],
+)
+def test_effective_tier_db_wrapper(budgets_db, days_from_now, has_cred, expected):
+    subscriber_until = TODAY + timedelta(days=days_from_now) if days_from_now is not None else None
+    with budgets_db.get_session() as session:
+        user = session.get(User, DEFAULT_USER_ID)
+        user.subscriber_until = subscriber_until
+        if has_cred:
+            session.add(
+                UserCredential(
+                    user_id=DEFAULT_USER_ID,
+                    vendor="gemini",
+                    encrypted_key=b"ciphertext",
+                    kms_key_name="projects/test/keyRings/test/cryptoKeys/test",
+                )
+            )
+
+    with budgets_db.get_session() as session:
+        tier = tiers.effective_tier(session, DEFAULT_USER_ID)
+    assert tier == expected

--- a/test/integration/test_budgets_db.py
+++ b/test/integration/test_budgets_db.py
@@ -57,6 +57,7 @@ def test_chat_turns_today(budgets_db, role, owner, when, expected_count):
     with budgets_db.get_session() as session:
         if owner == "other":
             session.merge(User(id=OTHER_USER, email="other@example.com"))
+            session.flush()  # OTHER_USER's row must exist before the FK-referencing insert below
         convo = Conversation(user_id=user_id)
         session.add(convo)
         session.flush()
@@ -102,6 +103,7 @@ def test_grounded_calls_today_per_user_vs_global(budgets_db):
     user_id must see only that user's."""
     with budgets_db.get_session() as session:
         session.merge(User(id=OTHER_USER, email="other@example.com"))
+        session.flush()  # OTHER_USER's row must exist before the FK-referencing Usage rows below
         session.add_all(
             [
                 Usage(

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -1,11 +1,15 @@
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 
 from agentic_librarian.api import auth
 from agentic_librarian.api import main as api_main
 from agentic_librarian.chat import transcript
+from agentic_librarian.core import budgets
 from agentic_librarian.core import usage as usage_mod
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import Conversation, Message
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -17,6 +21,7 @@ def client(db_url, monkeypatch):
     monkeypatch.setattr(api_main, "db_manager", manager)
     monkeypatch.setattr(transcript, "db_manager", manager)  # chat endpoints use the store's manager
     monkeypatch.setattr(usage_mod, "db_manager", manager)  # usage recorder writes to the test DB
+    monkeypatch.setattr(budgets, "db_manager", manager)  # chat quota check reads the store's manager
     # Endpoints wrap store calls in as_user(user.id), so a plain user object suffices.
     monkeypatch.setitem(
         api_main.app.dependency_overrides,
@@ -104,3 +109,39 @@ def test_conversations_current_payload_is_capped(client, monkeypatch):
     messages = resp.json()["messages"]
     assert len(messages) == 3
     assert [m["content"] for m in messages] == ["m3", "m4", "m5"]
+
+
+def test_chat_message_over_length_returns_422(client, monkeypatch):
+    # #100: cheap-string cap check — no need for a real 4000-char default here.
+    monkeypatch.setenv("CHAT_MESSAGE_MAX_CHARS", "50")
+    resp = client.post("/api/chat", json={"message": "x" * 51})
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "message_too_long"
+
+
+@pytest.mark.parametrize(
+    "seeded_today,expect_quota_blocked",
+    [
+        pytest.param(2, True, id="at_daily_limit_blocked"),
+        pytest.param(1, False, id="under_daily_limit_allowed"),
+    ],
+)
+def test_chat_quota_enforced_at_daily_limit(client, db_url, monkeypatch, seeded_today, expect_quota_blocked):
+    # #100 / #147 lesson: seed with an explicit, real "today" created_at rather than
+    # relying on the row default (avoids the same-timestamp/tie-break flake).
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", "2")
+    today = datetime.now(UTC)
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        convo = Conversation(user_id=DEFAULT_USER_ID)
+        session.add(convo)
+        session.flush()
+        for i in range(seeded_today):
+            session.add(Message(conversation_id=convo.id, role="user", content=f"seed-{i}", created_at=today))
+
+    resp = client.post("/api/chat", json={"message": "one more, please"})
+    if expect_quota_blocked:
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "chat_quota"
+    else:
+        assert resp.status_code != 429

--- a/test/integration/test_import_worker.py
+++ b/test/integration/test_import_worker.py
@@ -29,7 +29,7 @@ def wired(db_url, monkeypatch):
     monkeypatch.setattr(worker, "db_manager", manager)
     two_phase.set_db_manager(manager)
     # Never enqueue real Cloud Tasks from the worker in tests.
-    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id: True)
+    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id, user_id=None: True)
     return manager
 
 
@@ -84,14 +84,21 @@ def test_dedup_links_existing_catalog_work_without_scouts(wired, monkeypatch):
 def test_miss_creates_work_and_enqueues_deep(wired, monkeypatch):
     # Fake the fast scouts so a miss resolves to a created Work deterministically.
     monkeypatch.setattr(two_phase, "enrich_fast", lambda t, a, f="ebook": (_seed_work(wired, t, a), True))
-    enq = {"n": 0}
-    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id: enq.__setitem__("n", enq["n"] + 1) or True)
+    enq = {"n": 0, "user_id": None}
+
+    def _fake_enqueue(work_id, user_id=None):
+        enq["n"] += 1
+        enq["user_id"] = user_id
+        return True
+
+    monkeypatch.setattr(worker, "enqueue_enrichment", _fake_enqueue)
     row_id = _make_row(wired, raw_title="New Title", raw_author="New Author")
 
     assert worker.process_import_row(row_id) == "done"
     with wired.get_session() as s:
         assert s.get(ImportRow, row_id).outcome == "created"
     assert enq["n"] == 1
+    assert enq["user_id"] == str(DEFAULT_USER_ID)  # attributed to the row's user (#100)
 
 
 def test_not_found_marks_failed_and_does_not_retry(wired, monkeypatch):

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.core.user_context import current_user_id, get_required_user_id
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -88,7 +88,15 @@ def test_valid_queue_token_without_user_id_completion_unattributed(client, monke
 
     monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
     wid = uuid4()
-    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    # Neutralize the autouse _default_user_context fixture's ambient DEFAULT_USER_ID for
+    # this request only. TestClient copies the current contextvars into the ASGI call, so
+    # without this the probe would see an ambient user and never observe the "no user in
+    # context" path a real requeue-sweep task (no ?user_id=) actually exercises in prod.
+    token = current_user_id.set(None)
+    try:
+        resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    finally:
+        current_user_id.reset(token)
     assert resp.status_code == 200
     assert seen["raised"] is True
 

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -4,6 +4,7 @@ Mirrors test_internal_enrich_api.py: db_integration because the FastAPI app impo
 chain needs real settings, but complete_edition itself is monkeypatched — the pass's
 own behavior is covered by test/unit/test_edition_completion.py."""
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -12,6 +13,7 @@ from fastapi.testclient import TestClient
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
 from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
 
@@ -21,6 +23,9 @@ QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
 
 @pytest.fixture
 def client(db_url, monkeypatch):
+    # #100: point the budget gate at the isolated test DB, same reasoning as
+    # test_internal_enrich_api.py's client fixture.
+    monkeypatch.setattr(internal_mod.budgets, "db_manager", DatabaseManager(db_url))
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
@@ -119,3 +124,88 @@ def test_missing_format_param_is_422(client, monkeypatch):
     _as_queue(monkeypatch)
     resp = client.post(f"/internal/complete-edition/{uuid4()}", headers={"Authorization": "Bearer ok"})
     assert resp.status_code == 422
+
+
+def test_over_budget_defers_with_new_scheduled_task_and_never_calls_complete_edition(client, monkeypatch):
+    """#100: mirrors test_internal_enrich_api.py's deferral tests for the completion pass."""
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_complete = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase,
+        "complete_edition",
+        lambda wid, fmt: ran_complete.__setitem__("called", True) or "done",
+    )
+    calls = []
+
+    def fake_enqueue(wid, fmt, user_id=None, schedule_time=None):
+        calls.append((wid, fmt, user_id, schedule_time))
+        return True
+
+    monkeypatch.setattr(internal_mod, "enqueue_edition_completion", fake_enqueue)
+
+    wid = uuid4()
+    caller_id = uuid4()
+    before = datetime.now(UTC)
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={caller_id}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["work_id"] == str(wid)
+    assert body["format"] == "audiobook"
+    assert body["status"] == "deferred"
+    assert "until" in body
+    assert ran_complete["called"] is False
+    assert len(calls) == 1
+    call_wid, call_fmt, call_uid, when = calls[0]
+    assert call_wid == str(wid)
+    assert call_fmt == "audiobook"
+    assert call_uid == str(caller_id)
+    assert when > before
+
+
+def test_under_budget_runs_the_normal_completion_path_unchanged(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (True, ""))
+    called = {}
+
+    def fake_complete(wid, fmt):
+        called["args"] = (wid, fmt)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert called["args"] == (wid, "audiobook")
+
+
+def test_over_budget_and_enqueue_returns_false_is_deferred_enqueue_failed(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+    monkeypatch.setattr(
+        internal_mod, "enqueue_edition_completion", lambda wid, fmt, user_id=None, schedule_time=None: False
+    )
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "ebook", "status": "deferred_enqueue_failed"}
+
+
+def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+
+    def _boom(wid, fmt, user_id=None, schedule_time=None):
+        raise RuntimeError("cloud tasks unavailable")
+
+    monkeypatch.setattr(internal_mod, "enqueue_edition_completion", _boom)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "ebook", "status": "deferred_enqueue_failed"}

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import get_required_user_id
 
 pytestmark = pytest.mark.db_integration
 
@@ -45,6 +46,46 @@ def test_valid_queue_token_runs_completion(client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
     assert called["args"] == (wid, "audiobook")
+
+
+def test_valid_queue_token_with_user_id_attributes_completion(client, monkeypatch):
+    """#100: ?user_id=<uuid> attributes the completion pass's LLM usage to the requester."""
+    _as_queue(monkeypatch)
+    seen = {}
+
+    def fake_complete(wid, fmt):
+        seen["user_id"] = get_required_user_id()
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    caller_id = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={caller_id}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert seen["user_id"] == caller_id
+
+
+def test_valid_queue_token_without_user_id_completion_unattributed(client, monkeypatch):
+    """Back-compat: no user_id -> no user in context, and the pass still succeeds."""
+    _as_queue(monkeypatch)
+    seen = {}
+
+    def fake_complete(wid, fmt):
+        seen["raised"] = False
+        try:
+            get_required_user_id()
+        except RuntimeError:
+            seen["raised"] = True
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert seen["raised"] is True
 
 
 def test_missing_work_is_404_non_retryable(client, monkeypatch):

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -20,6 +21,10 @@ QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
 def client(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(two_phase, "db_manager", manager)
+    # #100: point the budget gate at the isolated test DB too, so enrichment_allowed's
+    # global-governor query sees the empty test Usage table (allowed) rather than
+    # whatever DATABASE_URL a fail-open real connection would otherwise hit.
+    monkeypatch.setattr(internal_mod.budgets, "db_manager", manager)
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
@@ -251,3 +256,95 @@ def test_unconfigured_audience_is_forbidden(client, monkeypatch):
     )
     resp = client.post(f"/internal/enrich/{uuid4()}", headers={"Authorization": "Bearer x"})
     assert resp.status_code == 403
+
+
+def _as_queue(monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+
+
+def test_over_budget_defers_with_new_scheduled_task_and_never_calls_enrich_deep(client, db_url, monkeypatch):
+    """#100: over budget -> 200 'deferred', a NEW task is enqueued with schedule_time strictly
+    after now (so the #97 give-up retry count never sees this attempt), and the paid deep pass
+    itself must NOT run."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_enrich_deep = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase, "enrich_deep", lambda wid: ran_enrich_deep.__setitem__("called", True) or "done"
+    )
+    calls = []
+
+    def fake_enqueue(wid, user_id=None, schedule_time=None):
+        calls.append((wid, user_id, schedule_time))
+        return True
+
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", fake_enqueue)
+
+    caller_id = uuid4()
+    before = datetime.now(UTC)
+    resp = client.post(f"/internal/enrich/{work_id}?user_id={caller_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "deferred"
+    assert body["work_id"] == str(work_id)
+    assert ran_enrich_deep["called"] is False
+    assert len(calls) == 1
+    wid, uid, when = calls[0]
+    assert wid == str(work_id)
+    assert uid == str(caller_id)
+    assert when > before
+
+
+def test_under_budget_runs_the_normal_enrich_path_unchanged(client, db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (True, ""))
+    called = {}
+
+    def _fake_enrich_deep(wid):
+        called["wid"] = wid
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
+    assert str(called["wid"]) == str(work_id)
+
+
+def test_over_budget_and_enqueue_returns_false_is_deferred_enqueue_failed(client, db_url, monkeypatch):
+    """No retry storm: a failed re-enqueue must not raise/503 — the requeue sweep is the backstop."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "per-user grounded budget reached (tier free)")
+    )
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", lambda wid, user_id=None, schedule_time=None: False)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+
+
+def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, db_url, monkeypatch):
+    """The re-enqueue is best-effort — an exception (e.g. Cloud Tasks outage) must be caught,
+    not propagate as a 500."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+
+    def _boom(wid, user_id=None, schedule_time=None):
+        raise RuntimeError("cloud tasks unavailable")
+
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", _boom)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "deferred_enqueue_failed"}

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.core.user_context import current_user_id, get_required_user_id
 from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
@@ -114,7 +114,15 @@ def test_valid_queue_token_without_user_id_runs_deep_enrich_unattributed(client,
 
     monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
 
-    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    # Neutralize the autouse _default_user_context fixture's ambient DEFAULT_USER_ID for
+    # this request only. TestClient copies the current contextvars into the ASGI call, so
+    # without this the probe would see an ambient user and never observe the "no user in
+    # context" path a real requeue-sweep task (no ?user_id=) actually exercises in prod.
+    token = current_user_id.set(None)
+    try:
+        resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    finally:
+        current_user_id.reset(token)
     assert resp.status_code == 200
     assert seen["raised"] is True  # no user in context, exactly as before #100
 

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
@@ -63,6 +64,54 @@ def test_valid_queue_token_runs_deep_enrich(client, db_url, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
     assert str(called["wid"]) == str(work_id)
+
+
+def test_valid_queue_token_with_user_id_runs_deep_enrich_attributed(client, db_url, monkeypatch):
+    """#100: the queue may pass ?user_id=<uuid> so the deep pass's LLM usage bills the
+    requesting user. as_user(...) wraps the call, so get_required_user_id() resolves inside
+    enrich_deep — this is the probe (patched at the handler's call site, per house pattern)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    seen = {}
+
+    def _fake_enrich_deep(wid):
+        seen["user_id"] = get_required_user_id()
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+    caller_id = uuid4()
+
+    resp = client.post(f"/internal/enrich/{work_id}?user_id={caller_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert seen["user_id"] == caller_id
+
+
+def test_valid_queue_token_without_user_id_runs_deep_enrich_unattributed(client, db_url, monkeypatch):
+    """Back-compat guarantee: pre-#100 (or requeue-sweep) tasks carry no user_id and must
+    still succeed, with no user identity in context (metering skips, nothing crashes)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    seen = {}
+
+    def _fake_enrich_deep(wid):
+        seen["raised"] = False
+        try:
+            get_required_user_id()
+        except RuntimeError:
+            seen["raised"] = True
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert seen["raised"] is True  # no user in context, exactly as before #100
 
 
 def test_missing_token_is_rejected(client):

--- a/test/unit/test_api_import_commit.py
+++ b/test/unit/test_api_import_commit.py
@@ -32,14 +32,42 @@ _GOODREADS_MAP = {
 }
 
 
+class _NullQuery:
+    """Chainable no-op ORM query stub. `.first()` returns whatever `result` was configured
+    with — the commit-cap unit tests only need to control that one value; the real
+    join/filter correctness is proven against Postgres in test_api_import_caps.py."""
+
+    def __init__(self, result=None):
+        self._result = result
+
+    def join(self, *a, **k):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._result
+
+
 class _Recorder:
-    def __init__(self):
+    def __init__(self, in_flight=None):
         self.jobs = []
         self.rows = []
+        # Configurable first()-result for any session.query(...) call made inside commit
+        # (the #100 in-flight check; effective_tier's own UserCredential query is bypassed
+        # in tests that need this by monkeypatching tiers.effective_tier directly instead).
+        self.in_flight = in_flight
 
     def add(self, obj):
         name = type(obj).__name__
         (self.jobs if name == "ImportJob" else self.rows).append(obj)
+
+    def get(self, model, obj_id):
+        return None  # no User row -> tiers.effective_tier resolves 'free' (subscriber_until None)
+
+    def query(self, *entities):
+        return _NullQuery(self.in_flight)
 
     def __enter__(self):
         return self
@@ -66,8 +94,8 @@ def _fake_manager(rec):
     return _M()
 
 
-def _commit(monkeypatch, *, to_read=True):
-    rec = _Recorder()
+def _commit(monkeypatch, *, to_read=True, in_flight=None):
+    rec = _Recorder(in_flight=in_flight)
     monkeypatch.setattr(imports_mod, "db_manager", _fake_manager(rec))
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda row_id: enq.append(row_id) or True)
@@ -109,3 +137,26 @@ def test_commit_422_when_required_mapping_missing(monkeypatch):
         data={"mapping": json.dumps(bad), "import_to_read": "true", "import_currently_reading": "true"},
     )
     assert r.status_code == 422
+
+
+def test_commit_413_when_over_tier_row_limit(monkeypatch):
+    """#100: wiring check only — the real free/supporter/DB-driven cap resolution is
+    covered end-to-end against Postgres in test_api_import_caps.py."""
+    monkeypatch.setattr(imports_mod.tiers, "import_max_rows", lambda tier: 1)
+    r, rec, enq = _commit(monkeypatch)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert rec.jobs == []  # rejected before anything was written
+    assert enq == []
+
+
+def test_commit_409_when_import_already_in_flight(monkeypatch):
+    """#100: wiring check only — real pending/processing-row detection against Postgres is
+    covered in test_api_import_caps.py."""
+    monkeypatch.setattr(imports_mod.tiers, "effective_tier", lambda session, user_id: "free")
+    r, rec, enq = _commit(monkeypatch, in_flight="some-row-id")
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "import_in_flight"
+    assert rec.jobs == []
+    assert enq == []

--- a/test/unit/test_api_import_commit.py
+++ b/test/unit/test_api_import_commit.py
@@ -141,13 +141,34 @@ def test_commit_422_when_required_mapping_missing(monkeypatch):
 
 def test_commit_413_when_over_tier_row_limit(monkeypatch):
     """#100: wiring check only — the real free/supporter/DB-driven cap resolution is
-    covered end-to-end against Postgres in test_api_import_caps.py."""
-    monkeypatch.setattr(imports_mod.tiers, "import_max_rows", lambda tier: 1)
+    covered end-to-end against Postgres in test_api_import_caps.py. Uses the real env
+    knob (not a stubbed tiers.import_max_rows) so the message's interpolated numbers stay
+    honest: the free limit shown must be the small override, and the supporter upsell
+    figure must be the real (untouched) env-tunable ceiling — not hardcoded text (#100
+    review fix)."""
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "1")
     r, rec, enq = _commit(monkeypatch)
     assert r.status_code == 413
     body = r.json()["detail"]
     assert body["code"] == "import_rows_limit"
+    assert "your current limit is 1" in body["message"]
+    assert "support Shelfwright for the full 2,000-row limit" in body["message"]
     assert rec.jobs == []  # rejected before anything was written
+    assert enq == []
+
+
+def test_commit_413_over_supporter_cap_has_no_upsell_pitch(monkeypatch):
+    """#100 review fix: a supporter already at their own ceiling shouldn't be told to
+    'support Shelfwright' for a limit they already have."""
+    monkeypatch.setattr(imports_mod.tiers, "effective_tier", lambda session, user_id: "supporter")
+    monkeypatch.setenv("IMPORT_MAX_ROWS_SUPPORTER", "1")
+    r, rec, enq = _commit(monkeypatch)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert "your current limit is 1" in body["message"]
+    assert "support Shelfwright" not in body["message"]
+    assert rec.jobs == []
     assert enq == []
 
 

--- a/test/unit/test_budgets_allowed.py
+++ b/test/unit/test_budgets_allowed.py
@@ -1,0 +1,136 @@
+"""DB-free unit tests for the two fail-open budget wrappers in core/budgets.py —
+chat_turn_allowed and enrichment_allowed (#100 Task 1 review carry-forward). No Postgres:
+the limit-reached/under-limit branches use a db_manager stub whose get_session() yields a
+sentinel (never queried directly — the counting/tier functions that would touch it are
+monkeypatched), and the fail-open branch points db_manager at an unreachable host
+(mirrors test/unit/test_usage_recorder.py)."""
+
+import logging
+from contextlib import contextmanager
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+from agentic_librarian.db.session import DatabaseManager
+
+
+class _StubManager:
+    """A db_manager stand-in that never touches a real database — get_session() yields a
+    sentinel object. Only safe when every function that would query the session is
+    monkeypatched out by the test."""
+
+    @contextmanager
+    def get_session(self):
+        yield object()
+
+
+@pytest.fixture
+def stub_db_manager():
+    """Point budgets.db_manager at the DB-free stub, restoring the real one after."""
+    original = budgets.db_manager
+    budgets.set_db_manager(_StubManager())
+    yield
+    budgets.set_db_manager(original)
+
+
+@pytest.fixture
+def unreachable_db_manager():
+    """Point budgets.db_manager at a host that can never resolve, restoring after."""
+    original = budgets.db_manager
+    budgets.set_db_manager(DatabaseManager("postgresql://x:x@nohost-never-resolves:1/x"))
+    yield
+    budgets.set_db_manager(original)
+
+
+@pytest.mark.parametrize(
+    "used,limit,expect_allowed",
+    [
+        pytest.param(0, 2, True, id="under_limit"),
+        pytest.param(1, 2, True, id="just_under_limit"),
+        pytest.param(2, 2, False, id="at_limit"),
+        pytest.param(5, 2, False, id="over_limit"),
+    ],
+)
+def test_chat_turn_allowed_limit_branches(monkeypatch, stub_db_manager, used, limit, expect_allowed):
+    monkeypatch.setattr(tiers, "effective_tier", lambda session, user_id: "free")
+    monkeypatch.setattr(tiers, "chat_turns_per_day", lambda tier: limit)
+    monkeypatch.setattr(budgets, "chat_turns_today", lambda session, user_id: used)
+
+    allowed, message = budgets.chat_turn_allowed(uuid4())
+
+    assert allowed is expect_allowed
+    if expect_allowed:
+        assert message == ""
+    else:
+        assert str(limit) in message
+
+
+def test_chat_turn_allowed_fails_open_on_db_error(caplog, unreachable_db_manager):
+    with caplog.at_level(logging.WARNING):
+        allowed, message = budgets.chat_turn_allowed(uuid4())
+    assert allowed is True
+    assert message == ""
+    assert "chat budget check failed open" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "global_used,global_limit,user_used,user_limit,expect_allowed,message_contains",
+    [
+        pytest.param(0, 100, 0, 5, True, None, id="under_both_budgets"),
+        pytest.param(0, 100, 4, 5, True, None, id="under_per_user_budget"),
+        pytest.param(100, 100, 0, 5, False, "governor", id="global_governor_reached"),
+        pytest.param(0, 100, 5, 5, False, "tier", id="per_user_budget_reached"),
+    ],
+)
+def test_enrichment_allowed_limit_branches(
+    monkeypatch,
+    stub_db_manager,
+    global_used,
+    global_limit,
+    user_used,
+    user_limit,
+    expect_allowed,
+    message_contains,
+):
+    monkeypatch.setattr(tiers, "grounded_calls_per_day_global", lambda: global_limit)
+    monkeypatch.setattr(tiers, "grounded_calls_per_day", lambda tier: user_limit)
+    monkeypatch.setattr(tiers, "effective_tier", lambda session, user_id: "free")
+
+    def _fake_grounded_calls_today(session, user_id):
+        return global_used if user_id is None else user_used
+
+    monkeypatch.setattr(budgets, "grounded_calls_today", _fake_grounded_calls_today)
+
+    allowed, message = budgets.enrichment_allowed(uuid4())
+
+    assert allowed is expect_allowed
+    if expect_allowed:
+        assert message == ""
+    else:
+        assert message_contains in message
+
+
+def test_enrichment_allowed_under_limit_with_no_user_checks_only_governor(monkeypatch, stub_db_manager):
+    """user_id=None (pre-attribution tasks) must check only the global governor — the
+    per-user branch is never reached (tier lookup would need a real user row)."""
+    monkeypatch.setattr(tiers, "grounded_calls_per_day_global", lambda: 100)
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("per-user tier lookup must not run when user_id is None")
+
+    monkeypatch.setattr(tiers, "effective_tier", _fail_if_called)
+    monkeypatch.setattr(budgets, "grounded_calls_today", lambda session, user_id: 0)
+
+    allowed, message = budgets.enrichment_allowed(None)
+
+    assert allowed is True
+    assert message == ""
+
+
+def test_enrichment_allowed_fails_open_on_db_error(caplog, unreachable_db_manager):
+    with caplog.at_level(logging.WARNING):
+        allowed, message = budgets.enrichment_allowed(uuid4())
+    assert allowed is True
+    assert message == ""
+    assert "enrichment budget check failed open" in caplog.text

--- a/test/unit/test_chat_enrich_reroute.py
+++ b/test/unit/test_chat_enrich_reroute.py
@@ -4,10 +4,14 @@ pass; the user-facing message says the Librarian is still investigating."""
 import uuid
 from unittest.mock import patch
 
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user
 from agentic_librarian.mcp import server as mcp_server
 
 
 def test_enrich_tool_routes_through_two_phase_and_enqueues():
+    # test/conftest.py's autouse _default_user_context fixture puts every test in
+    # as_user(DEFAULT_USER_ID) unless overridden -> that's the ambient attribution here
+    # (see test_enrich_tool_enqueue_attributed_to_ambient_user below for an explicit user).
     wid = uuid.uuid4()
     with (
         patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)) as fast,
@@ -16,7 +20,24 @@ def test_enrich_tool_routes_through_two_phase_and_enqueues():
         result = mcp_server.enrich_and_persist_work(title="Dune", author="Frank Herbert")
     assert result == str(wid)
     fast.assert_called_once()
-    enq.assert_called_once_with(str(wid))
+    enq.assert_called_once_with(str(wid), user_id=str(DEFAULT_USER_ID))
+
+
+def test_enrich_tool_enqueue_attributed_to_ambient_user():
+    """#100: enrich_and_persist_work is a chat tool that runs inside the turn's
+    as_user(...) scope (chat/stream.py sets it around the driver; make_async_tool's
+    asyncio.to_thread copies contextvars) — the deep-enrichment enqueue must carry that
+    user's id so the eventual /internal/enrich metering bills the requester, not nobody."""
+    wid = uuid.uuid4()
+    uid = uuid.uuid4()
+    with (
+        patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)),
+        patch.object(mcp_server, "enqueue_enrichment", return_value=True) as enq,
+        as_user(uid),
+    ):
+        result = mcp_server.enrich_and_persist_work(title="Dune", author="Frank Herbert")
+    assert result == str(wid)
+    enq.assert_called_once_with(str(wid), user_id=str(uid))
 
 
 def test_enrich_tool_dedup_hit_does_not_reenqueue():
@@ -59,6 +80,21 @@ def test_add_book_enqueue_failure_omits_background_note(monkeypatch):
         msg = mcp_server.add_book_to_history(title="Dune", author="Frank Herbert")
     assert "background" not in msg.lower()
     assert "Added" in msg
+
+
+def test_add_book_enqueue_attributed_to_ambient_user():
+    """#100: same attribution guarantee as enrich_and_persist_work, for the other
+    enqueue_enrichment call site (add_book_to_history)."""
+    wid = uuid.uuid4()
+    uid = uuid.uuid4()
+    with (
+        patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)),
+        patch.object(mcp_server, "enqueue_enrichment", return_value=True) as enq,
+        patch.object(mcp_server.two_phase, "add_read_event", return_value={"read_number": 1, "already_logged": False}),
+        as_user(uid),
+    ):
+        mcp_server.add_book_to_history(title="Dune", author="Frank Herbert")
+    enq.assert_called_once_with(str(wid), user_id=str(uid))
 
 
 def test_add_book_existing_work_has_no_background_note(monkeypatch):

--- a/test/unit/test_db_pool_consolidation.py
+++ b/test/unit/test_db_pool_consolidation.py
@@ -9,6 +9,7 @@ from agentic_librarian.api import auth as auth_mod
 from agentic_librarian.api import main as main_mod
 from agentic_librarian.api import recommendations as recommendations_mod
 from agentic_librarian.chat import transcript as transcript_mod
+from agentic_librarian.core import budgets as budgets_mod
 from agentic_librarian.core import usage as usage_mod
 
 
@@ -22,6 +23,7 @@ def _restore_db_managers():
         usage_mod.db_manager,
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
+        budgets_mod.db_manager,
     )
     yield
     (
@@ -31,6 +33,7 @@ def _restore_db_managers():
         usage_mod.db_manager,
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
+        budgets_mod.db_manager,
     ) = saved
 
 
@@ -45,3 +48,4 @@ def test_startup_consolidates_api_pools(_restore_db_managers):
         assert usage_mod.db_manager is shared
         assert recommendations_mod.db_manager is shared
         assert analysis_mod.db_manager is shared
+        assert budgets_mod.db_manager is shared

--- a/test/unit/test_enqueue_enrichment.py
+++ b/test/unit/test_enqueue_enrichment.py
@@ -1,3 +1,7 @@
+from datetime import UTC, datetime
+
+import pytest
+
 from agentic_librarian.enrichment import tasks
 
 
@@ -68,3 +72,91 @@ def test_enqueue_edition_completion_skips_when_not_configured(monkeypatch):
 
     assert tasks.enqueue_edition_completion("abc", "audiobook") is False
     assert called["n"] == 0
+
+
+@pytest.mark.parametrize(
+    "user_id,expected_url",
+    [
+        (
+            "22222222-2222-4222-8222-222222222222",
+            "https://librarian.example.run.app/internal/enrich/"
+            "11111111-1111-4111-8111-111111111111?user_id=22222222-2222-4222-8222-222222222222",
+        ),
+        (None, "https://librarian.example.run.app/internal/enrich/11111111-1111-4111-8111-111111111111"),
+    ],
+)
+def test_enqueue_enrichment_appends_user_id_query_when_given(monkeypatch, user_id, expected_url):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert tasks.enqueue_enrichment("11111111-1111-4111-8111-111111111111", user_id=user_id) is True
+
+    _parent, task = fake.created[0]
+    http = task["http_request"]
+    assert http["url"] == expected_url
+    # Audience is the bare path url regardless of user_id — a per-user audience would never
+    # match the receiver's single fixed ENRICH_OIDC_AUDIENCE.
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/enrich/11111111-1111-4111-8111-111111111111"
+    )
+
+
+@pytest.mark.parametrize(
+    "user_id,expected_url",
+    [
+        (
+            "22222222-2222-4222-8222-222222222222",
+            "https://librarian.example.run.app/internal/complete-edition/"
+            "11111111-1111-4111-8111-111111111111?format=audiobook"
+            "&user_id=22222222-2222-4222-8222-222222222222",
+        ),
+        (
+            None,
+            "https://librarian.example.run.app/internal/complete-edition/"
+            "11111111-1111-4111-8111-111111111111?format=audiobook",
+        ),
+    ],
+)
+def test_enqueue_edition_completion_appends_user_id_query_when_given(monkeypatch, user_id, expected_url):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert (
+        tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook", user_id=user_id) is True
+    )
+
+    _parent, task = fake.created[0]
+    http = task["http_request"]
+    assert http["url"] == expected_url
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/complete-edition/11111111-1111-4111-8111-111111111111"
+    )
+
+
+def test_enqueue_enrichment_sets_schedule_time_on_task(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+    when = datetime(2026, 8, 1, tzinfo=UTC)
+
+    assert tasks.enqueue_enrichment("11111111-1111-4111-8111-111111111111", schedule_time=when) is True
+
+    _parent, task = fake.created[0]
+    assert task["schedule_time"] == when
+
+
+def test_enqueue_edition_completion_sets_schedule_time_on_task(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+    when = datetime(2026, 8, 1, tzinfo=UTC)
+
+    assert (
+        tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook", schedule_time=when)
+        is True
+    )
+
+    _parent, task = fake.created[0]
+    assert task["schedule_time"] == when

--- a/test/unit/test_scout_metering.py
+++ b/test/unit/test_scout_metering.py
@@ -1,0 +1,48 @@
+"""#100: grounded-scout + embedding metering. Fake response objects — no network, no DB
+(record_llm_call is monkeypatched to a recorder)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentic_librarian.scouts import grounded_llm
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None):
+        self.calls.append((vendor, model, input_tokens, output_tokens))
+
+
+@pytest.mark.parametrize(
+    "usage,expected",
+    [
+        (SimpleNamespace(prompt_token_count=120, candidates_token_count=45), [("gemini", "gemini-2.5-flash", 120, 45)]),
+        (SimpleNamespace(prompt_token_count=None, candidates_token_count=None), [("gemini", "gemini-2.5-flash", 0, 0)]),
+        (None, []),  # no usage_metadata -> no row, no crash
+    ],
+)
+def test_record_gemini_usage(monkeypatch, usage, expected):
+    rec = _Recorder()
+    monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
+    response = SimpleNamespace(text="ok", usage_metadata=usage)
+    grounded_llm._record_gemini_usage("gemini-2.5-flash", response)
+    assert rec.calls == expected
+
+
+def test_embed_metering_records_only_on_cache_miss(monkeypatch):
+    from agentic_librarian.scouts import utils
+
+    rec = _Recorder()
+    monkeypatch.setattr(utils, "record_llm_call", rec)
+
+    fake_resp = SimpleNamespace(embeddings=[SimpleNamespace(values=[0.0] * 4)])
+    client = SimpleNamespace(models=SimpleNamespace(embed_content=lambda **kw: fake_resp))
+    monkeypatch.setattr(utils, "get_shared_genai_client", lambda: client)
+
+    utils.get_cached_embedding.cache_clear()
+    utils.get_cached_embedding("m", "some tag text!!")  # miss -> one row
+    utils.get_cached_embedding("m", "some tag text!!")  # hit -> no new row
+    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0)]

--- a/test/unit/test_tiers.py
+++ b/test/unit/test_tiers.py
@@ -1,0 +1,78 @@
+"""#100: tier decision + env-tunable budget knobs are DB-free and unit-testable
+(the un-gate-DB-free-paths lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "subscriber_until,has_cred,expected",
+    [
+        (None, False, "free"),
+        (NOW - timedelta(days=1), False, "free"),  # lapsed
+        (NOW + timedelta(days=1), False, "supporter"),
+        (None, True, "byok"),
+        (NOW + timedelta(days=1), True, "byok"),  # byok wins over supporter
+    ],
+)
+def test_tier_for(subscriber_until, has_cred, expected):
+    assert tiers.tier_for(subscriber_until, has_cred, now=NOW) == expected
+
+
+@pytest.mark.parametrize(
+    "fn,tier,expected",
+    [
+        (tiers.chat_turns_per_day, "free", 20),
+        (tiers.chat_turns_per_day, "supporter", 200),
+        (tiers.chat_turns_per_day, "byok", 2000),
+        (tiers.import_max_rows, "free", 300),
+        (tiers.import_max_rows, "supporter", 2000),
+        (tiers.grounded_calls_per_day, "free", 300),
+        (tiers.grounded_calls_per_day, "supporter", 1500),
+        (tiers.grounded_calls_per_day, "byok", 15000),
+    ],
+)
+def test_default_budgets(monkeypatch, fn, tier, expected):
+    for var in tiers._DEFAULTS:
+        monkeypatch.delenv(var, raising=False)
+    assert fn(tier) == expected
+
+
+def test_global_governor_default(monkeypatch):
+    monkeypatch.delenv("GROUNDED_CALLS_PER_DAY_GLOBAL", raising=False)
+    assert tiers.grounded_calls_per_day_global() == 1400
+
+
+@pytest.mark.parametrize("raw,expected", [("50", 50), ("abc", 20), ("", 20), ("-5", 20), ("0", 20)])
+def test_env_override_and_fallback(monkeypatch, raw, expected):
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", raw)
+    assert tiers.chat_turns_per_day("free") == expected
+
+
+def test_chat_message_max_chars_default(monkeypatch):
+    monkeypatch.delenv("CHAT_MESSAGE_MAX_CHARS", raising=False)
+    assert tiers.chat_message_max_chars() == 4000
+
+
+def test_grounding_model_name_default(monkeypatch):
+    monkeypatch.delenv("GROUNDING_MODEL", raising=False)
+    monkeypatch.delenv("EXPLORER_MODEL", raising=False)
+    assert tiers.grounding_model_name() == "gemini-2.5-flash"
+
+
+def test_next_utc_day_start_is_next_midnight_plus_jitter():
+    now = datetime(2026, 7, 25, 23, 50, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now, jitter_seconds=600)
+    assert when == datetime(2026, 7, 26, 0, 10, tzinfo=UTC)
+
+
+def test_next_utc_day_start_jitter_bounds():
+    now = datetime(2026, 7, 25, 3, 0, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now)
+    midnight = datetime(2026, 7, 26, tzinfo=UTC)
+    assert midnight <= when <= midnight + timedelta(seconds=1800)


### PR DESCRIPTION
Closes #100.

First of three stacked PRs in the monetization arc (this → Ko-fi subscriber tracking → BYOK). Merge in order; PR 2 targets this branch and retargets automatically on merge.

## What

**Tier model** — `users.subscriber_until` (nullable timestamptz, migration `a1b2c3d4e5f6`); computed tier `free | supporter | byok` in `core/tiers.py` (byok is inert until PR 3 — the credentials table has no writers). All budget knobs env-tunable with defaults: chat 20/200 turns/day, 4,000-char messages, 300/2,000 import rows, 300/1,500 grounded calls/day, global governor 1,400.

**Metering** — `record_llm_call` now covers the previously-invisible spend: Gemini grounded scouts (response `usage_metadata`, previously discarded), the Claude scout backend, and embedding cache misses (chars//4 estimate, visibility-grade). User attribution threads through Cloud Tasks payloads (`user_id` query param on `/internal/enrich` + `/internal/complete-edition`, `as_user` in the handlers and import worker); tasks enqueued before this deploy carry no user and run unattributed exactly as before.

**Enforcement** (fails open; metering stays best-effort) —
- Chat: length cap → 422, daily turn budget → 429, both raised before the SSE stream starts; the UI shows the server's human message.
- Imports: per-tier row cap → 413, one in-flight import per user (24h-bounded so a wedged job can't lock anyone out) → 409.
- Enrichment: per-user + global grounded budgets checked in the task handlers; over budget defers to next UTC day (+jitter) via a fresh `schedule_time` task — HTTP 200, so the #97 give-up count never accrues across days.

## Review

Per-task reviews (4 tasks, each spec ✅ + Approved) plus an opus whole-branch + adversarial pass: **0 Critical / 0 Important**. Governor overshoot bounded (~1,415 worst case vs Google's 1,500/day free allowance), deferral is a 1:1 chain (no fan-out), boundary races accepted per spec ("safety nets, not invoicing"), out-of-diff call sites (operator sweep, clean_catalog, MCP tools) verified compatible. Five Minors ride (indexing YAGNI, byok-untested-by-design, cosmetic ContextVar idiom, inert env-guard asymmetry, 422 shape tolerance); the review's one new finding (unattributed fast-pass embeds on REST add-book) is fixed in `9af5748`.

## Verification

- Local unit suite: **899 passed / 0 failed** (green-by-default, ADR-063); frontend vitest 149/149, tsc + eslint clean.
- `db_integration` additions (~24 tests across budgets counting, chat quota, import caps, deferral) execute first in CI — that run is the merge gate (house rule #5).
- **Rollout watch item:** proto-plus `datetime → Timestamp` coercion for `schedule_time` first executes when a real deferral fires in prod (CI cannot exercise it); the datetime is tz-aware UTC.

## Ops at rollout (operator)

Flip the shared Gemini key's project to the paid tier. If the flip lags the deploy, set `GROUNDED_CALLS_PER_DAY_GLOBAL=450` (free tier's grounding allowance is 500/day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3