### PR TITLE
feat: Buy Me a Coffee subscriber tracking + account menu (monetization arc 2/3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,7 @@ jobs:
             --allow-unauthenticated
             --service-account=librarian-api-runtime@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             --add-cloudsql-instances=${{ vars.GCP_CLOUDSQL_CONNECTION }}
-            --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest
+            --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest,KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest
             --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},AGENT_BACKEND=adk,GEMINI_MODEL=gemini-3.1-flash-lite,CLOUD_TASKS_QUEUE=${{ vars.GCP_CLOUD_TASKS_QUEUE }},IMPORT_TASKS_QUEUE=${{ vars.GCP_IMPORT_TASKS_QUEUE }},ENRICH_TARGET_BASE_URL=${{ vars.GCP_RUN_BASE_URL }},ENRICH_INVOKER_SA=${{ vars.GCP_ENRICH_INVOKER_SA }},ENRICH_OIDC_AUDIENCE=${{ vars.GCP_RUN_BASE_URL }},SEARCH_ENGINE_ID=${{ vars.GCP_SEARCH_ENGINE_ID }}
             --max-instances=2
             --memory=2Gi

--- a/alembic/versions/b2c3d4e5f6a7_payments_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_payments_table.py
@@ -1,0 +1,51 @@
+"""payments_table — GH #100 monetization arc: Ko-fi webhook event audit trail
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-26 00:00:00.000000
+
+Rule 11 note: this migration only ADDS a table; it alters nothing existing, so the
+pre-migration-schema rehearsal pressure that applies to migration-gating tools (dedup,
+requeue) is nil here — no query against an existing model changes shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "payments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kofi_transaction_id", sa.String(), nullable=False),
+        sa.Column("kofi_type", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("amount", sa.Numeric(10, 2), nullable=False),
+        sa.Column("currency", sa.String(), nullable=False),
+        sa.Column("tier_name", sa.String(), nullable=True),
+        sa.Column("is_subscription_payment", sa.Boolean(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=False),
+        sa.Column("matched_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("entitlement_days", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["matched_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kofi_transaction_id"),
+    )
+    op.create_index("ix_payments_email", "payments", ["email"])
+    op.create_index("ix_payments_matched_user_id", "payments", ["matched_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_payments_matched_user_id", table_name="payments")
+    op.drop_index("ix_payments_email", table_name="payments")
+    op.drop_table("payments")

--- a/docs/superpowers/plans/2026-07-26-kofi-subscriptions.md
+++ b/docs/superpowers/plans/2026-07-26-kofi-subscriptions.md
@@ -1,0 +1,537 @@
+# Ko-fi Subscriptions + Account Menu Implementation Plan (monetization arc 2/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ko-fi payments (webhook + CLI fallback) grant/extend `subscriber_until`; a top-bar avatar dropdown shows account status + Ko-fi support links; `GET /api/account` exposes the effective tier.
+
+**Architecture:** Pure entitlement rules in `core/entitlements.py`; a `payments` audit table; a root-level machine route `POST /webhooks/kofi` (token-verified, idempotent); argparse CLI extensions; one new React component (`AccountMenu`) replacing the standalone sign-out button.
+
+**Tech Stack:** Python 3.14/FastAPI/SQLAlchemy/Alembic, React+TS/vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md` — normative for entitlement rules (33/370 days, `extend = max(now, current or now) + days`), webhook status codes (400 malformed / 403 token / 200 everything processed incl. unmatched+duplicate / 500 only on DB failure), and menu behavior.
+- Env knobs read per call with fallback defaults (PR-1 `_env_int` pattern): `KOFI_ANNUAL_TIER_NAMES` (csv, default `"annual"`), `KOFI_ANNUAL_MIN_AMOUNT` (default 25). `KOFI_VERIFICATION_TOKEN` has NO default — unset means the webhook 403s (fail closed).
+- Token comparison via `hmac.compare_digest`. Never log the token or full payload at info level.
+- Ko-fi sends `application/x-www-form-urlencoded`, field `data` = JSON string.
+- The webhook route lives on `app` (root), NOT under `/api` (purpose-scoped namespacing, #151).
+- Entitlement write is transactional with the payment insert (same session).
+- Tests parametrized (no loops in test bodies); Postgres-only models → DB-backed tests `db_integration` (CI-first); DB-free guards unit-tested locally; frontend rejection paths use `...Once` mocks (vitest#1692); seeded rows get EXPLICIT distinct `created_at` (#147).
+- Local `test/unit` green-by-default (ADR-063); `.venv/Scripts/python -m pytest ...` from repo root; frontend `npm test -- --run` from `frontend/`.
+- `uvx ruff check` AND `uvx ruff format` before each commit; no `[skip ci]`.
+- Commit trailer — end every commit with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`
+
+---
+
+### Task 1: Entitlement rules + Payment model + migration
+
+**Files:**
+- Create: `src/agentic_librarian/core/entitlements.py`
+- Modify: `src/agentic_librarian/db/models.py` (Payment class after Usage)
+- Create: `alembic/versions/b2c3d4e5f6a7_payments_table.py` (down_revision `a1b2c3d4e5f6`)
+- Create: `test/unit/test_entitlements.py`
+
+**Interfaces (produced):**
+- `entitlements.classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Literal["monthly", "annual", "tip"]`
+- `entitlements.grant_days(kind) -> int` (monthly 33, annual 370, tip 0)
+- `entitlements.extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime`
+- `db/models.py` `Payment` exactly per the spec's column table.
+
+- [ ] **Step 1: Failing unit tests** — create `test/unit/test_entitlements.py`:
+
+```python
+"""Monetization arc 2/3: entitlement classification is pure and DB-free."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from agentic_librarian.core import entitlements
+
+NOW = datetime(2026, 7, 26, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected",
+    [
+        ("Subscription", True, "Supporter", Decimal("3.00"), "monthly"),
+        ("Subscription", True, None, Decimal("3.00"), "monthly"),
+        ("Shop Order", False, "Annual", Decimal("25.00"), "annual"),
+        ("Shop Order", False, "ANNUAL", Decimal("25.00"), "annual"),      # case-insensitive
+        ("Subscription", True, "Annual Supporter", Decimal("25.00"), "annual"),  # tier name wins over is_sub — but exact-name match only, see below
+        ("Donation", False, None, Decimal("25.00"), "annual"),            # one-off >= threshold
+        ("Donation", False, None, Decimal("30.00"), "annual"),
+        ("Donation", False, None, Decimal("24.99"), "tip"),
+        ("Donation", False, None, Decimal("3.00"), "tip"),
+        ("Commission", False, None, Decimal("10.00"), "tip"),
+    ],
+)
+def test_classify_defaults(monkeypatch, kofi_type, is_sub, tier_name, amount, expected):
+    monkeypatch.delenv("KOFI_ANNUAL_TIER_NAMES", raising=False)
+    monkeypatch.delenv("KOFI_ANNUAL_MIN_AMOUNT", raising=False)
+    assert entitlements.classify(kofi_type, is_sub, tier_name, amount) == expected
+
+
+def test_classify_env_tier_names(monkeypatch):
+    monkeypatch.setenv("KOFI_ANNUAL_TIER_NAMES", "yearly, gold ")
+    assert entitlements.classify("Shop Order", False, "Gold", Decimal("25.00")) == "annual"
+    assert entitlements.classify("Shop Order", False, "Annual", Decimal("10.00")) == "tip"
+
+
+@pytest.mark.parametrize("kind,days", [("monthly", 33), ("annual", 370), ("tip", 0)])
+def test_grant_days(kind, days):
+    assert entitlements.grant_days(kind) == days
+
+
+@pytest.mark.parametrize(
+    "current,days,expected",
+    [
+        (None, 33, NOW + timedelta(days=33)),                              # first sub
+        (NOW - timedelta(days=10), 33, NOW + timedelta(days=33)),          # lapsed: restart from now
+        (NOW + timedelta(days=5), 33, NOW + timedelta(days=38)),           # active: stack
+        (NOW + timedelta(days=100), 370, NOW + timedelta(days=470)),       # annual stacks too
+    ],
+)
+def test_extend(current, days, expected):
+    assert entitlements.extend(current, days, now=NOW) == expected
+```
+
+NOTE on the "Annual Supporter" case: `classify` matches tier names by exact
+(case-folded, stripped) equality against the csv entries — "Annual Supporter" only
+classifies annual if an env entry equals it. With the DEFAULT list ("annual") it does
+NOT match, so with `is_sub=True` that row's expected value is "monthly". **Fix the test
+table accordingly** (expected "monthly" for that row) — this note exists so you don't
+"fix" the implementation to substring-match instead; substring matching would misfire
+on names like "Not Annual".
+
+- [ ] **Step 2: Run — verify FAIL** (`.venv/Scripts/python -m pytest test/unit/test_entitlements.py -v`).
+
+- [ ] **Step 3: Implement `core/entitlements.py`**:
+
+```python
+"""Ko-fi payment → entitlement rules (monetization arc 2/3). Pure and DB-free: the
+webhook and the CLI both call these so grant math exists exactly once. Env knobs are
+read per call (prod-tunable): KOFI_ANNUAL_TIER_NAMES (csv of tier/product names that
+mean 'annual', default 'annual'; exact case-folded match — substring matching would
+misfire on e.g. 'Not Annual'), KOFI_ANNUAL_MIN_AMOUNT (one-off donations at/over this
+classify as annual, default 25). Grace is baked into the grant: 33/370 days cover
+Ko-fi's missing cancellation events and late renewals."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+Kind = Literal["monthly", "annual", "tip"]
+
+_GRANT_DAYS: dict[Kind, int] = {"monthly": 33, "annual": 370, "tip": 0}
+_DEFAULT_ANNUAL_MIN = Decimal(25)
+
+
+def _annual_tier_names() -> set[str]:
+    raw = os.environ.get("KOFI_ANNUAL_TIER_NAMES", "annual")
+    return {part.strip().casefold() for part in raw.split(",") if part.strip()}
+
+
+def _annual_min_amount() -> Decimal:
+    raw = os.environ.get("KOFI_ANNUAL_MIN_AMOUNT", "")
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return _DEFAULT_ANNUAL_MIN
+    return value if value > 0 else _DEFAULT_ANNUAL_MIN
+
+
+def classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Kind:
+    if tier_name is not None and tier_name.strip().casefold() in _annual_tier_names():
+        return "annual"
+    if is_subscription_payment:
+        return "monthly"
+    if amount >= _annual_min_amount():
+        return "annual"
+    return "tip"
+
+
+def grant_days(kind: Kind) -> int:
+    return _GRANT_DAYS[kind]
+
+
+def extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime:
+    """New subscriber_until: active subs stack; lapsed subs restart from now."""
+    now = now or datetime.now(UTC)
+    base = current if (current is not None and current > now) else now
+    return base + timedelta(days=days)
+```
+
+- [ ] **Step 4: Run unit tests — PASS.**
+
+- [ ] **Step 5: Model + migration.** Add to `db/models.py` (after `Usage`; import `Numeric`, `JSONB` is already imported for other models — verify):
+
+```python
+class Payment(Base):
+    """One row per Ko-fi webhook event (monetization arc 2/3) — the audit trail behind
+    users.subscriber_until. Idempotency key = kofi_transaction_id (Ko-fi retries).
+    matched_user_id NULL = payer email didn't match a user (CLI `payments match` fixes)."""
+
+    __tablename__ = "payments"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    kofi_transaction_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    kofi_type: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)  # lowercased at ingest
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String, nullable=False)
+    tier_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_subscription_payment: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    matched_user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    entitlement_days: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+```
+
+(match the file's existing import style; add `from decimal import Decimal` and `Boolean`/`Numeric` to the sqlalchemy imports as needed.) Hand-write
+`alembic/versions/b2c3d4e5f6a7_payments_table.py` mirroring the newest migration's
+style: `create_table("payments", ...)` with the unique constraint on
+kofi_transaction_id and indexes on email + matched_user_id; downgrade drops the table.
+
+- [ ] **Step 6: Full unit suite, lint, format, commit**
+`git commit -m "feat(payments): entitlement rules + payments table (Ko-fi arc 2/3)"`
+
+---
+
+### Task 2: `POST /webhooks/kofi` + deploy wiring
+
+**Files:**
+- Create: `src/agentic_librarian/api/kofi.py`
+- Modify: `src/agentic_librarian/api/main.py` (register router next to `internal_router`, line ~123)
+- Modify: `.github/workflows/deploy.yml` (append `KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest` to `--set-secrets`, line ~153)
+- Create: `test/unit/test_kofi_webhook.py`
+- Create: `test/integration/test_kofi_webhook_db.py`
+
+**Interfaces:** consumes `entitlements.*`, `Payment`, `User`. Produces route `POST /webhooks/kofi` on `app` root.
+
+- [ ] **Step 1: Failing unit tests (DB-free guards)** — `test/unit/test_kofi_webhook.py`: build a tiny FastAPI app with just the router (the `test_firebase_auth_proxy.py` pattern: `app.include_router(router)`); parametrized:
+  - no `data` field → 400; `data` not JSON → 400.
+  - `KOFI_VERIFICATION_TOKEN` unset → 403 (even with a token in payload).
+  - token mismatch → 403.
+  - Token OK but DB layer raises (patch the module's `db_manager` with a stub whose `get_session` raises) → 500 (Ko-fi will retry; idempotency makes that safe).
+
+- [ ] **Step 2: Run — FAIL.** Then implement `api/kofi.py`:
+
+```python
+"""Ko-fi payment webhook (monetization arc 2/3) — root-level machine route, like
+/internal/*: NOT under /api (purpose-scoped namespacing, #151). Authenticity is Ko-fi's
+shared verification_token (no HMAC exists); fail-closed when unset. Always 200 once the
+event is durably stored — Ko-fi retries non-2xx, and an unmatched payment is an operator
+task (CLI `payments match`), not a delivery failure. Idempotent on kofi_transaction_id."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from fastapi import APIRouter, Form, HTTPException
+
+from agentic_librarian.core import entitlements
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+@router.post("/webhooks/kofi")
+def kofi_webhook(data: str = Form(...)):  # noqa: B008
+    try:
+        event = json.loads(data)
+        if not isinstance(event, dict):
+            raise ValueError("payload is not an object")
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="malformed payload") from e
+
+    expected = os.environ.get("KOFI_VERIFICATION_TOKEN")
+    supplied = str(event.get("verification_token") or "")
+    if not expected or not hmac.compare_digest(supplied, expected):
+        # Unset env fails CLOSED (matches _require_queue_caller's posture).
+        raise HTTPException(status_code=403, detail="verification failed")
+
+    txn_id = str(event.get("kofi_transaction_id") or "").strip()
+    if not txn_id:
+        raise HTTPException(status_code=400, detail="missing kofi_transaction_id")
+    email = str(event.get("email") or "").strip().lower()
+    try:
+        amount = Decimal(str(event.get("amount") or "0"))
+    except InvalidOperation:
+        amount = Decimal(0)
+    tier_name = event.get("tier_name") or None
+    is_sub = bool(event.get("is_subscription_payment", False))
+    kofi_type = str(event.get("type") or "")
+
+    kind = entitlements.classify(kofi_type, is_sub, tier_name, amount)
+    days = entitlements.grant_days(kind)
+
+    with db_manager.get_session() as session:
+        if session.query(Payment.id).filter(Payment.kofi_transaction_id == txn_id).first() is not None:
+            return {"status": "duplicate"}
+        user = session.query(User).filter(User.email == email).first() if email else None
+        payment = Payment(
+            kofi_transaction_id=txn_id,
+            kofi_type=kofi_type,
+            email=email,
+            amount=amount,
+            currency=str(event.get("currency") or ""),
+            tier_name=tier_name,
+            is_subscription_payment=is_sub,
+            payload=event,
+            matched_user_id=user.id if user else None,
+            entitlement_days=days if user else 0,
+        )
+        session.add(payment)
+        if user is not None and days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+            session.flush()
+            logger.info("kofi %s: %s +%dd -> %s", kind, email, days, user.subscriber_until.isoformat())
+            return {"status": "applied", "kind": kind}
+        session.flush()
+    if user is not None:
+        logger.info("kofi tip recorded for %s", email)
+        return {"status": "recorded", "kind": kind}
+    logger.warning("kofi payment UNMATCHED (email %s, txn %s) — resolve via `payments match`", email, txn_id)
+    return {"status": "unmatched", "kind": kind}
+```
+
+Register in `api/main.py` next to `internal_router` (~line 123):
+`from agentic_librarian.api.kofi import router as kofi_router` + `app.include_router(kofi_router)`
+(root registration — must stay OUTSIDE `api_router`).
+
+- [ ] **Step 3: deploy.yml** — append `,KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest` to the `--set-secrets` list (line ~153). Do not touch anything else in the workflow.
+
+- [ ] **Step 4: db_integration tests (by inspection)** — `test/integration/test_kofi_webhook_db.py` (marker + fixture pattern from `test_budgets_db.py`; patch this module's `db_manager` via monkeypatch + `KOFI_VERIFICATION_TOKEN`): parametrized end-to-end matrix:
+  - membership payment, matched email → 200 applied; `subscriber_until` == extend(prior, 33) (seed prior both lapsed and active — assert exact datetimes with a frozen `now` is impossible through HTTP, so assert range: `>= before_call + 33d - small_slack` and `payments` row fields).
+  - annual (tier_name "Annual") → +370 path.
+  - tip (< threshold) → 200 recorded, entitlement_days 0, subscriber_until unchanged.
+  - unknown email → 200 unmatched, matched_user_id NULL.
+  - same txn replay → 200 duplicate, no second row, no double-extend.
+
+- [ ] **Step 5: Unit suite + collect-only, lint, format, commit**
+`git commit -m "feat(payments): Ko-fi webhook -> payments + subscriber_until (arc 2/3)"`
+
+---
+
+### Task 3: CLI — `user subscribe`, `payments list/match`
+
+**Files:**
+- Modify: `src/agentic_librarian/cli.py` (extend `_parse_args` subparsers + `_run_user`, add `_run_payments`; follow the existing `user invite` shape at cli.py:108-128 and its `_invite_db_manager` seam)
+- Modify/extend: the existing CLI test file (grep `test/` for the file testing `user invite`)
+
+**Interfaces:** consumes `entitlements.extend`/`grant_days`, `Payment`, `User`.
+
+- [ ] **Step 1: Failing tests** (extend the existing CLI test file, mirroring its invite-test style — it patches the db-manager seam; parametrized):
+  - `user subscribe x@y.com` (default) → subscriber_until ≈ now+33d printed; `--months 3` → +99d; `--days 45` → +45; `--until 2027-01-01` → exact; unknown email → exit 2 with error.
+  - `payments list --unmatched` prints only unmatched rows; `payments match <txn> <email>` sets matched_user_id + applies entitlement_days per stored classification, refuses (exit 2) when already matched or txn/email unknown.
+- [ ] **Step 2: Implement.** Parser additions in `_parse_args`:
+
+```python
+    sub_parser = user_sub.add_parser("subscribe", help="grant/extend supporter entitlement (comp or Ko-fi mismatch fix)")
+    sub_parser.add_argument("email")
+    group = sub_parser.add_mutually_exclusive_group()
+    group.add_argument("--months", type=int, default=None, help="N x 33-day grants (default 1)")
+    group.add_argument("--days", type=int, default=None)
+    group.add_argument("--until", default=None, help="YYYY-MM-DD (absolute)")
+
+    payments_parser = subparsers.add_parser("payments", help="Ko-fi payment records (operator)")
+    payments_sub = payments_parser.add_subparsers(dest="payments_command")
+    list_parser = payments_sub.add_parser("list", help="list payments")
+    list_parser.add_argument("--unmatched", action="store_true")
+    match_parser = payments_sub.add_parser("match", help="link an unmatched payment to a user and apply its entitlement")
+    match_parser.add_argument("kofi_transaction_id")
+    match_parser.add_argument("email")
+```
+
+`_run_user` grows a `subscribe` branch (validate email format like invite; load user;
+compute `days = months*33 | days | until-date` — for `--until`, set
+`subscriber_until` directly to that date at UTC midnight; else
+`user.subscriber_until = entitlements.extend(user.subscriber_until, days)`; print the
+result). New `_run_payments(args)` wired in `_dispatch`; `match` recomputes
+`classify`/`grant_days` from the stored row's fields (`kofi_type`,
+`is_subscription_payment`, `tier_name`, `amount`) so webhook and CLI grant identically,
+then applies `extend` and stamps `matched_user_id`/`entitlement_days`.
+Use the same db-manager seam pattern `_invite_db_manager` uses (reuse or mirror it).
+
+- [ ] **Step 3: Full unit suite, lint, format, commit**
+`git commit -m "feat(cli): user subscribe + payments list/match operator fallback (arc 2/3)"`
+
+---
+
+### Task 4: `GET /api/account` + avatar dropdown (AccountMenu)
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py` (new `@api_router.get("/account")` near the `/conversations/current` route ~line 460)
+- Create: `frontend/src/components/AccountMenu.tsx`
+- Modify: `frontend/src/components/TopBar.tsx` (avatar → menu trigger; remove standalone sign-out)
+- Modify: `frontend/src/components/AppShell.css` (menu styles — follow existing token/theme variables)
+- Modify: `frontend/src/api/client.ts` (add `getAccount`)
+- Create: `frontend/src/components/AccountMenu.test.tsx`; Modify: `frontend/src/components/TopBar.test.tsx`
+- Modify/extend: the chat API integration test file OR a small new `test/integration/test_account_api.py` for the endpoint
+
+**Interfaces:** consumes `tiers.effective_tier`. Produces `GET /api/account` → `{"email", "display_name", "tier", "subscriber_until"}` (subscriber_until ISO string or null); `client.ts` `getAccount(): Promise<Account>`.
+
+- [ ] **Step 1: Backend endpoint** (+ failing integration test first, by inspection if db_integration):
+
+```python
+@api_router.get("/account")
+def get_account(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    from agentic_librarian.core import tiers as tiers_mod
+    from agentic_librarian.db.models import User
+
+    with db_manager.get_session() as session:
+        tier = tiers_mod.effective_tier(session, user.id)
+        row = session.get(User, user.id)
+        until = row.subscriber_until.isoformat() if row and row.subscriber_until else None
+        return {
+            "email": row.email if row else None,
+            "display_name": row.display_name if row else None,
+            "tier": tier,
+            "subscriber_until": until,
+        }
+```
+
+(match main.py's actual db-session idiom — grep how other main.py routes open sessions; keep imports at module top per file style.)
+Integration test: free user → tier "free", null until; seeded future subscriber_until → "supporter" + ISO date.
+
+- [ ] **Step 2: client.ts** —
+
+```ts
+export interface Account {
+  email: string
+  display_name: string | null
+  tier: 'free' | 'supporter' | 'byok'
+  subscriber_until: string | null
+}
+
+export function getAccount(): Promise<Account> {
+  return getJson<Account>('/account')
+}
+```
+
+- [ ] **Step 3: Failing frontend tests** — `AccountMenu.test.tsx` (mock `getAccount` via `vi.mock('../api/client')`; `...Once` for the rejection case): opens on avatar click; shows email + "Free plan" for tier free; "Supporter until <formatted date>" for supporter; three Ko-fi links all `href="https://ko-fi.com/shelfwright"` with `target="_blank"` + `rel` containing `noopener`; Escape and outside-click close it; sign-out button calls the auth context's signOut even when `getAccount` rejects. Update `TopBar.test.tsx`: standalone sign-out button gone; avatar has `aria-expanded`.
+
+- [ ] **Step 4: Implement `AccountMenu.tsx`** (and TopBar changes):
+
+```tsx
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import { getAccount, type Account } from '../api/client'
+
+const KOFI_URL = 'https://ko-fi.com/shelfwright'
+
+/** Account dropdown off the top-bar avatar. Future home of username change and the
+ *  BYOK entry (arc PR 3). Sign-out must never depend on the API: account fetch failure
+ *  just hides the status line. */
+export default function AccountMenu() {
+  const { user, signOut } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [account, setAccount] = useState<Account | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    if (account === null) {
+      getAccount().then(setAccount).catch(() => setAccount(null))
+    }
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, account])
+
+  const status =
+    account?.tier === 'supporter' && account.subscriber_until
+      ? `Supporter until ${new Date(account.subscriber_until).toLocaleDateString()}`
+      : account?.tier === 'free'
+        ? 'Free plan'
+        : null
+
+  return (
+    <div className="account-menu" ref={rootRef}>
+      <button
+        className="avatar avatar-button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div className="account-menu-panel" role="menu">
+          <div className="account-menu-identity">
+            <div className="account-menu-name">{user?.displayName || user?.email}</div>
+            {user?.displayName && <div className="account-menu-email">{user?.email}</div>}
+            {status && <div className="account-menu-status">{status}</div>}
+          </div>
+          <div className="account-menu-support">
+            <div className="account-menu-heading">Support Shelfwright ♥</div>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$3 / month</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$25 / year</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">Leave a tip</a>
+            <div className="account-menu-nudge">
+              Use your Shelfwright sign-in email on Ko-fi so your support links up automatically.
+            </div>
+          </div>
+          <hr />
+          <button role="menuitem" onClick={() => void signOut()}>Sign out</button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+`TopBar.tsx`: replace the `<span className="avatar">` + sign-out button with
+`<AccountMenu />` (keep the theme toggle). Style the panel in `AppShell.css` using the
+existing CSS custom properties/tokens (absolute-positioned under the bar, right-aligned,
+themed background/border like existing surfaces — follow the `.topbar` block's variables;
+check both light and dark themes).
+
+- [ ] **Step 5: Suites** — frontend `npm test -- --run` + `tsc --noEmit`; backend unit suite + `--collect-only` on touched integration files; lint/format; commit
+`git commit -m "feat(account): /api/account + avatar dropdown with Ko-fi support links (arc 2/3)"`
+
+---
+
+## Post-implementation verification
+
+- [ ] Local unit + frontend suites green; collect-only clean.
+- [ ] CI green on the PR (db_integration first — gate #5).
+- [ ] Visual QC of the menu (the qc-harness pattern) is OPTIONAL here; note in the PR if skipped.
+
+## Self-review notes (coverage against spec)
+
+- Spec §1 table → Task 1 model/migration. §2 rules → Task 1 module (incl. exact-match tier-name note). §3 webhook semantics/status codes → Task 2 code verbatim. §4 CLI → Task 3. §5 endpoint → Task 4 Step 1. §6 menu behavior incl. lazy fetch + fetch-failure sign-out guarantee → Task 4 component. §7 deploy wiring → Task 2 Step 3 (secret creation + Ko-fi dashboard = operator steps, PR body). ✓
+- Names cross-checked: `entitlements.classify/grant_days/extend`, `Payment` columns, `getAccount`/`Account`, `set_db_manager` seam. ✓

--- a/docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md
+++ b/docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md
@@ -1,0 +1,178 @@
+# Design: Ko-fi subscriber tracking + account menu (monetization arc 2 of 3)
+
+**Date:** 2026-07-26
+**Arc:** Monetization (PR 1 = #100 metering/tiers/budgets, merged first; this PR stacks on it; PR 3 = BYOK)
+**Branch:** `feat/kofi-subscriptions` (base: `feat/metering-tiers-100` / PR #155)
+
+## Product decisions (user, 2026-07-25)
+
+- Payments run through **Ko-fi** (page: **ko-fi.com/shelfwright**, currently bare-bones;
+  Stripe under the hood on Ko-fi's side — we never touch card data).
+- Offers: **$3/month** membership, **$25/year**, and one-off **tips**.
+- Linkage: **webhook + CLI fallback** (auto-match by email; operator commands for
+  mismatches, comps, corrections).
+- Supporters get the generous env-tunable budgets defined in PR 1 (`supporter` tier).
+- Account UI is a **dropdown from the user bubble** in the top bar — NOT a Settings
+  card. It seeds the future home of username change etc. "Sign out" moves into it.
+
+## Ko-fi integration facts (constraints we design around)
+
+- Ko-fi POSTs `application/x-www-form-urlencoded` with a single field `data` whose
+  value is a JSON object: `verification_token`, `message_id`, `kofi_transaction_id`,
+  `type` ("Donation" | "Subscription" | "Shop Order" | "Commission"), `email`,
+  `amount` (string, e.g. "3.00"), `currency`, `tier_name`, `is_subscription_payment`,
+  `is_first_subscription_payment`, `timestamp`, and more. Authenticity = the shared
+  `verification_token` (no HMAC signature exists).
+- **No cancellation/expiry event** — Ko-fi only reports payments. Entitlement must be
+  an expiry horizon each payment extends; lapse is silent (tier computation in PR 1
+  already treats past `subscriber_until` as free).
+- Memberships are monthly-centric; the $25 annual will likely arrive as a Shop Order
+  or one-off Donation → classification must be configurable, not hardcoded on `type`.
+- The payer's Ko-fi email may differ from their Shelfwright sign-in email → unmatched
+  payments must be stored and operator-fixable, and the UI nudges users to pay with
+  their sign-in email.
+
+## Architecture
+
+### 1. `payments` table (one migration, head after PR 1's `a1b2c3d4e5f6`)
+
+`db/models.py` `Payment`:
+
+| column | type | notes |
+|---|---|---|
+| id | UUID pk | |
+| kofi_transaction_id | String, **unique**, not null | idempotency key (Ko-fi retries) |
+| kofi_type | String, not null | raw `type` |
+| email | String, not null, index | lowercased at ingest |
+| amount | Numeric(10,2), not null | parsed from Ko-fi's string |
+| currency | String, not null | |
+| tier_name | String, null | |
+| is_subscription_payment | Boolean, not null, default false | |
+| payload | JSONB, not null | full raw event (audit/forensics) |
+| matched_user_id | FK users.id, null, index | null = unmatched |
+| entitlement_days | Integer, not null, default 0 | what was granted (0 = tip/none) |
+| created_at | timestamptz, not null | our clock |
+
+### 2. Entitlement rules (pure module `core/entitlements.py`, DB-free)
+
+- `classify(kofi_type, is_subscription_payment, tier_name, amount) -> "monthly" | "annual" | "tip"`:
+  - **annual** if `tier_name` case-insensitively matches one of
+    `KOFI_ANNUAL_TIER_NAMES` (csv env, default `"annual"`), OR if it is NOT a
+    subscription payment and `amount >= KOFI_ANNUAL_MIN_AMOUNT` (default `25`).
+  - else **monthly** if `is_subscription_payment` is true.
+  - else **tip** (recorded, thanked, no entitlement).
+- `grant_days(kind) -> int`: monthly → **33**, annual → **370**, tip → **0**. The +3/+5
+  padding is the grace covering Ko-fi's no-cancellation-event gap and late renewals.
+- `extend(current: datetime | None, days: int, now) -> datetime`:
+  `max(now, current or now) + timedelta(days=days)` — stacking payments extends, a
+  lapsed sub restarts from now.
+- Env knobs read per call, `_env_int`-style fallbacks (PR 1 pattern; the tier-name list
+  is a string csv, whitespace-trimmed, case-folded).
+
+### 3. Webhook — `POST /webhooks/kofi` (root-level machine route)
+
+New `api/kofi.py` router registered on `app` next to `internal_router` (deliberately
+NOT under `/api` — purpose-scoped namespacing from #151; this is a machine route like
+`/internal/*`). Handler:
+
+1. Read form field `data`; `json.loads` it. Malformed/missing → **400**.
+2. Verify `payload["verification_token"] == KOFI_VERIFICATION_TOKEN` env. Env unset →
+   **403** fail-closed (like `_require_queue_caller`'s posture); mismatch → **403**.
+   Compare with `hmac.compare_digest`.
+3. Idempotency: existing `kofi_transaction_id` → **200** `{"status": "duplicate"}`,
+   nothing re-applied.
+4. Insert the `Payment` row (email lowercased); match `users.email`; if matched and
+   `grant_days > 0`, update `subscriber_until = extend(...)` **in the same session** and
+   stamp `matched_user_id` + `entitlement_days`.
+5. Always **200** with `{"status": "applied" | "recorded" | "unmatched"}` — an unmatched
+   payment is not an error (Ko-fi must not retry it); it's stored for the CLI. Log at
+   info (matched) / warning (unmatched, with the email).
+
+Never log the verification token or the full payload at info level.
+
+### 4. CLI fallback (extends the argparse `user` subcommands in `cli.py`)
+
+- `librarian user subscribe <email> [--months N | --days N | --until YYYY-MM-DD]`
+  (default `--months 1`; `--months N` = N×33 days via `extend`) — comps, corrections,
+  Ko-fi-email mismatch remedies. Prints the resulting `subscriber_until`. Unknown
+  email → error listing nothing (no user enumeration beyond the operator's own DB).
+- `librarian payments list [--unmatched]` — table: txn id, date, email, amount,
+  type/tier, matched?, entitlement_days.
+- `librarian payments match <kofi_transaction_id> <email>` — links a stored payment to
+  a user and applies its entitlement (idempotent: refuses if already matched).
+
+### 5. Account API — `GET /api/account`
+
+Returns `{"email", "display_name", "tier", "subscriber_until"}` using
+`tiers.effective_tier` (one query path — no second tier computation). Authed like every
+`/api` route.
+
+### 6. Frontend — avatar dropdown (`AccountMenu`)
+
+- `TopBar.tsx`: the `avatar` span becomes a button toggling a new
+  `components/AccountMenu.tsx` anchored top-right; the standalone "Sign out" button
+  moves inside. Theme toggle stays in the bar.
+- Menu content: identity header (avatar initial, display name, email); status line —
+  "Free plan" / "Supporter until {local date}" / (byok label arrives in PR 3);
+  "Support Shelfwright ♥" block with links to `https://ko-fi.com/shelfwright`
+  ($3/mo · $25/yr · tip — all land on the Ko-fi page; `target="_blank"
+  rel="noopener noreferrer"`), and the nudge line: "Use your Shelfwright sign-in email
+  on Ko-fi so your support links up automatically."; divider; Sign out.
+- Behavior: click toggles; click-outside and Escape close; `aria-expanded` +
+  `role="menu"`. Account data fetched lazily on first open via `client.ts
+  getAccount()`; fetch failure shows the identity from the auth context and hides the
+  status line (menu still works — sign-out must never depend on the API).
+- Future home (documented in the component): username change, BYOK entry (PR 3).
+
+### 7. Config & ops (operator steps at rollout)
+
+- `KOFI_VERIFICATION_TOKEN` → Secret Manager, wired in deploy.yml like existing
+  secrets (this PR edits deploy.yml; operator creates the secret).
+- Optional: `KOFI_ANNUAL_TIER_NAMES`, `KOFI_ANNUAL_MIN_AMOUNT` (defaults fine).
+- Ko-fi dashboard: set webhook URL `https://shelfwright.app/webhooks/kofi`; create the
+  $3/mo membership and the $25 annual product **named to match** an entry in
+  `KOFI_ANNUAL_TIER_NAMES` (e.g. "Annual").
+
+## Error handling
+
+- Webhook: 400 malformed, 403 bad/missing token, 200 for every processed outcome
+  (applied / recorded / unmatched / duplicate) — Ko-fi retry semantics demand success
+  once we've durably stored the event. A DB failure → 500 (Ko-fi retries; idempotency
+  key makes the retry safe).
+- Entitlement writes are transactional with the payment insert — no payment row without
+  its grant outcome recorded.
+- CLI: clear errors for unknown email / unknown txn / already matched.
+
+## Testing
+
+- Unit (local): `classify`/`grant_days`/`extend` full matrix (subscription, shop-order
+  annual by tier name, donation ≥/< threshold, case-insensitive tier names, env
+  overrides, lapsed-vs-active extend); webhook DB-free guards (missing `data`, bad
+  JSON, missing/mismatched/unset token) with the db seam patched; CLI arg parsing.
+- db_integration (CI): webhook end-to-end — applied (matched email, subscriber_until
+  extended exactly +33/+370 from max(now, current)), unmatched stored, duplicate
+  ignored, tip recorded with 0 days; CLI subscribe/match against real rows.
+- Frontend (vitest): menu open/close (click, outside, Escape), status rendering per
+  tier payload, Ko-fi links present with correct href/rel, sign-out still works when
+  `getAccount` rejects (`...Once` mocks), TopBar no longer renders the standalone
+  sign-out button.
+
+## Acceptance criteria
+
+1. A Ko-fi membership payment for a known email sets/extends `subscriber_until` by 33
+   days from `max(now, current)`; an annual product by 370; tips record with no grant.
+2. Replayed webhook deliveries (same `kofi_transaction_id`) are no-ops.
+3. Wrong-email payments are stored and fully resolvable via
+   `payments list --unmatched` + `payments match`; comps via `user subscribe`.
+4. `GET /api/account` reflects the tier PR 1's budgets actually enforce (single code
+   path through `effective_tier`).
+5. The avatar dropdown shows identity, status, Ko-fi links, and sign-out; the old
+   standalone sign-out button is gone; menu is keyboard/outside-click dismissible.
+6. Local unit + frontend suites green; db_integration green in CI.
+
+## Non-goals
+
+- BYOK (PR 3). Username change (future menu item). Refund/chargeback handling
+  (operator uses `user subscribe --until` to adjust). Automated dunning/expiry
+  notices (silent downgrade to free is the designed lapse behavior). Webhook IP
+  allow-listing (token is Ko-fi's documented mechanism).

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -24,6 +24,10 @@ vi.mock('./views/AddBookView', () => ({ default: () => <div>add-view</div> }))
 vi.mock('./views/HistoryEditView', () => ({ default: () => <div>history-edit-view</div> }))
 vi.mock('./views/ImportView', () => ({ default: () => <div>ImportView</div> }))
 vi.mock('./views/SettingsView', () => ({ default: () => <div>settings-view</div> }))
+// AccountMenu transitively imports api/client -> auth/firebase, whose module-level init
+// throws auth/invalid-api-key in CI (no VITE_FIREBASE_* env there — passes locally only
+// because the dev .env exists). Mock it like the views; its own tests cover it.
+vi.mock('./components/AccountMenu', () => ({ default: () => <div>account-menu</div> }))
 
 import App from './App'
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -118,6 +118,17 @@ export interface SavedLibrary {
   name: string
 }
 
+export interface Account {
+  email: string
+  display_name: string | null
+  tier: 'free' | 'supporter' | 'byok'
+  subscriber_until: string | null
+}
+
+export function getAccount(): Promise<Account> {
+  return getJson<Account>('/account')
+}
+
 /** fetch with the Firebase ID token attached. */
 async function authedFetchRaw(path: string, init: RequestInit = {}): Promise<Response> {
   const token = await getIdToken()

--- a/frontend/src/components/AccountMenu.test.tsx
+++ b/frontend/src/components/AccountMenu.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const signOut = vi.fn()
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'a@b.com', displayName: 'Ada' }, signOut }),
+}))
+
+vi.mock('../api/client', () => ({
+  getAccount: vi.fn(),
+}))
+
+import { getAccount } from '../api/client'
+import AccountMenu from './AccountMenu'
+
+afterEach(() => {
+  vi.mocked(getAccount).mockReset()
+  signOut.mockClear()
+})
+
+async function openMenu() {
+  render(<AccountMenu />)
+  const trigger = screen.getByRole('button', { name: /account menu/i })
+  await userEvent.click(trigger)
+  return trigger
+}
+
+describe('AccountMenu', () => {
+  it('is closed by default, with aria-expanded false on the trigger', () => {
+    render(<AccountMenu />)
+    const trigger = screen.getByRole('button', { name: /account menu/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('opens the panel on avatar click and marks aria-expanded true', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    const trigger = await openMenu()
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('shows "Free plan" for a free-tier account', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    await waitFor(() => expect(screen.getByText('Free plan')).toBeInTheDocument())
+  })
+
+  it('shows "Supporter until <date>" for a supporter-tier account', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'supporter', subscriber_until: '2026-08-25T00:00:00+00:00',
+    })
+    await openMenu()
+    const expected = `Supporter until ${new Date('2026-08-25T00:00:00+00:00').toLocaleDateString()}`
+    await waitFor(() => expect(screen.getByText(expected)).toBeInTheDocument())
+  })
+
+  it('shows no status line when the account fetch fails', async () => {
+    // ...Once variant (vitest#1692): a persistent mockRejectedValue leaks into other
+    // tests' unrelated calls as an unhandled rejection.
+    vi.mocked(getAccount).mockRejectedValueOnce(new Error('account → 500'))
+    await openMenu()
+    await waitFor(() => expect(vi.mocked(getAccount)).toHaveBeenCalled())
+    expect(screen.queryByText('Free plan')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Supporter until/)).not.toBeInTheDocument()
+  })
+
+  it('renders three Ko-fi support links, all pointing at ko-fi.com/shelfwright and opening in a new tab safely', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    const menuItems = await screen.findAllByRole('menuitem')
+    const links = menuItems.filter((el) => el.tagName === 'A')
+    expect(links).toHaveLength(3)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://ko-fi.com/shelfwright')
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link.getAttribute('rel')).toContain('noopener')
+    }
+    expect(screen.getByText(/sign-in email on Ko-fi/i)).toBeInTheDocument()
+  })
+
+  it('closes the panel on Escape', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the panel on an outside click', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    await userEvent.click(document.body)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('calls the auth context signOut when Sign out is clicked, even after getAccount rejected', async () => {
+    vi.mocked(getAccount).mockRejectedValueOnce(new Error('account → 500'))
+    await openMenu()
+    await waitFor(() => expect(vi.mocked(getAccount)).toHaveBeenCalled())
+    await userEvent.click(screen.getByRole('menuitem', { name: /sign out/i }))
+    expect(signOut).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import { getAccount, type Account } from '../api/client'
+
+const KOFI_URL = 'https://ko-fi.com/shelfwright'
+
+/** Account dropdown off the top-bar avatar. Future home of username change and the
+ *  BYOK entry (arc PR 3). Sign-out must never depend on the API: account fetch failure
+ *  just hides the status line. */
+export default function AccountMenu() {
+  const { user, signOut } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [account, setAccount] = useState<Account | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    if (account === null) {
+      getAccount().then(setAccount).catch(() => setAccount(null))
+    }
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, account])
+
+  const status =
+    account?.tier === 'supporter' && account.subscriber_until
+      ? `Supporter until ${new Date(account.subscriber_until).toLocaleDateString()}`
+      : account?.tier === 'free'
+        ? 'Free plan'
+        : null
+
+  return (
+    <div className="account-menu" ref={rootRef}>
+      <button
+        className="avatar avatar-button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div className="account-menu-panel" role="menu">
+          <div className="account-menu-identity">
+            <div className="account-menu-name">{user?.displayName || user?.email}</div>
+            {user?.displayName && <div className="account-menu-email">{user?.email}</div>}
+            {status && <div className="account-menu-status">{status}</div>}
+          </div>
+          <div className="account-menu-support">
+            <div className="account-menu-heading">Support Shelfwright ♥</div>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$3 / month</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$25 / year</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">Leave a tip</a>
+            <div className="account-menu-nudge">
+              Use your Shelfwright sign-in email on Ko-fi so your support links up automatically.
+            </div>
+          </div>
+          <hr />
+          <button role="menuitem" onClick={() => void signOut()}>Sign out</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/AppShell.css
+++ b/frontend/src/components/AppShell.css
@@ -21,6 +21,40 @@
   border: 1px solid var(--topbar-border); border-radius: var(--radius); padding: 4px 10px;
 }
 
+/* Avatar dropdown (account menu) — trigger reuses .avatar; the panel is a themed
+   surface positioned under the top bar, following .topbar's own token conventions. */
+.account-menu { position: relative; }
+.avatar-button { border: none; cursor: pointer; padding: 0; font: inherit; }
+.account-menu-panel {
+  position: absolute; top: calc(100% + 10px); right: 0; z-index: 20;
+  width: 260px; max-width: calc(100vw - 32px);
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: 0 12px 28px -12px var(--menu-shadow);
+  padding: var(--space-3) 0;
+  display: flex; flex-direction: column;
+}
+.account-menu-identity { padding: 0 var(--space-4) var(--space-2); }
+.account-menu-name { font-family: var(--font-display); font-weight: 600; color: var(--text); }
+.account-menu-email { font-size: var(--fs-sm); color: var(--text-muted); }
+.account-menu-status { margin-top: var(--space-1); font-size: var(--fs-sm); color: var(--accent); }
+.account-menu-support { padding: var(--space-2) var(--space-4); display: flex; flex-direction: column; gap: 2px; }
+.account-menu-heading {
+  font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: .04em;
+  color: var(--text-faint); margin-bottom: var(--space-1);
+}
+.account-menu-support a {
+  color: var(--text); text-decoration: none; padding: 4px 0; font-size: var(--fs-sm);
+}
+.account-menu-support a:hover { color: var(--accent); }
+.account-menu-nudge { margin-top: var(--space-2); font-size: var(--fs-xs); color: var(--text-faint); }
+.account-menu-panel hr { border: none; border-top: 1px solid var(--border); margin: var(--space-2) 0; }
+.account-menu-panel > button {
+  background: transparent; border: none; text-align: left; cursor: pointer;
+  padding: var(--space-2) var(--space-4); font-size: var(--fs-body); color: var(--text);
+}
+.account-menu-panel > button:hover { color: var(--accent); }
+
 /* Mobile-first: content sits below the top bar and above the bottom nav. */
 .content { padding: 72px 16px 88px; max-width: 820px; margin: 0 auto; }
 

--- a/frontend/src/components/TopBar.test.tsx
+++ b/frontend/src/components/TopBar.test.tsx
@@ -6,6 +6,12 @@ vi.mock('../auth/AuthContext', () => ({
   useAuth: () => ({ user: { email: 'a@b.com', displayName: 'A' }, signOut: vi.fn() }),
 }))
 
+// AccountMenu fetches lazily on first open — TopBar rendering alone must not need a
+// real client, but AccountMenu.tsx imports it at module scope.
+vi.mock('../api/client', () => ({
+  getAccount: vi.fn(),
+}))
+
 import TopBar from './TopBar'
 
 afterEach(() => {
@@ -27,5 +33,14 @@ describe('TopBar branding', () => {
   it('shows the Shelfwright product name', () => {
     render(<TopBar />)
     expect(screen.getByText('Shelfwright')).toBeInTheDocument()
+  })
+})
+
+describe('TopBar account menu', () => {
+  it('renders the avatar as the account menu trigger, with no standalone sign-out button', () => {
+    render(<TopBar />)
+    const trigger = screen.getByRole('button', { name: /account menu/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('button', { name: /^sign out$/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react'
-import { useAuth } from '../auth/AuthContext'
+import AccountMenu from './AccountMenu'
 import { setTheme, type Theme } from '../theme'
 
 export default function TopBar() {
-  const { user, signOut } = useAuth()
-  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
   const [theme, setThemeState] = useState<Theme>((document.documentElement.dataset.theme as Theme) || 'light')
 
   function toggleTheme() {
@@ -24,8 +22,7 @@ export default function TopBar() {
         >
           {theme === 'dark' ? '☀' : '🌙'}
         </button>
-        <span className="avatar" title={user?.email ?? ''}>{initial}</span>
-        <button onClick={() => void signOut()}>Sign out</button>
+        <AccountMenu />
       </div>
     </header>
   )

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -1,0 +1,89 @@
+"""Ko-fi payment webhook (monetization arc 2/3) — root-level machine route, like
+/internal/*: NOT under /api (purpose-scoped namespacing, #151). Authenticity is Ko-fi's
+shared verification_token (no HMAC exists); fail-closed when unset. Always 200 once the
+event is durably stored — Ko-fi retries non-2xx, and an unmatched payment is an operator
+task (CLI `payments match`), not a delivery failure. Idempotent on kofi_transaction_id."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from fastapi import APIRouter, Form, HTTPException
+
+from agentic_librarian.core import entitlements
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+@router.post("/webhooks/kofi")
+def kofi_webhook(data: str = Form(...)):  # noqa: B008
+    try:
+        event = json.loads(data)
+        if not isinstance(event, dict):
+            raise ValueError("payload is not an object")
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="malformed payload") from e
+
+    expected = os.environ.get("KOFI_VERIFICATION_TOKEN")
+    supplied = str(event.get("verification_token") or "")
+    if not expected or not hmac.compare_digest(supplied, expected):
+        # Unset env fails CLOSED (matches _require_queue_caller's posture).
+        raise HTTPException(status_code=403, detail="verification failed")
+
+    txn_id = str(event.get("kofi_transaction_id") or "").strip()
+    if not txn_id:
+        raise HTTPException(status_code=400, detail="missing kofi_transaction_id")
+    email = str(event.get("email") or "").strip().lower()
+    try:
+        amount = Decimal(str(event.get("amount") or "0"))
+    except InvalidOperation:
+        amount = Decimal(0)
+    tier_name = event.get("tier_name") or None
+    is_sub = bool(event.get("is_subscription_payment", False))
+    kofi_type = str(event.get("type") or "")
+
+    kind = entitlements.classify(kofi_type, is_sub, tier_name, amount)
+    days = entitlements.grant_days(kind)
+
+    with db_manager.get_session() as session:
+        if session.query(Payment.id).filter(Payment.kofi_transaction_id == txn_id).first() is not None:
+            return {"status": "duplicate"}
+        user = session.query(User).filter(User.email == email).first() if email else None
+        payment = Payment(
+            kofi_transaction_id=txn_id,
+            kofi_type=kofi_type,
+            email=email,
+            amount=amount,
+            currency=str(event.get("currency") or ""),
+            tier_name=tier_name,
+            is_subscription_payment=is_sub,
+            payload=event,
+            matched_user_id=user.id if user else None,
+            entitlement_days=days if user else 0,
+        )
+        session.add(payment)
+        if user is not None and days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+            session.flush()
+            logger.info("kofi %s: %s +%dd -> %s", kind, email, days, user.subscriber_until.isoformat())
+            return {"status": "applied", "kind": kind}
+        session.flush()
+    if user is not None:
+        logger.info("kofi tip recorded for %s", email)
+        return {"status": "recorded", "kind": kind}
+    logger.warning("kofi payment UNMATCHED (email %s, txn %s) — resolve via `payments match`", email, txn_id)
+    return {"status": "unmatched", "kind": kind}

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -52,6 +52,10 @@ def kofi_webhook(data: str = Form(...)):  # noqa: B008
         amount = Decimal(str(event.get("amount") or "0"))
     except InvalidOperation:
         amount = Decimal(0)
+    if not amount.is_finite():
+        # "nan"/"-nan"/"Infinity" parse successfully (no InvalidOperation above) but crash
+        # entitlements.classify()'s `amount >= threshold` ordering comparison.
+        amount = Decimal(0)
     tier_name = event.get("tier_name") or None
     is_sub = bool(event.get("is_subscription_payment", False))
     kofi_type = str(event.get("type") or "")

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -56,7 +56,10 @@ def kofi_webhook(data: str = Form(...)):  # noqa: B008
         # "nan"/"-nan"/"Infinity" parse successfully (no InvalidOperation above) but crash
         # entitlements.classify()'s `amount >= threshold` ordering comparison.
         amount = Decimal(0)
-    tier_name = event.get("tier_name") or None
+    # str-coerce like the sibling fields: a non-string tier_name would crash classify()'s
+    # .strip().casefold() before the event is persisted (same class as the amount guard).
+    raw_tier = event.get("tier_name")
+    tier_name = str(raw_tier) if raw_tier else None
     is_sub = bool(event.get("is_subscription_payment", False))
     kofi_type = str(event.get("type") or "")
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -25,6 +25,7 @@ from agentic_librarian.api.books import router as books_router
 from agentic_librarian.api.firebase_auth_proxy import router as firebase_auth_proxy_router
 from agentic_librarian.api.imports import router as imports_router
 from agentic_librarian.api.internal import router as internal_router
+from agentic_librarian.api.kofi import router as kofi_router
 from agentic_librarian.api.libraries import router as libraries_router
 from agentic_librarian.api.recommendations import router as recommendations_router
 from agentic_librarian.chat import stream, transcript
@@ -122,6 +123,7 @@ api_router.include_router(libraries_router)
 # break fixed contracts (Firebase /__/auth/*) or Cloud Tasks target URLs (/internal/*).
 app.include_router(firebase_auth_proxy_router)
 app.include_router(internal_router)
+app.include_router(kofi_router)
 
 
 @app.get("/health")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -17,6 +17,7 @@ from agentic_librarian.agents.runtime import LibrarianConversation, astart_conve
 from agentic_librarian.api import analysis, auth, recommendations
 from agentic_librarian.api import availability as availability_api
 from agentic_librarian.api import imports as imports_api
+from agentic_librarian.api import kofi as kofi_api
 from agentic_librarian.api import libraries as libraries_api
 from agentic_librarian.api.analysis import router as analysis_router
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
@@ -100,6 +101,7 @@ async def lifespan(app: FastAPI):
     two_phase.set_db_manager(shared)
     imports_worker.set_db_manager(shared)
     budgets.set_db_manager(shared)
+    kofi_api.set_db_manager(shared)
     yield
 
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -37,6 +37,7 @@ from agentic_librarian.db.migration_guard import check_migrations
 from agentic_librarian.db.models import (
     Edition,
     ReadingHistory,
+    User,
     Work,
     WorkContributor,
     WorkStyle,
@@ -460,6 +461,23 @@ class _SyncOpener:
     def close(self):
         if self._conv is not None:
             self._conv.close()
+
+
+@api_router.get("/account")
+def get_account(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    """Identity + entitlement summary for the avatar menu (#100 monetization arc 2/3).
+    tier comes from tiers.effective_tier — the single source of truth; no second
+    computation here."""
+    with db_manager.get_session() as session:
+        tier = tiers.effective_tier(session, user.id)
+        row = session.get(User, user.id)
+        until = row.subscriber_until.isoformat() if row and row.subscriber_until else None
+        return {
+            "email": row.email if row else None,
+            "display_name": row.display_name if row else None,
+            "tier": tier,
+            "subscriber_until": until,
+        }
 
 
 @api_router.get("/conversations/current")

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import sys
 import time
+from datetime import UTC, datetime
 
 from agentic_librarian.agents.backends import get_backend
 from agentic_librarian.chat_recorder import ConversationRecorder
@@ -35,6 +36,24 @@ def _parse_args(argv=None):
     invite_parser = user_sub.add_parser("invite", help="invite an email — creates the user row; they sign in later")
     invite_parser.add_argument("email", help="the invitee's email (the invite key; lowercased)")
     invite_parser.add_argument("--name", default=None, help="display name (optional)")
+    sub_parser = user_sub.add_parser(
+        "subscribe", help="grant/extend supporter entitlement (comp or Ko-fi mismatch fix)"
+    )
+    sub_parser.add_argument("email")
+    group = sub_parser.add_mutually_exclusive_group()
+    group.add_argument("--months", type=int, default=None, help="N x 33-day grants (default 1)")
+    group.add_argument("--days", type=int, default=None)
+    group.add_argument("--until", default=None, help="YYYY-MM-DD (absolute)")
+
+    payments_parser = subparsers.add_parser("payments", help="Ko-fi payment records (operator)")
+    payments_sub = payments_parser.add_subparsers(dest="payments_command")
+    list_parser = payments_sub.add_parser("list", help="list payments")
+    list_parser.add_argument("--unmatched", action="store_true")
+    match_parser = payments_sub.add_parser(
+        "match", help="link an unmatched payment to a user and apply its entitlement"
+    )
+    match_parser.add_argument("kofi_transaction_id")
+    match_parser.add_argument("email")
     return parser.parse_args(argv)
 
 
@@ -56,6 +75,8 @@ def main(argv=None) -> int:
 def _dispatch(args) -> int:
     if getattr(args, "command", None) == "user":
         return _run_user(args)
+    if getattr(args, "command", None) == "payments":
+        return _run_payments(args)
     if getattr(args, "command", None) == "add":
         return _run_add(args)
     if args.backend:
@@ -105,14 +126,29 @@ def _invite_db_manager():
     return DatabaseManager()
 
 
+def _normalize_email(raw: str) -> str:
+    return raw.strip().lower()
+
+
+def _is_valid_email(email: str) -> bool:
+    return "@" in email and not email.startswith("@") and not email.endswith("@")
+
+
 def _run_user(args) -> int:
-    if getattr(args, "user_command", None) != "invite":
-        print("usage: librarian user invite <email> [--name NAME]", file=sys.stderr)
-        return 2
+    user_command = getattr(args, "user_command", None)
+    if user_command == "invite":
+        return _run_user_invite(args)
+    if user_command == "subscribe":
+        return _run_user_subscribe(args)
+    print("usage: librarian user <invite|subscribe> ...", file=sys.stderr)
+    return 2
+
+
+def _run_user_invite(args) -> int:
     from agentic_librarian.db.models import User
 
-    email = args.email.strip().lower()
-    if "@" not in email or email.startswith("@") or email.endswith("@"):
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
         print(f"error: {email!r} does not look like an email address", file=sys.stderr)
         return 2
     db = _invite_db_manager()
@@ -125,6 +161,116 @@ def _run_user(args) -> int:
         session.add(User(email=email, display_name=args.name))
         session.flush()
     print(f"Invited {email}. They can now sign in (claim-by-email links their account on first sign-in).")
+    return 0
+
+
+def _run_user_subscribe(args) -> int:
+    """Operator comp / Ko-fi-mismatch fallback: grant or extend a user's supporter
+    entitlement directly. --months/--days extend (active subs stack, lapsed restart from
+    now, via entitlements.extend); --until SETS subscriber_until absolutely (UTC
+    midnight) — it does not stack."""
+    from agentic_librarian.core import entitlements
+    from agentic_librarian.db.models import User
+
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
+        print(f"error: {email!r} does not look like an email address", file=sys.stderr)
+        return 2
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        user = session.query(User).filter(User.email == email).first()
+        if user is None:
+            print(f"error: no user found for {email!r} (use `user invite` first)", file=sys.stderr)
+            return 2
+        if args.until is not None:
+            try:
+                until = datetime.strptime(args.until, "%Y-%m-%d").replace(tzinfo=UTC)
+            except ValueError:
+                print(f"error: {args.until!r} is not a valid YYYY-MM-DD date", file=sys.stderr)
+                return 2
+            user.subscriber_until = until
+        elif args.days is not None:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, args.days)
+        else:
+            months = args.months if args.months is not None else 1
+            user.subscriber_until = entitlements.extend(user.subscriber_until, months * 33)
+        session.flush()
+        result = user.subscriber_until
+    print(f"{email}: subscriber_until -> {result.isoformat()}")
+    return 0
+
+
+def _run_payments(args) -> int:
+    payments_command = getattr(args, "payments_command", None)
+    if payments_command == "list":
+        return _run_payments_list(args)
+    if payments_command == "match":
+        return _run_payments_match(args)
+    print("usage: librarian payments <list|match> ...", file=sys.stderr)
+    return 2
+
+
+def _run_payments_list(args) -> int:
+    from agentic_librarian.db.models import Payment
+
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        query = session.query(Payment).order_by(Payment.created_at)
+        if args.unmatched:
+            query = query.filter(Payment.matched_user_id.is_(None))
+        rows = query.all()
+        header = (
+            f"{'kofi_transaction_id':<24} {'created_at':<10} {'email':<30} "
+            f"{'amount':>8} {'type/tier':<16} {'matched':<7} {'entitlement_days':>16}"
+        )
+        print(header)
+        for p in rows:
+            type_tier = p.tier_name or p.kofi_type
+            matched = "yes" if p.matched_user_id else "no"
+            print(
+                f"{p.kofi_transaction_id:<24} {p.created_at.date().isoformat():<10} {p.email:<30} "
+                f"{p.amount:>8} {type_tier:<16} {matched:<7} {p.entitlement_days:>16}"
+            )
+    return 0
+
+
+def _run_payments_match(args) -> int:
+    """Recomputes classify()/grant_days() from the STORED row's fields (kofi_type,
+    is_subscription_payment, tier_name, amount) rather than trusting anything passed on
+    the command line, so the CLI and the webhook grant identically off a single source
+    of truth."""
+    from agentic_librarian.core import entitlements
+    from agentic_librarian.db.models import Payment, User
+
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
+        print(f"error: {email!r} does not look like an email address", file=sys.stderr)
+        return 2
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == args.kofi_transaction_id).first()
+        if payment is None:
+            print(f"error: no payment found for transaction {args.kofi_transaction_id!r}", file=sys.stderr)
+            return 2
+        user = session.query(User).filter(User.email == email).first()
+        if user is None:
+            print(f"error: no user found for {email!r} (use `user invite` first)", file=sys.stderr)
+            return 2
+        if payment.matched_user_id is not None:
+            print(f"error: payment {args.kofi_transaction_id!r} is already matched", file=sys.stderr)
+            return 2
+        kind = entitlements.classify(
+            payment.kofi_type, payment.is_subscription_payment, payment.tier_name, payment.amount
+        )
+        days = entitlements.grant_days(kind)
+        payment.matched_user_id = user.id
+        payment.entitlement_days = days
+        if days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+        session.flush()
+        result = user.subscriber_until
+    until_msg = result.isoformat() if result else "unchanged"
+    print(f"Matched {args.kofi_transaction_id} to {email} ({kind}, +{days}d) -> subscriber_until {until_msg}")
     return 0
 
 

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -176,6 +176,11 @@ def _run_user_subscribe(args) -> int:
     if not _is_valid_email(email):
         print(f"error: {email!r} does not look like an email address", file=sys.stderr)
         return 2
+    # Guardrail on a prod-mutating tool: a fat-fingered `--days -30` must not silently
+    # revoke paid time. Reducing/revoking is deliberate-only, via the absolute --until.
+    if (args.days is not None and args.days <= 0) or (args.months is not None and args.months <= 0):
+        print("error: --months/--days must be positive (to reduce or revoke, use --until)", file=sys.stderr)
+        return 2
     db = _invite_db_manager()
     with db.get_session() as session:
         user = session.query(User).filter(User.email == email).first()

--- a/src/agentic_librarian/core/entitlements.py
+++ b/src/agentic_librarian/core/entitlements.py
@@ -1,0 +1,54 @@
+"""Ko-fi payment → entitlement rules (monetization arc 2/3). Pure and DB-free: the
+webhook and the CLI both call these so grant math exists exactly once. Env knobs are
+read per call (prod-tunable): KOFI_ANNUAL_TIER_NAMES (csv of tier/product names that
+mean 'annual', default 'annual'; exact case-folded match — substring matching would
+misfire on e.g. 'Not Annual'), KOFI_ANNUAL_MIN_AMOUNT (one-off donations at/over this
+classify as annual, default 25). Grace is baked into the grant: 33/370 days cover
+Ko-fi's missing cancellation events and late renewals."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+Kind = Literal["monthly", "annual", "tip"]
+
+_GRANT_DAYS: dict[Kind, int] = {"monthly": 33, "annual": 370, "tip": 0}
+_DEFAULT_ANNUAL_MIN = Decimal(25)
+
+
+def _annual_tier_names() -> set[str]:
+    raw = os.environ.get("KOFI_ANNUAL_TIER_NAMES", "annual")
+    return {part.strip().casefold() for part in raw.split(",") if part.strip()}
+
+
+def _annual_min_amount() -> Decimal:
+    raw = os.environ.get("KOFI_ANNUAL_MIN_AMOUNT", "")
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return _DEFAULT_ANNUAL_MIN
+    return value if value > 0 else _DEFAULT_ANNUAL_MIN
+
+
+def classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Kind:
+    if tier_name is not None and tier_name.strip().casefold() in _annual_tier_names():
+        return "annual"
+    if is_subscription_payment:
+        return "monthly"
+    if amount >= _annual_min_amount():
+        return "annual"
+    return "tip"
+
+
+def grant_days(kind: Kind) -> int:
+    return _GRANT_DAYS[kind]
+
+
+def extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime:
+    """New subscriber_until: active subs stack; lapsed subs restart from now."""
+    now = now or datetime.now(UTC)
+    base = current if (current is not None and current > now) else now
+    return base + timedelta(days=days)

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -1,9 +1,11 @@
 from datetime import UTC, date, datetime
+from decimal import Decimal
 from uuid import UUID, uuid4
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     ARRAY,
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -12,6 +14,7 @@ from sqlalchemy import (
     Index,
     Integer,
     LargeBinary,
+    Numeric,
     String,
     Table,
     Text,
@@ -331,6 +334,29 @@ class Usage(Base):
     conversation_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True, index=True
     )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+
+
+class Payment(Base):
+    """One row per Ko-fi webhook event (monetization arc 2/3) — the audit trail behind
+    users.subscriber_until. Idempotency key = kofi_transaction_id (Ko-fi retries).
+    matched_user_id NULL = payer email didn't match a user (CLI `payments match` fixes)."""
+
+    __tablename__ = "payments"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    kofi_transaction_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    kofi_type: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)  # lowercased at ingest
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String, nullable=False)
+    tier_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_subscription_payment: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    matched_user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    entitlement_days: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )

--- a/test/integration/test_account_api.py
+++ b/test/integration/test_account_api.py
@@ -1,0 +1,52 @@
+"""#100 monetization arc 2/3: GET /api/account, executed against a real Postgres
+(db_integration — CI-only, see test/conftest.py). Tier comes straight from
+tiers.effective_tier — this test asserts the endpoint's shape, not a second tier
+computation. Rows are seeded with EXPLICIT, distinct created_at values (#147 lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import auth
+from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(api_main, "db_manager", manager)
+    monkeypatch.setitem(
+        api_main.app.dependency_overrides,
+        auth.get_current_user,
+        lambda: auth.AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL),
+    )
+    yield TestClient(api_main.app)
+
+
+def test_account_free_user_has_no_subscriber_until(client):
+    body = client.get("/api/account").json()
+    assert body == {
+        "email": DEFAULT_USER_EMAIL,
+        "display_name": "Justin",
+        "tier": "free",
+        "subscriber_until": None,
+    }
+
+
+def test_account_future_subscriber_until_is_supporter(client, db_url):
+    manager = DatabaseManager(db_url)
+    until = (datetime.now(UTC) + timedelta(days=30)).replace(microsecond=0)
+    with manager.get_session() as session:
+        row = session.get(User, DEFAULT_USER_ID)
+        row.subscriber_until = until
+
+    body = client.get("/api/account").json()
+    assert body["tier"] == "supporter"
+    assert body["subscriber_until"] == until.isoformat()
+    assert body["email"] == DEFAULT_USER_EMAIL

--- a/test/integration/test_cli_invite.py
+++ b/test/integration/test_cli_invite.py
@@ -128,6 +128,23 @@ def test_subscribe_rejects_non_email(_cli_db, capsys):
     assert "error" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "extra_args",
+    [["--days", "0"], ["--days", "-30"], ["--months", "0"], ["--months", "-5"]],
+    ids=["days-zero", "days-negative", "months-zero", "months-negative"],
+)
+def test_subscribe_rejects_non_positive_grants(_cli_db, capsys, extra_args):
+    """Fat-finger guardrail: a negative/zero grant must not silently shrink paid time —
+    reducing/revoking is deliberate-only via the absolute --until."""
+    email = "guard@example.com"
+    horizon = datetime.now(UTC) + timedelta(days=200)
+    user_id = _seed_user(_cli_db, email, subscriber_until=horizon)
+    assert main(["user", "subscribe", email, *extra_args]) == 2
+    assert "--until" in capsys.readouterr().err
+    with _cli_db.get_session() as session:
+        assert session.get(User, user_id).subscriber_until == horizon
+
+
 def test_payments_list_unmatched_filters_out_matched_rows(_cli_db, capsys):
     user_id = _seed_user(_cli_db, "matched@example.com")
     _seed_payment(

--- a/test/integration/test_cli_invite.py
+++ b/test/integration/test_cli_invite.py
@@ -1,12 +1,19 @@
-"""Operator invite tooling (Lift 1, ADR-048): adding a friend is a command, not psql."""
+"""Operator account tooling (Lift 1, ADR-048; monetization arc 2/3 task 3): adding a
+friend, comping/correcting a supporter entitlement, and reconciling a Ko-fi payment
+that couldn't be auto-matched to a user are all commands, not psql."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
 from agentic_librarian.cli import main
-from agentic_librarian.db.models import User
+from agentic_librarian.db.models import Payment, User
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
+
+SLACK = timedelta(minutes=5)
 
 
 @pytest.fixture(autouse=True)
@@ -14,6 +21,45 @@ def _cli_db(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr("agentic_librarian.cli._invite_db_manager", lambda: manager)
     yield manager
+
+
+def _seed_user(db, email, subscriber_until=None, created_at=None):
+    """Returns the new user's id only — never a live ORM object across a closed session
+    boundary (expire-on-commit + session close = DetachedInstanceError on later attribute
+    access, CI-only since local runs never hit a real Postgres to exercise this path).
+    Flushes immediately so later FK-dependent inserts (Payment.matched_user_id) in the
+    SAME test see the row (PR #155 lesson)."""
+    with db.get_session() as session:
+        user = User(
+            email=email,
+            subscriber_until=subscriber_until,
+            created_at=created_at or (datetime.now(UTC) - timedelta(days=1)),
+        )
+        session.add(user)
+        session.flush()
+        return user.id
+
+
+def _seed_payment(db, **overrides):
+    fields = {
+        "kofi_transaction_id": "txn-1",
+        "kofi_type": "Subscription",
+        "email": "payer@example.com",
+        "amount": Decimal("5.00"),
+        "currency": "USD",
+        "tier_name": None,
+        "is_subscription_payment": True,
+        "payload": {},
+        "matched_user_id": None,
+        "entitlement_days": 0,
+        "created_at": datetime.now(UTC) - timedelta(days=1),
+        **overrides,
+    }
+    with db.get_session() as session:
+        payment = Payment(**fields)
+        session.add(payment)
+        session.flush()
+        return payment.id
 
 
 def test_invite_creates_lowercased_row(_cli_db, capsys):
@@ -36,3 +82,145 @@ def test_invite_existing_email_is_idempotent(_cli_db, capsys):
 
 def test_invite_rejects_non_email(capsys):
     assert main(["user", "invite", "not-an-email"]) == 2
+
+
+@pytest.mark.parametrize(
+    "extra_args,expected_days",
+    [
+        pytest.param([], 33, id="default-is-one-month-33-days"),
+        pytest.param(["--months", "3"], 99, id="months-3-times-33"),
+        pytest.param(["--days", "45"], 45, id="days-exact"),
+    ],
+)
+def test_subscribe_grants_expected_days(_cli_db, capsys, extra_args, expected_days):
+    email = "comp@example.com"
+    user_id = _seed_user(_cli_db, email)
+    before = datetime.now(UTC)
+    assert main(["user", "subscribe", email, *extra_args]) == 0
+    with _cli_db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        expected_min = before + timedelta(days=expected_days) - SLACK
+        expected_max = before + timedelta(days=expected_days) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+    assert email in capsys.readouterr().out
+
+
+def test_subscribe_until_sets_absolute_not_extend(_cli_db, capsys):
+    """--until SETS subscriber_until to the given date at UTC midnight, even when an
+    existing (still-active) horizon is further out than that date — proving it's an
+    absolute set, not entitlements.extend()'s stack-if-active behavior."""
+    email = "comp-until@example.com"
+    user_id = _seed_user(_cli_db, email, subscriber_until=datetime.now(UTC) + timedelta(days=500))
+    assert main(["user", "subscribe", email, "--until", "2027-01-01"]) == 0
+    with _cli_db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        assert refreshed.subscriber_until == datetime(2027, 1, 1, tzinfo=UTC)
+    assert "2027-01-01" in capsys.readouterr().out
+
+
+def test_subscribe_unknown_email_exits_2(_cli_db, capsys):
+    assert main(["user", "subscribe", "nobody@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_subscribe_rejects_non_email(_cli_db, capsys):
+    assert main(["user", "subscribe", "not-an-email"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_list_unmatched_filters_out_matched_rows(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "matched@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-matched",
+        email="matched@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    _seed_payment(_cli_db, kofi_transaction_id="txn-unmatched", email="nobody@example.com")
+    assert main(["payments", "list", "--unmatched"]) == 0
+    out = capsys.readouterr().out
+    assert "txn-unmatched" in out
+    assert "txn-matched" not in out
+
+
+def test_payments_list_without_filter_shows_matched_and_unmatched(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "matched2@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-m2",
+        email="matched2@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    _seed_payment(_cli_db, kofi_transaction_id="txn-u2", email="nobody2@example.com")
+    assert main(["payments", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "txn-m2" in out
+    assert "txn-u2" in out
+    assert "nobody2@example.com" in out
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected_kind,expected_days",
+    [
+        pytest.param("Subscription", True, None, Decimal("5.00"), "monthly", 33, id="monthly"),
+        pytest.param("Shop Order", False, "Annual", Decimal("25.00"), "annual", 370, id="annual"),
+        pytest.param("Donation", False, None, Decimal("3.00"), "tip", 0, id="tip-no-entitlement"),
+    ],
+)
+def test_payments_match_recomputes_entitlement_from_stored_row(
+    _cli_db, capsys, kofi_type, is_sub, tier_name, amount, expected_kind, expected_days
+):
+    """match must recompute classify()/grant_days() from the STORED payment fields
+    (not anything on the command line) so CLI and webhook grant identically."""
+    email = f"match-{expected_kind}@example.com"
+    txn_id = f"txn-{expected_kind}"
+    user_id = _seed_user(_cli_db, email)
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id=txn_id,
+        kofi_type=kofi_type,
+        email=email,
+        amount=amount,
+        tier_name=tier_name,
+        is_subscription_payment=is_sub,
+    )
+    before = datetime.now(UTC)
+    assert main(["payments", "match", txn_id, email]) == 0
+    with _cli_db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == txn_id).one()
+        refreshed = session.get(User, user_id)
+        assert payment.matched_user_id == user_id
+        assert payment.entitlement_days == expected_days
+        if expected_days > 0:
+            expected_min = before + timedelta(days=expected_days) - SLACK
+            expected_max = before + timedelta(days=expected_days) + SLACK
+            assert expected_min <= refreshed.subscriber_until <= expected_max
+        else:
+            assert refreshed.subscriber_until is None
+
+
+def test_payments_match_refuses_unknown_transaction(_cli_db, capsys):
+    _seed_user(_cli_db, "someone@example.com")
+    assert main(["payments", "match", "nope-txn", "someone@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_match_refuses_unknown_email(_cli_db, capsys):
+    _seed_payment(_cli_db, kofi_transaction_id="txn-orphan", email="payer@example.com")
+    assert main(["payments", "match", "txn-orphan", "nobody@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_match_refuses_already_matched(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "already@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-already",
+        email="already@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    assert main(["payments", "match", "txn-already", "already@example.com"]) == 2
+    assert "already matched" in capsys.readouterr().err

--- a/test/integration/test_kofi_webhook_db.py
+++ b/test/integration/test_kofi_webhook_db.py
@@ -1,0 +1,178 @@
+"""End-to-end Ko-fi webhook matrix against a real Postgres (db_integration — CI-only,
+see test/conftest.py). Follows test_internal_complete_edition_api.py's pattern: full
+FastAPI app via TestClient (no lifespan, since it's used without a `with` block),
+module's db_manager monkeypatched to the isolated test DB.
+
+Exact subscriber_until timestamps aren't assertable through HTTP (no way to freeze the
+webhook's internal `now`), so the matrix asserts a slack range around each grant instead.
+Rows are seeded with EXPLICIT, distinct created_at values (the #147 same-timestamp
+flake lesson)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import kofi as kofi_mod
+from agentic_librarian.api import main as api_main
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+VALID_TOKEN = "test-kofi-verification-token"
+SLACK = timedelta(minutes=5)
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    monkeypatch.setattr(kofi_mod, "db_manager", DatabaseManager(db_url))
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    yield TestClient(api_main.app)
+
+
+def _seed_user(db, email: str, subscriber_until: datetime | None, created_at: datetime):
+    """Returns the new user's id only — never a live ORM object across a closed
+    session boundary (the #11 CLAUDE.md pitfall: expire-on-commit + session.close()
+    turns any later attribute access into DetachedInstanceError, CI-only since local
+    runs never reach a real Postgres to exercise this path)."""
+    with db.get_session() as session:
+        user = User(email=email, subscriber_until=subscriber_until, created_at=created_at)
+        session.add(user)
+        session.flush()
+        return user.id
+
+
+def _post(client, **event_overrides):
+    event = {
+        "verification_token": VALID_TOKEN,
+        "kofi_transaction_id": "txn-1",
+        "email": "Subscriber@Example.com",
+        "amount": "5.00",
+        "currency": "USD",
+        "type": "Subscription",
+        "is_subscription_payment": True,
+        "tier_name": None,
+        **event_overrides,
+    }
+    return client.post("/webhooks/kofi", data={"data": json.dumps(event)})
+
+
+@pytest.mark.parametrize(
+    "prior_offset_days,expected_days",
+    [
+        pytest.param(-10, 33, id="lapsed-subscriber-restarts-from-now"),
+        pytest.param(20, 33, id="active-subscriber-stacks-from-existing-expiry"),
+    ],
+)
+def test_membership_payment_matched_email_extends_subscriber_until(client, db_url, prior_offset_days, expected_days):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    prior = now + timedelta(days=prior_offset_days)
+    user_id = _seed_user(db, "subscriber@example.com", prior, now - timedelta(days=1))
+
+    before_call = datetime.now(UTC)
+    resp = _post(client, kofi_transaction_id="membership-txn", email="Subscriber@Example.com")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "applied", "kind": "monthly"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "membership-txn").first()
+        base = prior if prior > before_call else before_call
+        expected_min = base + timedelta(days=expected_days) - SLACK
+        expected_max = base + timedelta(days=expected_days) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+        assert payment is not None
+        assert payment.email == "subscriber@example.com"  # lowercased at ingest
+        assert payment.matched_user_id == user_id
+        assert payment.entitlement_days == 33
+        assert payment.is_subscription_payment is True
+
+
+def test_annual_tier_name_grants_370_days(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "annual@example.com", None, now - timedelta(days=1))
+
+    before_call = datetime.now(UTC)
+    resp = _post(
+        client,
+        kofi_transaction_id="annual-txn",
+        email="annual@example.com",
+        tier_name="Annual",
+        is_subscription_payment=True,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "applied", "kind": "annual"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "annual-txn").first()
+        expected_min = before_call + timedelta(days=370) - SLACK
+        expected_max = before_call + timedelta(days=370) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+        assert payment.entitlement_days == 370
+
+
+def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "tipper@example.com", None, now - timedelta(days=1))
+
+    resp = _post(
+        client,
+        kofi_transaction_id="tip-txn",
+        email="tipper@example.com",
+        amount="3.00",
+        type="Donation",
+        is_subscription_payment=False,
+        tier_name=None,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "recorded", "kind": "tip"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "tip-txn").first()
+        assert refreshed.subscriber_until is None
+        assert payment.entitlement_days == 0
+        assert payment.amount == Decimal("3.00")
+
+
+def test_unknown_email_is_unmatched(client):
+    resp = _post(
+        client,
+        kofi_transaction_id="unmatched-txn",
+        email="nobody-here@example.com",
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "unmatched", "kind": "monthly"}
+
+
+def test_same_txn_replay_is_duplicate_no_second_row_no_double_extend(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "replay@example.com", None, now - timedelta(days=1))
+
+    first = _post(client, kofi_transaction_id="replay-txn", email="replay@example.com")
+    assert first.status_code == 200
+    assert first.json()["status"] == "applied"
+
+    with db.get_session() as session:
+        after_first = session.get(User, user_id).subscriber_until
+
+    second = _post(client, kofi_transaction_id="replay-txn", email="replay@example.com")
+    assert second.status_code == 200
+    assert second.json() == {"status": "duplicate"}
+
+    with db.get_session() as session:
+        after_second = session.get(User, user_id).subscriber_until
+        rows = session.query(Payment).filter(Payment.kofi_transaction_id == "replay-txn").all()
+
+    assert after_second == after_first
+    assert len(rows) == 1

--- a/test/integration/test_kofi_webhook_db.py
+++ b/test/integration/test_kofi_webhook_db.py
@@ -117,6 +117,8 @@ def test_annual_tier_name_grants_370_days(client, db_url):
         expected_max = before_call + timedelta(days=370) + SLACK
         assert expected_min <= refreshed.subscriber_until <= expected_max
         assert payment.entitlement_days == 370
+        assert payment.tier_name == "Annual"
+        assert payment.is_subscription_payment is True
 
 
 def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
@@ -144,14 +146,25 @@ def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
         assert payment.amount == Decimal("3.00")
 
 
-def test_unknown_email_is_unmatched(client):
+def test_unknown_email_is_unmatched(client, db_url):
+    """The JSON response is only the delivery ack; the payments row is the durable
+    evidence the operator's `payments match` fallback actually depends on (CLAUDE.md
+    assertion-completeness rule #1) — assert the row directly, not just the ack body."""
+    db = DatabaseManager(db_url)
     resp = _post(
         client,
         kofi_transaction_id="unmatched-txn",
-        email="nobody-here@example.com",
+        email="Nobody-Here@Example.com",
     )
     assert resp.status_code == 200
     assert resp.json() == {"status": "unmatched", "kind": "monthly"}
+
+    with db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "unmatched-txn").first()
+        assert payment is not None
+        assert payment.matched_user_id is None
+        assert payment.entitlement_days == 0
+        assert payment.email == "nobody-here@example.com"  # lowercased at ingest
 
 
 def test_same_txn_replay_is_duplicate_no_second_row_no_double_extend(client, db_url):

--- a/test/unit/test_db_pool_consolidation.py
+++ b/test/unit/test_db_pool_consolidation.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import analysis as analysis_mod
 from agentic_librarian.api import auth as auth_mod
+from agentic_librarian.api import kofi as kofi_mod
 from agentic_librarian.api import main as main_mod
 from agentic_librarian.api import recommendations as recommendations_mod
 from agentic_librarian.chat import transcript as transcript_mod
@@ -24,6 +25,7 @@ def _restore_db_managers():
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
         budgets_mod.db_manager,
+        kofi_mod.db_manager,
     )
     yield
     (
@@ -34,6 +36,7 @@ def _restore_db_managers():
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
         budgets_mod.db_manager,
+        kofi_mod.db_manager,
     ) = saved
 
 
@@ -49,3 +52,4 @@ def test_startup_consolidates_api_pools(_restore_db_managers):
         assert recommendations_mod.db_manager is shared
         assert analysis_mod.db_manager is shared
         assert budgets_mod.db_manager is shared
+        assert kofi_mod.db_manager is shared

--- a/test/unit/test_entitlements.py
+++ b/test/unit/test_entitlements.py
@@ -1,0 +1,57 @@
+"""Monetization arc 2/3: entitlement classification is pure and DB-free."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from agentic_librarian.core import entitlements
+
+NOW = datetime(2026, 7, 26, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected",
+    [
+        ("Subscription", True, "Supporter", Decimal("3.00"), "monthly"),
+        ("Subscription", True, None, Decimal("3.00"), "monthly"),
+        ("Shop Order", False, "Annual", Decimal("25.00"), "annual"),
+        ("Shop Order", False, "ANNUAL", Decimal("25.00"), "annual"),  # case-insensitive
+        # "Annual Supporter" != "annual" under exact case-folded match, so tier_name does
+        # NOT win here; falls through to is_sub=True -> monthly. See NOTE in task-1-brief.md.
+        ("Subscription", True, "Annual Supporter", Decimal("25.00"), "monthly"),
+        ("Donation", False, None, Decimal("25.00"), "annual"),  # one-off >= threshold
+        ("Donation", False, None, Decimal("30.00"), "annual"),
+        ("Donation", False, None, Decimal("24.99"), "tip"),
+        ("Donation", False, None, Decimal("3.00"), "tip"),
+        ("Commission", False, None, Decimal("10.00"), "tip"),
+    ],
+)
+def test_classify_defaults(monkeypatch, kofi_type, is_sub, tier_name, amount, expected):
+    monkeypatch.delenv("KOFI_ANNUAL_TIER_NAMES", raising=False)
+    monkeypatch.delenv("KOFI_ANNUAL_MIN_AMOUNT", raising=False)
+    assert entitlements.classify(kofi_type, is_sub, tier_name, amount) == expected
+
+
+def test_classify_env_tier_names(monkeypatch):
+    monkeypatch.setenv("KOFI_ANNUAL_TIER_NAMES", "yearly, gold ")
+    assert entitlements.classify("Shop Order", False, "Gold", Decimal("25.00")) == "annual"
+    assert entitlements.classify("Shop Order", False, "Annual", Decimal("10.00")) == "tip"
+
+
+@pytest.mark.parametrize("kind,days", [("monthly", 33), ("annual", 370), ("tip", 0)])
+def test_grant_days(kind, days):
+    assert entitlements.grant_days(kind) == days
+
+
+@pytest.mark.parametrize(
+    "current,days,expected",
+    [
+        (None, 33, NOW + timedelta(days=33)),  # first sub
+        (NOW - timedelta(days=10), 33, NOW + timedelta(days=33)),  # lapsed: restart from now
+        (NOW + timedelta(days=5), 33, NOW + timedelta(days=38)),  # active: stack
+        (NOW + timedelta(days=100), 370, NOW + timedelta(days=470)),  # annual stacks too
+    ],
+)
+def test_extend(current, days, expected):
+    assert entitlements.extend(current, days, now=NOW) == expected

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -5,6 +5,9 @@ tiny-app-with-just-the-router pattern — no real DB, no real app lifespan."""
 
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -27,6 +30,39 @@ class _RaisingSessionManager:
 
     def get_session(self):
         raise RuntimeError("db unavailable")
+
+
+class _FakeQuery:
+    """Minimal chainable stand-in for a SQLAlchemy Query: every filter() no-ops, first()
+    always reports 'nothing found' (no duplicate row, no matched user)."""
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+
+class _FakeSession:
+    def query(self, *args, **kwargs):
+        return _FakeQuery()
+
+    def add(self, obj):
+        pass
+
+    def flush(self):
+        pass
+
+
+class _WorkingSessionManager:
+    """Stands in for DatabaseManager: get_session() yields a working fake session (the
+    _RaisingSessionManager's pattern inverted) so a handler run can reach a 2xx without a
+    real DB — used for the non-finite-amount guard, which must survive all the way to the
+    DB-write branch rather than crash in entitlements.classify() first."""
+
+    @contextmanager
+    def get_session(self):
+        yield _FakeSession()
 
 
 def _client() -> TestClient:
@@ -74,3 +110,38 @@ def test_db_layer_error_after_valid_token_is_500(monkeypatch):
     payload = f'{{"verification_token": "{VALID_TOKEN}", "kofi_transaction_id": "t1"}}'
     resp = _client().post("/webhooks/kofi", data={"data": payload})
     assert resp.status_code == 500
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    [
+        pytest.param("nan", id="amount-nan"),
+        pytest.param("-nan", id="amount-negative-nan"),
+        pytest.param("Infinity", id="amount-infinity"),
+    ],
+)
+def test_non_finite_amount_does_not_crash_classify(monkeypatch, amount_str):
+    """Decimal("nan")/Decimal("-nan")/Decimal("Infinity") all parse WITHOUT raising
+    InvalidOperation, so the handler's own try/except around Decimal(...) never catches
+    them. Without an explicit is_finite() guard, entitlements.classify()'s
+    `amount >= threshold` ordering comparison raises decimal.InvalidOperation on a
+    non-finite operand -> an uncaught 500 BEFORE the event is durably stored, and since
+    Ko-fi retries non-2xx responses with the SAME payload, that crash would repeat
+    forever. Uses a working fake session (not the 500 test's raising one) so the request
+    reaches the DB-write branch and actually returns 2xx."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_WorkingSessionManager())
+    payload = json.dumps(
+        {
+            "verification_token": VALID_TOKEN,
+            "kofi_transaction_id": f"txn-{amount_str}",
+            "amount": amount_str,
+            # No email -> no User lookup needed from the fake session; the payment still
+            # goes through the add()/flush() write path and lands on "unmatched".
+        }
+    )
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 200
+    # Non-finite amount is clamped to 0 -> classifies as a tip (amount 0 < the annual
+    # threshold, no tier_name, not a subscription payment).
+    assert resp.json() == {"status": "unmatched", "kind": "tip"}

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -1,0 +1,76 @@
+"""Unit tests for the Ko-fi webhook's DB-free guards (monetization arc 2/3): malformed
+payload, verification-token fail-closed posture, and the 500-on-DB-error path Ko-fi's
+retry logic relies on for idempotent recovery. Mirrors test_firebase_auth_proxy.py's
+tiny-app-with-just-the-router pattern — no real DB, no real app lifespan."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import kofi
+from agentic_librarian.api.kofi import router
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_manager():
+    """Reset the module-global db_manager after each test so a stub never leaks."""
+    original = kofi.db_manager
+    yield
+    kofi.set_db_manager(original)
+
+
+class _RaisingSessionManager:
+    """Stands in for DatabaseManager: get_session() raises before yielding, simulating
+    a DB outage — the webhook must surface it as 500 so Ko-fi retries."""
+
+    def get_session(self):
+        raise RuntimeError("db unavailable")
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+VALID_TOKEN = "the-shared-secret"
+
+
+@pytest.mark.parametrize(
+    "form,expected_status",
+    [
+        pytest.param({}, 422, id="no-data-field-is-422-fastapi-validation"),
+        pytest.param({"data": "not json"}, 400, id="data-not-json-is-400"),
+        pytest.param({"data": "[1, 2, 3]"}, 400, id="data-not-an-object-is-400"),
+    ],
+)
+def test_malformed_payload_guards(monkeypatch, form, expected_status):
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    resp = _client().post("/webhooks/kofi", data=form)
+    assert resp.status_code == expected_status
+
+
+def test_verification_token_unset_fails_closed_even_with_token_in_payload(monkeypatch):
+    monkeypatch.delenv("KOFI_VERIFICATION_TOKEN", raising=False)
+    payload = '{"verification_token": "anything", "kofi_transaction_id": "t1"}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 403
+
+
+def test_verification_token_mismatch_is_403(monkeypatch):
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    payload = '{"verification_token": "wrong-token", "kofi_transaction_id": "t1"}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 403
+
+
+def test_db_layer_error_after_valid_token_is_500(monkeypatch):
+    """Token OK but the DB layer raises -> 500, not a swallowed/misreported error. Ko-fi
+    retries non-2xx and kofi_transaction_id idempotency makes the retry safe."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_RaisingSessionManager())
+    payload = f'{{"verification_token": "{VALID_TOKEN}", "kofi_transaction_id": "t1"}}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 500

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -145,3 +145,31 @@ def test_non_finite_amount_does_not_crash_classify(monkeypatch, amount_str):
     # Non-finite amount is clamped to 0 -> classifies as a tip (amount 0 < the annual
     # threshold, no tier_name, not a subscription payment).
     assert resp.json() == {"status": "unmatched", "kind": "tip"}
+
+
+@pytest.mark.parametrize(
+    "raw_tier,expected_kind",
+    [
+        pytest.param(123, "tip", id="tier-name-int"),
+        pytest.param(["annual"], "tip", id="tier-name-list"),
+        pytest.param("Annual", "annual", id="tier-name-string-still-classifies"),
+    ],
+)
+def test_non_string_tier_name_does_not_crash_classify(monkeypatch, raw_tier, expected_kind):
+    """Same failure class as the non-finite amount: an attacker-shaped non-string
+    tier_name would crash classify()'s .strip().casefold() before the event is
+    persisted -> deterministic 500 retried forever. The handler str-coerces it like
+    the sibling fields (a coerced "123" simply matches no annual tier name)."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_WorkingSessionManager())
+    payload = json.dumps(
+        {
+            "verification_token": VALID_TOKEN,
+            "kofi_transaction_id": f"txn-tier-{expected_kind}-{type(raw_tier).__name__}",
+            "amount": "5.00",
+            "tier_name": raw_tier,
+        }
+    )
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "unmatched", "kind": expected_kind}


### PR DESCRIPTION
Revectored from Ko-fi to **Buy Me a Coffee** (provider decision 2026-07-31; spec amendment `docs/superpowers/specs/2026-07-31-bmc-subscriptions-design.md`). Supersedes the original Ko-fi scope of this PR; the provider-neutral core survives.

## What this delivers
- **`payments` audit table** (migration `b2c3d4e5f6a7`, provider-neutral columns, idempotent on `(provider, provider_event_id)`)
- **`POST /webhooks/bmc`** — HMAC-SHA256 raw-body verification (`x-signature-sha256`, fail-closed), full membership lifecycle: grants = `current_period_end + BMC_GRACE_DAYS` (default 5, never shrink), `cancelled`/`paused` caps (never extend; missing horizon never guess-shrinks paid standing), tips/refunds recorded, always-200-once-stored (BMC auto-disables after 10 consecutive failures)
- **Entitlement math** in pure `core/entitlements.py` — structural classification on `duration_type` month|year (no tier-name/amount heuristics)
- **Operator CLI**: `user subscribe` (comps; non-positive grants rejected), `payments list/match` (recomputes from the stored payload — single source of truth)
- **`GET /api/account`** + avatar-dropdown **AccountMenu** ($3/mo · $30/yr · tip → buymeacoffee.com/shelfwrighw)
- deploy.yml: `BMC_WEBHOOK_SECRET=librarian-bmc-webhook-secret` (secret already created)

## Review
4-task SDD with per-task reviews (2 Important findings fixed in-loop) + opus whole-branch adversarial review which caught a **confirmed blocker** pre-merge: signed `membership.cancelled` with `cancel_at_period_end` but missing/absurd `current_period_end` raised TypeError → repeated 500s toward BMC's webhook auto-disable. Fixed in `e9f2a18` (`apply_cap` treats an underivable cap as no-op). Verdict: READY TO MERGE.

## Ops at rollout (operator)
1. Merge → deploy (migration `b2c3d4e5f6a7` must be applied via the runbook proxy recipe **before** the deploy revision can start — same guard flow as #155).
2. In the BMC dashboard, fire test events for each membership/donation type against `https://shelfwright.app/webhooks/bmc`; if earlier accidental deliveries disabled the webhook, re-enable it.
3. **~2026-09-01 (first real renewal): check logs to confirm `membership.updated` fires per billing cycle.** If it doesn't, raise `BMC_GRACE_DAYS` and open an issue for a renewal source (documented residual).

## Riding residuals (triaged, non-blocking)
- Concurrent same-user deliveries have no row lock (last-write-wins; low likelihood — ops-watch)
- Concurrent duplicate deliveries: second may 500 then settle to `duplicate` on retry (safe by idempotency)
- `payments list` rendering assertions shallow (pre-existing debt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3