### PR TITLE
feat: BYOK — bring your own Gemini key (monetization arc 3/3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
             --service-account=librarian-api-runtime@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             --add-cloudsql-instances=${{ vars.GCP_CLOUDSQL_CONNECTION }}
             --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest,KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest
-            --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},AGENT_BACKEND=adk,GEMINI_MODEL=gemini-3.1-flash-lite,CLOUD_TASKS_QUEUE=${{ vars.GCP_CLOUD_TASKS_QUEUE }},IMPORT_TASKS_QUEUE=${{ vars.GCP_IMPORT_TASKS_QUEUE }},ENRICH_TARGET_BASE_URL=${{ vars.GCP_RUN_BASE_URL }},ENRICH_INVOKER_SA=${{ vars.GCP_ENRICH_INVOKER_SA }},ENRICH_OIDC_AUDIENCE=${{ vars.GCP_RUN_BASE_URL }},SEARCH_ENGINE_ID=${{ vars.GCP_SEARCH_ENGINE_ID }}
+            --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},AGENT_BACKEND=adk,GEMINI_MODEL=gemini-3.1-flash-lite,CLOUD_TASKS_QUEUE=${{ vars.GCP_CLOUD_TASKS_QUEUE }},IMPORT_TASKS_QUEUE=${{ vars.GCP_IMPORT_TASKS_QUEUE }},ENRICH_TARGET_BASE_URL=${{ vars.GCP_RUN_BASE_URL }},ENRICH_INVOKER_SA=${{ vars.GCP_ENRICH_INVOKER_SA }},ENRICH_OIDC_AUDIENCE=${{ vars.GCP_RUN_BASE_URL }},SEARCH_ENGINE_ID=${{ vars.GCP_SEARCH_ENGINE_ID }},KMS_KEY_NAME=projects/${{ vars.GCP_PROJECT_ID }}/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials
             --max-instances=2
             --memory=2Gi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,7 @@ jobs:
             --allow-unauthenticated
             --service-account=librarian-api-runtime@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
             --add-cloudsql-instances=${{ vars.GCP_CLOUDSQL_CONNECTION }}
-            --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest
+            --set-secrets=DATABASE_URL=librarian-db-url:latest,GOOGLE_SEARCH_API_KEY=librarian-google-search-key:latest,GOOGLE_BOOKS_API_KEY=librarian-google-books-key:latest,HARDCOVER_API_KEY=librarian-hardcover-key:latest,KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest
             --set-env-vars=SIGNUP_MODE=invite,GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},AGENT_BACKEND=adk,GEMINI_MODEL=gemini-3.1-flash-lite,CLOUD_TASKS_QUEUE=${{ vars.GCP_CLOUD_TASKS_QUEUE }},IMPORT_TASKS_QUEUE=${{ vars.GCP_IMPORT_TASKS_QUEUE }},ENRICH_TARGET_BASE_URL=${{ vars.GCP_RUN_BASE_URL }},ENRICH_INVOKER_SA=${{ vars.GCP_ENRICH_INVOKER_SA }},ENRICH_OIDC_AUDIENCE=${{ vars.GCP_RUN_BASE_URL }},SEARCH_ENGINE_ID=${{ vars.GCP_SEARCH_ENGINE_ID }}
             --max-instances=2
             --memory=2Gi

--- a/alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py
+++ b/alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py
@@ -1,0 +1,30 @@
+"""users_subscriber_until — GH #100 monetization arc: Ko-fi entitlement horizon column
+
+Revision ID: a1b2c3d4e5f6
+Revises: f871fd59415e
+Create Date: 2026-07-25 00:00:00.000000
+
+Rule 11 note: this migration only ADDS a nullable column to users; it alters nothing
+existing, so the pre-migration-schema rehearsal pressure that applies to
+migration-gating tools (dedup, requeue) is nil here — no query against an existing
+model changes shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "f871fd59415e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("subscriber_until", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "subscriber_until")

--- a/alembic/versions/b2c3d4e5f6a7_payments_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_payments_table.py
@@ -1,0 +1,51 @@
+"""payments_table — GH #100 monetization arc: Ko-fi webhook event audit trail
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-26 00:00:00.000000
+
+Rule 11 note: this migration only ADDS a table; it alters nothing existing, so the
+pre-migration-schema rehearsal pressure that applies to migration-gating tools (dedup,
+requeue) is nil here — no query against an existing model changes shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "payments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kofi_transaction_id", sa.String(), nullable=False),
+        sa.Column("kofi_type", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("amount", sa.Numeric(10, 2), nullable=False),
+        sa.Column("currency", sa.String(), nullable=False),
+        sa.Column("tier_name", sa.String(), nullable=True),
+        sa.Column("is_subscription_payment", sa.Boolean(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=False),
+        sa.Column("matched_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("entitlement_days", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["matched_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kofi_transaction_id"),
+    )
+    op.create_index("ix_payments_email", "payments", ["email"])
+    op.create_index("ix_payments_matched_user_id", "payments", ["matched_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_payments_matched_user_id", table_name="payments")
+    op.drop_index("ix_payments_email", table_name="payments")
+    op.drop_table("payments")

--- a/docs/superpowers/plans/2026-07-25-metering-tiers-budgets.md
+++ b/docs/superpowers/plans/2026-07-25-metering-tiers-budgets.md
@@ -1,0 +1,827 @@
+# Metering, Tiers & Budgets Implementation Plan (#100 — monetization arc 1/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every LLM/embedding call writes an attributed `usage` row; per-tier budgets (free/supporter/byok) are enforced at the chat, import, and enrichment chokepoints; over-budget background enrichment defers to the next UTC day via Cloud Tasks `schedule_time`.
+
+**Architecture:** New `core/tiers.py` (tier decision + env-tunable knobs) and `core/budgets.py` (counting queries + allow/defer decisions, own `db_manager` + `set_db_manager` seam like `core/usage.py`). Metering wires the existing `record_llm_call` into the grounded scouts and the embedding cache-miss path; user attribution reaches background tasks by threading `user_id` through the Cloud Tasks payload into `as_user(...)` in the handlers. Enforcement returns 429/413/409 with `{"code", "message"}` details interactively and re-enqueues with `schedule_time` in the queue handlers.
+
+**Tech Stack:** Python 3.14, FastAPI, SQLAlchemy (Postgres-only models), Alembic, google-genai, Cloud Tasks, React/TS (vitest).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md` — its budget table is normative: defaults 20/200 chat turns per day, 4000 chars, 300/2000 import rows, 300/1500 grounded calls per day, 1400 global; byok = supporter × 10 for chat/import/grounded.
+- Env knobs are read **per call** (never at import time); invalid or non-positive values fall back to the default (the `_seed_limit()` pattern from `chat/transcript.py`).
+- Metering is best-effort and NEVER blocks or breaks the user path; enforcement checks fail OPEN with a logged warning.
+- Meter at the **response object** (SDK-level HTTP retries must not double-count); scout-level retries are genuinely separate billable calls and record separately.
+- Budget windows are UTC days (`created_at >= UTC midnight today`).
+- Pre-deploy Cloud Tasks (no `user_id` in URL) MUST still work: handlers treat `user_id` as optional everywhere.
+- Deferral must NOT burn the #97 give-up retry count: defer = re-enqueue a NEW task with `schedule_time`, return 200.
+- Postgres-only models: DB-backed tests are `db_integration` (CI-gated); DB-free logic gets local unit tests. All tests parametrized — never loops inside a test body.
+- DB cap/count tests insert rows with EXPLICIT distinct `created_at` values (the #147 same-timestamp flake lesson).
+- Tests run via `.venv/Scripts/python -m pytest ...` from repo root; local `test/unit` is green-by-default (ADR-063) — any failure is real.
+- Before each commit: `uvx ruff check <files>` AND `uvx ruff format <files>`. No `[skip ci]`.
+- Commit trailer — end every commit message with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`
+
+## File Structure
+
+- `alembic/versions/<gen>_users_subscriber_until.py` — new migration (down_revision `f871fd59415e`)
+- `src/agentic_librarian/db/models.py` — `User.subscriber_until`
+- `src/agentic_librarian/core/tiers.py` — NEW: `Tier`, `tier_for`, `effective_tier`, knob accessors
+- `src/agentic_librarian/core/budgets.py` — NEW: counting queries + decisions + deferral time
+- `src/agentic_librarian/scouts/grounded_llm.py` — meter both providers
+- `src/agentic_librarian/scouts/utils.py` — meter embed cache misses
+- `src/agentic_librarian/enrichment/tasks.py` — `user_id` + `schedule_time` on both enqueue helpers
+- `src/agentic_librarian/api/internal.py` — `as_user` wrap + budget check + deferral
+- `src/agentic_librarian/imports/worker.py` — widen `as_user` scope; pass user to deep enqueue
+- `src/agentic_librarian/api/books.py`, `src/agentic_librarian/api/main.py` — pass user to enqueues; chat enforcement
+- `src/agentic_librarian/api/imports.py` — per-tier rows cap + one-in-flight rule
+- `frontend/src/api/client.ts`, `frontend/src/views/ChatView.tsx` (only if needed) — 429/422 detail surfacing
+
+---
+
+### Task 1: Tier model, budget knobs, counting queries, migration
+
+**Files:**
+- Create: `src/agentic_librarian/core/tiers.py`
+- Create: `src/agentic_librarian/core/budgets.py`
+- Modify: `src/agentic_librarian/db/models.py` (User, after `display_name`)
+- Create: `alembic/versions/<gen>_users_subscriber_until.py`
+- Create: `test/unit/test_tiers.py`
+- Create: `test/integration/test_budgets_db.py`
+
+**Interfaces (later tasks rely on these exact names):**
+- `tiers.Tier = Literal["free", "supporter", "byok"]`
+- `tiers.tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier` (pure)
+- `tiers.effective_tier(session, user_id: UUID) -> Tier` (DB wrapper)
+- `tiers.chat_turns_per_day(tier) -> int`, `tiers.chat_message_max_chars() -> int`, `tiers.import_max_rows(tier) -> int`, `tiers.grounded_calls_per_day(tier) -> int`, `tiers.grounded_calls_per_day_global() -> int`, `tiers.grounding_model_name() -> str`
+- `budgets.set_db_manager(m)`, `budgets.chat_turn_allowed(user_id) -> tuple[bool, str]`, `budgets.enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]`, `budgets.next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime`
+
+- [ ] **Step 1: Failing unit tests for the pure tier/knob logic**
+
+Create `test/unit/test_tiers.py`:
+
+```python
+"""#100: tier decision + env-tunable budget knobs are DB-free and unit-testable
+(the un-gate-DB-free-paths lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentic_librarian.core import tiers
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "subscriber_until,has_cred,expected",
+    [
+        (None, False, "free"),
+        (NOW - timedelta(days=1), False, "free"),          # lapsed
+        (NOW + timedelta(days=1), False, "supporter"),
+        (None, True, "byok"),
+        (NOW + timedelta(days=1), True, "byok"),           # byok wins over supporter
+    ],
+)
+def test_tier_for(subscriber_until, has_cred, expected):
+    assert tiers.tier_for(subscriber_until, has_cred, now=NOW) == expected
+
+
+@pytest.mark.parametrize(
+    "fn,tier,expected",
+    [
+        (tiers.chat_turns_per_day, "free", 20),
+        (tiers.chat_turns_per_day, "supporter", 200),
+        (tiers.chat_turns_per_day, "byok", 2000),
+        (tiers.import_max_rows, "free", 300),
+        (tiers.import_max_rows, "supporter", 2000),
+        (tiers.grounded_calls_per_day, "free", 300),
+        (tiers.grounded_calls_per_day, "supporter", 1500),
+        (tiers.grounded_calls_per_day, "byok", 15000),
+    ],
+)
+def test_default_budgets(monkeypatch, fn, tier, expected):
+    for var in tiers._DEFAULTS:
+        monkeypatch.delenv(var, raising=False)
+    assert fn(tier) == expected
+
+
+def test_global_governor_default(monkeypatch):
+    monkeypatch.delenv("GROUNDED_CALLS_PER_DAY_GLOBAL", raising=False)
+    assert tiers.grounded_calls_per_day_global() == 1400
+
+
+@pytest.mark.parametrize("raw,expected", [("50", 50), ("abc", 20), ("", 20), ("-5", 20), ("0", 20)])
+def test_env_override_and_fallback(monkeypatch, raw, expected):
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", raw)
+    assert tiers.chat_turns_per_day("free") == expected
+
+
+def test_chat_message_max_chars_default(monkeypatch):
+    monkeypatch.delenv("CHAT_MESSAGE_MAX_CHARS", raising=False)
+    assert tiers.chat_message_max_chars() == 4000
+
+
+def test_grounding_model_name_default(monkeypatch):
+    monkeypatch.delenv("GROUNDING_MODEL", raising=False)
+    monkeypatch.delenv("EXPLORER_MODEL", raising=False)
+    assert tiers.grounding_model_name() == "gemini-2.5-flash"
+```
+
+Also add (same file) the deferral-time tests:
+
+```python
+def test_next_utc_day_start_is_next_midnight_plus_jitter():
+    from agentic_librarian.core import budgets
+
+    now = datetime(2026, 7, 25, 23, 50, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now, jitter_seconds=600)
+    assert when == datetime(2026, 7, 26, 0, 10, tzinfo=UTC)
+
+
+def test_next_utc_day_start_jitter_bounds():
+    now = datetime(2026, 7, 25, 3, 0, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now)
+    midnight = datetime(2026, 7, 26, tzinfo=UTC)
+    assert midnight <= when <= midnight + timedelta(seconds=1800)
+```
+
+(import `budgets` at module top with `tiers`.)
+
+- [ ] **Step 2: Run — verify FAIL** (`cannot import name 'tiers'`):
+`.venv/Scripts/python -m pytest test/unit/test_tiers.py -v`
+
+- [ ] **Step 3: Implement `core/tiers.py`**
+
+```python
+"""Effective tier + env-tunable budget knobs (#100, monetization arc 1/3; spec
+2026-07-25-metering-tiers-budgets-design.md).
+
+Tier semantics: 'byok' requires a user_credentials row for vendor 'gemini' — that table
+has NO writers until arc PR3 lands, so today the branch is inert but the enum is stable
+across the arc. 'supporter' = subscriber_until in the future (Ko-fi entitlements are
+PR2). Knobs are read per call (prod-tunable without redeploy); invalid or non-positive
+values fall back to the defaults below."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+Tier = Literal["free", "supporter", "byok"]
+
+_DEFAULTS = {
+    "CHAT_TURNS_PER_DAY_FREE": 20,
+    "CHAT_TURNS_PER_DAY_SUPPORTER": 200,
+    "CHAT_MESSAGE_MAX_CHARS": 4000,
+    "IMPORT_MAX_ROWS_FREE": 300,
+    "IMPORT_MAX_ROWS_SUPPORTER": 2000,
+    "GROUNDED_CALLS_PER_DAY_FREE": 300,
+    "GROUNDED_CALLS_PER_DAY_SUPPORTER": 1500,
+    "GROUNDED_CALLS_PER_DAY_GLOBAL": 1400,
+}
+
+# byok budgets are structural sanity bounds, not cost protection (their key, their bill).
+_BYOK_MULTIPLIER = 10
+
+
+def _env_int(name: str) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULTS[name]
+    return value if value > 0 else _DEFAULTS[name]
+
+
+def tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier:
+    if has_byok_credential:
+        return "byok"
+    now = now or datetime.now(UTC)
+    if subscriber_until is not None and subscriber_until > now:
+        return "supporter"
+    return "free"
+
+
+def effective_tier(session, user_id: UUID) -> Tier:
+    from agentic_librarian.db.models import User, UserCredential
+
+    user = session.get(User, user_id)
+    has_cred = (
+        session.query(UserCredential.user_id)
+        .filter(UserCredential.user_id == user_id, UserCredential.vendor == "gemini")
+        .first()
+        is not None
+    )
+    return tier_for(user.subscriber_until if user else None, has_cred)
+
+
+def _tiered(free_var: str, supporter_var: str, tier: Tier) -> int:
+    if tier == "free":
+        return _env_int(free_var)
+    supporter = _env_int(supporter_var)
+    return supporter * _BYOK_MULTIPLIER if tier == "byok" else supporter
+
+
+def chat_turns_per_day(tier: Tier) -> int:
+    return _tiered("CHAT_TURNS_PER_DAY_FREE", "CHAT_TURNS_PER_DAY_SUPPORTER", tier)
+
+
+def chat_message_max_chars() -> int:
+    return _env_int("CHAT_MESSAGE_MAX_CHARS")
+
+
+def import_max_rows(tier: Tier) -> int:
+    return _tiered("IMPORT_MAX_ROWS_FREE", "IMPORT_MAX_ROWS_SUPPORTER", tier)
+
+
+def grounded_calls_per_day(tier: Tier) -> int:
+    return _tiered("GROUNDED_CALLS_PER_DAY_FREE", "GROUNDED_CALLS_PER_DAY_SUPPORTER", tier)
+
+
+def grounded_calls_per_day_global() -> int:
+    return _env_int("GROUNDED_CALLS_PER_DAY_GLOBAL")
+
+
+def grounding_model_name() -> str:
+    """Single source of truth for the grounded-scout model id — budgets count usage rows
+    by this name, and scouts/grounded_llm.py resolves its model from it."""
+    return os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
+```
+
+- [ ] **Step 4: Implement `core/budgets.py`**
+
+```python
+"""Budget decisions for #100 — counting queries over existing tables (messages, usage);
+no new counters, no Redis. Checks FAIL OPEN: a broken budget query logs and allows (the
+budget protects cost, not correctness). Module-level db_manager + set_db_manager seam
+mirrors core/usage.py."""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import UTC, datetime, time, timedelta
+from uuid import UUID
+
+from agentic_librarian.core import tiers
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+db_manager = DatabaseManager()
+
+_DEFER_JITTER_MAX_SECONDS = 1800  # spread the next-midnight thundering herd over 30 min
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+def _utc_day_start(now: datetime | None = None) -> datetime:
+    now = now or datetime.now(UTC)
+    return datetime.combine(now.date(), time.min, tzinfo=UTC)
+
+
+def chat_turns_today(session, user_id: UUID) -> int:
+    from agentic_librarian.db.models import Conversation, Message
+
+    return (
+        session.query(Message.id)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .filter(
+            Conversation.user_id == user_id,
+            Message.role == "user",
+            Message.created_at >= _utc_day_start(),
+        )
+        .count()
+    )
+
+
+def grounded_calls_today(session, user_id: UUID | None) -> int:
+    """App-key grounded-model usage rows today — per-user, or global when user_id is None."""
+    from agentic_librarian.db.models import Usage
+
+    q = session.query(Usage.id).filter(
+        Usage.model == tiers.grounding_model_name(),
+        Usage.key_source == "app",
+        Usage.created_at >= _utc_day_start(),
+    )
+    if user_id is not None:
+        q = q.filter(Usage.user_id == user_id)
+    return q.count()
+
+
+def chat_turn_allowed(user_id: UUID) -> tuple[bool, str]:
+    """(allowed, human_message). Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            tier = tiers.effective_tier(session, user_id)
+            limit = tiers.chat_turns_per_day(tier)
+            used = chat_turns_today(session, user_id)
+        if used >= limit:
+            return False, (
+                f"You've reached today's chat limit ({limit} messages). "
+                "It resets at midnight UTC — or support Shelfwright for a higher limit."
+            )
+        return True, ""
+    except Exception:
+        logger.warning("chat budget check failed open", exc_info=True)
+        return True, ""
+
+
+def enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]:
+    """Per-user grounded budget (when attributed) AND the global governor. Un-attributed
+    (pre-deploy) tasks check only the governor. Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            if grounded_calls_today(session, None) >= tiers.grounded_calls_per_day_global():
+                return False, "global grounded-call governor reached"
+            if user_id is not None:
+                tier = tiers.effective_tier(session, user_id)
+                if grounded_calls_today(session, user_id) >= tiers.grounded_calls_per_day(tier):
+                    return False, f"per-user grounded budget reached (tier {tier})"
+        return True, ""
+    except Exception:
+        logger.warning("enrichment budget check failed open", exc_info=True)
+        return True, ""
+
+
+def next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime:
+    if jitter_seconds is None:
+        jitter_seconds = random.randint(0, _DEFER_JITTER_MAX_SECONDS)
+    return _utc_day_start(now) + timedelta(days=1, seconds=jitter_seconds)
+```
+
+NOTE for the implementer: check the actual `conversations` model class name and its
+user column in `db/models.py` (~line 266) and adjust the import/filters if the names
+differ from `Conversation.user_id` — the QUERY SEMANTICS in the spec are normative, the
+names here are best-effort.
+
+- [ ] **Step 5: Model + migration**
+
+In `db/models.py`, add to `User` after `display_name`:
+
+```python
+    # #100 monetization: Ko-fi entitlement horizon (PR2 writes it; NULL/past = free tier).
+    subscriber_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+```
+
+Generate the migration file manually (do NOT run `alembic revision --autogenerate` — no
+local Postgres). Create `alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py`
+following the style of `f871fd59415e_detected_duplicates.py` (read it first):
+`revision = "a1b2c3d4e5f6"`, `down_revision = "f871fd59415e"`, upgrade =
+`op.add_column("users", sa.Column("subscriber_until", sa.DateTime(timezone=True), nullable=True))`,
+downgrade = `op.drop_column("users", "subscriber_until")`.
+
+- [ ] **Step 6: Run unit tests — verify PASS**
+`.venv/Scripts/python -m pytest test/unit/test_tiers.py -v`
+
+- [ ] **Step 7: db_integration tests (CI-only — write by inspection)**
+
+Create `test/integration/test_budgets_db.py` marked `@pytest.mark.db_integration`
+(follow the fixture pattern of an existing integration DB test file, e.g.
+`test/integration/test_transcript_store.py`). Cover, all parametrized, all rows with
+EXPLICIT distinct `created_at`:
+
+- `chat_turns_today`: user messages today count; yesterday's rows and OTHER users'
+  conversations excluded; assistant-role rows excluded.
+- `grounded_calls_today`: counts only rows with the grounding model name +
+  `key_source='app'` + today; per-user filter vs global (None) behavior.
+- `effective_tier` DB wrapper: user with future `subscriber_until` → supporter; with a
+  `user_credentials` row (vendor gemini) → byok; plain → free.
+
+- [ ] **Step 8: Full local unit suite, lint, format, commit**
+
+```bash
+.venv/Scripts/python -m pytest test/unit -q
+uvx ruff check src/agentic_librarian/core/tiers.py src/agentic_librarian/core/budgets.py src/agentic_librarian/db/models.py alembic/versions/a1b2c3d4e5f6_users_subscriber_until.py test/unit/test_tiers.py test/integration/test_budgets_db.py
+uvx ruff format <same files>
+git add <same files>
+git commit -m "feat(core): tier model, budget knobs, counting queries + subscriber_until migration (#100)"
+```
+
+---
+
+### Task 2: Meter scouts + embeddings; thread user attribution into background tasks
+
+**Files:**
+- Modify: `src/agentic_librarian/scouts/grounded_llm.py`
+- Modify: `src/agentic_librarian/scouts/utils.py`
+- Modify: `src/agentic_librarian/enrichment/tasks.py`
+- Modify: `src/agentic_librarian/api/internal.py`
+- Modify: `src/agentic_librarian/imports/worker.py`
+- Modify: `src/agentic_librarian/api/books.py` (enqueue call ~line 75)
+- Modify: `src/agentic_librarian/api/main.py` (PATCH /history enqueue call ~line 376)
+- Create: `test/unit/test_scout_metering.py`
+- Modify: `test/integration/` (extend the existing internal-endpoint/import-worker test files you find via `grep -rl "internal/enrich\|process_import_row" test/`)
+
+**Interfaces:**
+- Consumes: `record_llm_call` (core/usage.py), `as_user` (core/user_context.py), `tiers.grounding_model_name()`.
+- Produces: `enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool` and `enqueue_edition_completion(work_id: str, fmt: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool` (schedule_time is USED in Task 4 but added here so tasks.py is touched once). `/internal/enrich/{work_id}` and `/internal/complete-edition/{work_id}` accept optional `user_id` query param.
+
+- [ ] **Step 1: Failing unit tests for metering capture**
+
+Create `test/unit/test_scout_metering.py`:
+
+```python
+"""#100: grounded-scout + embedding metering. Fake response objects — no network, no DB
+(record_llm_call is monkeypatched to a recorder)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentic_librarian.scouts import grounded_llm
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None):
+        self.calls.append((vendor, model, input_tokens, output_tokens))
+
+
+@pytest.mark.parametrize(
+    "usage,expected",
+    [
+        (SimpleNamespace(prompt_token_count=120, candidates_token_count=45), [("gemini", "gemini-2.5-flash", 120, 45)]),
+        (SimpleNamespace(prompt_token_count=None, candidates_token_count=None), [("gemini", "gemini-2.5-flash", 0, 0)]),
+        (None, []),  # no usage_metadata -> no row, no crash
+    ],
+)
+def test_record_gemini_usage(monkeypatch, usage, expected):
+    rec = _Recorder()
+    monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
+    response = SimpleNamespace(text="ok", usage_metadata=usage)
+    grounded_llm._record_gemini_usage("gemini-2.5-flash", response)
+    assert rec.calls == expected
+```
+
+And the embed-metering test (same file):
+
+```python
+def test_embed_metering_records_only_on_cache_miss(monkeypatch):
+    from agentic_librarian.scouts import utils
+
+    rec = _Recorder()
+    monkeypatch.setattr(utils, "record_llm_call", rec)
+
+    fake_resp = SimpleNamespace(embeddings=[SimpleNamespace(values=[0.0] * 4)])
+    client = SimpleNamespace(models=SimpleNamespace(embed_content=lambda **kw: fake_resp))
+    monkeypatch.setattr(utils, "get_shared_genai_client", lambda: client)
+
+    utils.get_cached_embedding.cache_clear()
+    utils.get_cached_embedding("m", "some tag text!!")  # miss -> one row
+    utils.get_cached_embedding("m", "some tag text!!")  # hit -> no new row
+    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0)]
+```
+
+- [ ] **Step 2: Run — verify FAIL** (`no attribute '_record_gemini_usage'` / no `record_llm_call` in utils):
+`.venv/Scripts/python -m pytest test/unit/test_scout_metering.py -v`
+
+- [ ] **Step 3: Implement metering in `grounded_llm.py`**
+
+Add imports: `from agentic_librarian.core.usage import record_llm_call` and
+`from agentic_librarian.core.tiers import grounding_model_name`. Replace the
+`GeminiGroundedLLM.__init__` model resolution `os.environ.get("GROUNDING_MODEL") or
+os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"` with `grounding_model_name()`
+(single source of truth — budgets count by this name). Add:
+
+```python
+def _record_gemini_usage(model_name: str, response) -> None:
+    """Meter at the RESPONSE object (#100): the SDK's HTTP-level 429/5xx retry must not
+    double-count; scout-level retries are genuinely separate billable calls and each
+    records via its own response. record_llm_call never raises (warns + drops when no
+    user is in context, e.g. pre-#100 queued tasks)."""
+    um = getattr(response, "usage_metadata", None)
+    if um is None:
+        return
+    record_llm_call(
+        "gemini",
+        model_name,
+        int(getattr(um, "prompt_token_count", 0) or 0),
+        int(getattr(um, "candidates_token_count", 0) or 0),
+    )
+```
+
+In `GeminiGroundedLLM.generate`, between the `generate_content` call and the return:
+`_record_gemini_usage(self.model_name, response)`.
+
+In `ClaudeGroundedLLM._agenerate`, extend the message loop (mirrors
+`agents/backends/claude.py` — read its usage-recording lines first and match the
+attribute access it uses):
+
+```python
+        async for message in query(prompt=prompt, options=options):
+            result_val = getattr(message, "result", None)
+            if result_val and isinstance(result_val, str):
+                text = result_val
+            usage = getattr(message, "usage", None)
+            if usage:
+                record_llm_call(
+                    "anthropic",
+                    self.model,
+                    int(usage.get("input_tokens", 0) or 0),
+                    int(usage.get("output_tokens", 0) or 0),
+                )
+```
+
+(Known limit, do not fix: the ThreadPoolExecutor fallback path in `generate` does not
+propagate ContextVars, so metering warns+drops there — that path only runs under async
+test runners, never in the scout worker. Note this in the docstring.)
+
+- [ ] **Step 4: Implement embed metering in `scouts/utils.py`**
+
+Import `from agentic_librarian.core.usage import record_llm_call` (no import cycle:
+core.usage pulls only db + user_context). In `get_cached_embedding`, after the
+`if not response or not response.embeddings: raise` guard, before the return:
+
+```python
+    # #100: embed responses expose no token counts and lru_cache means only MISSES reach
+    # here — record per network call with a documented chars//4 estimate (visibility, not
+    # billing-grade; embeddings are $0.15/M).
+    record_llm_call("gemini", model_name, len(text) // 4, 0)
+    return response.embeddings[0].values
+```
+
+- [ ] **Step 5: Thread `user_id` through the enqueue helpers**
+
+In `enrichment/tasks.py`, change both signatures and URLs (audience handling UNCHANGED —
+it already deliberately excludes query strings; extend that comment to cover user_id):
+
+```python
+def enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool:
+```
+URL: `url = f"{base.rstrip('/')}/internal/enrich/{work_id}"`, then
+`if user_id: url += f"?user_id={quote(user_id)}"`; audience stays the PATH url (bind it
+to a variable before appending the query). After building `task`, add:
+
+```python
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
+```
+
+Same for `enqueue_edition_completion` (its URL already has `?format=`, so append
+`&user_id=` there), same schedule_time block. Add `from datetime import datetime` import.
+
+- [ ] **Step 6: Accept + use `user_id` in the internal handlers**
+
+In `api/internal.py`: add `import contextlib` and
+`from agentic_librarian.core.user_context import as_user`. In `enrich(...)` add parameter
+`user_id: UUID | None = Query(None)` and wrap the work:
+
+```python
+    _require_queue_caller(authorization)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
+    # skips; nothing crashes). Attributed tasks bill the requesting user.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.enrich_deep(work_id)
+```
+
+Same pattern in `complete_edition` around `two_phase.complete_edition(work_id, format)`.
+
+- [ ] **Step 7: Attribute the import worker + caller enqueues**
+
+In `imports/worker.py process_import_row`: lift the `as_user(...)` so steps 2–4 (the
+`enrich_fast` call through `enqueue_enrichment`) all run inside
+`with as_user(data["user_id"]):` — remove the now-nested inner `with as_user(...)` in the
+history branch (it would just re-set the same ContextVar). Change the enqueue to
+`enqueue_enrichment(str(work_id), user_id=str(data["user_id"]))`.
+
+In `api/books.py` (~line 75): `enqueue_enrichment(str(work_id), user_id=str(user.id))`.
+In `api/main.py` PATCH /history (~line 376): pass `user_id=str(user.id)` to
+`enqueue_edition_completion` (match the actual local variable names at the call site).
+
+- [ ] **Step 8: Run unit tests — verify PASS**; also run any existing unit tests
+covering these modules:
+`.venv/Scripts/python -m pytest test/unit/test_scout_metering.py test/unit -q`
+
+- [ ] **Step 9: Extend integration tests (CI-only — by inspection)**
+
+Find the existing files: `grep -rl "internal/enrich\|process_import_row\|enqueue_enrichment" test/`.
+Add parametrized cases:
+- `/internal/enrich/{id}?user_id=<uuid>` runs `enrich_deep` with the user set — assert
+  by monkeypatching a probe inside the handler's scope (e.g. patch `two_phase.enrich_deep`
+  to capture `get_required_user_id()`); and WITHOUT the param it still succeeds with no
+  user in context (pre-deploy task shape — the back-compat guarantee).
+- `process_import_row` calls `enqueue_enrichment` with `user_id=str(row.user_id)`
+  (patch the enqueue seam the existing tests already patch — they exist per the old-seam
+  CI lesson: search for patches of `enqueue_enrichment` and update ALL of them to the
+  new signature expectation).
+- Any existing test that patches/asserts `enqueue_enrichment(str(work_id))` (books flow)
+  must be updated for the new kwargs — grep the integration suites for the OLD seam
+  (CLAUDE.md gate #5).
+
+- [ ] **Step 10: Full unit suite, lint, format, commit**
+(as Task 1 Step 8, listing this task's files)
+`git commit -m "feat(metering): record scout + embedding usage with task-context user attribution (#100)"`
+
+---
+
+### Task 3: Chat enforcement (length cap, daily turn budget, 429) + frontend surfacing
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py` (the `/chat` handler, ~line 474)
+- Modify: `frontend/src/api/client.ts` (`streamChat`, ~line 246)
+- Modify: `test/integration/test_chat_api.py` (or the file that tests POST /api/chat — grep)
+- Modify: `frontend/src/api/client.test.ts` (or wherever streamChat is tested — grep `streamChat`)
+
+**Interfaces:**
+- Consumes: `tiers.chat_message_max_chars()`, `budgets.chat_turn_allowed(user_id)`.
+- Produces: POST /api/chat → 422 `{"detail": {"code": "message_too_long", "message": ...}}` when over-length; 429 `{"detail": {"code": "chat_quota", "message": ...}}` when over budget. SSE contract unchanged otherwise.
+
+- [ ] **Step 1: Write failing API tests** (extend the chat API integration file; follow
+its fixture pattern; parametrized):
+- over-length message (len = cap+1, monkeypatch `CHAT_MESSAGE_MAX_CHARS=50` for cheap
+  strings) → 422 with `code == "message_too_long"`.
+- budget: monkeypatch `CHAT_TURNS_PER_DAY_FREE=2`, seed 2 user messages TODAY (explicit
+  created_at, #147 lesson), POST /api/chat → 429 with `code == "chat_quota"`; with only
+  1 seeded → not 429.
+- If this file is `db_integration`/CI-only, write by inspection and verify collection:
+  `--collect-only -q`.
+
+- [ ] **Step 2: Implement in the chat handler**
+
+Add imports `from agentic_librarian.core import budgets, tiers` in main.py. New handler body
+(before the existing `with as_user(...)` block):
+
+```python
+@api_router.post("/chat")
+def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    max_chars = tiers.chat_message_max_chars()
+    if len(message) > max_chars:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "message_too_long", "message": f"Message too long (max {max_chars} characters)."},
+        )
+    allowed, why = budgets.chat_turn_allowed(user.id)
+    if not allowed:
+        # Must reject BEFORE the StreamingResponse exists — SSE cannot carry an HTTP 429.
+        raise HTTPException(status_code=429, detail={"code": "chat_quota", "message": why})
+    ...existing body unchanged...
+```
+
+- [ ] **Step 3: Frontend — surface the 429/422 detail**
+
+In `client.ts` `streamChat`, replace the `if (!res.ok || !res.body)` block:
+
+```ts
+  if (!res.ok || !res.body) {
+    if (res.status === 429 || res.status === 422) {
+      let message = ''
+      try {
+        const body = await res.json()
+        message = body?.detail?.message ?? ''
+      } catch {
+        // fall through to the generic copy
+      }
+      handlers.onError(message || GENERIC_CHAT_ERROR)
+      return
+    }
+    handlers.onError(GENERIC_CHAT_ERROR)
+    return
+  }
+```
+
+- [ ] **Step 4: Frontend test** (extend the existing streamChat/vitest suite; use
+`...Once` mock variants — the vitest#1692 lesson): a 429 response with
+`{"detail": {"code": "chat_quota", "message": "Daily limit reached."}}` → `onError`
+receives `"Daily limit reached."`; a 500 → generic copy unchanged.
+Run: `npm test -- --run` from `frontend/` (match the repo's script).
+
+- [ ] **Step 5: Local suites, lint, format, commit**
+Backend: `.venv/Scripts/python -m pytest test/unit -q` (+ `--collect-only` on touched
+integration files). Frontend: the repo's vitest command.
+`git commit -m "feat(chat): per-tier daily turn budget + message length cap, 429 surfaced in UI (#100)"`
+
+---
+
+### Task 4: Import caps + enrichment budget deferral
+
+**Files:**
+- Modify: `src/agentic_librarian/api/imports.py` (preview/commit, MAX_ROWS at line 27)
+- Modify: `src/agentic_librarian/api/internal.py` (enrich + complete_edition budget gate)
+- Modify: `frontend/src/api/client.ts` (import commit error detail — only if the current
+  generic `Error` hides the server message; follow the `updateHistory` ApiError pattern)
+- Modify: the imports API integration test file + internal-endpoint test file (grep as in Task 2)
+- Create/extend: `test/unit/` for any new pure helpers
+
+**Interfaces:**
+- Consumes: `tiers.import_max_rows`, `tiers.effective_tier`, `budgets.enrichment_allowed`, `budgets.next_utc_day_start_with_jitter`, `enqueue_enrichment(..., user_id=, schedule_time=)`.
+- Produces: import commit → 413 `{"code": "import_rows_limit", ...}` over tier cap; 409 `{"code": "import_in_flight", ...}` when the user already has a pending/processing import. `/internal/enrich` responds `{"status": "deferred"}` (HTTP 200) when over budget.
+
+- [ ] **Step 1: Failing tests for import caps** (extend the imports API test file;
+parametrized): free-tier user commits 301 rows → 413 with `code == "import_rows_limit"`
+(monkeypatch `IMPORT_MAX_ROWS_FREE` small, e.g. 5, and build a 6-row CSV to keep the
+test cheap); supporter (seed `subscriber_until` future) passes the same file; a second
+commit while rows from the first are still `pending` → 409 `import_in_flight`; after
+all rows reach a terminal status → commit allowed again.
+
+- [ ] **Step 2: Implement import caps** in `api/imports.py`: in `commit` (and `preview`
+if it validates row counts — mirror wherever `MAX_ROWS` is enforced today, line ~49):
+
+```python
+    with db_manager.get_session() as session:
+        tier = tiers.effective_tier(session, user.id)
+    limit = min(MAX_ROWS, tiers.import_max_rows(tier))
+    if row_count > limit:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "code": "import_rows_limit",
+                "message": f"This import has {row_count} rows; your current limit is {limit}. "
+                "Split the file — or support Shelfwright for the full 2,000-row limit.",
+            },
+        )
+```
+
+(match the function's actual local names/session handling — read the file first). In-flight
+check in `commit` before writing the new job:
+
+```python
+    in_flight = (
+        session.query(ImportRow.id)
+        .join(ImportJob, ImportJob.id == ImportRow.job_id)
+        .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+        .first()
+    )
+    if in_flight is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "import_in_flight", "message": "Your previous import is still running — wait for it to finish before starting another."},
+        )
+```
+
+(verify the actual status strings + model/column names against `db/models.py` and the worker.)
+
+- [ ] **Step 3: Failing tests for deferral** (internal-endpoint test file): monkeypatch
+`budgets.enrichment_allowed` → `(False, "global grounded-call governor reached")`, patch the
+enqueue seam, POST `/internal/enrich/{id}?user_id=...` → 200 with `status == "deferred"`,
+enqueue called once with same work_id/user_id and a `schedule_time` strictly after now;
+`enrichment_allowed` → `(True, "")` → normal path unchanged. Same shape for
+`/internal/complete-edition`. And: deferral with enqueue returning False → 200
+`status == "deferred_enqueue_failed"` (the requeue sweep is the backstop — no retry storm).
+
+- [ ] **Step 4: Implement the budget gate** in `api/internal.py` — in `enrich(...)`,
+after `_require_queue_caller`, before `enrich_deep`:
+
+```python
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_enrichment(str(work_id), user_id=str(user_id) if user_id else None, schedule_time=when)
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s", work_id)
+            requeued = False
+        if not requeued:
+            logger.warning("over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why)
+            return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+        logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
+        # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
+        # so the #97 give-up retry count does not accumulate across days.
+        return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
+```
+
+Mirror in `complete_edition` with `enqueue_edition_completion(str(work_id), format, user_id=..., schedule_time=when)`.
+Add the needed imports (`budgets`, the enqueue helpers).
+
+- [ ] **Step 5: Frontend import-error check**: read how the import view surfaces commit
+errors today; if the 413/409 `detail.message` doesn't reach the user (client.ts throws
+generic `Error`), extend `commitImport` to raise `ApiError` (the existing class,
+`updateHistory` pattern) and render `.detail.message` in the view's error slot. If it
+already surfaces server detail, skip this step and say so in the report.
+
+- [ ] **Step 6: Suites, lint, format, commit**
+`git commit -m "feat(budgets): per-tier import caps + enrichment budget deferral via schedule_time (#100)"`
+
+---
+
+## Post-implementation verification
+
+- [ ] Full local unit suite green; frontend vitest green.
+- [ ] `--collect-only` clean on every touched integration file.
+- [ ] CI green on the PR (db_integration executes there FIRST — gate #5); grep confirmed
+      no stale patches of the old `enqueue_enrichment(work_id)` seam remain.
+- [ ] Optional runtime sanity (no DB): uvicorn boots; POST /api/chat with an over-length
+      body → 422 JSON.
+
+## Self-review notes (coverage against spec)
+
+- Spec §1 tier model/migration → Task 1. §2 metering incl. Claude scout + embed
+  estimate + attribution threading/back-compat → Task 2. §3 chat → Task 3; imports +
+  governor/deferral → Task 4. ✓
+- Spec error posture (meter best-effort, enforce fail-open, 429 bodies with code+message)
+  → budgets.py design + handler code. ✓
+- Spec non-goals (Ko-fi, BYOK, queue fairness) → no task touches them. ✓
+- Names consistent across tasks (checked: `chat_turn_allowed`, `enrichment_allowed`,
+  `next_utc_day_start_with_jitter`, enqueue kwargs). ✓

--- a/docs/superpowers/plans/2026-07-26-byok.md
+++ b/docs/superpowers/plans/2026-07-26-byok.md
@@ -1,0 +1,153 @@
+# BYOK Implementation Plan (monetization arc 3/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Users can store a KMS-encrypted personal Gemini key; chat mesh + deep-enrichment scouts run on it (`usage.key_source='byok'`); Settings hosts a guided walkthrough; failures never fall back silently to the app key.
+
+**Architecture:** `core/byok.py` (KMS crypto + `resolve_gemini_key`), `api/credentials.py` (GET/PUT/DELETE `/api/me/credentials` with live validation), key threading as PARAMETERS (never env mutation): chat `astart_conversation → build_runner → create_agent_mesh → _gemini(api_key)`; scouts `internal handlers → two_phase → scout-manager factories → LLMScout(api_key)`. Embeddings stay app-keyed by design.
+
+**Tech Stack:** google-cloud-kms (net-new dep), google-genai, ADK, FastAPI, React/TS.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-26-byok-design.md` — normative for error codes/statuses (503 byok_unavailable, 422 invalid_api_key, 409 byok_key_error pre-stream, task 200 byok_key_error) and the no-silent-fallback rule.
+- Plaintext keys: never logged, never stored, never returned by any endpoint; live only in call scope. Ciphertext only in `user_credentials.encrypted_key`.
+- Key routing via parameters only — NEVER `os.environ` mutation (concurrency race).
+- Embeddings stay app-keyed; `get_cached_embedding` untouched. Non-byok behavior byte-identical.
+- `key_source` written in exactly one place (`record_llm_call` param, default "app").
+- Local Postgres IS reachable: EXECUTE db_integration tests (`POSTGRES_HOST=localhost .venv/Scripts/python -m pytest <file> -q -m db_integration`) and report real results. Extra users: create + flush before FK-dependent inserts; explicit distinct created_at (#147).
+- Tests parametrized; frontend rejection mocks use `...Once` (vitest#1692); App.test.tsx must mock any new component that transitively imports api/client or firebase (the ca0cc54 lesson).
+- Local `test/unit` 0 failed; frontend suite + `npx tsc --noEmit` green when frontend touched.
+- `uvx ruff check` AND `uvx ruff format` before each commit; no `[skip ci]`.
+- Commit trailer — end every commit with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`
+
+---
+
+### Task 1: KMS crypto + credentials API + infra wiring
+
+**Files:**
+- Create: `src/agentic_librarian/core/byok.py`
+- Create: `src/agentic_librarian/api/credentials.py`
+- Modify: `src/agentic_librarian/api/main.py` (include router in `api_router`; wire `credentials.set_db_manager` in lifespan; extend `test_db_pool_consolidation.py` accordingly)
+- Modify: `pyproject.toml` (`google-cloud-kms` in main deps)
+- Modify: `.github/workflows/deploy.yml` (`KMS_KEY_NAME=projects/${{ vars.GCP_PROJECT_ID }}/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials` appended to `--set-env-vars`)
+- Create: `infra/09-kms.sh` (keyring+key create, SA grant — mirror `infra/05-iam-wif.sh` style; operator-run)
+- Create: `test/unit/test_byok_crypto.py`, `test/unit/test_credentials_api.py`
+- Create: `test/integration/test_credentials_db.py`
+- Modify: `test/unit/test_db_pool_consolidation.py`
+
+**Interfaces (produced):**
+- `byok.ByokNotConfigured(Exception)`, `byok.ByokKeyError(Exception)`
+- `byok.encrypt_key(plaintext: str) -> bytes`, `byok.decrypt_key(ciphertext: bytes) -> str` (raise ByokNotConfigured when `KMS_KEY_NAME` unset; KMS failures on decrypt raise ByokKeyError)
+- `byok.set_kms_client(client)` test seam (module-cached client, lazy import of google.cloud.kms)
+- `byok.resolve_gemini_key(session, user_id: UUID) -> str | None` (None when no row; ByokKeyError on decrypt failure)
+- Routes: GET/PUT/DELETE `/api/me/credentials` per spec §2 (module `db_manager` + `set_db_manager`; PUT validation via module-level `_validate_key(api_key) -> bool` seam that does one `count_tokens` call on `gemini-3.1-flash-lite` with a fresh `genai.Client(api_key=...)`).
+
+- [ ] Step 1: failing unit tests — `test_byok_crypto.py`: fake KMS client (records encrypt/decrypt calls, returns SimpleNamespace responses) via `set_kms_client`; parametrized: round-trip plumbing (encrypt passes plaintext bytes + KMS_KEY_NAME, decrypt returns plaintext str); KMS_KEY_NAME unset → ByokNotConfigured from both; decrypt KMS exception → ByokKeyError. `test_credentials_api.py` (tiny FastAPI app + router, `test_kofi_webhook.py` pattern, patched db seam + `_validate_key` + fake KMS): PUT empty/whitespace/oversize key → 422 shape check; `_validate_key` False → 422 invalid_api_key; KMS_KEY_NAME unset → 503 byok_unavailable; GET unconfigured → configured false; DELETE idempotent 200. Auth: use the app's `get_current_user` override pattern from existing API unit tests.
+- [ ] Step 2: implement `core/byok.py` + `api/credentials.py` per spec (read `api/libraries.py` first and mirror its router/db/auth shape; `_validate_key` catches any exception from the probe call → False). Register: `api_router.include_router(credentials_router)` in main.py; `credentials.set_db_manager(shared)` in lifespan; extend the pool-consolidation test (import + snapshot/restore + assert — follow the kofi/budgets entries).
+- [ ] Step 3: pyproject dep, deploy.yml env var, `infra/09-kms.sh`:
+```bash
+#!/usr/bin/env bash
+# One-shot (not idempotent — like the other infra scripts): KMS keyring + key for BYOK
+# credential encryption, and the runtime SA grant. Run once by the operator.
+set -euo pipefail
+source "$(dirname "$0")/00-config.sh"
+gcloud kms keyrings create librarian --location=us-central1 --project="$PROJECT_ID"
+gcloud kms keys create byok-credentials --location=us-central1 --keyring=librarian \
+  --purpose=encryption --project="$PROJECT_ID"
+gcloud kms keys add-iam-policy-binding byok-credentials \
+  --location=us-central1 --keyring=librarian --project="$PROJECT_ID" \
+  --member="serviceAccount:librarian-api-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+```
+(verify `00-config.sh` variable names before writing; run `pip install -e .[dev]` or `uv pip install google-cloud-kms` into the venv so imports resolve locally.)
+- [ ] Step 4: `test/integration/test_credentials_db.py` (db_integration, EXECUTE): with fake KMS seam — PUT stores ciphertext bytes (assert stored value == fake ciphertext, NOT the plaintext; assert plaintext appears nowhere in the row), GET flips configured, `/api/account` tier flips free→byok→free across PUT/DELETE, DELETE removes row. Follow `test_account_api.py`'s client fixture (patch credentials + byok seams too).
+- [ ] Step 5: full unit suite + executed db_integration + lint/format + commit `feat(byok): KMS crypto + credentials API + infra wiring (arc 3/3)`.
+
+---
+
+### Task 2: Scout-path routing (deep enrichment on the user's key)
+
+**Files:**
+- Modify: `src/agentic_librarian/core/usage.py` (`record_llm_call(..., key_source: str = "app")` — replaces the hardcoded value; keep default)
+- Modify: `src/agentic_librarian/scouts/grounded_llm.py` (`GeminiGroundedLLM.__init__(..., key_source: str = "app")`; `_record_gemini_usage(model_name, response, key_source)`; Claude scout records its own vendor unchanged — key_source stays "app" there; `get_grounded_llm(api_key, model_name, key_source="app")`)
+- Modify: `src/agentic_librarian/scouts/metadata_scout.py` (`LLMScout.__init__` gains `key_source="app"`, threads to `get_grounded_llm`; ScoutManager untouched)
+- Modify: `src/agentic_librarian/orchestration/definitions.py` (`create_deep_scout_manager(api_key: str | None = None, key_source: str = "app")` and `create_completion_scout_manager(...)` — thread into each LLM-scout construction; `create_fast_scout_manager` untouched — API-only)
+- Modify: `src/agentic_librarian/enrichment/two_phase.py` (`enrich_deep(work_id, api_key=None, key_source="app")`, `complete_edition(work_id, fmt, api_key=None, key_source="app")` — thread into the factory calls at lines ~369/~257 and the bare `StyleScout()` at ~264)
+- Modify: `src/agentic_librarian/api/internal.py` (both handlers: inside the existing `as_user` scope, resolve via `byok.resolve_gemini_key` using a session from the module's shared manager (match how budgets are consulted there); pass `api_key`/`key_source="byok"` when a key exists; `ByokKeyError` → log + 200 `{"status": "byok_key_error"}` per spec)
+- Tests: extend `test/unit/test_scout_metering.py` (key_source recorded), `test/unit/test_usage_recorder.py` or equivalent (param default), new unit tests for factory threading (construct managers with a fake key, assert scouts' `_llm`/api_key), extend the internal-endpoint integration tests (byok user's enrich passes key + records key_source='byok' via probe seams; ByokKeyError path → 200 byok_key_error; EXECUTE db_integration).
+
+**Interfaces:** consumes Task 1's `byok.resolve_gemini_key`/`ByokKeyError`. Produces the threaded signatures above (Task 3 consumes nothing from here; PR-1 budgets already filter `key_source == 'app'` — verify no other code assumes the old 2-arg `_record_gemini_usage`).
+
+- [ ] TDD steps in the brief's order: failing tests → thread parameters (grep tests for old seams of `record_llm_call`, `_record_gemini_usage`, `get_grounded_llm`, factory calls, `enrich_deep(work_id)` — update ALL); full unit suite; executed db_integration; lint/format; commit `feat(byok): route deep-enrichment scouts through the user's key (arc 3/3)`.
+
+---
+
+### Task 3: Mesh/chat routing + 409 surfacing
+
+**Files:**
+- Modify: `src/agentic_librarian/agents/services.py` (`_gemini(model_name, api_key: str | None = None)` → `Gemini(model=..., api_key=api_key, retry_options=...)` when key present, else exactly as today; `create_agent_mesh(api_key: str | None = None)` threading into all four agents — read the file: agent constructors call `_gemini`/`_grounding_model` in several places; thread consistently)
+- Modify: `src/agentic_librarian/agents/runtime.py` (`build_runner(api_key: str | None = None)`; `astart_conversation(..., api_key: str | None = None, key_source: str = "app")`; `_record_event_usage` records the threaded key_source; `_ensure_adk_credentials` unchanged — still sets the APP env default; the param overrides per-model)
+- Modify: `src/agentic_librarian/api/main.py` chat handler + `_SyncOpener`: resolve the key once per turn (existing session usage in the handler; `byok.resolve_gemini_key`) → 409 `{"code": "byok_key_error", "message": "Your API key failed — check Settings."}` pre-stream on ByokKeyError; pass `api_key`/`key_source` through `_SyncOpener` → `astart_conversation`.
+- Modify: `frontend/src/api/client.ts` streamChat: add 409 to the parsed-detail status set (429/422/409).
+- Tests: unit — `_gemini` passes api_key to the ADK `Gemini` ctor (introspect constructed object/fake); `build_runner`/`astart_conversation` threading (existing runtime tests' seams); chat handler 409 on ByokKeyError (patch resolve seam); frontend streamChat 409 test (`...Once`). Extend chat integration test: byok-configured user's turn records mesh usage rows with key_source='byok' IF cheaply probeable (patch `record_llm_call`); EXECUTE what's executable.
+
+**Interfaces:** consumes Task 1 (`resolve_gemini_key`, `ByokKeyError`) and Task 2's `record_llm_call(key_source=)`.
+
+- [ ] TDD order; grep for old seams (`build_runner()`, `astart_conversation(` call sites incl. tests); full unit + frontend suites; lint/format; commit `feat(byok): chat mesh runs on the user's key with 409 surfacing (arc 3/3)`.
+
+---
+
+### Task 4: Frontend — Settings walkthrough + AccountMenu
+
+**Files:**
+- Modify: `frontend/src/views/SettingsView.tsx` (second section "Your API key": 3-step walkthrough copy — link `https://aistudio.google.com/apikey` (target _blank, rel noopener noreferrer), paste field (type="password", autoComplete="off"), Save (validates via PUT; disabled while empty/saving); configured state: "Using your own key since <local date>" + Remove button; error line surfaces server `detail.message`; aria-live status like the Libraries section)
+- Modify: `frontend/src/components/AccountMenu.tsx` (tier 'byok' → status "Using your own key"; new menuitem `<Link to="/settings">API key settings</Link>` — check whether the component is inside the Router context in tests; mirror how Nav links are tested)
+- Modify: `frontend/src/api/client.ts`:
+```ts
+export interface CredentialsStatus {
+  configured: boolean
+  updated_at: string | null
+}
+export function getCredentials(): Promise<CredentialsStatus> {
+  return getJson<CredentialsStatus>('/me/credentials')
+}
+export async function putCredentials(apiKey: string): Promise<void> {
+  const res = await authedFetchRaw('/me/credentials', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api_key: apiKey }),
+  })
+  if (!res.ok) {
+    let detail: unknown
+    try {
+      detail = (await res.json()).detail
+    } catch {
+      detail = undefined
+    }
+    throw new ApiError(res.status, detail)
+  }
+}
+export async function deleteCredentials(): Promise<void> {
+  const res = await authedFetchRaw('/me/credentials', { method: 'DELETE' })
+  if (!res.ok) throw new Error(`/me/credentials → ${res.status}`)
+}
+```
+(match ApiError's real constructor signature — read client.ts first.)
+- Tests: SettingsView (save success / invalid-key 422 error shows message / remove; `...Once` mocks; the view's existing tests must keep passing), AccountMenu byok status + settings link, App.test.tsx unaffected (AccountMenu already mocked — verify SettingsView mock still covers the new section).
+- [ ] TDD order; frontend suite + tsc; commit `feat(byok): Settings key walkthrough + AccountMenu status/link (arc 3/3)`.
+
+---
+
+## Post-implementation verification
+
+- [ ] Full local unit + frontend suites green; db_integration EXECUTED locally green; CI green on the PR.
+- [ ] Runtime sanity (no KMS locally): uvicorn boots; GET /api/me/credentials → 401 unauthed; PUT with auth but no KMS_KEY_NAME → 503 byok_unavailable (proves fail-closed).
+
+## Self-review notes (coverage against spec)
+
+- Spec §1 crypto/resolution → Task 1. §2 API → Task 1. §3 routing: usage/scouts → Task 2, mesh/chat + 409 → Task 3; embeddings untouched (no task touches utils.py). §4 frontend → Task 4 (+ streamChat in Task 3). §5 ops → Task 1 Step 3. Error table → Tasks 1-3 as mapped. ✓
+- Name consistency: `resolve_gemini_key`, `ByokKeyError`, `key_source` param names identical across Tasks 1-3; `CredentialsStatus` matches GET shape. ✓
+- Non-goals respected: no anthropic routing, no plaintext display, fast pass untouched. ✓

--- a/docs/superpowers/plans/2026-07-26-kofi-subscriptions.md
+++ b/docs/superpowers/plans/2026-07-26-kofi-subscriptions.md
@@ -1,0 +1,537 @@
+# Ko-fi Subscriptions + Account Menu Implementation Plan (monetization arc 2/3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ko-fi payments (webhook + CLI fallback) grant/extend `subscriber_until`; a top-bar avatar dropdown shows account status + Ko-fi support links; `GET /api/account` exposes the effective tier.
+
+**Architecture:** Pure entitlement rules in `core/entitlements.py`; a `payments` audit table; a root-level machine route `POST /webhooks/kofi` (token-verified, idempotent); argparse CLI extensions; one new React component (`AccountMenu`) replacing the standalone sign-out button.
+
+**Tech Stack:** Python 3.14/FastAPI/SQLAlchemy/Alembic, React+TS/vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md` — normative for entitlement rules (33/370 days, `extend = max(now, current or now) + days`), webhook status codes (400 malformed / 403 token / 200 everything processed incl. unmatched+duplicate / 500 only on DB failure), and menu behavior.
+- Env knobs read per call with fallback defaults (PR-1 `_env_int` pattern): `KOFI_ANNUAL_TIER_NAMES` (csv, default `"annual"`), `KOFI_ANNUAL_MIN_AMOUNT` (default 25). `KOFI_VERIFICATION_TOKEN` has NO default — unset means the webhook 403s (fail closed).
+- Token comparison via `hmac.compare_digest`. Never log the token or full payload at info level.
+- Ko-fi sends `application/x-www-form-urlencoded`, field `data` = JSON string.
+- The webhook route lives on `app` (root), NOT under `/api` (purpose-scoped namespacing, #151).
+- Entitlement write is transactional with the payment insert (same session).
+- Tests parametrized (no loops in test bodies); Postgres-only models → DB-backed tests `db_integration` (CI-first); DB-free guards unit-tested locally; frontend rejection paths use `...Once` mocks (vitest#1692); seeded rows get EXPLICIT distinct `created_at` (#147).
+- Local `test/unit` green-by-default (ADR-063); `.venv/Scripts/python -m pytest ...` from repo root; frontend `npm test -- --run` from `frontend/`.
+- `uvx ruff check` AND `uvx ruff format` before each commit; no `[skip ci]`.
+- Commit trailer — end every commit with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3`
+
+---
+
+### Task 1: Entitlement rules + Payment model + migration
+
+**Files:**
+- Create: `src/agentic_librarian/core/entitlements.py`
+- Modify: `src/agentic_librarian/db/models.py` (Payment class after Usage)
+- Create: `alembic/versions/b2c3d4e5f6a7_payments_table.py` (down_revision `a1b2c3d4e5f6`)
+- Create: `test/unit/test_entitlements.py`
+
+**Interfaces (produced):**
+- `entitlements.classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Literal["monthly", "annual", "tip"]`
+- `entitlements.grant_days(kind) -> int` (monthly 33, annual 370, tip 0)
+- `entitlements.extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime`
+- `db/models.py` `Payment` exactly per the spec's column table.
+
+- [ ] **Step 1: Failing unit tests** — create `test/unit/test_entitlements.py`:
+
+```python
+"""Monetization arc 2/3: entitlement classification is pure and DB-free."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from agentic_librarian.core import entitlements
+
+NOW = datetime(2026, 7, 26, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected",
+    [
+        ("Subscription", True, "Supporter", Decimal("3.00"), "monthly"),
+        ("Subscription", True, None, Decimal("3.00"), "monthly"),
+        ("Shop Order", False, "Annual", Decimal("25.00"), "annual"),
+        ("Shop Order", False, "ANNUAL", Decimal("25.00"), "annual"),      # case-insensitive
+        ("Subscription", True, "Annual Supporter", Decimal("25.00"), "annual"),  # tier name wins over is_sub — but exact-name match only, see below
+        ("Donation", False, None, Decimal("25.00"), "annual"),            # one-off >= threshold
+        ("Donation", False, None, Decimal("30.00"), "annual"),
+        ("Donation", False, None, Decimal("24.99"), "tip"),
+        ("Donation", False, None, Decimal("3.00"), "tip"),
+        ("Commission", False, None, Decimal("10.00"), "tip"),
+    ],
+)
+def test_classify_defaults(monkeypatch, kofi_type, is_sub, tier_name, amount, expected):
+    monkeypatch.delenv("KOFI_ANNUAL_TIER_NAMES", raising=False)
+    monkeypatch.delenv("KOFI_ANNUAL_MIN_AMOUNT", raising=False)
+    assert entitlements.classify(kofi_type, is_sub, tier_name, amount) == expected
+
+
+def test_classify_env_tier_names(monkeypatch):
+    monkeypatch.setenv("KOFI_ANNUAL_TIER_NAMES", "yearly, gold ")
+    assert entitlements.classify("Shop Order", False, "Gold", Decimal("25.00")) == "annual"
+    assert entitlements.classify("Shop Order", False, "Annual", Decimal("10.00")) == "tip"
+
+
+@pytest.mark.parametrize("kind,days", [("monthly", 33), ("annual", 370), ("tip", 0)])
+def test_grant_days(kind, days):
+    assert entitlements.grant_days(kind) == days
+
+
+@pytest.mark.parametrize(
+    "current,days,expected",
+    [
+        (None, 33, NOW + timedelta(days=33)),                              # first sub
+        (NOW - timedelta(days=10), 33, NOW + timedelta(days=33)),          # lapsed: restart from now
+        (NOW + timedelta(days=5), 33, NOW + timedelta(days=38)),           # active: stack
+        (NOW + timedelta(days=100), 370, NOW + timedelta(days=470)),       # annual stacks too
+    ],
+)
+def test_extend(current, days, expected):
+    assert entitlements.extend(current, days, now=NOW) == expected
+```
+
+NOTE on the "Annual Supporter" case: `classify` matches tier names by exact
+(case-folded, stripped) equality against the csv entries — "Annual Supporter" only
+classifies annual if an env entry equals it. With the DEFAULT list ("annual") it does
+NOT match, so with `is_sub=True` that row's expected value is "monthly". **Fix the test
+table accordingly** (expected "monthly" for that row) — this note exists so you don't
+"fix" the implementation to substring-match instead; substring matching would misfire
+on names like "Not Annual".
+
+- [ ] **Step 2: Run — verify FAIL** (`.venv/Scripts/python -m pytest test/unit/test_entitlements.py -v`).
+
+- [ ] **Step 3: Implement `core/entitlements.py`**:
+
+```python
+"""Ko-fi payment → entitlement rules (monetization arc 2/3). Pure and DB-free: the
+webhook and the CLI both call these so grant math exists exactly once. Env knobs are
+read per call (prod-tunable): KOFI_ANNUAL_TIER_NAMES (csv of tier/product names that
+mean 'annual', default 'annual'; exact case-folded match — substring matching would
+misfire on e.g. 'Not Annual'), KOFI_ANNUAL_MIN_AMOUNT (one-off donations at/over this
+classify as annual, default 25). Grace is baked into the grant: 33/370 days cover
+Ko-fi's missing cancellation events and late renewals."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+Kind = Literal["monthly", "annual", "tip"]
+
+_GRANT_DAYS: dict[Kind, int] = {"monthly": 33, "annual": 370, "tip": 0}
+_DEFAULT_ANNUAL_MIN = Decimal(25)
+
+
+def _annual_tier_names() -> set[str]:
+    raw = os.environ.get("KOFI_ANNUAL_TIER_NAMES", "annual")
+    return {part.strip().casefold() for part in raw.split(",") if part.strip()}
+
+
+def _annual_min_amount() -> Decimal:
+    raw = os.environ.get("KOFI_ANNUAL_MIN_AMOUNT", "")
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return _DEFAULT_ANNUAL_MIN
+    return value if value > 0 else _DEFAULT_ANNUAL_MIN
+
+
+def classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Kind:
+    if tier_name is not None and tier_name.strip().casefold() in _annual_tier_names():
+        return "annual"
+    if is_subscription_payment:
+        return "monthly"
+    if amount >= _annual_min_amount():
+        return "annual"
+    return "tip"
+
+
+def grant_days(kind: Kind) -> int:
+    return _GRANT_DAYS[kind]
+
+
+def extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime:
+    """New subscriber_until: active subs stack; lapsed subs restart from now."""
+    now = now or datetime.now(UTC)
+    base = current if (current is not None and current > now) else now
+    return base + timedelta(days=days)
+```
+
+- [ ] **Step 4: Run unit tests — PASS.**
+
+- [ ] **Step 5: Model + migration.** Add to `db/models.py` (after `Usage`; import `Numeric`, `JSONB` is already imported for other models — verify):
+
+```python
+class Payment(Base):
+    """One row per Ko-fi webhook event (monetization arc 2/3) — the audit trail behind
+    users.subscriber_until. Idempotency key = kofi_transaction_id (Ko-fi retries).
+    matched_user_id NULL = payer email didn't match a user (CLI `payments match` fixes)."""
+
+    __tablename__ = "payments"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    kofi_transaction_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    kofi_type: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)  # lowercased at ingest
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String, nullable=False)
+    tier_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_subscription_payment: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    matched_user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    entitlement_days: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+```
+
+(match the file's existing import style; add `from decimal import Decimal` and `Boolean`/`Numeric` to the sqlalchemy imports as needed.) Hand-write
+`alembic/versions/b2c3d4e5f6a7_payments_table.py` mirroring the newest migration's
+style: `create_table("payments", ...)` with the unique constraint on
+kofi_transaction_id and indexes on email + matched_user_id; downgrade drops the table.
+
+- [ ] **Step 6: Full unit suite, lint, format, commit**
+`git commit -m "feat(payments): entitlement rules + payments table (Ko-fi arc 2/3)"`
+
+---
+
+### Task 2: `POST /webhooks/kofi` + deploy wiring
+
+**Files:**
+- Create: `src/agentic_librarian/api/kofi.py`
+- Modify: `src/agentic_librarian/api/main.py` (register router next to `internal_router`, line ~123)
+- Modify: `.github/workflows/deploy.yml` (append `KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest` to `--set-secrets`, line ~153)
+- Create: `test/unit/test_kofi_webhook.py`
+- Create: `test/integration/test_kofi_webhook_db.py`
+
+**Interfaces:** consumes `entitlements.*`, `Payment`, `User`. Produces route `POST /webhooks/kofi` on `app` root.
+
+- [ ] **Step 1: Failing unit tests (DB-free guards)** — `test/unit/test_kofi_webhook.py`: build a tiny FastAPI app with just the router (the `test_firebase_auth_proxy.py` pattern: `app.include_router(router)`); parametrized:
+  - no `data` field → 400; `data` not JSON → 400.
+  - `KOFI_VERIFICATION_TOKEN` unset → 403 (even with a token in payload).
+  - token mismatch → 403.
+  - Token OK but DB layer raises (patch the module's `db_manager` with a stub whose `get_session` raises) → 500 (Ko-fi will retry; idempotency makes that safe).
+
+- [ ] **Step 2: Run — FAIL.** Then implement `api/kofi.py`:
+
+```python
+"""Ko-fi payment webhook (monetization arc 2/3) — root-level machine route, like
+/internal/*: NOT under /api (purpose-scoped namespacing, #151). Authenticity is Ko-fi's
+shared verification_token (no HMAC exists); fail-closed when unset. Always 200 once the
+event is durably stored — Ko-fi retries non-2xx, and an unmatched payment is an operator
+task (CLI `payments match`), not a delivery failure. Idempotent on kofi_transaction_id."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from fastapi import APIRouter, Form, HTTPException
+
+from agentic_librarian.core import entitlements
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+@router.post("/webhooks/kofi")
+def kofi_webhook(data: str = Form(...)):  # noqa: B008
+    try:
+        event = json.loads(data)
+        if not isinstance(event, dict):
+            raise ValueError("payload is not an object")
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="malformed payload") from e
+
+    expected = os.environ.get("KOFI_VERIFICATION_TOKEN")
+    supplied = str(event.get("verification_token") or "")
+    if not expected or not hmac.compare_digest(supplied, expected):
+        # Unset env fails CLOSED (matches _require_queue_caller's posture).
+        raise HTTPException(status_code=403, detail="verification failed")
+
+    txn_id = str(event.get("kofi_transaction_id") or "").strip()
+    if not txn_id:
+        raise HTTPException(status_code=400, detail="missing kofi_transaction_id")
+    email = str(event.get("email") or "").strip().lower()
+    try:
+        amount = Decimal(str(event.get("amount") or "0"))
+    except InvalidOperation:
+        amount = Decimal(0)
+    tier_name = event.get("tier_name") or None
+    is_sub = bool(event.get("is_subscription_payment", False))
+    kofi_type = str(event.get("type") or "")
+
+    kind = entitlements.classify(kofi_type, is_sub, tier_name, amount)
+    days = entitlements.grant_days(kind)
+
+    with db_manager.get_session() as session:
+        if session.query(Payment.id).filter(Payment.kofi_transaction_id == txn_id).first() is not None:
+            return {"status": "duplicate"}
+        user = session.query(User).filter(User.email == email).first() if email else None
+        payment = Payment(
+            kofi_transaction_id=txn_id,
+            kofi_type=kofi_type,
+            email=email,
+            amount=amount,
+            currency=str(event.get("currency") or ""),
+            tier_name=tier_name,
+            is_subscription_payment=is_sub,
+            payload=event,
+            matched_user_id=user.id if user else None,
+            entitlement_days=days if user else 0,
+        )
+        session.add(payment)
+        if user is not None and days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+            session.flush()
+            logger.info("kofi %s: %s +%dd -> %s", kind, email, days, user.subscriber_until.isoformat())
+            return {"status": "applied", "kind": kind}
+        session.flush()
+    if user is not None:
+        logger.info("kofi tip recorded for %s", email)
+        return {"status": "recorded", "kind": kind}
+    logger.warning("kofi payment UNMATCHED (email %s, txn %s) — resolve via `payments match`", email, txn_id)
+    return {"status": "unmatched", "kind": kind}
+```
+
+Register in `api/main.py` next to `internal_router` (~line 123):
+`from agentic_librarian.api.kofi import router as kofi_router` + `app.include_router(kofi_router)`
+(root registration — must stay OUTSIDE `api_router`).
+
+- [ ] **Step 3: deploy.yml** — append `,KOFI_VERIFICATION_TOKEN=librarian-kofi-verification-token:latest` to the `--set-secrets` list (line ~153). Do not touch anything else in the workflow.
+
+- [ ] **Step 4: db_integration tests (by inspection)** — `test/integration/test_kofi_webhook_db.py` (marker + fixture pattern from `test_budgets_db.py`; patch this module's `db_manager` via monkeypatch + `KOFI_VERIFICATION_TOKEN`): parametrized end-to-end matrix:
+  - membership payment, matched email → 200 applied; `subscriber_until` == extend(prior, 33) (seed prior both lapsed and active — assert exact datetimes with a frozen `now` is impossible through HTTP, so assert range: `>= before_call + 33d - small_slack` and `payments` row fields).
+  - annual (tier_name "Annual") → +370 path.
+  - tip (< threshold) → 200 recorded, entitlement_days 0, subscriber_until unchanged.
+  - unknown email → 200 unmatched, matched_user_id NULL.
+  - same txn replay → 200 duplicate, no second row, no double-extend.
+
+- [ ] **Step 5: Unit suite + collect-only, lint, format, commit**
+`git commit -m "feat(payments): Ko-fi webhook -> payments + subscriber_until (arc 2/3)"`
+
+---
+
+### Task 3: CLI — `user subscribe`, `payments list/match`
+
+**Files:**
+- Modify: `src/agentic_librarian/cli.py` (extend `_parse_args` subparsers + `_run_user`, add `_run_payments`; follow the existing `user invite` shape at cli.py:108-128 and its `_invite_db_manager` seam)
+- Modify/extend: the existing CLI test file (grep `test/` for the file testing `user invite`)
+
+**Interfaces:** consumes `entitlements.extend`/`grant_days`, `Payment`, `User`.
+
+- [ ] **Step 1: Failing tests** (extend the existing CLI test file, mirroring its invite-test style — it patches the db-manager seam; parametrized):
+  - `user subscribe x@y.com` (default) → subscriber_until ≈ now+33d printed; `--months 3` → +99d; `--days 45` → +45; `--until 2027-01-01` → exact; unknown email → exit 2 with error.
+  - `payments list --unmatched` prints only unmatched rows; `payments match <txn> <email>` sets matched_user_id + applies entitlement_days per stored classification, refuses (exit 2) when already matched or txn/email unknown.
+- [ ] **Step 2: Implement.** Parser additions in `_parse_args`:
+
+```python
+    sub_parser = user_sub.add_parser("subscribe", help="grant/extend supporter entitlement (comp or Ko-fi mismatch fix)")
+    sub_parser.add_argument("email")
+    group = sub_parser.add_mutually_exclusive_group()
+    group.add_argument("--months", type=int, default=None, help="N x 33-day grants (default 1)")
+    group.add_argument("--days", type=int, default=None)
+    group.add_argument("--until", default=None, help="YYYY-MM-DD (absolute)")
+
+    payments_parser = subparsers.add_parser("payments", help="Ko-fi payment records (operator)")
+    payments_sub = payments_parser.add_subparsers(dest="payments_command")
+    list_parser = payments_sub.add_parser("list", help="list payments")
+    list_parser.add_argument("--unmatched", action="store_true")
+    match_parser = payments_sub.add_parser("match", help="link an unmatched payment to a user and apply its entitlement")
+    match_parser.add_argument("kofi_transaction_id")
+    match_parser.add_argument("email")
+```
+
+`_run_user` grows a `subscribe` branch (validate email format like invite; load user;
+compute `days = months*33 | days | until-date` — for `--until`, set
+`subscriber_until` directly to that date at UTC midnight; else
+`user.subscriber_until = entitlements.extend(user.subscriber_until, days)`; print the
+result). New `_run_payments(args)` wired in `_dispatch`; `match` recomputes
+`classify`/`grant_days` from the stored row's fields (`kofi_type`,
+`is_subscription_payment`, `tier_name`, `amount`) so webhook and CLI grant identically,
+then applies `extend` and stamps `matched_user_id`/`entitlement_days`.
+Use the same db-manager seam pattern `_invite_db_manager` uses (reuse or mirror it).
+
+- [ ] **Step 3: Full unit suite, lint, format, commit**
+`git commit -m "feat(cli): user subscribe + payments list/match operator fallback (arc 2/3)"`
+
+---
+
+### Task 4: `GET /api/account` + avatar dropdown (AccountMenu)
+
+**Files:**
+- Modify: `src/agentic_librarian/api/main.py` (new `@api_router.get("/account")` near the `/conversations/current` route ~line 460)
+- Create: `frontend/src/components/AccountMenu.tsx`
+- Modify: `frontend/src/components/TopBar.tsx` (avatar → menu trigger; remove standalone sign-out)
+- Modify: `frontend/src/components/AppShell.css` (menu styles — follow existing token/theme variables)
+- Modify: `frontend/src/api/client.ts` (add `getAccount`)
+- Create: `frontend/src/components/AccountMenu.test.tsx`; Modify: `frontend/src/components/TopBar.test.tsx`
+- Modify/extend: the chat API integration test file OR a small new `test/integration/test_account_api.py` for the endpoint
+
+**Interfaces:** consumes `tiers.effective_tier`. Produces `GET /api/account` → `{"email", "display_name", "tier", "subscriber_until"}` (subscriber_until ISO string or null); `client.ts` `getAccount(): Promise<Account>`.
+
+- [ ] **Step 1: Backend endpoint** (+ failing integration test first, by inspection if db_integration):
+
+```python
+@api_router.get("/account")
+def get_account(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    from agentic_librarian.core import tiers as tiers_mod
+    from agentic_librarian.db.models import User
+
+    with db_manager.get_session() as session:
+        tier = tiers_mod.effective_tier(session, user.id)
+        row = session.get(User, user.id)
+        until = row.subscriber_until.isoformat() if row and row.subscriber_until else None
+        return {
+            "email": row.email if row else None,
+            "display_name": row.display_name if row else None,
+            "tier": tier,
+            "subscriber_until": until,
+        }
+```
+
+(match main.py's actual db-session idiom — grep how other main.py routes open sessions; keep imports at module top per file style.)
+Integration test: free user → tier "free", null until; seeded future subscriber_until → "supporter" + ISO date.
+
+- [ ] **Step 2: client.ts** —
+
+```ts
+export interface Account {
+  email: string
+  display_name: string | null
+  tier: 'free' | 'supporter' | 'byok'
+  subscriber_until: string | null
+}
+
+export function getAccount(): Promise<Account> {
+  return getJson<Account>('/account')
+}
+```
+
+- [ ] **Step 3: Failing frontend tests** — `AccountMenu.test.tsx` (mock `getAccount` via `vi.mock('../api/client')`; `...Once` for the rejection case): opens on avatar click; shows email + "Free plan" for tier free; "Supporter until <formatted date>" for supporter; three Ko-fi links all `href="https://ko-fi.com/shelfwright"` with `target="_blank"` + `rel` containing `noopener`; Escape and outside-click close it; sign-out button calls the auth context's signOut even when `getAccount` rejects. Update `TopBar.test.tsx`: standalone sign-out button gone; avatar has `aria-expanded`.
+
+- [ ] **Step 4: Implement `AccountMenu.tsx`** (and TopBar changes):
+
+```tsx
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import { getAccount, type Account } from '../api/client'
+
+const KOFI_URL = 'https://ko-fi.com/shelfwright'
+
+/** Account dropdown off the top-bar avatar. Future home of username change and the
+ *  BYOK entry (arc PR 3). Sign-out must never depend on the API: account fetch failure
+ *  just hides the status line. */
+export default function AccountMenu() {
+  const { user, signOut } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [account, setAccount] = useState<Account | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    if (account === null) {
+      getAccount().then(setAccount).catch(() => setAccount(null))
+    }
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, account])
+
+  const status =
+    account?.tier === 'supporter' && account.subscriber_until
+      ? `Supporter until ${new Date(account.subscriber_until).toLocaleDateString()}`
+      : account?.tier === 'free'
+        ? 'Free plan'
+        : null
+
+  return (
+    <div className="account-menu" ref={rootRef}>
+      <button
+        className="avatar avatar-button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div className="account-menu-panel" role="menu">
+          <div className="account-menu-identity">
+            <div className="account-menu-name">{user?.displayName || user?.email}</div>
+            {user?.displayName && <div className="account-menu-email">{user?.email}</div>}
+            {status && <div className="account-menu-status">{status}</div>}
+          </div>
+          <div className="account-menu-support">
+            <div className="account-menu-heading">Support Shelfwright ♥</div>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$3 / month</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$25 / year</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">Leave a tip</a>
+            <div className="account-menu-nudge">
+              Use your Shelfwright sign-in email on Ko-fi so your support links up automatically.
+            </div>
+          </div>
+          <hr />
+          <button role="menuitem" onClick={() => void signOut()}>Sign out</button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+`TopBar.tsx`: replace the `<span className="avatar">` + sign-out button with
+`<AccountMenu />` (keep the theme toggle). Style the panel in `AppShell.css` using the
+existing CSS custom properties/tokens (absolute-positioned under the bar, right-aligned,
+themed background/border like existing surfaces — follow the `.topbar` block's variables;
+check both light and dark themes).
+
+- [ ] **Step 5: Suites** — frontend `npm test -- --run` + `tsc --noEmit`; backend unit suite + `--collect-only` on touched integration files; lint/format; commit
+`git commit -m "feat(account): /api/account + avatar dropdown with Ko-fi support links (arc 2/3)"`
+
+---
+
+## Post-implementation verification
+
+- [ ] Local unit + frontend suites green; collect-only clean.
+- [ ] CI green on the PR (db_integration first — gate #5).
+- [ ] Visual QC of the menu (the qc-harness pattern) is OPTIONAL here; note in the PR if skipped.
+
+## Self-review notes (coverage against spec)
+
+- Spec §1 table → Task 1 model/migration. §2 rules → Task 1 module (incl. exact-match tier-name note). §3 webhook semantics/status codes → Task 2 code verbatim. §4 CLI → Task 3. §5 endpoint → Task 4 Step 1. §6 menu behavior incl. lazy fetch + fetch-failure sign-out guarantee → Task 4 component. §7 deploy wiring → Task 2 Step 3 (secret creation + Ko-fi dashboard = operator steps, PR body). ✓
+- Names cross-checked: `entitlements.classify/grant_days/extend`, `Payment` columns, `getAccount`/`Account`, `set_db_manager` seam. ✓

--- a/docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md
+++ b/docs/superpowers/specs/2026-07-25-metering-tiers-budgets-design.md
@@ -1,0 +1,210 @@
+# Design: Metering, tiers, and budgets (#100 — sub-project 1 of the monetization arc)
+
+**Date:** 2026-07-25
+**Issue:** #100 — per-user quotas, rate limiting, and enrichment metering
+**Arc:** Monetization (1 of 3: this → Ko-fi subscriber tracking → BYOK)
+**Branch:** `feat/metering-tiers-100` (PRs stack; user merges in order at end of arc)
+
+## Product decisions (user, 2026-07-25)
+
+- Scope: meter everything + per-tier budgets; the shared Gemini key flips to **paid tier**
+  at rollout (operator step). Pricing data measured for a month before any price tuning.
+- Tiers: **free** = trial quotas (~20 chat turns/day, ~300-row import); **supporter**
+  (Ko-fi $3/mo / $25/yr, PR2) = generous env-tunable safety budgets, not unlimited;
+  **byok** (PR3) = own key, bypasses app-key budgets.
+- Cost model measured from prod: chat turn ≈ 0.7¢; deep-enrich ≈ 2¢/work under the paid
+  tier's free 1,500 grounded-prompts/day, ≈ 13¢ past it ($35/1k). The **global grounding
+  governor** below is what keeps the worst-case bill at "fixed floor + tokens".
+
+## Problem
+
+`record_llm_call` is wired into the chat mesh backends only. The most expensive path —
+grounded scouts + embeddings (every one of prod's 1,127 works) — writes zero usage rows,
+and nothing anywhere is enforced: no chat rate limit, no message length cap, no per-user
+import/enrichment budget. One 2,000-row import ≈ 6k grounded calls, unmetered.
+
+## Architecture
+
+Three layers, all in this PR:
+
+1. **Tier model** — schema + one pure function.
+2. **Metering** — every Gemini/Claude call site records a `usage` row, including
+   background tasks (requires threading `user_id` into task payloads).
+3. **Enforcement** — pre-LLM chokepoint checks against the `usage`/domain tables
+   (no Redis), returning 429 to interactive callers and *deferring* background work
+   via Cloud Tasks `schedule_time`.
+
+### 1. Tier model
+
+- Migration: `users.subscriber_until` (timestamptz, nullable). Comps = far-future value
+  (CLI to set it lands in PR2; until then operator SQL or nothing — acceptable, merge
+  order is 1→2→3).
+- New `core/tiers.py`:
+  - `effective_tier(session, user_id) -> Literal["free", "supporter", "byok"]`:
+    `byok` if a `user_credentials` row exists for vendor `gemini` (table has NO writers
+    until PR3, so this branch is inert but the enum is stable across the arc);
+    else `supporter` if `subscriber_until` is set and `> now()`; else `free`.
+  - Budget lookups, all env-tunable with defaults (the `_seed_limit()` parse pattern —
+    invalid/non-positive → default, read per call):
+
+    | Env var | Default | Meaning |
+    |---|---|---|
+    | `CHAT_TURNS_PER_DAY_FREE` | 20 | user messages / UTC day |
+    | `CHAT_TURNS_PER_DAY_SUPPORTER` | 200 | |
+    | `CHAT_MESSAGE_MAX_CHARS` | 4000 | all tiers (structural) |
+    | `IMPORT_MAX_ROWS_FREE` | 300 | per import file |
+    | `IMPORT_MAX_ROWS_SUPPORTER` | 2000 | = existing absolute `MAX_ROWS` |
+    | `GROUNDED_CALLS_PER_DAY_FREE` | 300 | ≈100 works/day |
+    | `GROUNDED_CALLS_PER_DAY_SUPPORTER` | 1500 | can consume the whole free allowance |
+    | `GROUNDED_CALLS_PER_DAY_GLOBAL` | 1400 | governor: all users, headroom under Google's free 1,500/day |
+
+  - `byok` tier: chat/import budgets use the supporter values ×10 (structural sanity,
+    not cost protection); grounded budgets don't apply once PR3 routes to their key —
+    in THIS PR byok cannot occur (no credential writers), so no special-casing beyond
+    the enum.
+- Budget *counting* queries the existing tables — no new counters to keep consistent:
+  - chat turns today = `messages` rows with `role='user'`, joined via `conversations.user_id`, `created_at >= UTC midnight`.
+  - grounded calls today (per-user / global) = `usage` rows with `model = <grounding model>`, `key_source='app'`, same window.
+
+### 2. Metering
+
+- **Gemini grounded scout** (`scouts/grounded_llm.py` `GeminiGroundedLLM.generate`):
+  the response already carries `usage_metadata` (prompt/candidates token counts) and
+  `_extract_text` discards it. Capture it and call `record_llm_call("gemini", model,
+  prompt_tokens, candidates_tokens)`. Meter **at the response object** — the SDK-level
+  429/5xx retry (`genai_http_options`) must not double-count; scout-level retries are
+  genuinely second billable calls and record again (correct).
+- **Claude grounded scout** (`ClaudeGroundedLLM._agenerate`): read the SDK
+  `ResultMessage.usage` the same way `agents/backends/claude.py` already does; record
+  with vendor `anthropic`.
+- **Embeddings** (`scouts/utils.py get_cached_embedding`): embed responses expose no
+  token counts, and the `@lru_cache` means only cache misses hit the network. Record
+  **inside the cached function body** (misses only), `input_tokens = len(text) // 4`
+  (documented estimate — embeddings are $0.15/M, this is visibility, not billing-grade),
+  `output_tokens = 0`, model `gemini-embedding-001`. This transparently covers all
+  callers (trope/style managers, MCP warming, two-phase warming, analysis_style).
+- **Failure posture unchanged:** `record_llm_call` never raises; a metering failure
+  logs and the call proceeds (ADR-048 best-effort stands until billing-grade is needed).
+
+#### User attribution in background tasks (the prerequisite)
+
+`record_llm_call` → `get_required_user_id()` fails closed, and today the enrichment
+handlers have **no user in context**, so metering there would silently drop every row:
+
+- `enqueue_enrichment(work_id)` and `enqueue_edition_completion(work_id, fmt)` gain a
+  `user_id: str | None = None` parameter, appended to the task URL as a query parameter.
+  Callers pass the acting user: `books.py` add-book and `main.py` PATCH /history (current
+  user), `imports/worker.py` (the row's `user_id`).
+- `/internal/enrich/{work_id}`, `/internal/complete-edition/{work_id}` accept the
+  optional `user_id` query param and wrap their work in `as_user(user_id)` when present.
+  **Tasks enqueued before this deploy carry no user_id — handlers must tolerate its
+  absence** (run un-attributed exactly as today; metering skips, nothing crashes).
+- `imports/worker.py process_import_row`: the `as_user(...)` block moves up to also
+  cover `enrich_fast(...)` (today it covers only the history/suggestion writes), so
+  import-triggered fast-scout calls are attributed.
+- Enrichment for a shared work bills to whoever requested it (catalog sharing means
+  later users of the same work pay nothing — by design).
+
+### 3. Enforcement
+
+**Chat** (`api/main.py /chat`):
+- Length cap as an explicit handler check (`len(message) > chat_message_max_chars()`),
+  NOT a Pydantic `max_length` constant — the env value must be tunable without redeploy
+  and read per call. Over-length → 422 with a clear detail.
+- After `get_current_user`, before the `StreamingResponse` is created (the map confirms
+  429 is impossible once streaming starts): count today's user messages; at/over the
+  tier budget → `HTTPException(429, detail={"code": "chat_quota", "message": ..., "tier": ...})`.
+- Frontend `streamChat` (client.ts): today any non-OK collapses to a generic error.
+  Add: `res.status === 429` → parse detail → show its message (friendly copy: daily
+  limit reached — support Shelfwright or bring your own key soon). No toast system is
+  built (none exists; per-view error slots are the house pattern).
+
+**Imports** (`api/imports.py`):
+- Per-tier rows/import: preview/commit reject files over the tier's `IMPORT_MAX_ROWS_*`
+  (existing absolute `MAX_ROWS=2000` stays as the ceiling). 413/422-style JSON detail the
+  ImportView already renders; include the tier and the limit in the message.
+- **One in-flight import per user** (any tier): commit refuses (409) while the user has
+  a job with pending/running rows (query `import_jobs` + `import_rows` status; no new
+  columns).
+
+**Enrichment budget + global governor** (`api/internal.py` enrich / complete-edition):
+- At task execution, BEFORE running scouts: if the acting user's grounded calls today
+  ≥ tier budget, OR the global count ≥ `GROUNDED_CALLS_PER_DAY_GLOBAL`, **defer**: the
+  handler re-enqueues the same task with `schedule_time` = next UTC midnight + jitter
+  (0–30 min, spreads the morning thundering herd) and returns 200 (task consumed —
+  deferral must NOT burn the #97 give-up retry count).
+- Un-attributed tasks (pre-deploy backlog, no user_id) check only the global governor.
+- `enrichment/tasks.py` + `imports/tasks.py` gain optional `schedule_time` support on
+  the Task dict (protobuf timestamp) — the missing knob the map identified.
+- `/books` gets no separate in-flight cap: the daily grounded budget bounds the same
+  cost (the issue's suggestion is subsumed).
+
+**Queue fairness** (issue item 4): NOT in this PR. The governor + per-user budgets bound
+the cost; FIFO fairness between a bulk import and an interactive add remains a 6.5/6.6
+follow-up. Noted here so the deferral is deliberate.
+
+## Data flow (enforcement read path)
+
+Every check is one indexed COUNT against existing tables (`messages`, `usage`,
+`import_rows`) scoped to a UTC day — no new state, no Redis, consistent-enough (a
+racing pair of requests can each pass at N-1; budgets are safety nets, not invoicing).
+`usage.created_at` has no index today; `usage(user_id)` is indexed — the per-day scan
+per user is trivial at this scale. Add a composite index only if CI's query plans say so
+(YAGNI now).
+
+## Error handling
+
+- Metering: best-effort, never blocks the user path (unchanged posture).
+- Enforcement failures fail OPEN with a logged warning (a broken budget query must not
+  take chat down — the budget protects cost, not correctness).
+- 429 bodies always carry `{"code", "message"}` so the frontend renders a human
+  sentence, never a bare status.
+
+## Testing
+
+Per house rules: parametrized cases only; Postgres-only models → counting/attribution
+tests are `db_integration` (CI-first gate); DB-free logic (env parsing, tier decision
+with injected rows, usage-capture with fake response objects) unit-tests locally.
+
+- Unit: `effective_tier` matrix (subscriber_until past/future/null × credential
+  present/absent); budget env parsing (valid/invalid/non-positive); Gemini scout
+  metering captures usage_metadata off a fake response (and records once despite
+  `_extract_text` retry paths); embed metering records only on cache miss with the
+  documented estimate; deferral schedule_time computation (next-UTC-midnight + jitter
+  bounds).
+- db_integration: chat-turn counting query (today vs yesterday rows, other users'
+  rows excluded); grounded-call counting (per-user and global, key_source filter);
+  worker attribution — `process_import_row` writes usage rows with the row's user_id;
+  enrich handler defers (returns 200, re-enqueues with schedule_time) when over budget
+  — enqueue helper faked, assert the schedule_time argument.
+- API integration: /chat 429 at the budget boundary (seed N user messages today, N+1th
+  turn refused; under-budget passes); over-length message 422; import commit 409 with
+  an in-flight job; per-tier rows/import rejection.
+- Frontend (vitest): streamChat surfaces the 429 detail message; generic errors
+  unchanged.
+
+## Acceptance criteria
+
+1. Every Gemini/Claude LLM call and every embedding cache-miss writes a `usage` row
+   with correct user attribution, including Cloud-Tasks-driven enrichment.
+2. Free tier: 21st chat turn of the day → 429 with human-readable detail; 301-row
+   import rejected; supporter limits are the higher numbers; all env-tunable.
+3. Over-budget/over-governor enrichment tasks defer to next UTC day via
+   `schedule_time` without burning give-up retries; pre-deploy tasks (no user_id)
+   still complete.
+4. Frontend shows the quota message on chat 429 (not the generic error).
+5. Full local unit suite green; db_integration/API additions green in CI; no frontend
+   regression.
+
+## Non-goals (deferred within the arc or later)
+
+- Ko-fi webhook, payments table, subscribe CLI, avatar-dropdown UI → PR2.
+- BYOK storage/routing/walkthrough → PR3.
+- Queue fairness (bulk vs interactive), summarizing old chat context, billing-grade
+  metering, `usage` table rotation → later phases.
+
+## Ops at rollout (operator, with sub-project 1's deploy)
+
+Flip the shared Gemini key's project to the paid tier (billing on). Until then the
+governor still helps (free tier's 500 grounded RPD << 1,500) — set
+`GROUNDED_CALLS_PER_DAY_GLOBAL=450` in the interim if the flip lags the deploy.

--- a/docs/superpowers/specs/2026-07-26-byok-design.md
+++ b/docs/superpowers/specs/2026-07-26-byok-design.md
@@ -1,0 +1,163 @@
+# Design: BYOK — bring your own Gemini key (monetization arc 3 of 3)
+
+**Date:** 2026-07-26
+**Arc:** Monetization (PR 1 = #100 metering/tiers/budgets; PR 2 = Ko-fi tracking; this PR stacks on both)
+**Branch:** `feat/byok` (base: `feat/kofi-subscriptions` / PR #156)
+
+## Product decisions (user, 2026-07-25)
+
+BYOK is the **free tier's escape valve**: users who bring their own (free-tier) Google
+AI Studio key ride at no marginal cost to the operator, are **tracked**
+(`usage.key_source='byok'`, tier `byok`), and get a **guided walkthrough**. The
+`user_credentials` table (KMS ciphertext, Lift-1 placeholder) and `usage.key_source`
+were built for exactly this; PR 1's tier logic already returns `byok` when a
+credential row exists — this PR creates the first writer and the actual routing.
+
+## Scope boundaries (from the code survey)
+
+1. **Embeddings stay on the app key — deliberately NOT routed per-user.** The embed
+   path is a process-wide client + `lru_cache` keyed `(model, text)` with miss-only
+   metering: per-user routing would misattribute costs across users via cache hits and
+   buy nothing (embeddings are $0.15/M and have separate, higher quota). Documented in
+   code where the decision bites.
+2. **BYOK is a *Gemini* key.** On `AGENT_BACKEND=claude` deployments the generation
+   path ignores it (Max subscription, no API key at all). Prod runs `adk`, so routing
+   covers: the chat mesh (ADK `Gemini` models) and the grounded scouts
+   (`GeminiGroundedLLM`). The claude branch is untouched.
+3. **Never route a key by mutating `os.environ`** (`_ensure_adk_credentials` is
+   global state — a per-request env swap races across concurrent turns). The key
+   threads as a **parameter**: the mesh is rebuilt per conversation turn and ADK
+   `Gemini(api_key=...)` accepts one; scouts already take `api_key` per instance.
+4. **No silent fallback to the app key.** A byok user whose key fails gets an error
+   telling them to check Settings — not a quiet bill for the operator.
+
+## Architecture
+
+### 1. `core/byok.py` — KMS crypto + key resolution
+
+- New dependency `google-cloud-kms`. Env `KMS_KEY_NAME` (full resource name
+  `projects/agentic-librarian-prod/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials`).
+- `encrypt_key(plaintext: str) -> bytes` / `decrypt_key(ciphertext: bytes) -> str` via
+  `kms.KeyManagementServiceClient` (cached client, `_client()` seam like
+  `enrichment/tasks.py`; lazy import so the dependency is only needed where used).
+  `KMS_KEY_NAME` unset → `ByokNotConfigured` (API layer maps to 503).
+- `resolve_gemini_key(session, user_id) -> str | None`: load the
+  `UserCredential(user_id, vendor='gemini')` row; None when absent; decrypt when
+  present. Decrypt failure raises `ByokKeyError` (callers surface it — no fallback).
+  Plaintext keys are NEVER logged, never stored, and live only in call scope.
+- Module `db_manager`-free: takes a session (callers own sessions), keeping crypto
+  pure of pool concerns.
+
+### 2. Credentials API — `api/credentials.py` (mirrors `api/libraries.py` shape)
+
+- `GET /api/me/credentials` → `{"configured": bool, "updated_at": iso-or-null}`
+  (never the key, never a fragment — the table stores ciphertext only).
+- `PUT /api/me/credentials` `{"api_key": "..."}`:
+  1. Shape check (non-empty, trimmed, sane length ≤ 200).
+  2. **Live validation**: one `count_tokens` call on `gemini-3.1-flash-lite` with a
+     fresh `genai.Client(api_key=candidate)` (free, fast). Auth failure → 422
+     `{"code": "invalid_api_key", "message": ...}` (seam-injectable for tests).
+  3. `encrypt_key` → upsert `UserCredential` (`kms_key_name` = env value). → 200
+     `{"configured": true}`. The user's tier flips to `byok` automatically (PR 1's
+     `effective_tier` reads row existence).
+- `DELETE /api/me/credentials` → remove the row (idempotent 200; tier reverts).
+- `KMS_KEY_NAME` unset → 503 `{"code": "byok_unavailable"}` on PUT; GET still answers.
+
+### 3. Key routing
+
+- **`core/usage.py`**: `record_llm_call(..., key_source: str = "app")` — the one
+  place `key_source` is written stays one place. PR 1's budgets already filter
+  `key_source == 'app'`, so byok calls fall out of the app-key governor automatically,
+  and `tier == 'byok'` already bypasses/relaxes budgets.
+- **Chat mesh**: `astart_conversation(..., api_key: str | None = None)` →
+  `build_runner(api_key)` → `create_agent_mesh(api_key)` → `_gemini(model_name,
+  api_key)` → `Gemini(model=..., api_key=..., retry_options=...)`. The chat handler
+  (`api/main.py`) resolves the key once per turn (inside its existing session usage)
+  and passes it through `_SyncOpener`; `stream.sse_turn` needs the key_source so
+  runtime's `_record_event_usage` records `'byok'` — thread a `key_source` value
+  alongside (default `'app'`). `ByokKeyError` at resolution → 409
+  `{"code": "byok_key_error", "message": "Your API key failed — check Settings."}`
+  raised BEFORE the stream starts (same pattern as the 429).
+- **Grounded scouts (deep enrichment)**: `/internal/enrich` + `/internal/complete-edition`
+  handlers (which already `as_user(user_id)`) resolve the key and pass
+  `api_key`/`key_source` into `two_phase.enrich_deep(work_id, api_key=None,
+  key_source="app")` (and `complete_edition`), which threads them into the
+  `LLMScout(api_key=...)`/`GeminiGroundedLLM(api_key=...)` constructions it makes.
+  `grounded_llm` metering records the threaded `key_source`. `ByokKeyError` in a task
+  → log + 200 `{"status": "byok_key_error"}` (task consumed — retrying can't fix a
+  revoked key; the user re-adds enrichment by fixing the key and using the requeue
+  sweep / next add). Key revoked at Google mid-call → the scout call 401s → existing
+  scout-exception path (retry → give-up bound) — acceptable, documented residual.
+- **Fast pass** (`enrich_fast` — API-only scouts, no LLM): untouched.
+- **Embeddings**: untouched (app key, decision #1) — byok users' embed rows stay
+  `key_source='app'` and are the only app-key spend they generate (fractions of a cent).
+
+### 4. Frontend
+
+- **Settings** (`SettingsView.tsx` gains a second section — "Your API key"): the
+  walkthrough stepper copy — (1) create a free key at aistudio.google.com/apikey
+  (external link), (2) paste it here, (3) Save validates it live. Status line when
+  configured ("Using your own key since <date>") + Remove button. Errors surface the
+  server's `message` (invalid key / byok unavailable). Follows the existing section's
+  save-button + `status` aria-live pattern.
+- **AccountMenu**: `tier === 'byok'` status renders "Using your own key"; new
+  menuitem link "API key settings" → `/settings` (the earmarked BYOK entry).
+- `client.ts`: `getCredentials()`, `putCredentials(apiKey)`, `deleteCredentials()`.
+- Chat 409 `byok_key_error` surfaces via the same streamChat non-OK detail path as
+  429/422 (extend the status allowlist).
+
+### 5. Config & ops (operator steps, PR body)
+
+- New `infra/09-kms.sh`: create keyring `librarian` + key `byok-credentials`
+  (us-central1, symmetric encrypt/decrypt), grant
+  `roles/cloudkms.cryptoKeyEncrypterDecrypter` to
+  `librarian-api-runtime@agentic-librarian-prod.iam.gserviceaccount.com`.
+- deploy.yml: add `KMS_KEY_NAME` to `--set-env-vars` (a resource name, not a secret).
+- `pyproject.toml`: `google-cloud-kms` dependency.
+
+## Error handling summary
+
+| Failure | Where | Behavior |
+|---|---|---|
+| KMS_KEY_NAME unset | PUT credentials | 503 byok_unavailable; GET works; nothing else affected |
+| Invalid key at save | PUT validation | 422 invalid_api_key, nothing stored |
+| Decrypt fails / KMS down at use | chat | 409 byok_key_error pre-stream ("check Settings") |
+| Decrypt fails / KMS down at use | enrich task | log + 200 byok_key_error (task consumed, no retry storm) |
+| Key revoked at Google mid-call | scouts | existing scout-exception → retry → give-up path (residual) |
+| Key revoked at Google mid-call | mesh | ADK call fails → existing SSE generic error (residual: not byok-specific copy) |
+
+## Testing
+
+- Unit (local): byok crypto seams (fake KMS client — encrypt/decrypt round-trip,
+  ByokNotConfigured on unset env); credentials API guards (shape 422, byok_unavailable
+  503, validation-seam auth-fail 422, success upsert flow with patched session/KMS);
+  key threading — `_gemini`/`create_agent_mesh`/`build_runner` accept and pass
+  `api_key` (fake ADK objects or introspection of constructed `Gemini` args);
+  `two_phase` threads `api_key` into `LLMScout` (existing scout-construction seams);
+  `record_llm_call` key_source parameter; chat handler 409 pre-stream on ByokKeyError.
+- db_integration (EXECUTE locally — Postgres is up): credentials PUT/GET/DELETE
+  round-trip with a fake-KMS seam (ciphertext bytes stored, never plaintext); tier
+  flips free→byok→free across PUT/DELETE (through `/api/account`); enrich handler
+  passes a byok user's key into `enrich_deep` (probe seam) and usage rows record
+  `key_source='byok'`.
+- Frontend (vitest): Settings section (save success/invalid-key error/remove;
+  `...Once` mocks), AccountMenu byok status + settings link, streamChat 409 detail.
+
+## Acceptance criteria
+
+1. A user can save a validated Gemini key (stored as KMS ciphertext only), see
+   "configured" status, and remove it; their tier reads `byok` while configured.
+2. Chat turns and deep-enrichment scouts for a byok user run on THEIR key and write
+   `usage` rows with `key_source='byok'`; app-key budgets/governor ignore those rows.
+3. A failing/unconfigured-at-use key produces the defined errors — never a silent
+   fallback to the app key.
+4. Embeddings remain app-keyed (documented), and non-byok users' behavior is
+   byte-identical to before this PR.
+5. Settings walkthrough + AccountMenu status/link work; suites green (frontend, unit,
+   db_integration executed locally + CI).
+
+## Non-goals
+
+- Anthropic-vendor BYOK (schema supports it; no routing — the claude backend is
+  subscription-auth). Key health dashboards/notifications. Plaintext key display
+  after save. Per-key usage export. Migrating existing users.

--- a/docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md
+++ b/docs/superpowers/specs/2026-07-26-kofi-subscriptions-design.md
@@ -1,0 +1,178 @@
+# Design: Ko-fi subscriber tracking + account menu (monetization arc 2 of 3)
+
+**Date:** 2026-07-26
+**Arc:** Monetization (PR 1 = #100 metering/tiers/budgets, merged first; this PR stacks on it; PR 3 = BYOK)
+**Branch:** `feat/kofi-subscriptions` (base: `feat/metering-tiers-100` / PR #155)
+
+## Product decisions (user, 2026-07-25)
+
+- Payments run through **Ko-fi** (page: **ko-fi.com/shelfwright**, currently bare-bones;
+  Stripe under the hood on Ko-fi's side — we never touch card data).
+- Offers: **$3/month** membership, **$25/year**, and one-off **tips**.
+- Linkage: **webhook + CLI fallback** (auto-match by email; operator commands for
+  mismatches, comps, corrections).
+- Supporters get the generous env-tunable budgets defined in PR 1 (`supporter` tier).
+- Account UI is a **dropdown from the user bubble** in the top bar — NOT a Settings
+  card. It seeds the future home of username change etc. "Sign out" moves into it.
+
+## Ko-fi integration facts (constraints we design around)
+
+- Ko-fi POSTs `application/x-www-form-urlencoded` with a single field `data` whose
+  value is a JSON object: `verification_token`, `message_id`, `kofi_transaction_id`,
+  `type` ("Donation" | "Subscription" | "Shop Order" | "Commission"), `email`,
+  `amount` (string, e.g. "3.00"), `currency`, `tier_name`, `is_subscription_payment`,
+  `is_first_subscription_payment`, `timestamp`, and more. Authenticity = the shared
+  `verification_token` (no HMAC signature exists).
+- **No cancellation/expiry event** — Ko-fi only reports payments. Entitlement must be
+  an expiry horizon each payment extends; lapse is silent (tier computation in PR 1
+  already treats past `subscriber_until` as free).
+- Memberships are monthly-centric; the $25 annual will likely arrive as a Shop Order
+  or one-off Donation → classification must be configurable, not hardcoded on `type`.
+- The payer's Ko-fi email may differ from their Shelfwright sign-in email → unmatched
+  payments must be stored and operator-fixable, and the UI nudges users to pay with
+  their sign-in email.
+
+## Architecture
+
+### 1. `payments` table (one migration, head after PR 1's `a1b2c3d4e5f6`)
+
+`db/models.py` `Payment`:
+
+| column | type | notes |
+|---|---|---|
+| id | UUID pk | |
+| kofi_transaction_id | String, **unique**, not null | idempotency key (Ko-fi retries) |
+| kofi_type | String, not null | raw `type` |
+| email | String, not null, index | lowercased at ingest |
+| amount | Numeric(10,2), not null | parsed from Ko-fi's string |
+| currency | String, not null | |
+| tier_name | String, null | |
+| is_subscription_payment | Boolean, not null, default false | |
+| payload | JSONB, not null | full raw event (audit/forensics) |
+| matched_user_id | FK users.id, null, index | null = unmatched |
+| entitlement_days | Integer, not null, default 0 | what was granted (0 = tip/none) |
+| created_at | timestamptz, not null | our clock |
+
+### 2. Entitlement rules (pure module `core/entitlements.py`, DB-free)
+
+- `classify(kofi_type, is_subscription_payment, tier_name, amount) -> "monthly" | "annual" | "tip"`:
+  - **annual** if `tier_name` case-insensitively matches one of
+    `KOFI_ANNUAL_TIER_NAMES` (csv env, default `"annual"`), OR if it is NOT a
+    subscription payment and `amount >= KOFI_ANNUAL_MIN_AMOUNT` (default `25`).
+  - else **monthly** if `is_subscription_payment` is true.
+  - else **tip** (recorded, thanked, no entitlement).
+- `grant_days(kind) -> int`: monthly → **33**, annual → **370**, tip → **0**. The +3/+5
+  padding is the grace covering Ko-fi's no-cancellation-event gap and late renewals.
+- `extend(current: datetime | None, days: int, now) -> datetime`:
+  `max(now, current or now) + timedelta(days=days)` — stacking payments extends, a
+  lapsed sub restarts from now.
+- Env knobs read per call, `_env_int`-style fallbacks (PR 1 pattern; the tier-name list
+  is a string csv, whitespace-trimmed, case-folded).
+
+### 3. Webhook — `POST /webhooks/kofi` (root-level machine route)
+
+New `api/kofi.py` router registered on `app` next to `internal_router` (deliberately
+NOT under `/api` — purpose-scoped namespacing from #151; this is a machine route like
+`/internal/*`). Handler:
+
+1. Read form field `data`; `json.loads` it. Malformed/missing → **400**.
+2. Verify `payload["verification_token"] == KOFI_VERIFICATION_TOKEN` env. Env unset →
+   **403** fail-closed (like `_require_queue_caller`'s posture); mismatch → **403**.
+   Compare with `hmac.compare_digest`.
+3. Idempotency: existing `kofi_transaction_id` → **200** `{"status": "duplicate"}`,
+   nothing re-applied.
+4. Insert the `Payment` row (email lowercased); match `users.email`; if matched and
+   `grant_days > 0`, update `subscriber_until = extend(...)` **in the same session** and
+   stamp `matched_user_id` + `entitlement_days`.
+5. Always **200** with `{"status": "applied" | "recorded" | "unmatched"}` — an unmatched
+   payment is not an error (Ko-fi must not retry it); it's stored for the CLI. Log at
+   info (matched) / warning (unmatched, with the email).
+
+Never log the verification token or the full payload at info level.
+
+### 4. CLI fallback (extends the argparse `user` subcommands in `cli.py`)
+
+- `librarian user subscribe <email> [--months N | --days N | --until YYYY-MM-DD]`
+  (default `--months 1`; `--months N` = N×33 days via `extend`) — comps, corrections,
+  Ko-fi-email mismatch remedies. Prints the resulting `subscriber_until`. Unknown
+  email → error listing nothing (no user enumeration beyond the operator's own DB).
+- `librarian payments list [--unmatched]` — table: txn id, date, email, amount,
+  type/tier, matched?, entitlement_days.
+- `librarian payments match <kofi_transaction_id> <email>` — links a stored payment to
+  a user and applies its entitlement (idempotent: refuses if already matched).
+
+### 5. Account API — `GET /api/account`
+
+Returns `{"email", "display_name", "tier", "subscriber_until"}` using
+`tiers.effective_tier` (one query path — no second tier computation). Authed like every
+`/api` route.
+
+### 6. Frontend — avatar dropdown (`AccountMenu`)
+
+- `TopBar.tsx`: the `avatar` span becomes a button toggling a new
+  `components/AccountMenu.tsx` anchored top-right; the standalone "Sign out" button
+  moves inside. Theme toggle stays in the bar.
+- Menu content: identity header (avatar initial, display name, email); status line —
+  "Free plan" / "Supporter until {local date}" / (byok label arrives in PR 3);
+  "Support Shelfwright ♥" block with links to `https://ko-fi.com/shelfwright`
+  ($3/mo · $25/yr · tip — all land on the Ko-fi page; `target="_blank"
+  rel="noopener noreferrer"`), and the nudge line: "Use your Shelfwright sign-in email
+  on Ko-fi so your support links up automatically."; divider; Sign out.
+- Behavior: click toggles; click-outside and Escape close; `aria-expanded` +
+  `role="menu"`. Account data fetched lazily on first open via `client.ts
+  getAccount()`; fetch failure shows the identity from the auth context and hides the
+  status line (menu still works — sign-out must never depend on the API).
+- Future home (documented in the component): username change, BYOK entry (PR 3).
+
+### 7. Config & ops (operator steps at rollout)
+
+- `KOFI_VERIFICATION_TOKEN` → Secret Manager, wired in deploy.yml like existing
+  secrets (this PR edits deploy.yml; operator creates the secret).
+- Optional: `KOFI_ANNUAL_TIER_NAMES`, `KOFI_ANNUAL_MIN_AMOUNT` (defaults fine).
+- Ko-fi dashboard: set webhook URL `https://shelfwright.app/webhooks/kofi`; create the
+  $3/mo membership and the $25 annual product **named to match** an entry in
+  `KOFI_ANNUAL_TIER_NAMES` (e.g. "Annual").
+
+## Error handling
+
+- Webhook: 400 malformed, 403 bad/missing token, 200 for every processed outcome
+  (applied / recorded / unmatched / duplicate) — Ko-fi retry semantics demand success
+  once we've durably stored the event. A DB failure → 500 (Ko-fi retries; idempotency
+  key makes the retry safe).
+- Entitlement writes are transactional with the payment insert — no payment row without
+  its grant outcome recorded.
+- CLI: clear errors for unknown email / unknown txn / already matched.
+
+## Testing
+
+- Unit (local): `classify`/`grant_days`/`extend` full matrix (subscription, shop-order
+  annual by tier name, donation ≥/< threshold, case-insensitive tier names, env
+  overrides, lapsed-vs-active extend); webhook DB-free guards (missing `data`, bad
+  JSON, missing/mismatched/unset token) with the db seam patched; CLI arg parsing.
+- db_integration (CI): webhook end-to-end — applied (matched email, subscriber_until
+  extended exactly +33/+370 from max(now, current)), unmatched stored, duplicate
+  ignored, tip recorded with 0 days; CLI subscribe/match against real rows.
+- Frontend (vitest): menu open/close (click, outside, Escape), status rendering per
+  tier payload, Ko-fi links present with correct href/rel, sign-out still works when
+  `getAccount` rejects (`...Once` mocks), TopBar no longer renders the standalone
+  sign-out button.
+
+## Acceptance criteria
+
+1. A Ko-fi membership payment for a known email sets/extends `subscriber_until` by 33
+   days from `max(now, current)`; an annual product by 370; tips record with no grant.
+2. Replayed webhook deliveries (same `kofi_transaction_id`) are no-ops.
+3. Wrong-email payments are stored and fully resolvable via
+   `payments list --unmatched` + `payments match`; comps via `user subscribe`.
+4. `GET /api/account` reflects the tier PR 1's budgets actually enforce (single code
+   path through `effective_tier`).
+5. The avatar dropdown shows identity, status, Ko-fi links, and sign-out; the old
+   standalone sign-out button is gone; menu is keyboard/outside-click dismissible.
+6. Local unit + frontend suites green; db_integration green in CI.
+
+## Non-goals
+
+- BYOK (PR 3). Username change (future menu item). Refund/chargeback handling
+  (operator uses `user subscribe --until` to adjust). Automated dunning/expiry
+  notices (silent downgrade to free is the designed lapse behavior). Webhook IP
+  allow-listing (token is Ko-fi's documented mechanism).

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -24,6 +24,10 @@ vi.mock('./views/AddBookView', () => ({ default: () => <div>add-view</div> }))
 vi.mock('./views/HistoryEditView', () => ({ default: () => <div>history-edit-view</div> }))
 vi.mock('./views/ImportView', () => ({ default: () => <div>ImportView</div> }))
 vi.mock('./views/SettingsView', () => ({ default: () => <div>settings-view</div> }))
+// AccountMenu transitively imports api/client -> auth/firebase, whose module-level init
+// throws auth/invalid-api-key in CI (no VITE_FIREBASE_* env there — passes locally only
+// because the dev .env exists). Mock it like the views; its own tests cover it.
+vi.mock('./components/AccountMenu', () => ({ default: () => <div>account-menu</div> }))
 
 import App from './App'
 

--- a/frontend/src/api/client.import.test.ts
+++ b/frontend/src/api/client.import.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { commitImport, getImportJob, previewImport, retryImport } from './client'
+import { ApiError, commitImport, getImportJob, previewImport, retryImport } from './client'
 
 vi.mock('../auth/firebase', () => ({ getIdToken: async () => 'tok' }))
 
@@ -33,6 +33,49 @@ describe('import client', () => {
     const body = (f.mock.calls[0][1] as RequestInit).body as FormData
     expect(body.get('import_to_read')).toBe('true')
     expect(body.get('import_currently_reading')).toBe('false')
+  })
+
+  it('commitImport surfaces the server detail.message on 413 as an ApiError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({
+        detail: {
+          code: 'import_rows_limit',
+          message: 'This import has 301 rows; your current limit is 300. Split the file.',
+        },
+      }),
+    } as Response)
+    const file = new File(['x'], 'export.csv', { type: 'text/csv' })
+    let caught: unknown
+    try {
+      await commitImport(file, { title: 'Title' }, { importToRead: true, importCurrentlyReading: false })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ApiError)
+    expect((caught as InstanceType<typeof ApiError>).status).toBe(413)
+    expect((caught as InstanceType<typeof ApiError>).detail).toContain('current limit is 300')
+  })
+
+  it('commitImport surfaces the server detail.message on 409 as an ApiError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        detail: { code: 'import_in_flight', message: 'Your previous import is still running.' },
+      }),
+    } as Response)
+    const file = new File(['x'], 'export.csv', { type: 'text/csv' })
+    let caught: unknown
+    try {
+      await commitImport(file, { title: 'Title' }, { importToRead: true, importCurrentlyReading: false })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ApiError)
+    expect((caught as InstanceType<typeof ApiError>).status).toBe(409)
+    expect((caught as InstanceType<typeof ApiError>).detail).toBe('Your previous import is still running.')
   })
 
   it('getImportJob fetches status', async () => {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -68,26 +68,15 @@ describe('api client', () => {
     expect(detail).toBe('boom')
   })
 
-  it('streamChat surfaces the 429 quota detail message', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ detail: { code: 'chat_quota', message: 'Daily limit reached.' } }), {
-        status: 429,
-      }),
-    )
+  it.each([
+    { status: 429, code: 'chat_quota', message: 'Daily limit reached.' },
+    { status: 422, code: 'message_too_long', message: 'Message too long.' },
+    { status: 409, code: 'byok_key_error', message: 'Your API key failed — check Settings.' },
+  ])('streamChat surfaces the $status $code detail message', async ({ status, code, message }) => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(JSON.stringify({ detail: { code, message } }), { status }))
     let detail = ''
     await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
-    expect(detail).toBe('Daily limit reached.')
-  })
-
-  it('streamChat surfaces the 422 message-too-long detail message', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ detail: { code: 'message_too_long', message: 'Message too long.' } }), {
-        status: 422,
-      }),
-    )
-    let detail = ''
-    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
-    expect(detail).toBe('Message too long.')
+    expect(detail).toBe(message)
   })
 
   it('streamChat falls back to the generic copy on a 500', async () => {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -67,6 +67,35 @@ describe('api client', () => {
     await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
     expect(detail).toBe('boom')
   })
+
+  it('streamChat surfaces the 429 quota detail message', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { code: 'chat_quota', message: 'Daily limit reached.' } }), {
+        status: 429,
+      }),
+    )
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('Daily limit reached.')
+  })
+
+  it('streamChat surfaces the 422 message-too-long detail message', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { code: 'message_too_long', message: 'Message too long.' } }), {
+        status: 422,
+      }),
+    )
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('Message too long.')
+  })
+
+  it('streamChat falls back to the generic copy on a 500', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('boom', { status: 500 }))
+    let detail = ''
+    await streamChat('hi', { onActivity: () => {}, onText: () => {}, onError: (d) => (detail = d) })
+    expect(detail).toBe('The Librarian hit a problem. Please try again.')
+  })
 })
 
 describe('addBook', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -422,6 +422,40 @@ export async function saveMyLibraries(libraries: SavedLibrary[]): Promise<void> 
   if (!res.ok) throw new Error(`save libraries → ${res.status}`)
 }
 
+export interface CredentialsStatus {
+  configured: boolean
+  updated_at: string | null
+}
+
+export function getCredentials(): Promise<CredentialsStatus> {
+  return getJson<CredentialsStatus>('/me/credentials')
+}
+
+export async function putCredentials(apiKey: string): Promise<void> {
+  const res = await authedFetchRaw('/me/credentials', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api_key: apiKey }),
+  })
+  if (!res.ok) {
+    // Error bodies here are {"detail": {"code": ..., "message": ...}} — the same
+    // object-shaped detail as the chat 429/422/409 path and commitImport's 413/409.
+    let detail = `/me/credentials → ${res.status}`
+    try {
+      const parsed = await res.json()
+      if (typeof parsed?.detail?.message === 'string') detail = parsed.detail.message
+    } catch {
+      // non-JSON error body — keep the generic detail
+    }
+    throw new ApiError(res.status, detail)
+  }
+}
+
+export async function deleteCredentials(): Promise<void> {
+  const res = await authedFetchRaw('/me/credentials', { method: 'DELETE' })
+  if (!res.ok) throw new Error(`/me/credentials → ${res.status}`)
+}
+
 function dispatchFrame(frame: string, handlers: ChatHandlers): void {
   let event = 'message'
   let data = ''

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -118,6 +118,17 @@ export interface SavedLibrary {
   name: string
 }
 
+export interface Account {
+  email: string
+  display_name: string | null
+  tier: 'free' | 'supporter' | 'byok'
+  subscriber_until: string | null
+}
+
+export function getAccount(): Promise<Account> {
+  return getJson<Account>('/account')
+}
+
 /** fetch with the Firebase ID token attached. */
 async function authedFetchRaw(path: string, init: RequestInit = {}): Promise<Response> {
   const token = await getIdToken()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -257,6 +257,17 @@ export async function streamChat(message: string, handlers: ChatHandlers): Promi
     return
   }
   if (!res.ok || !res.body) {
+    if (res.status === 429 || res.status === 422) {
+      let message = ''
+      try {
+        const body = await res.json()
+        message = body?.detail?.message ?? ''
+      } catch {
+        // fall through to the generic copy
+      }
+      handlers.onError(message || GENERIC_CHAT_ERROR)
+      return
+    }
     handlers.onError(GENERIC_CHAT_ERROR)
     return
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -268,7 +268,7 @@ export async function streamChat(message: string, handlers: ChatHandlers): Promi
     return
   }
   if (!res.ok || !res.body) {
-    if (res.status === 429 || res.status === 422) {
+    if (res.status === 429 || res.status === 422 || res.status === 409) {
       let message = ''
       try {
         const body = await res.json()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -356,7 +356,20 @@ export async function commitImport(
   form.set('import_currently_reading', String(opts.importCurrentlyReading))
   form.set('original_filename', file.name)
   const res = await authedFetchRaw('/import/commit', { method: 'POST', body: form })
-  if (!res.ok) throw new Error(`commit import → ${res.status}`)
+  if (!res.ok) {
+    // #100: 413 import_rows_limit / 409 import_in_flight carry a human message in
+    // detail.message (updateHistory's ApiError pattern, adapted for the object-shaped
+    // detail the chat 429 path also uses — see streamChat above).
+    let detail = `commit import → ${res.status}`
+    try {
+      const parsed = await res.json()
+      if (typeof parsed?.detail === 'string') detail = parsed.detail
+      else if (typeof parsed?.detail?.message === 'string') detail = parsed.detail.message
+    } catch {
+      // non-JSON error body — keep the generic detail
+    }
+    throw new ApiError(res.status, detail)
+  }
   return res.json() as Promise<ImportCommitResult>
 }
 

--- a/frontend/src/components/AccountMenu.test.tsx
+++ b/frontend/src/components/AccountMenu.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const signOut = vi.fn()
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'a@b.com', displayName: 'Ada' }, signOut }),
+}))
+
+vi.mock('../api/client', () => ({
+  getAccount: vi.fn(),
+}))
+
+import { getAccount } from '../api/client'
+import AccountMenu from './AccountMenu'
+
+afterEach(() => {
+  vi.mocked(getAccount).mockReset()
+  signOut.mockClear()
+})
+
+async function openMenu() {
+  render(<AccountMenu />)
+  const trigger = screen.getByRole('button', { name: /account menu/i })
+  await userEvent.click(trigger)
+  return trigger
+}
+
+describe('AccountMenu', () => {
+  it('is closed by default, with aria-expanded false on the trigger', () => {
+    render(<AccountMenu />)
+    const trigger = screen.getByRole('button', { name: /account menu/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('opens the panel on avatar click and marks aria-expanded true', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    const trigger = await openMenu()
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('shows "Free plan" for a free-tier account', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    await waitFor(() => expect(screen.getByText('Free plan')).toBeInTheDocument())
+  })
+
+  it('shows "Supporter until <date>" for a supporter-tier account', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'supporter', subscriber_until: '2026-08-25T00:00:00+00:00',
+    })
+    await openMenu()
+    const expected = `Supporter until ${new Date('2026-08-25T00:00:00+00:00').toLocaleDateString()}`
+    await waitFor(() => expect(screen.getByText(expected)).toBeInTheDocument())
+  })
+
+  it('shows no status line when the account fetch fails', async () => {
+    // ...Once variant (vitest#1692): a persistent mockRejectedValue leaks into other
+    // tests' unrelated calls as an unhandled rejection.
+    vi.mocked(getAccount).mockRejectedValueOnce(new Error('account → 500'))
+    await openMenu()
+    await waitFor(() => expect(vi.mocked(getAccount)).toHaveBeenCalled())
+    expect(screen.queryByText('Free plan')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Supporter until/)).not.toBeInTheDocument()
+  })
+
+  it('renders three Ko-fi support links, all pointing at ko-fi.com/shelfwright and opening in a new tab safely', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    const menuItems = await screen.findAllByRole('menuitem')
+    const links = menuItems.filter((el) => el.tagName === 'A')
+    expect(links).toHaveLength(3)
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', 'https://ko-fi.com/shelfwright')
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link.getAttribute('rel')).toContain('noopener')
+    }
+    expect(screen.getByText(/sign-in email on Ko-fi/i)).toBeInTheDocument()
+  })
+
+  it('closes the panel on Escape', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the panel on an outside click', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    await userEvent.click(document.body)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('calls the auth context signOut when Sign out is clicked, even after getAccount rejected', async () => {
+    vi.mocked(getAccount).mockRejectedValueOnce(new Error('account → 500'))
+    await openMenu()
+    await waitFor(() => expect(vi.mocked(getAccount)).toHaveBeenCalled())
+    await userEvent.click(screen.getByRole('menuitem', { name: /sign out/i }))
+    expect(signOut).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/AccountMenu.test.tsx
+++ b/frontend/src/components/AccountMenu.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const signOut = vi.fn()
@@ -21,7 +22,7 @@ afterEach(() => {
 })
 
 async function openMenu() {
-  render(<AccountMenu />)
+  render(<AccountMenu />, { wrapper: MemoryRouter })
   const trigger = screen.getByRole('button', { name: /account menu/i })
   await userEvent.click(trigger)
   return trigger
@@ -29,7 +30,7 @@ async function openMenu() {
 
 describe('AccountMenu', () => {
   it('is closed by default, with aria-expanded false on the trigger', () => {
-    render(<AccountMenu />)
+    render(<AccountMenu />, { wrapper: MemoryRouter })
     const trigger = screen.getByRole('button', { name: /account menu/i })
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
@@ -78,7 +79,7 @@ describe('AccountMenu', () => {
     })
     await openMenu()
     const menuItems = await screen.findAllByRole('menuitem')
-    const links = menuItems.filter((el) => el.tagName === 'A')
+    const links = menuItems.filter((el) => el.getAttribute('href') === 'https://ko-fi.com/shelfwright')
     expect(links).toHaveLength(3)
     for (const link of links) {
       expect(link).toHaveAttribute('href', 'https://ko-fi.com/shelfwright')
@@ -114,5 +115,22 @@ describe('AccountMenu', () => {
     await waitFor(() => expect(vi.mocked(getAccount)).toHaveBeenCalled())
     await userEvent.click(screen.getByRole('menuitem', { name: /sign out/i }))
     expect(signOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows "Using your own key" for a byok-tier account', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'byok', subscriber_until: null,
+    })
+    await openMenu()
+    await waitFor(() => expect(screen.getByText('Using your own key')).toBeInTheDocument())
+  })
+
+  it('has an "API key settings" menuitem linking to /settings', async () => {
+    vi.mocked(getAccount).mockResolvedValueOnce({
+      email: 'a@b.com', display_name: 'Ada', tier: 'free', subscriber_until: null,
+    })
+    await openMenu()
+    const link = await screen.findByRole('menuitem', { name: /api key settings/i })
+    expect(link).toHaveAttribute('href', '/settings')
   })
 })

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
 import { useAuth } from '../auth/AuthContext'
 import { getAccount, type Account } from '../api/client'
 
 const KOFI_URL = 'https://ko-fi.com/shelfwright'
 
-/** Account dropdown off the top-bar avatar. Future home of username change and the
- *  BYOK entry (arc PR 3). Sign-out must never depend on the API: account fetch failure
- *  just hides the status line. */
+/** Account dropdown off the top-bar avatar. Sign-out must never depend on the API:
+ *  account fetch failure just hides the status line. */
 export default function AccountMenu() {
   const { user, signOut } = useAuth()
   const [open, setOpen] = useState(false)
@@ -36,9 +36,11 @@ export default function AccountMenu() {
   const status =
     account?.tier === 'supporter' && account.subscriber_until
       ? `Supporter until ${new Date(account.subscriber_until).toLocaleDateString()}`
-      : account?.tier === 'free'
-        ? 'Free plan'
-        : null
+      : account?.tier === 'byok'
+        ? 'Using your own key'
+        : account?.tier === 'free'
+          ? 'Free plan'
+          : null
 
   return (
     <div className="account-menu" ref={rootRef}>
@@ -68,6 +70,7 @@ export default function AccountMenu() {
             </div>
           </div>
           <hr />
+          <Link to="/settings" role="menuitem" onClick={() => setOpen(false)}>API key settings</Link>
           <button role="menuitem" onClick={() => void signOut()}>Sign out</button>
         </div>
       )}

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import { getAccount, type Account } from '../api/client'
+
+const KOFI_URL = 'https://ko-fi.com/shelfwright'
+
+/** Account dropdown off the top-bar avatar. Future home of username change and the
+ *  BYOK entry (arc PR 3). Sign-out must never depend on the API: account fetch failure
+ *  just hides the status line. */
+export default function AccountMenu() {
+  const { user, signOut } = useAuth()
+  const [open, setOpen] = useState(false)
+  const [account, setAccount] = useState<Account | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    if (account === null) {
+      getAccount().then(setAccount).catch(() => setAccount(null))
+    }
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, account])
+
+  const status =
+    account?.tier === 'supporter' && account.subscriber_until
+      ? `Supporter until ${new Date(account.subscriber_until).toLocaleDateString()}`
+      : account?.tier === 'free'
+        ? 'Free plan'
+        : null
+
+  return (
+    <div className="account-menu" ref={rootRef}>
+      <button
+        className="avatar avatar-button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div className="account-menu-panel" role="menu">
+          <div className="account-menu-identity">
+            <div className="account-menu-name">{user?.displayName || user?.email}</div>
+            {user?.displayName && <div className="account-menu-email">{user?.email}</div>}
+            {status && <div className="account-menu-status">{status}</div>}
+          </div>
+          <div className="account-menu-support">
+            <div className="account-menu-heading">Support Shelfwright ♥</div>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$3 / month</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">$25 / year</a>
+            <a href={KOFI_URL} target="_blank" rel="noopener noreferrer" role="menuitem">Leave a tip</a>
+            <div className="account-menu-nudge">
+              Use your Shelfwright sign-in email on Ko-fi so your support links up automatically.
+            </div>
+          </div>
+          <hr />
+          <button role="menuitem" onClick={() => void signOut()}>Sign out</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/AppShell.css
+++ b/frontend/src/components/AppShell.css
@@ -21,6 +21,40 @@
   border: 1px solid var(--topbar-border); border-radius: var(--radius); padding: 4px 10px;
 }
 
+/* Avatar dropdown (account menu) — trigger reuses .avatar; the panel is a themed
+   surface positioned under the top bar, following .topbar's own token conventions. */
+.account-menu { position: relative; }
+.avatar-button { border: none; cursor: pointer; padding: 0; font: inherit; }
+.account-menu-panel {
+  position: absolute; top: calc(100% + 10px); right: 0; z-index: 20;
+  width: 260px; max-width: calc(100vw - 32px);
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  box-shadow: 0 12px 28px -12px var(--menu-shadow);
+  padding: var(--space-3) 0;
+  display: flex; flex-direction: column;
+}
+.account-menu-identity { padding: 0 var(--space-4) var(--space-2); }
+.account-menu-name { font-family: var(--font-display); font-weight: 600; color: var(--text); }
+.account-menu-email { font-size: var(--fs-sm); color: var(--text-muted); }
+.account-menu-status { margin-top: var(--space-1); font-size: var(--fs-sm); color: var(--accent); }
+.account-menu-support { padding: var(--space-2) var(--space-4); display: flex; flex-direction: column; gap: 2px; }
+.account-menu-heading {
+  font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: .04em;
+  color: var(--text-faint); margin-bottom: var(--space-1);
+}
+.account-menu-support a {
+  color: var(--text); text-decoration: none; padding: 4px 0; font-size: var(--fs-sm);
+}
+.account-menu-support a:hover { color: var(--accent); }
+.account-menu-nudge { margin-top: var(--space-2); font-size: var(--fs-xs); color: var(--text-faint); }
+.account-menu-panel hr { border: none; border-top: 1px solid var(--border); margin: var(--space-2) 0; }
+.account-menu-panel > button {
+  background: transparent; border: none; text-align: left; cursor: pointer;
+  padding: var(--space-2) var(--space-4); font-size: var(--fs-body); color: var(--text);
+}
+.account-menu-panel > button:hover { color: var(--accent); }
+
 /* Mobile-first: content sits below the top bar and above the bottom nav. */
 .content { padding: 72px 16px 88px; max-width: 820px; margin: 0 auto; }
 

--- a/frontend/src/components/TopBar.test.tsx
+++ b/frontend/src/components/TopBar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../auth/AuthContext', () => ({
@@ -22,7 +23,7 @@ afterEach(() => {
 describe('TopBar theme toggle', () => {
   it('flips data-theme and the label on click', async () => {
     document.documentElement.dataset.theme = 'light'
-    render(<TopBar />)
+    render(<TopBar />, { wrapper: MemoryRouter })
     await userEvent.click(screen.getByRole('button', { name: /switch to dark mode/i }))
     expect(document.documentElement.dataset.theme).toBe('dark')
     expect(screen.getByRole('button', { name: /switch to light mode/i })).toBeInTheDocument()
@@ -31,14 +32,14 @@ describe('TopBar theme toggle', () => {
 
 describe('TopBar branding', () => {
   it('shows the Shelfwright product name', () => {
-    render(<TopBar />)
+    render(<TopBar />, { wrapper: MemoryRouter })
     expect(screen.getByText('Shelfwright')).toBeInTheDocument()
   })
 })
 
 describe('TopBar account menu', () => {
   it('renders the avatar as the account menu trigger, with no standalone sign-out button', () => {
-    render(<TopBar />)
+    render(<TopBar />, { wrapper: MemoryRouter })
     const trigger = screen.getByRole('button', { name: /account menu/i })
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByRole('button', { name: /^sign out$/i })).not.toBeInTheDocument()

--- a/frontend/src/components/TopBar.test.tsx
+++ b/frontend/src/components/TopBar.test.tsx
@@ -6,6 +6,12 @@ vi.mock('../auth/AuthContext', () => ({
   useAuth: () => ({ user: { email: 'a@b.com', displayName: 'A' }, signOut: vi.fn() }),
 }))
 
+// AccountMenu fetches lazily on first open — TopBar rendering alone must not need a
+// real client, but AccountMenu.tsx imports it at module scope.
+vi.mock('../api/client', () => ({
+  getAccount: vi.fn(),
+}))
+
 import TopBar from './TopBar'
 
 afterEach(() => {
@@ -27,5 +33,14 @@ describe('TopBar branding', () => {
   it('shows the Shelfwright product name', () => {
     render(<TopBar />)
     expect(screen.getByText('Shelfwright')).toBeInTheDocument()
+  })
+})
+
+describe('TopBar account menu', () => {
+  it('renders the avatar as the account menu trigger, with no standalone sign-out button', () => {
+    render(<TopBar />)
+    const trigger = screen.getByRole('button', { name: /account menu/i })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('button', { name: /^sign out$/i })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react'
-import { useAuth } from '../auth/AuthContext'
+import AccountMenu from './AccountMenu'
 import { setTheme, type Theme } from '../theme'
 
 export default function TopBar() {
-  const { user, signOut } = useAuth()
-  const initial = (user?.displayName || user?.email || '?').charAt(0).toUpperCase()
   const [theme, setThemeState] = useState<Theme>((document.documentElement.dataset.theme as Theme) || 'light')
 
   function toggleTheme() {
@@ -24,8 +22,7 @@ export default function TopBar() {
         >
           {theme === 'dark' ? '☀' : '🌙'}
         </button>
-        <span className="avatar" title={user?.email ?? ''}>{initial}</span>
-        <button onClick={() => void signOut()}>Sign out</button>
+        <AccountMenu />
       </div>
     </header>
   )

--- a/frontend/src/views/ImportView.test.tsx
+++ b/frontend/src/views/ImportView.test.tsx
@@ -6,6 +6,7 @@ vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null)
 
 import ImportView from './ImportView'
 import * as client from '../api/client'
+import { ApiError } from '../api/client'
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -112,6 +113,21 @@ describe('ImportView', () => {
     fireEvent.click(screen.getByRole('button', { name: /continue/i }))     // map → review
     fireEvent.click(screen.getByRole('button', { name: /start import/i })) // review → progress
     await waitFor(() => expect(screen.getByText(/2 \/ 2/)).toBeInTheDocument())
+  })
+
+  it('surfaces the server detail.message when commit is rejected over the row cap (#100)', async () => {
+    vi.spyOn(client, 'previewImport').mockResolvedValue(PREVIEW)
+    // #100: a persistent mockRejectedValue overrides EVERY call (vitest#1692) and would fail
+    // as an "unhandled error" outside the awaited assertion — use ...Once (frontend-test-pitfalls).
+    vi.spyOn(client, 'commitImport').mockRejectedValueOnce(
+      new ApiError(413, 'This import has 301 rows; your current limit is 300. Split the file.'),
+    )
+    render(<ImportView />)
+    uploadFile()
+    await screen.findByText(/Detected: goodreads/i)
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))     // map → review
+    fireEvent.click(screen.getByRole('button', { name: /start import/i })) // review → progress
+    await screen.findByText(/your current limit is 300/i)
   })
 
   it('offers retry when rows are stalled (not yet complete)', async () => {

--- a/frontend/src/views/ImportView.tsx
+++ b/frontend/src/views/ImportView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import {
-  commitImport, getImportJob, previewImport, retryImport,
+  ApiError, commitImport, getImportJob, previewImport, retryImport,
   type ColumnMapping, type ImportPreview, type ImportStatus,
 } from '../api/client'
 import './ImportView.css'
@@ -77,8 +77,10 @@ export default function ImportView() {
       const res = await commitImport(file, mapping, { importToRead: toRead, importCurrentlyReading: currently })
       setJobId(res.import_job_id)
       setStep('progress')
-    } catch {
-      setError('Import could not start. Please try again.')
+    } catch (e) {
+      // #100: 413 import_rows_limit / 409 import_in_flight carry a human message worth
+      // showing verbatim; anything else falls back to the generic copy.
+      setError(e instanceof ApiError ? e.detail : 'Import could not start. Please try again.')
     } finally {
       setBusy(false)
     }

--- a/frontend/src/views/SettingsView.css
+++ b/frontend/src/views/SettingsView.css
@@ -7,4 +7,5 @@
 /* In the view-head, push Save/status to the right so it stays visible regardless of list length. */
 .settings__actions { display: flex; gap: var(--space-2); align-items: center; margin-left: auto; }
 .settings__status { color: var(--text-muted); font-size: var(--fs-sm); }
+.settings__byok { margin-top: var(--space-5); }
 .settings__byok-steps { padding-left: var(--space-4); margin: 0; display: flex; flex-direction: column; gap: var(--space-1); }

--- a/frontend/src/views/SettingsView.css
+++ b/frontend/src/views/SettingsView.css
@@ -7,3 +7,4 @@
 /* In the view-head, push Save/status to the right so it stays visible regardless of list length. */
 .settings__actions { display: flex; gap: var(--space-2); align-items: center; margin-left: auto; }
 .settings__status { color: var(--text-muted); font-size: var(--fs-sm); }
+.settings__byok-steps { padding-left: var(--space-4); margin: 0; display: flex; flex-direction: column; gap: var(--space-1); }

--- a/frontend/src/views/SettingsView.test.tsx
+++ b/frontend/src/views/SettingsView.test.tsx
@@ -83,6 +83,25 @@ describe('SettingsView — Your API key', () => {
     expect(screen.getByRole('button', { name: 'Remove key' })).toBeInTheDocument()
   })
 
+  it('shows the configured state and clears the input even when the post-save refetch fails', async () => {
+    vi.mocked(client.getCredentials)
+      .mockResolvedValueOnce({ configured: false, updated_at: null })
+      .mockRejectedValueOnce(new Error('getCredentials → 500'))
+    vi.mocked(client.putCredentials).mockResolvedValueOnce(undefined)
+    render(<SettingsView />)
+
+    const field = await screen.findByLabelText(/gemini api key/i)
+    fireEvent.change(field, { target: { value: 'AIza-fake-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+
+    await waitFor(() => expect(client.putCredentials).toHaveBeenCalledWith('AIza-fake-key'))
+    expect(await screen.findByText(/using your own key since/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove key' })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/gemini api key/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Save failed')).not.toBeInTheDocument()
+    expect(screen.queryByText('Could not save your key. Please try again.')).not.toBeInTheDocument()
+  })
+
   it('shows the server message on an invalid key (422)', async () => {
     vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
     vi.mocked(client.putCredentials).mockRejectedValueOnce(new ApiError(422, 'That key looks invalid.'))

--- a/frontend/src/views/SettingsView.test.tsx
+++ b/frontend/src/views/SettingsView.test.tsx
@@ -1,16 +1,30 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import SettingsView from './SettingsView'
+import { ApiError } from '../api/client'
 import * as client from '../api/client'
 
 vi.mock('../auth/firebase', () => ({ getIdToken: vi.fn().mockResolvedValue(null) }))
-vi.mock('../api/client')
+// Preserve the real ApiError class (automocking a class export replaces its constructor
+// body, so `new ApiError(status, detail)` in tests would lose `.status`/`.detail`).
+vi.mock('../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/client')>()),
+  getMyLibraries: vi.fn(),
+  searchLibraries: vi.fn(),
+  saveMyLibraries: vi.fn(),
+  getCredentials: vi.fn(),
+  putCredentials: vi.fn(),
+  deleteCredentials: vi.fn(),
+}))
 
 describe('SettingsView', () => {
   beforeEach(() => {
     vi.mocked(client.getMyLibraries).mockResolvedValue([{ slug: 'kcls', name: 'KCLS' }])
     vi.mocked(client.searchLibraries).mockResolvedValue([{ slug: 'spl', name: 'Seattle PL' }])
     vi.mocked(client.saveMyLibraries).mockResolvedValue(undefined)
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    vi.mocked(client.putCredentials).mockResolvedValue(undefined)
+    vi.mocked(client.deleteCredentials).mockResolvedValue(undefined)
   })
 
   it('loads and shows saved libraries', async () => {
@@ -22,9 +36,94 @@ describe('SettingsView', () => {
     render(<SettingsView />)
     fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'seattle' } })
     fireEvent.click(await screen.findByText(/add/i))
-    fireEvent.click(screen.getByText(/save/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() => expect(client.saveMyLibraries).toHaveBeenCalled())
     const saved = vi.mocked(client.saveMyLibraries).mock.calls[0][0]
     expect(saved.map((l) => l.slug)).toContain('spl')
+  })
+})
+
+describe('SettingsView — Your API key', () => {
+  beforeEach(() => {
+    vi.mocked(client.getMyLibraries).mockResolvedValue([])
+    vi.mocked(client.searchLibraries).mockResolvedValue([])
+    vi.mocked(client.saveMyLibraries).mockResolvedValue(undefined)
+  })
+
+  it('links "Create a free Gemini API key" to aistudio.google.com/apikey, opening safely in a new tab', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    render(<SettingsView />)
+    const link = await screen.findByRole('link', { name: /create a free gemini api key/i })
+    expect(link).toHaveAttribute('href', 'https://aistudio.google.com/apikey')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+    expect(link.getAttribute('rel')).toContain('noreferrer')
+  })
+
+  it('renders the key paste field as a password input with autocomplete off', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    render(<SettingsView />)
+    const field = await screen.findByLabelText(/gemini api key/i)
+    expect(field).toHaveAttribute('type', 'password')
+    expect(field).toHaveAttribute('autoComplete', 'off')
+  })
+
+  it('saves a new key and shows the configured state from a fresh getCredentials call', async () => {
+    vi.mocked(client.getCredentials)
+      .mockResolvedValueOnce({ configured: false, updated_at: null })
+      .mockResolvedValueOnce({ configured: true, updated_at: '2026-07-20T00:00:00Z' })
+    vi.mocked(client.putCredentials).mockResolvedValueOnce(undefined)
+    render(<SettingsView />)
+
+    fireEvent.change(await screen.findByLabelText(/gemini api key/i), { target: { value: 'AIza-fake-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+
+    await waitFor(() => expect(client.putCredentials).toHaveBeenCalledWith('AIza-fake-key'))
+    expect(await screen.findByText(/using your own key since/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove key' })).toBeInTheDocument()
+  })
+
+  it('shows the server message on an invalid key (422)', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    vi.mocked(client.putCredentials).mockRejectedValueOnce(new ApiError(422, 'That key looks invalid.'))
+    render(<SettingsView />)
+
+    fireEvent.change(await screen.findByLabelText(/gemini api key/i), { target: { value: 'bad-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+
+    expect(await screen.findByText('That key looks invalid.')).toBeInTheDocument()
+  })
+
+  it('shows the server message when BYOK is unavailable (503)', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    vi.mocked(client.putCredentials).mockRejectedValueOnce(new ApiError(503, 'BYOK is not available right now.'))
+    render(<SettingsView />)
+
+    fireEvent.change(await screen.findByLabelText(/gemini api key/i), { target: { value: 'AIza-fake-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+
+    expect(await screen.findByText('BYOK is not available right now.')).toBeInTheDocument()
+  })
+
+  it('falls back to a generic message on a non-ApiError save failure', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValue({ configured: false, updated_at: null })
+    vi.mocked(client.putCredentials).mockRejectedValueOnce(new Error('network down'))
+    render(<SettingsView />)
+
+    fireEvent.change(await screen.findByLabelText(/gemini api key/i), { target: { value: 'AIza-fake-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }))
+
+    expect(await screen.findByText('Could not save your key. Please try again.')).toBeInTheDocument()
+  })
+
+  it('removes a configured key and returns to the walkthrough', async () => {
+    vi.mocked(client.getCredentials).mockResolvedValueOnce({ configured: true, updated_at: '2026-07-20T00:00:00Z' })
+    vi.mocked(client.deleteCredentials).mockResolvedValueOnce(undefined)
+    render(<SettingsView />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove key' }))
+
+    await waitFor(() => expect(client.deleteCredentials).toHaveBeenCalled())
+    expect(await screen.findByRole('link', { name: /create a free gemini api key/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -64,12 +64,23 @@ export default function SettingsView() {
     setByokStatus('Saving…')
     try {
       await putCredentials(apiKey)
-      const next = await getCredentials()
-      setCredentials(next)
-      setApiKeyInput('')
-      setByokStatus('Key saved')
     } catch (err) {
       setByokStatus(err instanceof ApiError ? err.detail : BYOK_SAVE_FAILED)
+      setByokBusy(false)
+      return
+    }
+    // The key is stored and the tier already flipped server-side — treat this as
+    // success regardless of the refetch below. Optimistic `updated_at` covers a
+    // refetch failure; a follow-up getCredentials() (own try/catch) just refines it
+    // with the server's real timestamp when available.
+    setApiKeyInput('')
+    setCredentials({ configured: true, updated_at: new Date().toISOString() })
+    setByokStatus('Key saved')
+    try {
+      const next = await getCredentials()
+      setCredentials(next)
+    } catch {
+      // Keep the optimistic configured state — the save itself already succeeded.
     } finally {
       setByokBusy(false)
     }

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -1,6 +1,20 @@
 import { useEffect, useState } from 'react'
-import { getMyLibraries, searchLibraries, saveMyLibraries, type SavedLibrary } from '../api/client'
+import {
+  ApiError,
+  deleteCredentials,
+  getCredentials,
+  getMyLibraries,
+  putCredentials,
+  searchLibraries,
+  saveMyLibraries,
+  type CredentialsStatus,
+  type SavedLibrary,
+} from '../api/client'
 import './SettingsView.css'
+
+const GEMINI_KEY_URL = 'https://aistudio.google.com/apikey'
+const BYOK_SAVE_FAILED = 'Could not save your key. Please try again.'
+const BYOK_REMOVE_FAILED = 'Could not remove your key. Please try again.'
 
 export default function SettingsView() {
   const [saved, setSaved] = useState<SavedLibrary[]>([])
@@ -8,7 +22,15 @@ export default function SettingsView() {
   const [results, setResults] = useState<SavedLibrary[]>([])
   const [status, setStatus] = useState<string>('')
 
-  useEffect(() => { void getMyLibraries().then(setSaved) }, [])
+  const [credentials, setCredentials] = useState<CredentialsStatus | null>(null)
+  const [apiKeyInput, setApiKeyInput] = useState('')
+  const [byokStatus, setByokStatus] = useState<string>('')
+  const [byokBusy, setByokBusy] = useState(false)
+
+  useEffect(() => {
+    void getMyLibraries().then(setSaved)
+    void getCredentials().then(setCredentials)
+  }, [])
 
   useEffect(() => {
     const q = query.trim()
@@ -35,42 +57,122 @@ export default function SettingsView() {
     try { await saveMyLibraries(saved); setStatus('Saved') } catch { setStatus('Save failed') }
   }
 
+  async function saveKey() {
+    const apiKey = apiKeyInput.trim()
+    if (!apiKey) return
+    setByokBusy(true)
+    setByokStatus('Saving…')
+    try {
+      await putCredentials(apiKey)
+      const next = await getCredentials()
+      setCredentials(next)
+      setApiKeyInput('')
+      setByokStatus('Key saved')
+    } catch (err) {
+      setByokStatus(err instanceof ApiError ? err.detail : BYOK_SAVE_FAILED)
+    } finally {
+      setByokBusy(false)
+    }
+  }
+
+  async function removeKey() {
+    setByokBusy(true)
+    setByokStatus('Removing…')
+    try {
+      await deleteCredentials()
+      setCredentials({ configured: false, updated_at: null })
+      setByokStatus('Key removed')
+    } catch (err) {
+      setByokStatus(err instanceof ApiError ? err.detail : BYOK_REMOVE_FAILED)
+    } finally {
+      setByokBusy(false)
+    }
+  }
+
   return (
-    <div className="settings">
-      <header className="view-head">
-        <h2>Libraries</h2>
-        <div className="settings__actions">
-          <button className="btn" onClick={() => void save()}>Save</button>
-          {status && <span className="settings__status" aria-live="polite">{status}</span>}
-        </div>
-      </header>
-      <p className="settings__hint">Search for the library systems you have a Libby card for. We'll show live
-        availability for these on your recommendations, in your priority order.</p>
+    <>
+      <div className="settings">
+        <header className="view-head">
+          <h2>Libraries</h2>
+          <div className="settings__actions">
+            <button className="btn" onClick={() => void save()}>Save</button>
+            {status && <span className="settings__status" aria-live="polite">{status}</span>}
+          </div>
+        </header>
+        <p className="settings__hint">Search for the library systems you have a Libby card for. We'll show live
+          availability for these on your recommendations, in your priority order.</p>
 
-      <ul className="settings__saved">
-        {saved.map((lib, i) => (
-          <li key={lib.slug} className="settings__saved-row">
-            <span>{lib.name}</span>
-            <span className="settings__controls">
-              <button className="btn btn--ghost" onClick={() => move(i, -1)} aria-label="Move up">↑</button>
-              <button className="btn btn--ghost" onClick={() => move(i, 1)} aria-label="Move down">↓</button>
-              <button className="btn btn--ghost" onClick={() => remove(lib.slug)}>Remove</button>
-            </span>
-          </li>
-        ))}
-      </ul>
+        <ul className="settings__saved">
+          {saved.map((lib, i) => (
+            <li key={lib.slug} className="settings__saved-row">
+              <span>{lib.name}</span>
+              <span className="settings__controls">
+                <button className="btn btn--ghost" onClick={() => move(i, -1)} aria-label="Move up">↑</button>
+                <button className="btn btn--ghost" onClick={() => move(i, 1)} aria-label="Move down">↓</button>
+                <button className="btn btn--ghost" onClick={() => remove(lib.slug)}>Remove</button>
+              </span>
+            </li>
+          ))}
+        </ul>
 
-      <input className="settings__search" placeholder="Search for your library…"
-             aria-label="Search for your library"
-             value={query} onChange={(e) => setQuery(e.target.value)} />
-      <ul className="settings__results">
-        {results.map((lib) => (
-          <li key={lib.slug} className="settings__result-row">
-            <span>{lib.name}</span>
-            <button className="btn" onClick={() => add(lib)}>Add</button>
-          </li>
-        ))}
-      </ul>
-    </div>
+        <input className="settings__search" placeholder="Search for your library…"
+               aria-label="Search for your library"
+               value={query} onChange={(e) => setQuery(e.target.value)} />
+        <ul className="settings__results">
+          {results.map((lib) => (
+            <li key={lib.slug} className="settings__result-row">
+              <span>{lib.name}</span>
+              <button className="btn" onClick={() => add(lib)}>Add</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="settings settings__byok">
+        <header className="view-head">
+          <h2>Your API key</h2>
+          <div className="settings__actions">
+            {credentials?.configured ? (
+              <button className="btn btn--ghost" onClick={() => void removeKey()} disabled={byokBusy}>
+                Remove key
+              </button>
+            ) : (
+              <button className="btn" onClick={() => void saveKey()} disabled={byokBusy || !apiKeyInput.trim()}>
+                Save key
+              </button>
+            )}
+            {byokStatus && <span className="settings__status" aria-live="polite">{byokStatus}</span>}
+          </div>
+        </header>
+
+        {credentials?.configured ? (
+          <p className="settings__hint">
+            Using your own key since{' '}
+            {credentials.updated_at ? new Date(credentials.updated_at).toLocaleDateString() : 'recently'}.
+          </p>
+        ) : (
+          <>
+            <ol className="settings__hint settings__byok-steps">
+              <li>
+                <a href={GEMINI_KEY_URL} target="_blank" rel="noopener noreferrer">
+                  Create a free Gemini API key
+                </a>
+              </li>
+              <li>Paste it below.</li>
+              <li>Save — we verify it works before storing it.</li>
+            </ol>
+            <input
+              className="settings__search"
+              type="password"
+              autoComplete="off"
+              aria-label="Gemini API key"
+              placeholder="Paste your Gemini API key"
+              value={apiKeyInput}
+              onChange={(e) => setApiKeyInput(e.target.value)}
+            />
+          </>
+        )}
+      </div>
+    </>
   )
 }

--- a/infra/10-kms.sh
+++ b/infra/10-kms.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# One-shot (not idempotent — like the other infra scripts): KMS keyring + key for BYOK
+# credential encryption (core/byok.py), and the runtime SA grant. Run once by the
+# operator. (Numbered 10, not 9 — 09-prod-secrets.sh already claims that slot.)
+set -euo pipefail
+source "$(dirname "$0")/00-config.sh"
+
+gcloud kms keyrings create librarian --location=us-central1 --project="${PROJECT_ID}"
+gcloud kms keys create byok-credentials --location=us-central1 --keyring=librarian \
+  --purpose=encryption --project="${PROJECT_ID}"
+gcloud kms keys add-iam-policy-binding byok-credentials \
+  --location=us-central1 --keyring=librarian --project="${PROJECT_ID}" \
+  --member="serviceAccount:${RUNTIME_SA}" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+echo "KMS keyring 'librarian' / key 'byok-credentials' created; ${RUNTIME_SA} granted encrypt/decrypt."
+echo "Set repo VARIABLE (or confirm) GCP_PROJECT_ID=${PROJECT_ID} — deploy.yml derives KMS_KEY_NAME from it."

--- a/infra/10-kms.sh
+++ b/infra/10-kms.sh
@@ -5,11 +5,11 @@
 set -euo pipefail
 source "$(dirname "$0")/00-config.sh"
 
-gcloud kms keyrings create librarian --location=us-central1 --project="${PROJECT_ID}"
-gcloud kms keys create byok-credentials --location=us-central1 --keyring=librarian \
+gcloud kms keyrings create librarian --location="${REGION}" --project="${PROJECT_ID}"
+gcloud kms keys create byok-credentials --location="${REGION}" --keyring=librarian \
   --purpose=encryption --project="${PROJECT_ID}"
 gcloud kms keys add-iam-policy-binding byok-credentials \
-  --location=us-central1 --keyring=librarian --project="${PROJECT_ID}" \
+  --location="${REGION}" --keyring=librarian --project="${PROJECT_ID}" \
   --member="serviceAccount:${RUNTIME_SA}" \
   --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ dependencies = [
     "firebase-admin>=6.5",
     # Cloud Tasks enqueue for deep enrichment (Lift 2 Stage 3) — queues a fresh request
     # so the slow LLM pass runs with full Cloud Run CPU + long timeout.
-    "google-cloud-tasks>=2.16"
+    "google-cloud-tasks>=2.16",
+    # BYOK credential encryption (monetization arc 3/3, core/byok.py) — envelope
+    # encrypt/decrypt of user-supplied Gemini keys via a Cloud KMS symmetric key.
+    "google-cloud-kms>=2.24",
 ]
 
 [project.scripts]

--- a/src/agentic_librarian/agents/runtime.py
+++ b/src/agentic_librarian/agents/runtime.py
@@ -37,10 +37,15 @@ def _ensure_adk_credentials() -> None:
             os.environ["GOOGLE_API_KEY"] = key
 
 
-def build_runner() -> Runner:
-    """Build a Runner hosting the Librarian (root of the agent mesh)."""
+def build_runner(api_key: str | None = None) -> Runner:
+    """Build a Runner hosting the Librarian (root of the agent mesh).
+
+    api_key (arc 3/3 BYOK): threaded into create_agent_mesh so every agent in this
+    Runner's mesh rides the byok user's key. `_ensure_adk_credentials` still runs
+    unconditionally — it only sets the APP-key env default (GOOGLE_API_KEY), which the
+    per-model `api_key` override takes precedence over; it is never mutated per-request."""
     _ensure_adk_credentials()
-    mesh = create_agent_mesh()
+    mesh = create_agent_mesh(api_key)
     return Runner(
         agent=mesh["librarian"],
         app_name=APP_NAME,
@@ -48,9 +53,13 @@ def build_runner() -> Runner:
     )
 
 
-async def _record_event_usage(event, conversation_id: uuid.UUID | None) -> None:
+async def _record_event_usage(event, conversation_id: uuid.UUID | None, key_source: str = "app") -> None:
     """Meter one ADK event if it carries usage (duck-typed: unit-test fakes and
-    non-LLM events simply lack usage_metadata)."""
+    non-LLM events simply lack usage_metadata).
+
+    key_source (arc 3/3 BYOK): passed as a parameter (not module-level state) because
+    concurrent turns from different users can be in flight in the same process — a
+    module global would race between them."""
     # NOTE: with StreamingMode.SSE each partial event would carry usage; run_async is
     # used in default (non-streaming) mode here — one usage-bearing event per LLM call.
     um = getattr(event, "usage_metadata", None)
@@ -65,6 +74,7 @@ async def _record_event_usage(event, conversation_id: uuid.UUID | None) -> None:
         input_tokens=getattr(um, "prompt_token_count", 0) or 0,
         output_tokens=getattr(um, "candidates_token_count", 0) or 0,
         conversation_id=conversation_id,
+        key_source=key_source,
     )
 
 
@@ -72,10 +82,15 @@ class LibrarianConversation:
     """A multi-turn conversation with the Librarian. Reusing one session across
     sends is what gives the agent conversational memory (ADR-036)."""
 
-    def __init__(self, runner: Runner, user_id: str, session_id: str, on_event=None):
+    def __init__(self, runner: Runner, user_id: str, session_id: str, on_event=None, key_source: str = "app"):
         self._runner = runner
         self.user_id = user_id
         self.session_id = session_id
+        # arc 3/3 BYOK: carried as an instance attribute (not a module global) so
+        # concurrent conversations from different users never race on it — each turn
+        # rebuilds its own mesh + conversation (astart_conversation), so this is
+        # resolved once and fixed for the conversation's lifetime.
+        self.key_source = key_source
         try:
             self.conversation_id = uuid.UUID(session_id)  # session ids are uuid4().hex
         except (ValueError, AttributeError):
@@ -95,7 +110,7 @@ class LibrarianConversation:
         async for event in self._runner.run_async(
             user_id=self.user_id, session_id=self.session_id, new_message=content
         ):
-            await _record_event_usage(event, self.conversation_id)
+            await _record_event_usage(event, self.conversation_id, self.key_source)
             if self.on_event:
                 author = getattr(event, "author", None)
                 if author and author != last_author:
@@ -126,12 +141,20 @@ async def astart_conversation(
     on_event=None,
     session_id: str | None = None,
     history: list[dict] | None = None,
+    api_key: str | None = None,
+    key_source: str = "app",
 ) -> LibrarianConversation:
     """Open a conversation. `session_id` lets the caller pin the ADK session id to a
     stored conversation id (so usage rows line up). `history` (oldest first, each
     {'role': 'user'|'assistant', 'content': str}) is seeded into the session as events
-    so the mesh has prior context WITHOUT re-running earlier turns (Lift 2)."""
-    runner = runner or build_runner()
+    so the mesh has prior context WITHOUT re-running earlier turns (Lift 2).
+
+    api_key/key_source (arc 3/3 BYOK): when a `runner` is passed explicitly (tests, or a
+    caller that already built one), `api_key` is NOT re-threaded into it — the runner's
+    mesh is already fixed; only `key_source` is carried onto the returned conversation so
+    usage rows record it correctly. The chat handler never passes both `runner` and
+    `api_key` together — it lets this function build the runner via `build_runner`."""
+    runner = runner or build_runner(api_key)
     session_id = session_id or uuid.uuid4().hex
     session = await runner.session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
     for turn in history or []:
@@ -139,7 +162,7 @@ async def astart_conversation(
         author = "user" if turn["role"] == "user" else "librarian"
         content = types.Content(role=role, parts=[types.Part(text=turn["content"])])
         await runner.session_service.append_event(session, Event(author=author, content=content))
-    return LibrarianConversation(runner, user_id, session_id, on_event=on_event)
+    return LibrarianConversation(runner, user_id, session_id, on_event=on_event, key_source=key_source)
 
 
 def start_conversation(
@@ -148,9 +171,19 @@ def start_conversation(
     on_event=None,
     session_id: str | None = None,
     history: list[dict] | None = None,
+    api_key: str | None = None,
+    key_source: str = "app",
 ) -> LibrarianConversation:
     return asyncio.run(
-        astart_conversation(user_id=user_id, runner=runner, on_event=on_event, session_id=session_id, history=history)
+        astart_conversation(
+            user_id=user_id,
+            runner=runner,
+            on_event=on_event,
+            session_id=session_id,
+            history=history,
+            api_key=api_key,
+            key_source=key_source,
+        )
     )
 
 

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -7,6 +7,7 @@ from google.adk.agents import LlmAgent
 from google.adk.models.google_llm import Gemini
 from google.adk.tools import AgentTool, FunctionTool
 from google.adk.tools.google_search_tool import GoogleSearchTool
+from pydantic import Field
 
 from agentic_librarian.agents import prompts
 from agentic_librarian.agents.schemas import Targets
@@ -77,7 +78,10 @@ class _ByokGemini(Gemini):
     read `GOOGLE_API_KEY` (the app key) for that path unless `_live_api_client` is given
     the same treatment as `api_client` here."""
 
-    byok_api_key: str
+    # repr=False + exclude=True: the plaintext key must never surface in repr()/str()/
+    # model_dump()/model_dump_json() of this model or any agent that embeds it (the
+    # spec's never-logged mandate) — a plain field would print it in every repr.
+    byok_api_key: str = Field(repr=False, exclude=True)
 
     @functools.cached_property
     def api_client(self):

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -56,9 +56,54 @@ def _grounding_model() -> str:
     return os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
 
 
-def _gemini(model_name: str) -> Gemini:
+class _ByokGemini(Gemini):
+    """A Gemini model bound to one byok user's key (arc 3/3). ADK's Gemini (google-adk
+    2.2.0, verified against the installed package) has NO `api_key` field of its own —
+    passing `api_key=` to its constructor is silently dropped (pydantic extra='ignore'),
+    and its `api_client` cached_property builds a `google.genai.Client()` that reads
+    `GOOGLE_API_KEY` from the process environment when no key is given. That is exactly
+    the global mutable state the spec forbids per-request (`_ensure_adk_credentials`'s
+    own docstring: a per-request env swap races across concurrent turns). The class's
+    own docstring names `api_client` as the sanctioned subclass-override extension point
+    for exactly this ("Customizing the underlying Client"), so this mirrors its default
+    `api_client` construction (headers/retry/base_url/api_version) and adds only
+    `api_key`, reusing the parent's private helpers rather than guessing at them. If a
+    future google-adk changes that construction, this needs a matching update — there is
+    no public per-instance-credential seam as of 2.2.0."""
+
+    byok_api_key: str
+
+    @functools.cached_property
+    def api_client(self):
+        from google.genai import Client
+        from google.genai import types as genai_types
+
+        base_url, api_version = self._base_url_and_api_version
+        http_kwargs: dict = {
+            "headers": self._tracking_headers(),
+            "retry_options": self.retry_options,
+            "base_url": base_url,
+        }
+        if api_version:
+            http_kwargs["api_version"] = api_version
+        client_kwargs: dict = {
+            "http_options": genai_types.HttpOptions(**http_kwargs),
+            "api_key": self.byok_api_key,
+        }
+        if self.model.startswith("projects/"):
+            client_kwargs["vertexai"] = True
+        return Client(**client_kwargs)
+
+
+def _gemini(model_name: str, api_key: str | None = None) -> Gemini:
     """Wrap a model id in an ADK Gemini model carrying the shared transient-error retry config, so
-    every mesh agent rides through 429/5xx demand spikes instead of crashing the run (REC-020)."""
+    every mesh agent rides through 429/5xx demand spikes instead of crashing the run (REC-020).
+
+    api_key (arc 3/3 BYOK): when given, returns a `_ByokGemini` bound to that user's key
+    (see its docstring for why a plain `api_key=` kwarg doesn't work on this ADK version).
+    `api_key=None` (the default / non-byok path) is BYTE-IDENTICAL to before this arc."""
+    if api_key is not None:
+        return _ByokGemini(model=model_name, retry_options=RETRY_OPTIONS, byok_api_key=api_key)
     return Gemini(model=model_name, retry_options=RETRY_OPTIONS)
 
 
@@ -68,9 +113,9 @@ def _gemini(model_name: str) -> Gemini:
 class AnalystAgent(LlmAgent):
     """The Strategist. Decomposes vibes into structured tropes/styles and manages User Profile."""
 
-    def __init__(self):
+    def __init__(self, api_key: str | None = None):
         super().__init__(
-            model=_gemini(_model_name()),
+            model=_gemini(_model_name(), api_key),
             name="Analyst",
             description="Specializes in extracting structured book attributes and analyzing user taste.",
             instruction=prompts.ANALYST_INSTRUCTION,
@@ -83,9 +128,9 @@ class AnalystAgent(LlmAgent):
 class ExplorerAgent(LlmAgent):
     """The Scout. External web discovery via grounded search (ADR-035)."""
 
-    def __init__(self):
+    def __init__(self, api_key: str | None = None):
         super().__init__(
-            model=_gemini(_grounding_model()),
+            model=_gemini(_grounding_model(), api_key),
             name="Explorer",
             description="Discovers new/recent books from the web using grounded search.",
             instruction=prompts.EXPLORER_INSTRUCTION,
@@ -105,9 +150,9 @@ class CriticAgent(LlmAgent):
     response is written to session state under that key so the pipeline can read it. The
     conversational mesh constructs it without an output_key (it reads the AgentTool return value)."""
 
-    def __init__(self, output_key: str | None = None):
+    def __init__(self, output_key: str | None = None, api_key: str | None = None):
         super().__init__(
-            model=_gemini(_model_name()),
+            model=_gemini(_model_name(), api_key),
             name="Critic",
             description="Ranks book candidates using vector similarity and ensures no duplicates in history.",
             instruction=prompts.CRITIC_INSTRUCTION,
@@ -221,9 +266,9 @@ ADK_LIBRARIAN_INSTRUCTION = """
 class LibrarianAgent(LlmAgent):
     """The Orchestrator. Manages delegation and conversational feedback."""
 
-    def __init__(self, analyst, explorer, critic):
+    def __init__(self, analyst, explorer, critic, api_key: str | None = None):
         super().__init__(
-            model=_gemini(_model_name()),
+            model=_gemini(_model_name(), api_key),
             name="Librarian",
             description="The entry point for users. Orchestrates the recommendation process.",
             instruction=ADK_LIBRARIAN_INSTRUCTION,
@@ -246,13 +291,17 @@ class LibrarianAgent(LlmAgent):
 # --- THE MESH FACTORY ---
 
 
-def create_agent_mesh():
-    """Initializes and connects the agents using the AgentTool delegation pattern."""
-    analyst = AnalystAgent()
-    explorer = ExplorerAgent()
-    critic = CriticAgent()
+def create_agent_mesh(api_key: str | None = None):
+    """Initializes and connects the agents using the AgentTool delegation pattern.
+
+    api_key (arc 3/3 BYOK): threaded into every agent's model construction, including
+    the Explorer's grounding model — a byok user's chat turn runs entirely on their own
+    key. `api_key=None` (default) is unchanged from before this arc."""
+    analyst = AnalystAgent(api_key=api_key)
+    explorer = ExplorerAgent(api_key=api_key)
+    critic = CriticAgent(api_key=api_key)
 
     # The Librarian is initialized with its staff of specialists
-    librarian = LibrarianAgent(analyst=analyst, explorer=explorer, critic=critic)
+    librarian = LibrarianAgent(analyst=analyst, explorer=explorer, critic=critic, api_key=api_key)
 
     return {"librarian": librarian, "analyst": analyst, "explorer": explorer, "critic": critic}

--- a/src/agentic_librarian/agents/services.py
+++ b/src/agentic_librarian/agents/services.py
@@ -69,7 +69,13 @@ class _ByokGemini(Gemini):
     `api_client` construction (headers/retry/base_url/api_version) and adds only
     `api_key`, reusing the parent's private helpers rather than guessing at them. If a
     future google-adk changes that construction, this needs a matching update — there is
-    no public per-instance-credential seam as of 2.2.0."""
+    no public per-instance-credential seam as of 2.2.0.
+
+    NON-GOAL: this does NOT override `_live_api_client` (the live/bidi-streaming
+    connection path). Nothing in this codebase configures ADK's live/bidi mode today, so
+    it is unreachable — but a future live-chat feature built on this class would silently
+    read `GOOGLE_API_KEY` (the app key) for that path unless `_live_api_client` is given
+    the same treatment as `api_client` here."""
 
     byok_api_key: str
 

--- a/src/agentic_librarian/api/books.py
+++ b/src/agentic_librarian/api/books.py
@@ -55,7 +55,10 @@ class AddBookRequest(BaseModel):
 
 @router.post("/books")
 def add_book(req: AddBookRequest, user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
-    fast = two_phase.enrich_fast(req.title, req.author, req.format)
+    # as_user covers the fast pass so its embed cache-miss metering attributes to the
+    # requester (#100 AC#1) — fast scouts make no grounded calls, so no budget effect.
+    with as_user(user.id):
+        fast = two_phase.enrich_fast(req.title, req.author, req.format)
     if fast is None:
         raise HTTPException(
             status_code=404,

--- a/src/agentic_librarian/api/books.py
+++ b/src/agentic_librarian/api/books.py
@@ -72,7 +72,7 @@ def add_book(req: AddBookRequest, user: AuthenticatedUser = Depends(get_current_
     if created:
         # A failed enqueue must not fail the add — the book is already saved.
         try:
-            enqueued = enqueue_enrichment(str(work_id))
+            enqueued = enqueue_enrichment(str(work_id), user_id=str(user.id))
         except Exception:  # noqa: BLE001 - enqueue is best-effort; deep pass can be retried later
             logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 

--- a/src/agentic_librarian/api/credentials.py
+++ b/src/agentic_librarian/api/credentials.py
@@ -1,0 +1,105 @@
+"""BYOK credential endpoints (monetization arc 3/3) — mirrors api/libraries.py's
+router/db/auth shape. The table stores KMS ciphertext ONLY: GET never returns the key,
+never a fragment of it, and PUT's request body is never logged. A saved/removed
+credential is the ONLY writer of `user_credentials`, so it is also the thing that flips
+a user's tier free<->byok (core/tiers.effective_tier reads row existence, not a flag
+here — single source of truth)."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
+
+from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.core import byok
+from agentic_librarian.db.models import UserCredential
+from agentic_librarian.db.session import DatabaseManager
+
+router = APIRouter()
+db_manager = DatabaseManager()
+
+_MAX_KEY_LENGTH = 200
+
+
+def set_db_manager(new_manager: DatabaseManager) -> None:
+    global db_manager
+    db_manager = new_manager
+
+
+def _validate_key(api_key: str) -> bool:
+    """Live probe seam: one free/fast `count_tokens` call proves the key actually
+    authenticates against Gemini before we store it. A fresh `genai.Client` per call
+    (never the shared app-key client). ANY exception (auth failure, malformed key,
+    network hiccup) maps to False — tests patch THIS function directly rather than
+    mocking genai.Client."""
+    from google import genai
+
+    try:
+        client = genai.Client(api_key=api_key)
+        client.models.count_tokens(model="gemini-3.1-flash-lite", contents="ping")
+        return True
+    except Exception:  # noqa: BLE001 - any failure means "not a usable key"
+        return False
+
+
+class CredentialIn(BaseModel):
+    api_key: str
+
+
+def _invalid_key(message: str) -> HTTPException:
+    return HTTPException(status_code=422, detail={"code": "invalid_api_key", "message": message})
+
+
+@router.get("/me/credentials")
+def get_credentials(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with db_manager.get_session() as session:
+        row = session.get(UserCredential, (user.id, "gemini"))
+        if row is None:
+            return {"configured": False, "updated_at": None}
+        return {"configured": True, "updated_at": row.updated_at.isoformat()}
+
+
+@router.put("/me/credentials")
+def put_credentials(
+    body: CredentialIn = Body(...),  # noqa: B008
+    user: AuthenticatedUser = Depends(get_current_user),  # noqa: B008
+):
+    api_key = body.api_key.strip()
+    if not api_key or len(api_key) > _MAX_KEY_LENGTH:
+        raise _invalid_key("API key must be non-empty and no more than 200 characters.")
+
+    if not _validate_key(api_key):
+        raise _invalid_key("That key did not authenticate with Gemini — check it and try again.")
+
+    try:
+        ciphertext = byok.encrypt_key(api_key)
+    except byok.ByokNotConfigured as e:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "byok_unavailable", "message": "BYOK is not available right now — try again later."},
+        ) from e
+
+    kms_key_name = os.environ.get("KMS_KEY_NAME", "").strip()
+    with db_manager.get_session() as session:
+        row = session.get(UserCredential, (user.id, "gemini"))
+        if row is None:
+            session.add(
+                UserCredential(user_id=user.id, vendor="gemini", encrypted_key=ciphertext, kms_key_name=kms_key_name)
+            )
+        else:
+            row.encrypted_key = ciphertext
+            row.kms_key_name = kms_key_name
+        session.flush()
+    return {"configured": True}
+
+
+@router.delete("/me/credentials")
+def delete_credentials(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    with db_manager.get_session() as session:
+        row = session.get(UserCredential, (user.id, "gemini"))
+        if row is not None:
+            session.delete(row)
+            session.flush()
+    return {"configured": False}

--- a/src/agentic_librarian/api/credentials.py
+++ b/src/agentic_librarian/api/credentials.py
@@ -7,15 +7,20 @@ here — single source of truth)."""
 
 from __future__ import annotations
 
+import logging
 import os
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
 from agentic_librarian.core import byok
 from agentic_librarian.db.models import UserCredential
 from agentic_librarian.db.session import DatabaseManager
+from agentic_librarian.llm_retry import genai_http_options
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 db_manager = DatabaseManager()
@@ -31,16 +36,21 @@ def set_db_manager(new_manager: DatabaseManager) -> None:
 def _validate_key(api_key: str) -> bool:
     """Live probe seam: one free/fast `count_tokens` call proves the key actually
     authenticates against Gemini before we store it. A fresh `genai.Client` per call
-    (never the shared app-key client). ANY exception (auth failure, malformed key,
-    network hiccup) maps to False — tests patch THIS function directly rather than
-    mocking genai.Client."""
+    (never the shared app-key client), with the same shared retry/timeout options every
+    other genai.Client call site uses (llm_retry.genai_http_options) — a bare Client
+    otherwise has no request timeout and could pin the request thread. ANY exception
+    (auth failure, malformed key, network hiccup) maps to False — tests patch THIS
+    function directly rather than mocking genai.Client. The exception TYPE (never the
+    key, never the exception message which can echo request details) is logged so a bad
+    key is distinguishable server-side from a transient network blip."""
     from google import genai
 
     try:
-        client = genai.Client(api_key=api_key)
+        client = genai.Client(api_key=api_key, http_options=genai_http_options())
         client.models.count_tokens(model="gemini-3.1-flash-lite", contents="ping")
         return True
-    except Exception:  # noqa: BLE001 - any failure means "not a usable key"
+    except Exception as e:  # noqa: BLE001 - any failure means "not a usable key"
+        logger.info("BYOK key validation failed: %s", type(e).__name__)
         return False
 
 
@@ -80,18 +90,40 @@ def put_credentials(
             status_code=503,
             detail={"code": "byok_unavailable", "message": "BYOK is not available right now — try again later."},
         ) from e
+    except Exception as e:  # noqa: BLE001 - any KMS-side failure (outage, quota, transport) must map to
+        # a clean 503, never a raw 500 traceback. Log the exception TYPE only — never the plaintext key,
+        # never a message that could echo request details.
+        logger.warning("BYOK encrypt_key failed: %s", type(e).__name__)
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "byok_unavailable", "message": "Key storage is temporarily unavailable — try again."},
+        ) from e
 
     kms_key_name = os.environ.get("KMS_KEY_NAME", "").strip()
     with db_manager.get_session() as session:
         row = session.get(UserCredential, (user.id, "gemini"))
         if row is None:
-            session.add(
-                UserCredential(user_id=user.id, vendor="gemini", encrypted_key=ciphertext, kms_key_name=kms_key_name)
-            )
-        else:
+            # Two concurrent first-time PUTs can both see no row: the loser's flush hits
+            # the (user_id, vendor) primary key and raises IntegrityError. SAVEPOINT
+            # (begin_nested) so the rollback only undoes this insert attempt, not the
+            # whole request (get_or_create.py's pattern) — recover by re-querying and
+            # falling through to the update path below instead of a spurious 500.
+            try:
+                with session.begin_nested():
+                    session.add(
+                        UserCredential(
+                            user_id=user.id, vendor="gemini", encrypted_key=ciphertext, kms_key_name=kms_key_name
+                        )
+                    )
+                    session.flush()
+            except IntegrityError:
+                row = session.get(UserCredential, (user.id, "gemini"))
+                if row is None:  # constraint fired but nothing found back -- not our race
+                    raise
+        if row is not None:
             row.encrypted_key = ciphertext
             row.kms_key_name = kms_key_name
-        session.flush()
+            session.flush()
     return {"configured": True}
 
 

--- a/src/agentic_librarian/api/imports.py
+++ b/src/agentic_librarian/api/imports.py
@@ -16,6 +16,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.core import tiers
 from agentic_librarian.db.models import ImportJob, ImportRow
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.imports import bucketing, parsing
@@ -139,6 +140,38 @@ async def commit(
 
     enqueue_ids: list[str] = []
     with db_manager.get_session() as session:
+        # Per-tier row cap (#100): the hard MAX_ROWS ceiling above is absolute (protects
+        # the parser/DB regardless of tier); this is the tighter, tier-aware limit.
+        tier = tiers.effective_tier(session, user.id)
+        limit = min(MAX_ROWS, tiers.import_max_rows(tier))
+        row_count = len(parsed)
+        if row_count > limit:
+            raise HTTPException(
+                status_code=413,
+                detail={
+                    "code": "import_rows_limit",
+                    "message": f"This import has {row_count} rows; your current limit is {limit}. "
+                    "Split the file — or support Shelfwright for the full 2,000-row limit.",
+                },
+            )
+
+        # One in-flight import at a time (#100): a prior commit's rows still pending/processing
+        # blocks a new commit — avoids two jobs' Cloud Tasks racing on the same user's history.
+        in_flight = (
+            session.query(ImportRow.id)
+            .join(ImportJob, ImportJob.id == ImportRow.import_job_id)
+            .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+            .first()
+        )
+        if in_flight is not None:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "import_in_flight",
+                    "message": "Your previous import is still running — wait for it to finish before starting another.",
+                },
+            )
+
         job = ImportJob(user_id=user.id, source=source, original_filename=original_filename, total_rows=len(parsed))
         session.add(job)
         session.flush()  # populate job.id for the ImportRow FK

--- a/src/agentic_librarian/api/imports.py
+++ b/src/agentic_librarian/api/imports.py
@@ -27,6 +27,13 @@ router = APIRouter()
 
 MAX_ROWS = 2000
 STALLED_AFTER = timedelta(minutes=15)
+# #100 review fix: bounds the in-flight-import lockout. An import-row task has no give-up
+# retry bound (unlike /internal/enrich's GIVE_UP_AFTER_RETRIES), and job recovery UI lives
+# only in React state — so a row wedged in 'processing' forever would otherwise block every
+# future commit for that user permanently. Invariant: a wedged job stops counting as
+# in-flight once it's older than this window; the daily enrichment budget still bounds the
+# cost of any rows from an overlapping "second" import that slips through afterward.
+IN_FLIGHT_WINDOW = timedelta(hours=24)
 
 db_manager = DatabaseManager()
 
@@ -146,21 +153,33 @@ async def commit(
         limit = min(MAX_ROWS, tiers.import_max_rows(tier))
         row_count = len(parsed)
         if row_count > limit:
+            # Un-hardcode the upsell figure (env-tunable, #100 review fix) and only pitch
+            # it to a free-tier user — a supporter already at their ceiling shouldn't be
+            # told to "support" for a limit they already have.
+            supporter_limit = min(MAX_ROWS, tiers.import_max_rows("supporter"))
+            message = f"This import has {row_count} rows; your current limit is {limit}. Split the file"
+            message += (
+                f" — or support Shelfwright for the full {supporter_limit:,}-row limit." if tier == "free" else "."
+            )
             raise HTTPException(
                 status_code=413,
-                detail={
-                    "code": "import_rows_limit",
-                    "message": f"This import has {row_count} rows; your current limit is {limit}. "
-                    "Split the file — or support Shelfwright for the full 2,000-row limit.",
-                },
+                detail={"code": "import_rows_limit", "message": message},
             )
 
         # One in-flight import at a time (#100): a prior commit's rows still pending/processing
-        # blocks a new commit — avoids two jobs' Cloud Tasks racing on the same user's history.
+        # on a RECENT job (#100 review fix, see IN_FLIGHT_WINDOW) blocks a new commit — avoids
+        # two jobs' Cloud Tasks racing on the same user's history. Two concurrent commits can
+        # both pass this check before either writes its job (query-then-insert race) — accepted:
+        # the worst case is two jobs' worth of duplicate rows, never corruption, and the daily
+        # enrichment budget still bounds the cost.
         in_flight = (
             session.query(ImportRow.id)
             .join(ImportJob, ImportJob.id == ImportRow.import_job_id)
-            .filter(ImportJob.user_id == user.id, ImportRow.status.in_(("pending", "processing")))
+            .filter(
+                ImportJob.user_id == user.id,
+                ImportRow.status.in_(("pending", "processing")),
+                ImportJob.created_at >= datetime.now(UTC) - IN_FLIGHT_WINDOW,
+            )
             .first()
         )
         if in_flight is not None:

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -7,12 +7,14 @@ Idempotent: Cloud Tasks may redeliver, and two_phase.enrich_deep is retry-safe."
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, Query
 
+from agentic_librarian.core.user_context import as_user
 from agentic_librarian.enrichment import two_phase
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
@@ -88,9 +90,14 @@ def enrich(
     work_id: UUID,
     authorization: str | None = Header(None),  # noqa: B008
     x_cloudtasks_taskretrycount: str | None = Header(None),  # noqa: B008
+    user_id: UUID | None = Query(None),  # noqa: B008
 ):
     _require_queue_caller(authorization)
-    result = two_phase.enrich_deep(work_id)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
+    # skips; nothing crashes). Attributed tasks bill the requesting user.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.enrich_deep(work_id)
     if result == "missing":
         # Non-retryable: the work no longer exists. 404 stops Cloud Tasks from retrying.
         raise HTTPException(status_code=404, detail="work not found")
@@ -128,6 +135,7 @@ def complete_edition(
     work_id: UUID,
     format: str = Query(..., max_length=50),  # noqa: B008
     authorization: str | None = Header(None),  # noqa: B008
+    user_id: UUID | None = Query(None),  # noqa: B008
 ):
     """Format-completion pass target (history-format-edit spec). Same OIDC gate as
     /internal/enrich. 'missing' → 404 (non-retryable: work/edition gone); 'empty' and
@@ -140,7 +148,10 @@ def complete_edition(
     A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
     (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
-    result = two_phase.complete_edition(work_id, format)
+    # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
+    ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
+    with ctx:
+        result = two_phase.complete_edition(work_id, format)
     if result == "missing":
         raise HTTPException(status_code=404, detail="work or edition not found")
     return {"work_id": str(work_id), "format": format, "status": result}

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -110,23 +110,6 @@ def enrich(
     user_id: UUID | None = Query(None),  # noqa: B008
 ):
     _require_queue_caller(authorization)
-    allowed, why = budgets.enrichment_allowed(user_id)
-    if not allowed:
-        when = budgets.next_utc_day_start_with_jitter()
-        try:
-            requeued = enqueue_enrichment(
-                str(work_id), user_id=str(user_id) if user_id is not None else None, schedule_time=when
-            )
-        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
-            logger.exception("deferral re-enqueue failed for work %s", work_id)
-            requeued = False
-        if not requeued:
-            logger.warning("over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why)
-            return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
-        logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
-        # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
-        # so the #97 give-up retry count does not accumulate across days.
-        return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
     # skips; nothing crashes). Attributed tasks bill the requesting user.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
@@ -134,11 +117,13 @@ def enrich(
         api_key: str | None = None
         key_source = "app"
         if user_id is not None:
-            # arc 3/3 BYOK: resolve the requesting user's Gemini key, if any. No credential
-            # row -> (None, "app"), same as today. A decrypt/config failure must never fall
-            # back to the app key (spec §"No silent fallback") — log the failure TYPE only
-            # (never key material) and consume the task: retrying can't fix a revoked key,
-            # the operator's requeue sweep is the backstop.
+            # arc 3/3 BYOK: resolve the requesting user's Gemini key, if any, BEFORE the
+            # budget gate below (task-2 review, spec AC#2) — a byok pass must never be
+            # deferred by the tier-blind app-key governor. No credential row -> (None,
+            # "app"), same as today. A decrypt/config failure must never fall back to the
+            # app key (spec §"No silent fallback") — log the failure TYPE only (never key
+            # material) and consume the task: retrying can't fix a revoked key, the
+            # operator's requeue sweep is the backstop.
             try:
                 api_key, key_source = _resolve_byok_key(user_id)
             except (byok.ByokKeyError, byok.ByokNotConfigured) as e:
@@ -149,6 +134,29 @@ def enrich(
                     type(e).__name__,
                 )
                 return {"work_id": str(work_id), "status": "byok_key_error"}
+        if api_key is None:
+            # App-key path only: a byok pass spends the user's own quota, so the tier-blind
+            # global governor and per-user app budgets don't apply to it — its usage rows
+            # are excluded from those counts by the key_source=='app' filter already.
+            allowed, why = budgets.enrichment_allowed(user_id)
+            if not allowed:
+                when = budgets.next_utc_day_start_with_jitter()
+                try:
+                    requeued = enqueue_enrichment(
+                        str(work_id), user_id=str(user_id) if user_id is not None else None, schedule_time=when
+                    )
+                except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+                    logger.exception("deferral re-enqueue failed for work %s", work_id)
+                    requeued = False
+                if not requeued:
+                    logger.warning(
+                        "over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why
+                    )
+                    return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+                logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
+                # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
+                # so the #97 give-up retry count does not accumulate across days.
+                return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
         result = (
             two_phase.enrich_deep(work_id, api_key=api_key, key_source=key_source)
             if api_key is not None
@@ -204,35 +212,14 @@ def complete_edition(
     A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
     (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
-    allowed, why = budgets.enrichment_allowed(user_id)
-    if not allowed:
-        when = budgets.next_utc_day_start_with_jitter()
-        try:
-            requeued = enqueue_edition_completion(
-                str(work_id), format, user_id=str(user_id) if user_id is not None else None, schedule_time=when
-            )
-        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
-            logger.exception("deferral re-enqueue failed for work %s format %s", work_id, format)
-            requeued = False
-        if not requeued:
-            logger.warning(
-                "over budget and could not defer completion of work %s format %s (%s) — dropping to the requeue sweep",
-                work_id,
-                format,
-                why,
-            )
-            return {"work_id": str(work_id), "format": format, "status": "deferred_enqueue_failed"}
-        logger.info(
-            "deferred edition completion of work %s format %s to %s (%s)", work_id, format, when.isoformat(), why
-        )
-        return {"work_id": str(work_id), "format": format, "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
     with ctx:
         api_key: str | None = None
         key_source = "app"
         if user_id is not None:
-            # arc 3/3 BYOK — same resolution + no-silent-fallback rule as /internal/enrich.
+            # arc 3/3 BYOK — same resolution + no-silent-fallback rule as /internal/enrich,
+            # resolved BEFORE the budget gate below (task-2 review, spec AC#2).
             try:
                 api_key, key_source = _resolve_byok_key(user_id)
             except (byok.ByokKeyError, byok.ByokNotConfigured) as e:
@@ -244,6 +231,37 @@ def complete_edition(
                     type(e).__name__,
                 )
                 return {"work_id": str(work_id), "format": format, "status": "byok_key_error"}
+        if api_key is None:
+            # App-key path only: a byok pass spends the user's own quota, so the tier-blind
+            # global governor and per-user app budgets don't apply to it — its usage rows
+            # are excluded from those counts by the key_source=='app' filter already.
+            allowed, why = budgets.enrichment_allowed(user_id)
+            if not allowed:
+                when = budgets.next_utc_day_start_with_jitter()
+                try:
+                    requeued = enqueue_edition_completion(
+                        str(work_id), format, user_id=str(user_id) if user_id is not None else None, schedule_time=when
+                    )
+                except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+                    logger.exception("deferral re-enqueue failed for work %s format %s", work_id, format)
+                    requeued = False
+                if not requeued:
+                    logger.warning(
+                        "over budget and could not defer completion of work %s format %s (%s) — dropping to the "
+                        "requeue sweep",
+                        work_id,
+                        format,
+                        why,
+                    )
+                    return {"work_id": str(work_id), "format": format, "status": "deferred_enqueue_failed"}
+                logger.info(
+                    "deferred edition completion of work %s format %s to %s (%s)",
+                    work_id,
+                    format,
+                    when.isoformat(),
+                    why,
+                )
+                return {"work_id": str(work_id), "format": format, "status": "deferred", "until": when.isoformat()}
         result = (
             two_phase.complete_edition(work_id, format, api_key=api_key, key_source=key_source)
             if api_key is not None

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, Query
 
-from agentic_librarian.core import budgets
+from agentic_librarian.core import budgets, byok
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.enrichment import two_phase
 from agentic_librarian.enrichment.tasks import enqueue_edition_completion, enqueue_enrichment
@@ -22,6 +22,21 @@ from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _resolve_byok_key(user_id: UUID) -> tuple[str | None, str]:
+    """Resolve a byok user's Gemini key for the internal enrichment endpoints (arc 3/3).
+    Returns (api_key, key_source) — (None, "app") when the user has no byok credential
+    (the common case). A short session, opened via two_phase's shared db_manager (the same
+    DB-access pattern _has_real_trope below already uses) — resolution is not worth holding
+    a session across the whole scout pass for. Raises ByokKeyError/ByokNotConfigured on
+    decrypt/config failure so callers map it to the documented byok_key_error response
+    (spec §3 error table) instead of silently falling back to the app key."""
+    with two_phase.db_manager.get_session() as session:
+        key = byok.resolve_gemini_key(session, user_id)
+    if key is None:
+        return None, "app"
+    return key, "byok"
 
 
 def _verify_oidc(token: str, audience: str) -> dict:
@@ -116,7 +131,29 @@ def enrich(
     # skips; nothing crashes). Attributed tasks bill the requesting user.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
     with ctx:
-        result = two_phase.enrich_deep(work_id)
+        api_key: str | None = None
+        key_source = "app"
+        if user_id is not None:
+            # arc 3/3 BYOK: resolve the requesting user's Gemini key, if any. No credential
+            # row -> (None, "app"), same as today. A decrypt/config failure must never fall
+            # back to the app key (spec §"No silent fallback") — log the failure TYPE only
+            # (never key material) and consume the task: retrying can't fix a revoked key,
+            # the operator's requeue sweep is the backstop.
+            try:
+                api_key, key_source = _resolve_byok_key(user_id)
+            except (byok.ByokKeyError, byok.ByokNotConfigured) as e:
+                logger.warning(
+                    "byok key resolution failed for enrich work_id=%s user_id=%s: %s",
+                    work_id,
+                    user_id,
+                    type(e).__name__,
+                )
+                return {"work_id": str(work_id), "status": "byok_key_error"}
+        result = (
+            two_phase.enrich_deep(work_id, api_key=api_key, key_source=key_source)
+            if api_key is not None
+            else two_phase.enrich_deep(work_id)
+        )
     if result == "missing":
         # Non-retryable: the work no longer exists. 404 stops Cloud Tasks from retrying.
         raise HTTPException(status_code=404, detail="work not found")
@@ -192,7 +229,26 @@ def complete_edition(
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
     with ctx:
-        result = two_phase.complete_edition(work_id, format)
+        api_key: str | None = None
+        key_source = "app"
+        if user_id is not None:
+            # arc 3/3 BYOK — same resolution + no-silent-fallback rule as /internal/enrich.
+            try:
+                api_key, key_source = _resolve_byok_key(user_id)
+            except (byok.ByokKeyError, byok.ByokNotConfigured) as e:
+                logger.warning(
+                    "byok key resolution failed for complete-edition work_id=%s format=%s user_id=%s: %s",
+                    work_id,
+                    format,
+                    user_id,
+                    type(e).__name__,
+                )
+                return {"work_id": str(work_id), "format": format, "status": "byok_key_error"}
+        result = (
+            two_phase.complete_edition(work_id, format, api_key=api_key, key_source=key_source)
+            if api_key is not None
+            else two_phase.complete_edition(work_id, format)
+        )
     if result == "missing":
         raise HTTPException(status_code=404, detail="work or edition not found")
     return {"work_id": str(work_id), "format": format, "status": result}

--- a/src/agentic_librarian/api/internal.py
+++ b/src/agentic_librarian/api/internal.py
@@ -14,8 +14,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Header, HTTPException, Query
 
+from agentic_librarian.core import budgets
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.enrichment import two_phase
+from agentic_librarian.enrichment.tasks import enqueue_edition_completion, enqueue_enrichment
 from agentic_librarian.etl.trope_predicate import is_fallback_trope_name
 
 logger = logging.getLogger(__name__)
@@ -93,6 +95,23 @@ def enrich(
     user_id: UUID | None = Query(None),  # noqa: B008
 ):
     _require_queue_caller(authorization)
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_enrichment(
+                str(work_id), user_id=str(user_id) if user_id is not None else None, schedule_time=when
+            )
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s", work_id)
+            requeued = False
+        if not requeued:
+            logger.warning("over budget and could not defer work %s (%s) — dropping to the requeue sweep", work_id, why)
+            return {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+        logger.info("deferred enrichment of work %s to %s (%s)", work_id, when.isoformat(), why)
+        # 200 on purpose: the ORIGINAL task is consumed; the deferred copy is a NEW task,
+        # so the #97 give-up retry count does not accumulate across days.
+        return {"work_id": str(work_id), "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before (metering
     # skips; nothing crashes). Attributed tasks bill the requesting user.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
@@ -148,6 +167,28 @@ def complete_edition(
     A 500 → normal Cloud Tasks retry only fires for a failure OUTSIDE the scout manager
     (persist/DB error) propagating uncaught, never for the scouts merely finding nothing."""
     _require_queue_caller(authorization)
+    allowed, why = budgets.enrichment_allowed(user_id)
+    if not allowed:
+        when = budgets.next_utc_day_start_with_jitter()
+        try:
+            requeued = enqueue_edition_completion(
+                str(work_id), format, user_id=str(user_id) if user_id is not None else None, schedule_time=when
+            )
+        except Exception:  # noqa: BLE001 - deferral is best-effort; the sweep is the backstop
+            logger.exception("deferral re-enqueue failed for work %s format %s", work_id, format)
+            requeued = False
+        if not requeued:
+            logger.warning(
+                "over budget and could not defer completion of work %s format %s (%s) — dropping to the requeue sweep",
+                work_id,
+                format,
+                why,
+            )
+            return {"work_id": str(work_id), "format": format, "status": "deferred_enqueue_failed"}
+        logger.info(
+            "deferred edition completion of work %s format %s to %s (%s)", work_id, format, when.isoformat(), why
+        )
+        return {"work_id": str(work_id), "format": format, "status": "deferred", "until": when.isoformat()}
     # Pre-#100 tasks carry no user_id — run un-attributed exactly as before.
     ctx = as_user(user_id) if user_id is not None else contextlib.nullcontext()
     with ctx:

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -1,0 +1,89 @@
+"""Ko-fi payment webhook (monetization arc 2/3) — root-level machine route, like
+/internal/*: NOT under /api (purpose-scoped namespacing, #151). Authenticity is Ko-fi's
+shared verification_token (no HMAC exists); fail-closed when unset. Always 200 once the
+event is durably stored — Ko-fi retries non-2xx, and an unmatched payment is an operator
+task (CLI `payments match`), not a delivery failure. Idempotent on kofi_transaction_id."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+from decimal import Decimal, InvalidOperation
+
+from fastapi import APIRouter, Form, HTTPException
+
+from agentic_librarian.core import entitlements
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+db_manager = DatabaseManager()
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+@router.post("/webhooks/kofi")
+def kofi_webhook(data: str = Form(...)):  # noqa: B008
+    try:
+        event = json.loads(data)
+        if not isinstance(event, dict):
+            raise ValueError("payload is not an object")
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="malformed payload") from e
+
+    expected = os.environ.get("KOFI_VERIFICATION_TOKEN")
+    supplied = str(event.get("verification_token") or "")
+    if not expected or not hmac.compare_digest(supplied, expected):
+        # Unset env fails CLOSED (matches _require_queue_caller's posture).
+        raise HTTPException(status_code=403, detail="verification failed")
+
+    txn_id = str(event.get("kofi_transaction_id") or "").strip()
+    if not txn_id:
+        raise HTTPException(status_code=400, detail="missing kofi_transaction_id")
+    email = str(event.get("email") or "").strip().lower()
+    try:
+        amount = Decimal(str(event.get("amount") or "0"))
+    except InvalidOperation:
+        amount = Decimal(0)
+    tier_name = event.get("tier_name") or None
+    is_sub = bool(event.get("is_subscription_payment", False))
+    kofi_type = str(event.get("type") or "")
+
+    kind = entitlements.classify(kofi_type, is_sub, tier_name, amount)
+    days = entitlements.grant_days(kind)
+
+    with db_manager.get_session() as session:
+        if session.query(Payment.id).filter(Payment.kofi_transaction_id == txn_id).first() is not None:
+            return {"status": "duplicate"}
+        user = session.query(User).filter(User.email == email).first() if email else None
+        payment = Payment(
+            kofi_transaction_id=txn_id,
+            kofi_type=kofi_type,
+            email=email,
+            amount=amount,
+            currency=str(event.get("currency") or ""),
+            tier_name=tier_name,
+            is_subscription_payment=is_sub,
+            payload=event,
+            matched_user_id=user.id if user else None,
+            entitlement_days=days if user else 0,
+        )
+        session.add(payment)
+        if user is not None and days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+            session.flush()
+            logger.info("kofi %s: %s +%dd -> %s", kind, email, days, user.subscriber_until.isoformat())
+            return {"status": "applied", "kind": kind}
+        session.flush()
+    if user is not None:
+        logger.info("kofi tip recorded for %s", email)
+        return {"status": "recorded", "kind": kind}
+    logger.warning("kofi payment UNMATCHED (email %s, txn %s) — resolve via `payments match`", email, txn_id)
+    return {"status": "unmatched", "kind": kind}

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -52,6 +52,10 @@ def kofi_webhook(data: str = Form(...)):  # noqa: B008
         amount = Decimal(str(event.get("amount") or "0"))
     except InvalidOperation:
         amount = Decimal(0)
+    if not amount.is_finite():
+        # "nan"/"-nan"/"Infinity" parse successfully (no InvalidOperation above) but crash
+        # entitlements.classify()'s `amount >= threshold` ordering comparison.
+        amount = Decimal(0)
     tier_name = event.get("tier_name") or None
     is_sub = bool(event.get("is_subscription_payment", False))
     kofi_type = str(event.get("type") or "")

--- a/src/agentic_librarian/api/kofi.py
+++ b/src/agentic_librarian/api/kofi.py
@@ -56,7 +56,10 @@ def kofi_webhook(data: str = Form(...)):  # noqa: B008
         # "nan"/"-nan"/"Infinity" parse successfully (no InvalidOperation above) but crash
         # entitlements.classify()'s `amount >= threshold` ordering comparison.
         amount = Decimal(0)
-    tier_name = event.get("tier_name") or None
+    # str-coerce like the sibling fields: a non-string tier_name would crash classify()'s
+    # .strip().casefold() before the event is persisted (same class as the amount guard).
+    raw_tier = event.get("tier_name")
+    tier_name = str(raw_tier) if raw_tier else None
     is_sub = bool(event.get("is_subscription_payment", False))
     kofi_type = str(event.get("type") or "")
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -98,6 +98,7 @@ async def lifespan(app: FastAPI):
     mcp_server.set_db_manager(shared)
     two_phase.set_db_manager(shared)
     imports_worker.set_db_manager(shared)
+    budgets.set_db_manager(shared)
     yield
 
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -25,6 +25,7 @@ from agentic_librarian.api.books import router as books_router
 from agentic_librarian.api.firebase_auth_proxy import router as firebase_auth_proxy_router
 from agentic_librarian.api.imports import router as imports_router
 from agentic_librarian.api.internal import router as internal_router
+from agentic_librarian.api.kofi import router as kofi_router
 from agentic_librarian.api.libraries import router as libraries_router
 from agentic_librarian.api.recommendations import router as recommendations_router
 from agentic_librarian.chat import stream, transcript
@@ -122,6 +123,7 @@ api_router.include_router(libraries_router)
 # break fixed contracts (Firebase /__/auth/*) or Cloud Tasks target URLs (/internal/*).
 app.include_router(firebase_auth_proxy_router)
 app.include_router(internal_router)
+app.include_router(kofi_router)
 
 
 @app.get("/health")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -17,6 +17,7 @@ from agentic_librarian.agents.runtime import LibrarianConversation, astart_conve
 from agentic_librarian.api import analysis, auth, recommendations
 from agentic_librarian.api import availability as availability_api
 from agentic_librarian.api import imports as imports_api
+from agentic_librarian.api import kofi as kofi_api
 from agentic_librarian.api import libraries as libraries_api
 from agentic_librarian.api.analysis import router as analysis_router
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
@@ -100,6 +101,7 @@ async def lifespan(app: FastAPI):
     two_phase.set_db_manager(shared)
     imports_worker.set_db_manager(shared)
     budgets.set_db_manager(shared)
+    kofi_api.set_db_manager(shared)
     yield
 
 

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -37,6 +37,7 @@ from agentic_librarian.db.migration_guard import check_migrations
 from agentic_librarian.db.models import (
     Edition,
     ReadingHistory,
+    User,
     Work,
     WorkContributor,
     WorkStyle,
@@ -460,6 +461,23 @@ class _SyncOpener:
     def close(self):
         if self._conv is not None:
             self._conv.close()
+
+
+@api_router.get("/account")
+def get_account(user: AuthenticatedUser = Depends(get_current_user)):  # noqa: B008
+    """Identity + entitlement summary for the avatar menu (#100 monetization arc 2/3).
+    tier comes from tiers.effective_tier — the single source of truth; no second
+    computation here."""
+    with db_manager.get_session() as session:
+        tier = tiers.effective_tier(session, user.id)
+        row = session.get(User, user.id)
+        until = row.subscriber_until.isoformat() if row and row.subscriber_until else None
+        return {
+            "email": row.email if row else None,
+            "display_name": row.display_name if row else None,
+            "tier": tier,
+            "subscriber_until": until,
+        }
 
 
 @api_router.get("/conversations/current")

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -28,7 +28,7 @@ from agentic_librarian.api.internal import router as internal_router
 from agentic_librarian.api.libraries import router as libraries_router
 from agentic_librarian.api.recommendations import router as recommendations_router
 from agentic_librarian.chat import stream, transcript
-from agentic_librarian.core import usage
+from agentic_librarian.core import budgets, tiers, usage
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.migration_guard import check_migrations
@@ -473,6 +473,16 @@ def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # no
 
 @api_router.post("/chat")
 def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
+    max_chars = tiers.chat_message_max_chars()
+    if len(message) > max_chars:
+        raise HTTPException(
+            status_code=422,
+            detail={"code": "message_too_long", "message": f"Message too long (max {max_chars} characters)."},
+        )
+    allowed, why = budgets.chat_turn_allowed(user.id)
+    if not allowed:
+        # Must reject BEFORE the StreamingResponse exists — SSE cannot carry an HTTP 429.
+        raise HTTPException(status_code=429, detail={"code": "chat_quota", "message": why})
     with as_user(user.id):
         ctx = transcript.get_or_create_active_conversation()
     adk_user_id = str(user.id)

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -373,7 +373,7 @@ def update_history(
     enqueued = False
     if needs_completion:
         try:
-            enqueued = enqueue_edition_completion(work_id_str, fmt_str)
+            enqueued = enqueue_edition_completion(work_id_str, fmt_str, user_id=str(user.id))
         except Exception:  # noqa: BLE001 - enqueue is best-effort
             logger.exception("edition-completion enqueue failed for work %s", work_id_str)
     payload["enrichment_enqueued"] = enqueued

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -32,7 +32,7 @@ from agentic_librarian.api.kofi import router as kofi_router
 from agentic_librarian.api.libraries import router as libraries_router
 from agentic_librarian.api.recommendations import router as recommendations_router
 from agentic_librarian.chat import stream, transcript
-from agentic_librarian.core import budgets, tiers, usage
+from agentic_librarian.core import budgets, byok, tiers, usage
 from agentic_librarian.core.user_context import as_user
 from agentic_librarian.db.get_or_create import get_or_create
 from agentic_librarian.db.migration_guard import check_migrations
@@ -435,21 +435,42 @@ def get_works(
 # ---------------------------------------------------------------------------
 
 
-async def _open_conversation(*, user_id: str, session_id: str, history: list[dict], on_event) -> LibrarianConversation:
+async def _open_conversation(
+    *,
+    user_id: str,
+    session_id: str,
+    history: list[dict],
+    on_event,
+    api_key: str | None = None,
+    key_source: str = "app",
+) -> LibrarianConversation:
     """Open the mesh conversation for one turn (seam: tests replace this)."""
-    return await astart_conversation(user_id=user_id, session_id=session_id, history=history, on_event=on_event)
+    return await astart_conversation(
+        user_id=user_id,
+        session_id=session_id,
+        history=history,
+        on_event=on_event,
+        api_key=api_key,
+        key_source=key_source,
+    )
 
 
 class _SyncOpener:
     """The conversation object returned by the factory passed to sse_turn. Lazily opens
     the async mesh conversation on first asend — deferred so the open runs inside the
     event loop, not the sync endpoint frame. session_id = conversation_id.hex so usage
-    rows (keyed off the ADK session uuid) FK to the transcript row."""
+    rows (keyed off the ADK session uuid) FK to the transcript row.
 
-    def __init__(self, user_id, ctx, on_event):
+    api_key/key_source (arc 3/3 BYOK): resolved once per turn by the chat handler
+    (before this object is constructed) and carried through to astart_conversation so
+    the whole mesh for this turn runs on the byok user's key."""
+
+    def __init__(self, user_id, ctx, on_event, api_key: str | None = None, key_source: str = "app"):
         self._user_id = user_id
         self._ctx = ctx
         self._on_event = on_event
+        self._api_key = api_key
+        self._key_source = key_source
         self._conv = None  # opened lazily on first asend
 
     async def asend(self, message: str) -> str:
@@ -459,6 +480,8 @@ class _SyncOpener:
                 session_id=self._ctx.conversation_id.hex,
                 history=self._ctx.history,
                 on_event=self._on_event,
+                api_key=self._api_key,
+                key_source=self._key_source,
             )
         return await self._conv.asend(message)
 
@@ -498,6 +521,21 @@ def new_conversation(user: AuthenticatedUser = Depends(get_current_user)):  # no
     return {"id": str(ctx.conversation_id), "messages": ctx.history}
 
 
+def _resolve_byok_chat_key(user_id: UUID) -> tuple[str | None, str]:
+    """Resolve the caller's byok Gemini key for one chat turn (arc 3/3, mirrors
+    api/internal.py's `_resolve_byok_key`). Returns (api_key, key_source) — (None, "app")
+    when the user has no byok credential (the common case). A short session off this
+    module's db_manager — not worth holding one across the whole mesh turn. Raises
+    byok.ByokKeyError/ByokNotConfigured on decrypt/config failure so the handler can
+    surface the documented 409 pre-stream (spec §3) instead of silently falling back to
+    the app key."""
+    with db_manager.get_session() as session:
+        key = byok.resolve_gemini_key(session, user_id)
+    if key is None:
+        return None, "app"
+    return key, "byok"
+
+
 @api_router.post("/chat")
 def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Body(..., embed=True)):  # noqa: B008
     max_chars = tiers.chat_message_max_chars()
@@ -510,13 +548,25 @@ def chat(user: AuthenticatedUser = Depends(get_current_user), message: str = Bod
     if not allowed:
         # Must reject BEFORE the StreamingResponse exists — SSE cannot carry an HTTP 429.
         raise HTTPException(status_code=429, detail={"code": "chat_quota", "message": why})
+    try:
+        api_key, key_source = _resolve_byok_chat_key(user.id)
+    except (byok.ByokKeyError, byok.ByokNotConfigured):
+        # arc 3/3: must reject BEFORE the StreamingResponse exists, same as the 429 above
+        # — SSE cannot carry an HTTP error status once streaming has started. No silent
+        # fallback to the app key (spec §"No silent fallback").
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "byok_key_error", "message": "Your API key failed — check Settings."},
+        ) from None
     with as_user(user.id):
         ctx = transcript.get_or_create_active_conversation()
     adk_user_id = str(user.id)
     return StreamingResponse(
         stream.sse_turn(
             message=message,
-            conversation=lambda on_event: _SyncOpener(adk_user_id, ctx, on_event),
+            conversation=lambda on_event: _SyncOpener(
+                adk_user_id, ctx, on_event, api_key=api_key, key_source=key_source
+            ),
             on_persist=lambda role, content: transcript.append_message(ctx.conversation_id, role, content),
             user_id=user.id,
         ),

--- a/src/agentic_librarian/api/main.py
+++ b/src/agentic_librarian/api/main.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import joinedload, selectinload
 from agentic_librarian.agents.runtime import LibrarianConversation, astart_conversation
 from agentic_librarian.api import analysis, auth, recommendations
 from agentic_librarian.api import availability as availability_api
+from agentic_librarian.api import credentials as credentials_api
 from agentic_librarian.api import imports as imports_api
 from agentic_librarian.api import kofi as kofi_api
 from agentic_librarian.api import libraries as libraries_api
@@ -23,6 +24,7 @@ from agentic_librarian.api.analysis import router as analysis_router
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
 from agentic_librarian.api.availability import router as availability_router
 from agentic_librarian.api.books import router as books_router
+from agentic_librarian.api.credentials import router as credentials_router
 from agentic_librarian.api.firebase_auth_proxy import router as firebase_auth_proxy_router
 from agentic_librarian.api.imports import router as imports_router
 from agentic_librarian.api.internal import router as internal_router
@@ -95,6 +97,7 @@ async def lifespan(app: FastAPI):
     imports_api.set_db_manager(shared)
     availability_api.set_db_manager(shared)
     libraries_api.set_db_manager(shared)
+    credentials_api.set_db_manager(shared)
     # GH #102: the in-process chat tools (mcp/server), the enrichment paths
     # (two_phase), and the import worker previously each held their own lazy pool —
     # up to ~9 engines/process. One pool per process keeps the connection math sane.
@@ -121,6 +124,7 @@ api_router.include_router(availability_router)
 api_router.include_router(books_router)
 api_router.include_router(imports_router)
 api_router.include_router(libraries_router)
+api_router.include_router(credentials_router)
 
 # Machine-only routers stay at root — never SPA-route collisions, and moving them would
 # break fixed contracts (Firebase /__/auth/*) or Cloud Tasks target URLs (/internal/*).

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import sys
 import time
+from datetime import UTC, datetime
 
 from agentic_librarian.agents.backends import get_backend
 from agentic_librarian.chat_recorder import ConversationRecorder
@@ -35,6 +36,24 @@ def _parse_args(argv=None):
     invite_parser = user_sub.add_parser("invite", help="invite an email — creates the user row; they sign in later")
     invite_parser.add_argument("email", help="the invitee's email (the invite key; lowercased)")
     invite_parser.add_argument("--name", default=None, help="display name (optional)")
+    sub_parser = user_sub.add_parser(
+        "subscribe", help="grant/extend supporter entitlement (comp or Ko-fi mismatch fix)"
+    )
+    sub_parser.add_argument("email")
+    group = sub_parser.add_mutually_exclusive_group()
+    group.add_argument("--months", type=int, default=None, help="N x 33-day grants (default 1)")
+    group.add_argument("--days", type=int, default=None)
+    group.add_argument("--until", default=None, help="YYYY-MM-DD (absolute)")
+
+    payments_parser = subparsers.add_parser("payments", help="Ko-fi payment records (operator)")
+    payments_sub = payments_parser.add_subparsers(dest="payments_command")
+    list_parser = payments_sub.add_parser("list", help="list payments")
+    list_parser.add_argument("--unmatched", action="store_true")
+    match_parser = payments_sub.add_parser(
+        "match", help="link an unmatched payment to a user and apply its entitlement"
+    )
+    match_parser.add_argument("kofi_transaction_id")
+    match_parser.add_argument("email")
     return parser.parse_args(argv)
 
 
@@ -56,6 +75,8 @@ def main(argv=None) -> int:
 def _dispatch(args) -> int:
     if getattr(args, "command", None) == "user":
         return _run_user(args)
+    if getattr(args, "command", None) == "payments":
+        return _run_payments(args)
     if getattr(args, "command", None) == "add":
         return _run_add(args)
     if args.backend:
@@ -105,14 +126,29 @@ def _invite_db_manager():
     return DatabaseManager()
 
 
+def _normalize_email(raw: str) -> str:
+    return raw.strip().lower()
+
+
+def _is_valid_email(email: str) -> bool:
+    return "@" in email and not email.startswith("@") and not email.endswith("@")
+
+
 def _run_user(args) -> int:
-    if getattr(args, "user_command", None) != "invite":
-        print("usage: librarian user invite <email> [--name NAME]", file=sys.stderr)
-        return 2
+    user_command = getattr(args, "user_command", None)
+    if user_command == "invite":
+        return _run_user_invite(args)
+    if user_command == "subscribe":
+        return _run_user_subscribe(args)
+    print("usage: librarian user <invite|subscribe> ...", file=sys.stderr)
+    return 2
+
+
+def _run_user_invite(args) -> int:
     from agentic_librarian.db.models import User
 
-    email = args.email.strip().lower()
-    if "@" not in email or email.startswith("@") or email.endswith("@"):
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
         print(f"error: {email!r} does not look like an email address", file=sys.stderr)
         return 2
     db = _invite_db_manager()
@@ -125,6 +161,116 @@ def _run_user(args) -> int:
         session.add(User(email=email, display_name=args.name))
         session.flush()
     print(f"Invited {email}. They can now sign in (claim-by-email links their account on first sign-in).")
+    return 0
+
+
+def _run_user_subscribe(args) -> int:
+    """Operator comp / Ko-fi-mismatch fallback: grant or extend a user's supporter
+    entitlement directly. --months/--days extend (active subs stack, lapsed restart from
+    now, via entitlements.extend); --until SETS subscriber_until absolutely (UTC
+    midnight) — it does not stack."""
+    from agentic_librarian.core import entitlements
+    from agentic_librarian.db.models import User
+
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
+        print(f"error: {email!r} does not look like an email address", file=sys.stderr)
+        return 2
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        user = session.query(User).filter(User.email == email).first()
+        if user is None:
+            print(f"error: no user found for {email!r} (use `user invite` first)", file=sys.stderr)
+            return 2
+        if args.until is not None:
+            try:
+                until = datetime.strptime(args.until, "%Y-%m-%d").replace(tzinfo=UTC)
+            except ValueError:
+                print(f"error: {args.until!r} is not a valid YYYY-MM-DD date", file=sys.stderr)
+                return 2
+            user.subscriber_until = until
+        elif args.days is not None:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, args.days)
+        else:
+            months = args.months if args.months is not None else 1
+            user.subscriber_until = entitlements.extend(user.subscriber_until, months * 33)
+        session.flush()
+        result = user.subscriber_until
+    print(f"{email}: subscriber_until -> {result.isoformat()}")
+    return 0
+
+
+def _run_payments(args) -> int:
+    payments_command = getattr(args, "payments_command", None)
+    if payments_command == "list":
+        return _run_payments_list(args)
+    if payments_command == "match":
+        return _run_payments_match(args)
+    print("usage: librarian payments <list|match> ...", file=sys.stderr)
+    return 2
+
+
+def _run_payments_list(args) -> int:
+    from agentic_librarian.db.models import Payment
+
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        query = session.query(Payment).order_by(Payment.created_at)
+        if args.unmatched:
+            query = query.filter(Payment.matched_user_id.is_(None))
+        rows = query.all()
+        header = (
+            f"{'kofi_transaction_id':<24} {'created_at':<10} {'email':<30} "
+            f"{'amount':>8} {'type/tier':<16} {'matched':<7} {'entitlement_days':>16}"
+        )
+        print(header)
+        for p in rows:
+            type_tier = p.tier_name or p.kofi_type
+            matched = "yes" if p.matched_user_id else "no"
+            print(
+                f"{p.kofi_transaction_id:<24} {p.created_at.date().isoformat():<10} {p.email:<30} "
+                f"{p.amount:>8} {type_tier:<16} {matched:<7} {p.entitlement_days:>16}"
+            )
+    return 0
+
+
+def _run_payments_match(args) -> int:
+    """Recomputes classify()/grant_days() from the STORED row's fields (kofi_type,
+    is_subscription_payment, tier_name, amount) rather than trusting anything passed on
+    the command line, so the CLI and the webhook grant identically off a single source
+    of truth."""
+    from agentic_librarian.core import entitlements
+    from agentic_librarian.db.models import Payment, User
+
+    email = _normalize_email(args.email)
+    if not _is_valid_email(email):
+        print(f"error: {email!r} does not look like an email address", file=sys.stderr)
+        return 2
+    db = _invite_db_manager()
+    with db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == args.kofi_transaction_id).first()
+        if payment is None:
+            print(f"error: no payment found for transaction {args.kofi_transaction_id!r}", file=sys.stderr)
+            return 2
+        user = session.query(User).filter(User.email == email).first()
+        if user is None:
+            print(f"error: no user found for {email!r} (use `user invite` first)", file=sys.stderr)
+            return 2
+        if payment.matched_user_id is not None:
+            print(f"error: payment {args.kofi_transaction_id!r} is already matched", file=sys.stderr)
+            return 2
+        kind = entitlements.classify(
+            payment.kofi_type, payment.is_subscription_payment, payment.tier_name, payment.amount
+        )
+        days = entitlements.grant_days(kind)
+        payment.matched_user_id = user.id
+        payment.entitlement_days = days
+        if days > 0:
+            user.subscriber_until = entitlements.extend(user.subscriber_until, days)
+        session.flush()
+        result = user.subscriber_until
+    until_msg = result.isoformat() if result else "unchanged"
+    print(f"Matched {args.kofi_transaction_id} to {email} ({kind}, +{days}d) -> subscriber_until {until_msg}")
     return 0
 
 

--- a/src/agentic_librarian/cli.py
+++ b/src/agentic_librarian/cli.py
@@ -176,6 +176,11 @@ def _run_user_subscribe(args) -> int:
     if not _is_valid_email(email):
         print(f"error: {email!r} does not look like an email address", file=sys.stderr)
         return 2
+    # Guardrail on a prod-mutating tool: a fat-fingered `--days -30` must not silently
+    # revoke paid time. Reducing/revoking is deliberate-only, via the absolute --until.
+    if (args.days is not None and args.days <= 0) or (args.months is not None and args.months <= 0):
+        print("error: --months/--days must be positive (to reduce or revoke, use --until)", file=sys.stderr)
+        return 2
     db = _invite_db_manager()
     with db.get_session() as session:
         user = session.query(User).filter(User.email == email).first()

--- a/src/agentic_librarian/core/budgets.py
+++ b/src/agentic_librarian/core/budgets.py
@@ -1,0 +1,100 @@
+"""Budget decisions for #100 — counting queries over existing tables (messages, usage);
+no new counters, no Redis. Checks FAIL OPEN: a broken budget query logs and allows (the
+budget protects cost, not correctness). Module-level db_manager + set_db_manager seam
+mirrors core/usage.py."""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import UTC, datetime, time, timedelta
+from uuid import UUID
+
+from agentic_librarian.core import tiers
+from agentic_librarian.db.session import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+db_manager = DatabaseManager()
+
+_DEFER_JITTER_MAX_SECONDS = 1800  # spread the next-midnight thundering herd over 30 min
+
+
+def set_db_manager(new_manager: DatabaseManager):
+    global db_manager
+    db_manager = new_manager
+
+
+def _utc_day_start(now: datetime | None = None) -> datetime:
+    now = now or datetime.now(UTC)
+    return datetime.combine(now.date(), time.min, tzinfo=UTC)
+
+
+def chat_turns_today(session, user_id: UUID) -> int:
+    from agentic_librarian.db.models import Conversation, Message
+
+    return (
+        session.query(Message.id)
+        .join(Conversation, Conversation.id == Message.conversation_id)
+        .filter(
+            Conversation.user_id == user_id,
+            Message.role == "user",
+            Message.created_at >= _utc_day_start(),
+        )
+        .count()
+    )
+
+
+def grounded_calls_today(session, user_id: UUID | None) -> int:
+    """App-key grounded-model usage rows today — per-user, or global when user_id is None."""
+    from agentic_librarian.db.models import Usage
+
+    q = session.query(Usage.id).filter(
+        Usage.model == tiers.grounding_model_name(),
+        Usage.key_source == "app",
+        Usage.created_at >= _utc_day_start(),
+    )
+    if user_id is not None:
+        q = q.filter(Usage.user_id == user_id)
+    return q.count()
+
+
+def chat_turn_allowed(user_id: UUID) -> tuple[bool, str]:
+    """(allowed, human_message). Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            tier = tiers.effective_tier(session, user_id)
+            limit = tiers.chat_turns_per_day(tier)
+            used = chat_turns_today(session, user_id)
+        if used >= limit:
+            return False, (
+                f"You've reached today's chat limit ({limit} messages). "
+                "It resets at midnight UTC — or support Shelfwright for a higher limit."
+            )
+        return True, ""
+    except Exception:
+        logger.warning("chat budget check failed open", exc_info=True)
+        return True, ""
+
+
+def enrichment_allowed(user_id: UUID | None) -> tuple[bool, str]:
+    """Per-user grounded budget (when attributed) AND the global governor. Un-attributed
+    (pre-deploy) tasks check only the governor. Fail-open on any error."""
+    try:
+        with db_manager.get_session() as session:
+            if grounded_calls_today(session, None) >= tiers.grounded_calls_per_day_global():
+                return False, "global grounded-call governor reached"
+            if user_id is not None:
+                tier = tiers.effective_tier(session, user_id)
+                if grounded_calls_today(session, user_id) >= tiers.grounded_calls_per_day(tier):
+                    return False, f"per-user grounded budget reached (tier {tier})"
+        return True, ""
+    except Exception:
+        logger.warning("enrichment budget check failed open", exc_info=True)
+        return True, ""
+
+
+def next_utc_day_start_with_jitter(now: datetime | None = None, jitter_seconds: int | None = None) -> datetime:
+    if jitter_seconds is None:
+        jitter_seconds = random.randint(0, _DEFER_JITTER_MAX_SECONDS)
+    return _utc_day_start(now) + timedelta(days=1, seconds=jitter_seconds)

--- a/src/agentic_librarian/core/byok.py
+++ b/src/agentic_librarian/core/byok.py
@@ -1,0 +1,98 @@
+"""KMS-backed BYOK credential crypto (monetization arc 3/3). `KMS_KEY_NAME` (the full
+resource name, e.g. `projects/<p>/locations/us-central1/keyRings/librarian/cryptoKeys/
+byok-credentials`) is read PER CALL — not cached — so an operator can point at a new key
+without a redeploy. `_client()` is the lazy-import/cached-client seam
+(enrichment/tasks.py's `_client()` pattern): `google.cloud.kms` is only imported where
+BYOK crypto actually runs, and `set_kms_client` lets tests inject a fake without the
+dependency installed.
+
+Module is `db_manager`-free by design (spec §1): callers own their own session, keeping
+this module pure of pool concerns. Plaintext keys are NEVER logged, never persisted, and
+live only in call-scope local variables — every caller must treat the `str` this module
+hands back the same way.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class ByokNotConfigured(Exception):  # noqa: N818 - name is a binding contract (spec + task brief)
+    """`KMS_KEY_NAME` is unset — BYOK crypto is unavailable. The API layer maps this to
+    a 503 `byok_unavailable` response (GET still answers; only PUT needs KMS)."""
+
+
+class ByokKeyError(Exception):
+    """A stored credential could not be decrypted (KMS outage, corrupted ciphertext, or
+    a revoked key). Callers must surface this — never silently fall back to the app key
+    (spec §"No silent fallback")."""
+
+
+_client_cached = None
+_client_lock = threading.Lock()
+
+
+def _client():
+    """Lazy, thread-safe, cached KMS client — mirrors enrichment/tasks.py's `_client()`
+    so `google-cloud-kms` is only imported where BYOK crypto runs."""
+    global _client_cached
+    if _client_cached is None:
+        with _client_lock:
+            if _client_cached is None:
+                from google.cloud import kms
+
+                _client_cached = kms.KeyManagementServiceClient()
+    return _client_cached
+
+
+def set_kms_client(client) -> None:
+    """Test seam: inject a fake KMS client, bypassing the lazy `google.cloud.kms`
+    import entirely. Pass `None` to reset to the lazy-real-client state."""
+    global _client_cached
+    _client_cached = client
+
+
+def _key_name() -> str:
+    key_name = os.environ.get("KMS_KEY_NAME", "").strip()
+    if not key_name:
+        raise ByokNotConfigured("KMS_KEY_NAME is not set")
+    return key_name
+
+
+def encrypt_key(plaintext: str) -> bytes:
+    """Encrypt a plaintext Gemini API key for storage. Raises ByokNotConfigured when
+    `KMS_KEY_NAME` is unset."""
+    key_name = _key_name()
+    response = _client().encrypt(request={"name": key_name, "plaintext": plaintext.encode("utf-8")})
+    return response.ciphertext
+
+
+def decrypt_key(ciphertext: bytes) -> str:
+    """Decrypt stored ciphertext back to the plaintext key. Raises ByokNotConfigured
+    when `KMS_KEY_NAME` is unset; raises ByokKeyError on any KMS-side decrypt failure
+    (outage, corrupted ciphertext, revoked key) so callers never fall back silently."""
+    key_name = _key_name()
+    try:
+        response = _client().decrypt(request={"name": key_name, "ciphertext": ciphertext})
+    except Exception as e:
+        raise ByokKeyError("failed to decrypt stored BYOK credential") from e
+    return response.plaintext.decode("utf-8")
+
+
+def resolve_gemini_key(session: Session, user_id: UUID) -> str | None:
+    """Load the caller's `UserCredential(vendor='gemini')` row and decrypt it. Returns
+    None when no row exists (not-byok is the common case, not an error). Decrypt
+    failure propagates as ByokKeyError — callers surface it, they never fall back to
+    the app key."""
+    from agentic_librarian.db.models import UserCredential
+
+    row = session.get(UserCredential, (user_id, "gemini"))
+    if row is None:
+        return None
+    return decrypt_key(row.encrypted_key)

--- a/src/agentic_librarian/core/entitlements.py
+++ b/src/agentic_librarian/core/entitlements.py
@@ -1,0 +1,54 @@
+"""Ko-fi payment → entitlement rules (monetization arc 2/3). Pure and DB-free: the
+webhook and the CLI both call these so grant math exists exactly once. Env knobs are
+read per call (prod-tunable): KOFI_ANNUAL_TIER_NAMES (csv of tier/product names that
+mean 'annual', default 'annual'; exact case-folded match — substring matching would
+misfire on e.g. 'Not Annual'), KOFI_ANNUAL_MIN_AMOUNT (one-off donations at/over this
+classify as annual, default 25). Grace is baked into the grant: 33/370 days cover
+Ko-fi's missing cancellation events and late renewals."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+Kind = Literal["monthly", "annual", "tip"]
+
+_GRANT_DAYS: dict[Kind, int] = {"monthly": 33, "annual": 370, "tip": 0}
+_DEFAULT_ANNUAL_MIN = Decimal(25)
+
+
+def _annual_tier_names() -> set[str]:
+    raw = os.environ.get("KOFI_ANNUAL_TIER_NAMES", "annual")
+    return {part.strip().casefold() for part in raw.split(",") if part.strip()}
+
+
+def _annual_min_amount() -> Decimal:
+    raw = os.environ.get("KOFI_ANNUAL_MIN_AMOUNT", "")
+    try:
+        value = Decimal(raw)
+    except InvalidOperation:
+        return _DEFAULT_ANNUAL_MIN
+    return value if value > 0 else _DEFAULT_ANNUAL_MIN
+
+
+def classify(kofi_type: str, is_subscription_payment: bool, tier_name: str | None, amount: Decimal) -> Kind:
+    if tier_name is not None and tier_name.strip().casefold() in _annual_tier_names():
+        return "annual"
+    if is_subscription_payment:
+        return "monthly"
+    if amount >= _annual_min_amount():
+        return "annual"
+    return "tip"
+
+
+def grant_days(kind: Kind) -> int:
+    return _GRANT_DAYS[kind]
+
+
+def extend(current: datetime | None, days: int, now: datetime | None = None) -> datetime:
+    """New subscriber_until: active subs stack; lapsed subs restart from now."""
+    now = now or datetime.now(UTC)
+    base = current if (current is not None and current > now) else now
+    return base + timedelta(days=days)

--- a/src/agentic_librarian/core/tiers.py
+++ b/src/agentic_librarian/core/tiers.py
@@ -1,0 +1,95 @@
+"""Effective tier + env-tunable budget knobs (#100, monetization arc 1/3; spec
+2026-07-25-metering-tiers-budgets-design.md).
+
+Tier semantics: 'byok' requires a user_credentials row for vendor 'gemini' — that table
+has NO writers until arc PR3 lands, so today the branch is inert but the enum is stable
+across the arc. 'supporter' = subscriber_until in the future (Ko-fi entitlements are
+PR2). Knobs are read per call (prod-tunable without redeploy); invalid or non-positive
+values fall back to the defaults below."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Literal
+from uuid import UUID
+
+Tier = Literal["free", "supporter", "byok"]
+
+_DEFAULTS = {
+    "CHAT_TURNS_PER_DAY_FREE": 20,
+    "CHAT_TURNS_PER_DAY_SUPPORTER": 200,
+    "CHAT_MESSAGE_MAX_CHARS": 4000,
+    "IMPORT_MAX_ROWS_FREE": 300,
+    "IMPORT_MAX_ROWS_SUPPORTER": 2000,
+    "GROUNDED_CALLS_PER_DAY_FREE": 300,
+    "GROUNDED_CALLS_PER_DAY_SUPPORTER": 1500,
+    "GROUNDED_CALLS_PER_DAY_GLOBAL": 1400,
+}
+
+# byok budgets are structural sanity bounds, not cost protection (their key, their bill).
+_BYOK_MULTIPLIER = 10
+
+
+def _env_int(name: str) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULTS[name]
+    return value if value > 0 else _DEFAULTS[name]
+
+
+def tier_for(subscriber_until: datetime | None, has_byok_credential: bool, now: datetime | None = None) -> Tier:
+    if has_byok_credential:
+        return "byok"
+    now = now or datetime.now(UTC)
+    if subscriber_until is not None and subscriber_until > now:
+        return "supporter"
+    return "free"
+
+
+def effective_tier(session, user_id: UUID) -> Tier:
+    from agentic_librarian.db.models import User, UserCredential
+
+    user = session.get(User, user_id)
+    has_cred = (
+        session.query(UserCredential.user_id)
+        .filter(UserCredential.user_id == user_id, UserCredential.vendor == "gemini")
+        .first()
+        is not None
+    )
+    return tier_for(user.subscriber_until if user else None, has_cred)
+
+
+def _tiered(free_var: str, supporter_var: str, tier: Tier) -> int:
+    if tier == "free":
+        return _env_int(free_var)
+    supporter = _env_int(supporter_var)
+    return supporter * _BYOK_MULTIPLIER if tier == "byok" else supporter
+
+
+def chat_turns_per_day(tier: Tier) -> int:
+    return _tiered("CHAT_TURNS_PER_DAY_FREE", "CHAT_TURNS_PER_DAY_SUPPORTER", tier)
+
+
+def chat_message_max_chars() -> int:
+    return _env_int("CHAT_MESSAGE_MAX_CHARS")
+
+
+def import_max_rows(tier: Tier) -> int:
+    return _tiered("IMPORT_MAX_ROWS_FREE", "IMPORT_MAX_ROWS_SUPPORTER", tier)
+
+
+def grounded_calls_per_day(tier: Tier) -> int:
+    return _tiered("GROUNDED_CALLS_PER_DAY_FREE", "GROUNDED_CALLS_PER_DAY_SUPPORTER", tier)
+
+
+def grounded_calls_per_day_global() -> int:
+    return _env_int("GROUNDED_CALLS_PER_DAY_GLOBAL")
+
+
+def grounding_model_name() -> str:
+    """Single source of truth for the grounded-scout model id — budgets count usage rows
+    by this name, and scouts/grounded_llm.py resolves its model from it."""
+    return os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"

--- a/src/agentic_librarian/core/usage.py
+++ b/src/agentic_librarian/core/usage.py
@@ -34,16 +34,18 @@ def record_llm_call(
     input_tokens: int,
     output_tokens: int,
     conversation_id: UUID | None = None,
+    key_source: str = "app",
 ) -> None:
-    """Write one usage row for the current context user. key_source is 'app' until
-    Lift 3's BYOK routing exists. Never raises."""
+    """Write one usage row for the current context user. key_source is 'app' unless
+    the caller threaded a byok-resolved key through (arc 3/3) — this is the ONE place
+    key_source is written. Never raises."""
     try:
         user_id = get_required_user_id()
         with db_manager.get_session() as session:
             session.add(
                 Usage(
                     user_id=user_id,
-                    key_source="app",
+                    key_source=key_source,
                     vendor=vendor,
                     model=model,
                     input_tokens=int(input_tokens or 0),

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -308,6 +308,8 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, nullable=False)  # lowercased; the invite key
     firebase_uid: Mapped[str | None] = mapped_column(String, unique=True, nullable=True)
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    # #100 monetization: Ko-fi entitlement horizon (PR2 writes it; NULL/past = free tier).
+    subscriber_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )

--- a/src/agentic_librarian/db/models.py
+++ b/src/agentic_librarian/db/models.py
@@ -1,9 +1,11 @@
 from datetime import UTC, date, datetime
+from decimal import Decimal
 from uuid import UUID, uuid4
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     ARRAY,
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -12,6 +14,7 @@ from sqlalchemy import (
     Index,
     Integer,
     LargeBinary,
+    Numeric,
     String,
     Table,
     Text,
@@ -331,6 +334,29 @@ class Usage(Base):
     conversation_id: Mapped[UUID | None] = mapped_column(
         PG_UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True, index=True
     )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+
+
+class Payment(Base):
+    """One row per Ko-fi webhook event (monetization arc 2/3) — the audit trail behind
+    users.subscriber_until. Idempotency key = kofi_transaction_id (Ko-fi retries).
+    matched_user_id NULL = payer email didn't match a user (CLI `payments match` fixes)."""
+
+    __tablename__ = "payments"
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False)
+    kofi_transaction_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    kofi_type: Mapped[str] = mapped_column(String, nullable=False)
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)  # lowercased at ingest
+    amount: Mapped[Decimal] = mapped_column(Numeric(10, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String, nullable=False)
+    tier_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_subscription_payment: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    matched_user_id: Mapped[UUID | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
+    entitlement_days: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )

--- a/src/agentic_librarian/enrichment/tasks.py
+++ b/src/agentic_librarian/enrichment/tasks.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from datetime import datetime
 from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
@@ -44,10 +45,14 @@ def _client():
     return _client_cached
 
 
-def enqueue_enrichment(work_id: str) -> bool:
+def enqueue_enrichment(work_id: str, user_id: str | None = None, schedule_time: datetime | None = None) -> bool:
     """Enqueue the deep-enrichment task for work_id. Returns True if enqueued, False if
     Cloud Tasks is not configured (local dev) — the caller treats a False/raised result as
-    non-fatal so the fast add still succeeds."""
+    non-fatal so the fast add still succeeds.
+
+    user_id (#100) attributes the eventual /internal/enrich metering to the requesting user;
+    omitted for pre-#100 callers, which run un-attributed exactly as before. schedule_time is
+    added here (used starting Task 4) so tasks.py is touched once for the arc."""
     queue = os.environ.get("CLOUD_TASKS_QUEUE")
     base = os.environ.get("ENRICH_TARGET_BASE_URL")
     sa = os.environ.get("ENRICH_INVOKER_SA")
@@ -55,8 +60,14 @@ def enqueue_enrichment(work_id: str) -> bool:
         logger.info("enrichment enqueue skipped — Cloud Tasks not configured (work %s)", work_id)
         return False
 
-    url = f"{base.rstrip('/')}/internal/enrich/{work_id}"
-    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or url
+    # Audience is bound to the bare PATH url on purpose — see enqueue_edition_completion's
+    # comment: a per-call query string (user_id here, format there) must never leak into the
+    # audience the receiver checks against a single fixed ENRICH_OIDC_AUDIENCE.
+    audience_url = f"{base.rstrip('/')}/internal/enrich/{work_id}"
+    url = audience_url
+    if user_id:
+        url += f"?user_id={quote(user_id)}"
+    audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or audience_url
     task = {
         "http_request": {
             # String, not tasks_v2.HttpMethod.POST, on purpose: proto-plus coerces it, and
@@ -67,15 +78,22 @@ def enqueue_enrichment(work_id: str) -> bool:
             "oidc_token": {"service_account_email": sa, "audience": audience},
         }
     }
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
     _client().create_task(parent=queue, task=task)
     logger.info("enqueued deep enrichment for work %s", work_id)
     return True
 
 
-def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
+def enqueue_edition_completion(
+    work_id: str, fmt: str, user_id: str | None = None, schedule_time: datetime | None = None
+) -> bool:
     """Enqueue the format-completion pass for (work_id, fmt) — history-format-edit spec.
     Returns True if enqueued, False if Cloud Tasks is not configured (local dev); the
-    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved."""
+    caller (PATCH /history) treats False/raised as non-fatal — the edit is already saved.
+
+    user_id (#100) attributes the eventual /internal/complete-edition metering to the
+    requesting user; omitted for pre-#100 callers. schedule_time added for Task 4."""
     queue = os.environ.get("CLOUD_TASKS_QUEUE")
     base = os.environ.get("ENRICH_TARGET_BASE_URL")
     sa = os.environ.get("ENRICH_INVOKER_SA")
@@ -85,8 +103,10 @@ def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
 
     path_url = f"{base.rstrip('/')}/internal/complete-edition/{work_id}"
     url = f"{path_url}?format={quote(fmt)}"
+    if user_id:
+        url += f"&user_id={quote(user_id)}"
     # Audience deliberately excludes the query string: the receiver verifies against a
-    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format audience would never match.
+    # single fixed ENRICH_OIDC_AUDIENCE, so a per-format/per-user audience would never match.
     audience = os.environ.get("ENRICH_OIDC_AUDIENCE") or path_url
     task = {
         "http_request": {
@@ -95,6 +115,8 @@ def enqueue_edition_completion(work_id: str, fmt: str) -> bool:
             "oidc_token": {"service_account_email": sa, "audience": audience},
         }
     }
+    if schedule_time is not None:
+        task["schedule_time"] = schedule_time  # proto-plus coerces datetime -> Timestamp
     _client().create_task(parent=queue, task=task)
     logger.info("enqueued edition completion for work %s format %s", work_id, fmt)
     return True

--- a/src/agentic_librarian/enrichment/two_phase.py
+++ b/src/agentic_librarian/enrichment/two_phase.py
@@ -214,7 +214,7 @@ def add_read_event(work_id: UUID, *, completed, rating: int | None, notes: str |
         return {"read_number": len(prior_reads) + 1, "already_logged": False, "pick_resolved": pick_resolved}
 
 
-def complete_edition(work_id: UUID, fmt: str) -> str:
+def complete_edition(work_id: UUID, fmt: str, api_key: str | None = None, key_source: str = "app") -> str:
     """Format-completion pass (history-format-edit spec): fill the (work_id, fmt)
     edition's metadata after a history-entry format change. Fast API scouts always
     (ISBN, pages/audio minutes, publication date); audiobook scouts + per-narrator
@@ -239,7 +239,11 @@ def complete_edition(work_id: UUID, fmt: str) -> str:
                   requeue-sweep backstop economics to protect. A 500 → Cloud Tasks retry only
                   occurs for failures OUTSIDE the scout manager (persist/DB errors), which
                   propagate uncaught.
-      "done"    — scouted values merged onto the edition."""
+      "done"    — scouted values merged onto the edition.
+
+    `api_key`/`key_source` (arc 3/3 BYOK) thread into the completion scout manager's LLM
+    scouts and the narrator-style StyleScout call below — a byok user's own key, or the
+    app key by default."""
     fmt = (fmt or "")[:50]
 
     with db_manager.get_session() as session:
@@ -254,14 +258,14 @@ def complete_edition(work_id: UUID, fmt: str) -> str:
         if edition is None:
             return "missing"
 
-    enriched = create_completion_scout_manager().enrich(title=title, author=author, format=fmt)
+    enriched = create_completion_scout_manager(api_key, key_source).enrich(title=title, author=author, format=fmt)
     if not enriched:
         return "empty"
 
     narrator_names = [n for n in (enriched.get("narrator_names") or []) if isinstance(n, str) and n.strip()]
     narrator_styles: dict[str, dict] = {}
     if "audiobook" in fmt.lower() and narrator_names:
-        style_scout = StyleScout()
+        style_scout = StyleScout(api_key, key_source=key_source)
         for n_name in narrator_names:
             try:
                 narrator_styles[n_name] = style_scout.scout_narrator_style(n_name)
@@ -304,7 +308,7 @@ def complete_edition(work_id: UUID, fmt: str) -> str:
     return "done"
 
 
-def enrich_deep(work_id: UUID) -> str:
+def enrich_deep(work_id: UUID, api_key: str | None = None, key_source: str = "app") -> str:
     """Deep pass (Cloud Tasks target): read the Work's identity in a short session, run
     the slow LLM scouts with NO session held (#94 — previously minutes idle-in-transaction
     at enrich-queue concurrency 4, where a late transient failure also re-paid every LLM
@@ -345,6 +349,9 @@ def enrich_deep(work_id: UUID) -> str:
                      row is recorded; the twin's data is untouched by this function beyond
                      persist's own write. Non-retryable success — see api/internal.py.
 
+    `api_key`/`key_source` (arc 3/3 BYOK) thread into the deep scout manager's LLM scouts —
+    a byok user's own key, or the app key by default.
+
     Reviewer-found bug (fixed here): the redirect branch used to INSERT the detected_duplicates
     row (work_id_a=work_id) BEFORE re-loading the invoked work by id. If the invoked row had
     been deleted mid-pass, that insert FK-violated on work_id_a, and the raised exception rolled
@@ -366,7 +373,7 @@ def enrich_deep(work_id: UUID) -> str:
         title = work.title  # scalars captured before close (detached-instance rule)
         fmt = work.editions[0].format if work.editions else "ebook"
 
-    row = _run_scouts(create_deep_scout_manager(), title=title, author=author, fmt=fmt)
+    row = _run_scouts(create_deep_scout_manager(api_key, key_source), title=title, author=author, fmt=fmt)
     if row is None:
         # scouts found nothing to add; the pass is done (not retryable on its own), but
         # stamp completion so the requeue sweep doesn't treat this work as never-attempted.

--- a/src/agentic_librarian/imports/worker.py
+++ b/src/agentic_librarian/imports/worker.py
@@ -85,22 +85,24 @@ def process_import_row(row_id: UUID) -> str:
             "user_id": row.user_id,
         }
 
-    # 2. Resolve the work (de-dup, else shallow scouts) OUTSIDE our session — enrich_fast
-    #    owns its own session/pool.
-    try:
-        fast = two_phase.enrich_fast(data["title"], data["author"], data["fmt"])
-    except Exception as e:  # noqa: BLE001 - transient: record + re-raise so Cloud Tasks retries
-        _record_error(row_id, f"{type(e).__name__}: {e}")
-        raise
-    if fast is None:
-        _finish(row_id, status="failed", outcome="not_found")
-        return "not_found"
-    work_id, created = fast
+    # 2-4 all run attributed to the row's user (#100): enrich_fast's grounded/embed calls,
+    # the history/suggestion write, and the deep-enrichment enqueue all bill/attribute to
+    # this user. OUTSIDE our claim session — enrich_fast owns its own session/pool.
+    with as_user(data["user_id"]):
+        # 2. Resolve the work (de-dup, else shallow scouts).
+        try:
+            fast = two_phase.enrich_fast(data["title"], data["author"], data["fmt"])
+        except Exception as e:  # noqa: BLE001 - transient: record + re-raise so Cloud Tasks retries
+            _record_error(row_id, f"{type(e).__name__}: {e}")
+            raise
+        if fast is None:
+            _finish(row_id, status="failed", outcome="not_found")
+            return "not_found"
+        work_id, created = fast
 
-    # 3. Write to the routed destination.
-    try:
-        if data["destination"] == "history":
-            with as_user(data["user_id"]):
+        # 3. Write to the routed destination.
+        try:
+            if data["destination"] == "history":
                 event = two_phase.add_read_event(
                     work_id,
                     completed=data["completed"],
@@ -108,23 +110,23 @@ def process_import_row(row_id: UUID) -> str:
                     notes=data["notes"],
                     fmt=data["fmt"],
                 )
-            outcome = "duplicate" if event["already_logged"] else ("created" if created else "linked")
-        else:  # 'suggestion'. ('skip' rows are never enqueued — commit filters them — so they never reach here.)
-            shelf = data["shelf"]
-            context = f"imported:{shelf}" if shelf in ("to-read", "currently-reading") else "imported"
-            with db_manager.get_session() as session:
-                is_new = _upsert_suggestion(session, work_id=work_id, user_id=data["user_id"], context=context)
-            outcome = "created" if (is_new and created) else ("linked" if is_new else "duplicate")
-    except Exception as e:  # noqa: BLE001 - transient: record + re-raise for retry
-        _record_error(row_id, f"{type(e).__name__}: {e}")
-        raise
+                outcome = "duplicate" if event["already_logged"] else ("created" if created else "linked")
+            else:  # 'suggestion'. ('skip' rows are never enqueued — commit filters them — so they never reach here.)
+                shelf = data["shelf"]
+                context = f"imported:{shelf}" if shelf in ("to-read", "currently-reading") else "imported"
+                with db_manager.get_session() as session:
+                    is_new = _upsert_suggestion(session, work_id=work_id, user_id=data["user_id"], context=context)
+                outcome = "created" if (is_new and created) else ("linked" if is_new else "duplicate")
+        except Exception as e:  # noqa: BLE001 - transient: record + re-raise for retry
+            _record_error(row_id, f"{type(e).__name__}: {e}")
+            raise
 
-    # 4. Queue the deep pass only for newly-created works (best-effort).
-    if created:
-        try:
-            enqueue_enrichment(str(work_id))
-        except Exception:  # noqa: BLE001 - deep pass can be retried later; never fail the row
-            logger.exception("deep-enrichment enqueue failed for work %s", work_id)
+        # 4. Queue the deep pass only for newly-created works (best-effort).
+        if created:
+            try:
+                enqueue_enrichment(str(work_id), user_id=str(data["user_id"]))
+            except Exception:  # noqa: BLE001 - deep pass can be retried later; never fail the row
+                logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 
     _finish(row_id, status="done", outcome=outcome, work_id=work_id)
     return "done"

--- a/src/agentic_librarian/mcp/server.py
+++ b/src/agentic_librarian/mcp/server.py
@@ -64,6 +64,17 @@ def _parse_uuid(value) -> UUID | None:
         return None
 
 
+def _current_user_id_or_none() -> str | None:
+    """Best-effort attribution for the deep-enrichment enqueue (#100): chat tools run inside
+    the turn's as_user(...) scope (chat/stream.py sets it around the driver; make_async_tool's
+    asyncio.to_thread copies contextvars), so the user is normally present here — but the
+    enqueue itself is best-effort by design, so a missing ambient user must never crash it."""
+    try:
+        return str(get_required_user_id())
+    except Exception:  # noqa: BLE001 - defensive: no ambient user is a valid state for this call
+        return None
+
+
 def _normalize_status(value, allowed: tuple[str, ...]) -> str | None:
     """Case-insensitively match an agent-supplied status to a canonical member of
     `allowed`; None if it matches nothing (SEC-002: strict enum, no coercion)."""
@@ -733,7 +744,7 @@ def add_book_to_history(
     enqueued = False
     if created:
         try:
-            enqueued = enqueue_enrichment(str(work_id))
+            enqueued = enqueue_enrichment(str(work_id), user_id=_current_user_id_or_none())
         except Exception:  # noqa: BLE001 - deep pass is best-effort
             logger.exception("deep-enrichment enqueue failed for work %s", work_id)
 
@@ -977,7 +988,7 @@ def enrich_and_persist_work(title: str, author: str, format: str = "ebook") -> s
         work_id, created = resolved
         if created:
             try:
-                enqueue_enrichment(str(work_id))
+                enqueue_enrichment(str(work_id), user_id=_current_user_id_or_none())
             except Exception:  # noqa: BLE001 - deep pass is best-effort; fast data already persisted
                 logger.exception("deep-enrichment enqueue failed for work %s", work_id)
         return str(work_id)

--- a/src/agentic_librarian/orchestration/definitions.py
+++ b/src/agentic_librarian/orchestration/definitions.py
@@ -38,30 +38,37 @@ def create_fast_scout_manager() -> ScoutManager:
     return manager
 
 
-def create_deep_scout_manager() -> ScoutManager:
+def create_deep_scout_manager(api_key: str | None = None, key_source: str = "app") -> ScoutManager:
     """Deep tier (Lift 2 Stage 3): the slow LLM scouts (audiobook, style, tropes) run later
     via the Cloud Tasks internal endpoint. Audiobook/DirectKnowledge self-skip on non-audiobook
-    formats; StyleScout (5) runs after them so narrator_names is populated; LLMTropeScout (6) last."""
+    formats; StyleScout (5) runs after them so narrator_names is populated; LLMTropeScout (6) last.
+
+    `api_key`/`key_source` (arc 3/3 BYOK) thread into every LLM scout here — the ones that
+    call Gemini via GroundedLLM — so a byok user's deep-enrichment pass runs on their own
+    key and its usage rows record key_source='byok'."""
     manager = ScoutManager()
-    manager.register_scout(AudiobookScout(), priority=3)
-    manager.register_scout(DirectKnowledgeScout(), priority=4)
-    manager.register_scout(StyleScout(), priority=5)
-    manager.register_scout(LLMTropeScout(), priority=6)
+    manager.register_scout(AudiobookScout(api_key, key_source=key_source), priority=3)
+    manager.register_scout(DirectKnowledgeScout(api_key, key_source=key_source), priority=4)
+    manager.register_scout(StyleScout(api_key, key_source=key_source), priority=5)
+    manager.register_scout(LLMTropeScout(api_key, key_source=key_source), priority=6)
     return manager
 
 
-def create_completion_scout_manager() -> ScoutManager:
+def create_completion_scout_manager(api_key: str | None = None, key_source: str = "app") -> ScoutManager:
     """Format-completion pass (history-format-edit): the fast API scouts fetch the new
     format's edition metadata (ISBN, pages/audio minutes, publication date); the audiobook
     scouts (which self-skip on non-audiobook formats) add narrators. Deliberately NO
     LLMTropeScout and NO StyleScout — tropes and author/work styles belong to the Work,
     which a format change does not touch; narrator styles are scouted directly by
-    two_phase.complete_edition."""
+    two_phase.complete_edition.
+
+    `api_key`/`key_source` (arc 3/3 BYOK) thread ONLY into the two LLM scouts (Audiobook,
+    DirectKnowledge) — HardcoverScout/GoogleBooksScout use their own, unrelated API keys."""
     manager = ScoutManager()
     manager.register_scout(HardcoverScout(), priority=1)
     manager.register_scout(GoogleBooksScout(), priority=2)
-    manager.register_scout(AudiobookScout(), priority=3)
-    manager.register_scout(DirectKnowledgeScout(), priority=4)
+    manager.register_scout(AudiobookScout(api_key, key_source=key_source), priority=3)
+    manager.register_scout(DirectKnowledgeScout(api_key, key_source=key_source), priority=4)
     return manager
 
 

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -112,7 +112,9 @@ class ClaudeGroundedLLM:
             if result_val and isinstance(result_val, str):
                 text = result_val
             usage = getattr(message, "usage", None)
-            if usage:
+            # isinstance guard matches agents/backends/claude.py: a non-dict usage on a
+            # non-Result message must not crash the scout path.
+            if isinstance(usage, dict):
                 record_llm_call(
                     "anthropic",
                     self.model,

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -11,6 +11,8 @@ from typing import Protocol, runtime_checkable
 
 from google import genai
 
+from agentic_librarian.core.tiers import grounding_model_name
+from agentic_librarian.core.usage import record_llm_call
 from agentic_librarian.llm_retry import genai_http_options
 
 
@@ -34,14 +36,28 @@ def _extract_text(response) -> str | None:
     return "".join(texts) if texts else None
 
 
+def _record_gemini_usage(model_name: str, response) -> None:
+    """Meter at the RESPONSE object (#100): the SDK's HTTP-level 429/5xx retry must not
+    double-count; scout-level retries are genuinely separate billable calls and each
+    records via its own response. record_llm_call never raises (warns + drops when no
+    user is in context, e.g. pre-#100 queued tasks)."""
+    um = getattr(response, "usage_metadata", None)
+    if um is None:
+        return
+    record_llm_call(
+        "gemini",
+        model_name,
+        int(getattr(um, "prompt_token_count", 0) or 0),
+        int(getattr(um, "candidates_token_count", 0) or 0),
+    )
+
+
 class GeminiGroundedLLM:
     """Grounded generation via Gemini's google_search tool — the prior scout behavior, relocated."""
 
     def __init__(self, api_key: str | None = None, model_name: str | None = None):
         self.api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
-        self.model_name = (
-            model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
-        )
+        self.model_name = model_name or grounding_model_name()
         self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
 
     def generate(self, prompt: str, grounded: bool = True) -> str:
@@ -51,6 +67,7 @@ class GeminiGroundedLLM:
             contents=prompt,
             config={"tools": [{"google_search": {}}] if use_grounding else []},
         )
+        _record_gemini_usage(self.model_name, response)
         return _extract_text(response) or ""
 
 
@@ -73,6 +90,9 @@ class ClaudeGroundedLLM:
             return asyncio.run(self._agenerate(prompt, grounded))
         # Called from within a running event loop (async test runner / framework): asyncio.run can't
         # run inside one, so offload to a worker thread that gets its own loop.
+        # Known limit, do not fix (#100): ThreadPoolExecutor does not propagate ContextVars, so
+        # usage metering warns+drops on this fallback path — it only runs under async test
+        # runners, never in the scout worker (which always drives the no-running-loop branch).
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
@@ -91,6 +111,14 @@ class ClaudeGroundedLLM:
             result_val = getattr(message, "result", None)
             if result_val and isinstance(result_val, str):
                 text = result_val
+            usage = getattr(message, "usage", None)
+            if usage:
+                record_llm_call(
+                    "anthropic",
+                    self.model,
+                    int(usage.get("input_tokens", 0) or 0),
+                    int(usage.get("output_tokens", 0) or 0),
+                )
         return text
 
 

--- a/src/agentic_librarian/scouts/grounded_llm.py
+++ b/src/agentic_librarian/scouts/grounded_llm.py
@@ -36,11 +36,12 @@ def _extract_text(response) -> str | None:
     return "".join(texts) if texts else None
 
 
-def _record_gemini_usage(model_name: str, response) -> None:
+def _record_gemini_usage(model_name: str, response, key_source: str = "app") -> None:
     """Meter at the RESPONSE object (#100): the SDK's HTTP-level 429/5xx retry must not
     double-count; scout-level retries are genuinely separate billable calls and each
     records via its own response. record_llm_call never raises (warns + drops when no
-    user is in context, e.g. pre-#100 queued tasks)."""
+    user is in context, e.g. pre-#100 queued tasks). key_source threads through from the
+    scout's construction (arc 3/3 BYOK routing) — 'app' unless a byok key was used."""
     um = getattr(response, "usage_metadata", None)
     if um is None:
         return
@@ -49,15 +50,17 @@ def _record_gemini_usage(model_name: str, response) -> None:
         model_name,
         int(getattr(um, "prompt_token_count", 0) or 0),
         int(getattr(um, "candidates_token_count", 0) or 0),
+        key_source=key_source,
     )
 
 
 class GeminiGroundedLLM:
     """Grounded generation via Gemini's google_search tool — the prior scout behavior, relocated."""
 
-    def __init__(self, api_key: str | None = None, model_name: str | None = None):
+    def __init__(self, api_key: str | None = None, model_name: str | None = None, key_source: str = "app"):
         self.api_key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
         self.model_name = model_name or grounding_model_name()
+        self.key_source = key_source
         self._client = genai.Client(api_key=self.api_key, http_options=genai_http_options())
 
     def generate(self, prompt: str, grounded: bool = True) -> str:
@@ -67,7 +70,7 @@ class GeminiGroundedLLM:
             contents=prompt,
             config={"tools": [{"google_search": {}}] if use_grounding else []},
         )
-        _record_gemini_usage(self.model_name, response)
+        _record_gemini_usage(self.model_name, response, self.key_source)
         return _extract_text(response) or ""
 
 
@@ -124,13 +127,15 @@ class ClaudeGroundedLLM:
         return text
 
 
-def get_grounded_llm(api_key: str | None = None, model_name: str | None = None) -> GroundedLLM:
+def get_grounded_llm(api_key: str | None = None, model_name: str | None = None, key_source: str = "app") -> GroundedLLM:
     """Pick the grounding-LLM provider from AGENT_BACKEND (default/'adk' -> Gemini; 'claude' -> Claude).
-    `model_name` applies only to the Gemini provider; the Claude provider uses CLAUDE_MODEL."""
+    `model_name` applies only to the Gemini provider; the Claude provider uses CLAUDE_MODEL.
+    `key_source` (arc 3/3 BYOK) threads to the Gemini provider only — the Claude provider
+    records its own vendor ('anthropic') and is unaffected by a user's Gemini key."""
     choice = os.environ.get("AGENT_BACKEND", "adk").strip().lower()
     if choice == "claude":
         return ClaudeGroundedLLM()
     if choice not in ("adk", ""):
         # Fail loudly on a typo rather than silently defaulting to Gemini (matches agents.get_backend).
         raise ValueError(f"Unknown AGENT_BACKEND={choice!r} (expected 'adk' or 'claude').")
-    return GeminiGroundedLLM(api_key, model_name)
+    return GeminiGroundedLLM(api_key, model_name, key_source=key_source)

--- a/src/agentic_librarian/scouts/metadata_scout.py
+++ b/src/agentic_librarian/scouts/metadata_scout.py
@@ -102,7 +102,13 @@ class APIScout(BaseScout):
 class LLMScout(BaseScout):
     """Abstract base class for scouts using LLMs for unstructured data."""
 
-    def __init__(self, api_key: str = None, model_name: str = None, llm: GroundedLLM | None = None):
+    def __init__(
+        self,
+        api_key: str = None,
+        model_name: str = None,
+        llm: GroundedLLM | None = None,
+        key_source: str = "app",
+    ):
         # Fallback to GOOGLE_SEARCH_API_KEY if no specific key provided (also used by AudiobookScout's
         # Custom Search and by the Gemini provider/embeddings).
         key = api_key or os.environ.get("GOOGLE_SEARCH_API_KEY")
@@ -114,7 +120,9 @@ class LLMScout(BaseScout):
         self.model_name = (
             model_name or os.environ.get("GROUNDING_MODEL") or os.environ.get("EXPLORER_MODEL") or "gemini-2.5-flash"
         )
-        self._llm = llm or get_grounded_llm(self.api_key, model_name=self.model_name)
+        # key_source (arc 3/3 BYOK) threads through to grounded-scout usage metering; 'app'
+        # unless the caller passed a byok-resolved user key (orchestration/definitions.py).
+        self._llm = llm or get_grounded_llm(self.api_key, model_name=self.model_name, key_source=key_source)
 
     def _safe_extract_json(self, response_text: str, title: str, author: str, retry_count: int = 0) -> dict | None:
         """Cleans and parses LLM JSON output with descriptive error logging."""

--- a/src/agentic_librarian/scouts/utils.py
+++ b/src/agentic_librarian/scouts/utils.py
@@ -6,6 +6,8 @@ from functools import lru_cache
 from google import genai
 from google.genai import types
 
+from agentic_librarian.core.usage import record_llm_call
+
 # Current GA Gemini embedding model — the single source of truth for the model name (managers
 # and the #123 warm-before-session callers all reference this instead of copying the string).
 EMBED_MODEL = "gemini-embedding-001"
@@ -82,4 +84,8 @@ def get_cached_embedding(model_name: str, text: str) -> list[float]:
     )
     if not response or not response.embeddings:
         raise ValueError(f"Embedding generation returned no result for text: {text!r}")
+    # #100: embed responses expose no token counts and lru_cache means only MISSES reach
+    # here — record per network call with a documented chars//4 estimate (visibility, not
+    # billing-grade; embeddings are $0.15/M).
+    record_llm_call("gemini", model_name, len(text) // 4, 0)
     return response.embeddings[0].values

--- a/test/integration/test_account_api.py
+++ b/test/integration/test_account_api.py
@@ -1,0 +1,52 @@
+"""#100 monetization arc 2/3: GET /api/account, executed against a real Postgres
+(db_integration — CI-only, see test/conftest.py). Tier comes straight from
+tiers.effective_tier — this test asserts the endpoint's shape, not a second tier
+computation. Rows are seeded with EXPLICIT, distinct created_at values (#147 lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import auth
+from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(api_main, "db_manager", manager)
+    monkeypatch.setitem(
+        api_main.app.dependency_overrides,
+        auth.get_current_user,
+        lambda: auth.AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL),
+    )
+    yield TestClient(api_main.app)
+
+
+def test_account_free_user_has_no_subscriber_until(client):
+    body = client.get("/api/account").json()
+    assert body == {
+        "email": DEFAULT_USER_EMAIL,
+        "display_name": "Justin",
+        "tier": "free",
+        "subscriber_until": None,
+    }
+
+
+def test_account_future_subscriber_until_is_supporter(client, db_url):
+    manager = DatabaseManager(db_url)
+    until = (datetime.now(UTC) + timedelta(days=30)).replace(microsecond=0)
+    with manager.get_session() as session:
+        row = session.get(User, DEFAULT_USER_ID)
+        row.subscriber_until = until
+
+    body = client.get("/api/account").json()
+    assert body["tier"] == "supporter"
+    assert body["subscriber_until"] == until.isoformat()
+    assert body["email"] == DEFAULT_USER_EMAIL

--- a/test/integration/test_api_history_db.py
+++ b/test/integration/test_api_history_db.py
@@ -324,17 +324,23 @@ def test_patch_date_collision_is_409_not_500(two_user_client, db_url):
 
 def test_patch_format_enqueues_completion_for_new_audiobook(two_user_client, monkeypatch):
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append((wid, fmt)) or True)
+    monkeypatch.setattr(
+        api_main,
+        "enqueue_edition_completion",
+        lambda wid, fmt, user_id=None: calls.append((wid, fmt, user_id)) or True,
+    )
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
     assert resp.status_code == 200
     assert resp.json()["enrichment_enqueued"] is True
-    assert len(calls) == 1 and calls[0][1] == "audiobook"
+    assert len(calls) == 1
+    assert calls[0][1] == "audiobook"
+    assert calls[0][2] == str(DEFAULT_USER_ID)  # attributed to the authenticated caller (#100)
 
 
 def test_patch_format_enqueue_failure_never_fails_the_edit(two_user_client, monkeypatch):
-    def _boom(wid, fmt):
+    def _boom(wid, fmt, user_id=None):
         raise RuntimeError("tasks down")
 
     monkeypatch.setattr(api_main, "enqueue_edition_completion", _boom)
@@ -356,7 +362,7 @@ def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_ur
         s.add(done)
         s.flush()
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt, user_id=None: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"format": "audiobook"})
@@ -367,7 +373,7 @@ def test_patch_format_skips_enqueue_when_edition_complete(two_user_client, db_ur
 
 def test_patch_notes_only_never_enqueues(two_user_client, monkeypatch):
     calls = []
-    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt: calls.append(1) or True)
+    monkeypatch.setattr(api_main, "enqueue_edition_completion", lambda wid, fmt, user_id=None: calls.append(1) or True)
     client = two_user_client(DEFAULT_USER_ID, "jaydee829@gmail.com")
     entry = _my_entry(client)
     resp = client.patch(f"/api/history/{entry['id']}", json={"notes": "just notes"})

--- a/test/integration/test_api_import_caps.py
+++ b/test/integration/test_api_import_caps.py
@@ -16,7 +16,7 @@ from agentic_librarian.api import imports as imports_mod
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
 from agentic_librarian.api.imports import router
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
-from agentic_librarian.db.models import ImportRow, User
+from agentic_librarian.db.models import ImportJob, ImportRow, User
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -72,12 +72,32 @@ def test_supporter_tier_same_file_passes(client, monkeypatch):
 
 
 def test_second_commit_while_first_still_pending_is_409(client):
+    """A RECENT in-flight job (created just now, by the commit above) blocks — the other
+    half of the #100 review fix's window invariant."""
     c, _manager = client
     first = _commit(c, 2)
     assert first.status_code == 200
     second = _commit(c, 2)
     assert second.status_code == 409
     assert second.json()["detail"]["code"] == "import_in_flight"
+
+
+def test_old_wedged_pending_row_does_not_block_a_new_commit(client):
+    """#100 review fix: an import-row task has no give-up retry bound and job-recovery UI
+    lives only in React state, so a row permanently wedged in 'pending'/'processing' must
+    not lock the user out of ever importing again. A job older than IN_FLIGHT_WINDOW no
+    longer counts as in-flight. #147 lesson: seed created_at explicitly, don't rely on
+    wall-clock proximity to a boundary."""
+    c, manager = client
+    stale = datetime.now(UTC) - timedelta(hours=25)  # older than the 24h IN_FLIGHT_WINDOW
+    with manager.get_session() as s:
+        job = ImportJob(user_id=DEFAULT_USER_ID, source="goodreads", total_rows=1, created_at=stale)
+        s.add(job)
+        s.flush()
+        s.add(ImportRow(import_job_id=job.id, user_id=DEFAULT_USER_ID, destination="history", status="pending"))
+
+    r = _commit(c, 2)
+    assert r.status_code == 200
 
 
 def test_commit_allowed_again_once_all_rows_reach_terminal_status(client):

--- a/test/integration/test_api_import_caps.py
+++ b/test/integration/test_api_import_caps.py
@@ -1,0 +1,94 @@
+"""#100: per-tier import row caps + the one-in-flight-import rule (api/imports.py commit),
+executed against a real Postgres (db_integration — CI-only, see test/conftest.py). The fast
+wiring-only checks (fake session, no real tier/DB behavior) live in
+test/unit/test_api_import_commit.py; this file proves the real tier resolution (including a
+future subscriber_until) and the real pending/processing-row join."""
+
+import io
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import imports as imports_mod
+from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.api.imports import router
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import ImportRow, User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+_MAPPING = {"title": "Title", "author": "Author", "date_completed": "Date Read", "shelf": "Exclusive Shelf"}
+
+
+@pytest.fixture()
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(imports_mod, "db_manager", manager)
+    # Never hit real Cloud Tasks; the enqueue call itself is covered in test_api_import_status.py.
+    monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda row_id: True)
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL)
+    return TestClient(app), manager
+
+
+def _csv(n_rows: int) -> bytes:
+    header = "Title,Author,Date Read,Exclusive Shelf\n"
+    body = "".join(f"Book {i},Author {i},2024/01/{(i % 27) + 1:02d},read\n" for i in range(n_rows))
+    return (header + body).encode()
+
+
+def _commit(c, n_rows):
+    return c.post(
+        "/api/import/commit",
+        files={"file": ("export.csv", io.BytesIO(_csv(n_rows)), "text/csv")},
+        data={"mapping": json.dumps(_MAPPING), "import_to_read": "false", "import_currently_reading": "false"},
+    )
+
+
+def test_free_tier_over_cap_is_413(client, monkeypatch):
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "5")
+    c, _manager = client
+    r = _commit(c, 6)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert "5" in body["message"]
+
+
+def test_supporter_tier_same_file_passes(client, monkeypatch):
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "5")
+    c, manager = client
+    with manager.get_session() as s:
+        user = s.get(User, DEFAULT_USER_ID)
+        user.subscriber_until = datetime.now(UTC) + timedelta(days=30)
+    r = _commit(c, 6)
+    assert r.status_code == 200
+    assert r.json()["total_rows"] == 6
+
+
+def test_second_commit_while_first_still_pending_is_409(client):
+    c, _manager = client
+    first = _commit(c, 2)
+    assert first.status_code == 200
+    second = _commit(c, 2)
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "import_in_flight"
+
+
+def test_commit_allowed_again_once_all_rows_reach_terminal_status(client):
+    c, manager = client
+    first = _commit(c, 2)
+    assert first.status_code == 200
+    job_id = first.json()["import_job_id"]
+    with manager.get_session() as s:
+        rows = s.query(ImportRow).filter(ImportRow.import_job_id == job_id).all()
+        for row in rows:
+            row.status = "done"
+
+    third = _commit(c, 2)
+    assert third.status_code == 200

--- a/test/integration/test_books_api.py
+++ b/test/integration/test_books_api.py
@@ -42,7 +42,11 @@ def _stub_fast(monkeypatch, result):
 
 def test_add_book_persists_logs_and_enqueues(client, monkeypatch):
     enqueued = []
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: enqueued.append(wid) or True)
+    monkeypatch.setattr(
+        books_mod,
+        "enqueue_enrichment",
+        lambda wid, user_id=None: enqueued.append((wid, user_id)) or True,
+    )
     _stub_fast(
         monkeypatch,
         {
@@ -63,11 +67,12 @@ def test_add_book_persists_logs_and_enqueues(client, monkeypatch):
     assert body["read_number"] == 1
     assert body["already_logged"] is False
     assert body["enrichment_enqueued"] is True
-    assert enqueued == [body["work_id"]]  # newly created → deep pass enqueued
+    # newly created → deep pass enqueued, attributed to the authenticated caller (#100)
+    assert enqueued == [(body["work_id"], str(DEFAULT_USER_ID))]
 
 
 def test_add_book_not_found_returns_404(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {})  # scouts find nothing
 
     resp = client.post("/api/books", json={"title": "Nope", "author": "Nobody"})
@@ -76,7 +81,7 @@ def test_add_book_not_found_returns_404(client, monkeypatch):
 
 def test_add_book_rereads_do_not_reenqueue(client, db_url, monkeypatch):
     calls = []
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: calls.append(wid) or True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: calls.append(wid) or True)
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
         work = Work(title="Dune")
@@ -100,7 +105,7 @@ def test_add_book_rereads_do_not_reenqueue(client, db_url, monkeypatch):
 
 
 def test_add_book_rejects_future_date(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
     tomorrow = (date.today() + timedelta(days=1)).isoformat()
     resp = client.post("/api/books", json={"title": "X", "author": "Y", "date_completed": tomorrow})
@@ -114,7 +119,7 @@ def test_add_book_rejects_blank_title(client):
 
 def test_add_book_is_user_scoped(client, db_url, monkeypatch):
     # The read-event lands on the authenticated user, not another.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     other = uuid4()
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
@@ -131,14 +136,14 @@ def test_add_book_is_user_scoped(client, db_url, monkeypatch):
 
 
 def test_add_book_rejects_boolean_rating(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "X", "contributors": [{"name": "Y", "role": "Author"}]})
     resp = client.post("/api/books", json={"title": "X", "author": "Y", "rating": True})
     assert resp.status_code == 422
 
 
 def test_add_book_same_date_reports_already_logged(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(
         monkeypatch,
         {"title": "Solaris", "contributors": [{"name": "Stanislaw Lem", "role": "Author"}], "genres": [], "moods": []},
@@ -154,7 +159,7 @@ def test_add_book_same_date_reports_already_logged(client, monkeypatch):
 
 
 def test_add_book_survives_enqueue_failure(client, monkeypatch):
-    def _boom(wid):
+    def _boom(wid, user_id=None):
         raise RuntimeError("cloud tasks down")
 
     monkeypatch.setattr(books_mod, "enqueue_enrichment", _boom)
@@ -187,7 +192,7 @@ def _seed_picked_work(db_url, *, title, author, status="Suggested", user_id=DEFA
 
 def test_add_book_resolves_active_pick(client, db_url, monkeypatch):
     # GH #130 invariant: a book in your history is never simultaneously an active pick.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     work_id, sug_id = _seed_picked_work(db_url, title="The Fifth Season", author="N. K. Jemisin")
     _stub_fast(
         monkeypatch, {"title": "The Fifth Season", "contributors": [{"name": "N. K. Jemisin", "role": "Author"}]}
@@ -206,7 +211,7 @@ def test_add_book_resolves_active_pick(client, db_url, monkeypatch):
 
 
 def test_add_book_without_pick_reports_not_resolved(client, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _stub_fast(monkeypatch, {"title": "Piranesi", "contributors": [{"name": "Susanna Clarke", "role": "Author"}]})
 
     resp = client.post("/api/books", json={"title": "Piranesi", "author": "Susanna Clarke"})
@@ -217,7 +222,7 @@ def test_add_book_without_pick_reports_not_resolved(client, monkeypatch):
 def test_add_book_duplicate_still_resolves_pick(client, db_url, monkeypatch):
     # The already_logged early-return branch must ALSO resolve (re-adding a book
     # already in history still clears its stale pick).
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     work_id, sug_id = _seed_picked_work(db_url, title="Annihilation", author="Jeff VanderMeer")
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:
@@ -243,7 +248,7 @@ def test_add_book_duplicate_still_resolves_pick(client, db_url, monkeypatch):
 
 def test_add_book_leaves_dismissed_pick_untouched(client, db_url, monkeypatch):
     # Resolution only touches 'Suggested' rows — it never rewrites resolved statuses.
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     _work_id, sug_id = _seed_picked_work(db_url, title="Uprooted", author="Naomi Novik", status="Dismissed")
     _stub_fast(monkeypatch, {"title": "Uprooted", "contributors": [{"name": "Naomi Novik", "role": "Author"}]})
 
@@ -256,7 +261,7 @@ def test_add_book_leaves_dismissed_pick_untouched(client, db_url, monkeypatch):
 
 
 def test_add_book_leaves_other_users_pick_untouched(client, db_url, monkeypatch):
-    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid: True)
+    monkeypatch.setattr(books_mod, "enqueue_enrichment", lambda wid, user_id=None: True)
     other = uuid4()
     manager = DatabaseManager(db_url)
     with manager.get_session() as s:

--- a/test/integration/test_budgets_db.py
+++ b/test/integration/test_budgets_db.py
@@ -1,0 +1,163 @@
+"""#100: budget counting queries + the effective_tier DB wrapper, executed against a
+real Postgres (db_integration — CI-only, see test/conftest.py). Rows are seeded with
+EXPLICIT, distinct created_at values (the #147 same-timestamp flake lesson)."""
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+from agentic_librarian.core.user_context import DEFAULT_USER_ID
+from agentic_librarian.db.models import Conversation, Message, Usage, User, UserCredential
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+OTHER_USER = UUID("00000000-0000-4000-8000-0000000000ff")
+
+# Fixed at noon so it's always >= today's midnight regardless of the real wall-clock
+# time the suite happens to run at; _utc_day_start() has no upper bound, so a "today"
+# row need not be <= "now".
+_NOW = datetime.now(UTC)
+TODAY = _NOW.replace(hour=12, minute=0, second=0, microsecond=0)
+YESTERDAY = TODAY - timedelta(days=1)
+
+GROUNDING_MODEL = tiers.grounding_model_name()
+
+
+@pytest.fixture
+def budgets_db(db_url):
+    """Point the budgets module at the isolated test DB (test_usage_db.py pattern)."""
+    manager = DatabaseManager(db_url)
+    original = budgets.db_manager
+    budgets.set_db_manager(manager)
+    yield manager
+    budgets.set_db_manager(original)
+
+
+@pytest.mark.parametrize(
+    "role,owner,when,expected_count",
+    [
+        ("user", "self", "today", 1),
+        ("assistant", "self", "today", 0),
+        ("user", "self", "yesterday", 0),
+        ("user", "other", "today", 0),
+    ],
+    ids=[
+        "todays-user-message-counts",
+        "assistant-role-excluded",
+        "yesterdays-message-excluded",
+        "other-users-conversation-excluded",
+    ],
+)
+def test_chat_turns_today(budgets_db, role, owner, when, expected_count):
+    user_id = OTHER_USER if owner == "other" else DEFAULT_USER_ID
+    created_at = TODAY if when == "today" else YESTERDAY
+    with budgets_db.get_session() as session:
+        if owner == "other":
+            session.merge(User(id=OTHER_USER, email="other@example.com"))
+        convo = Conversation(user_id=user_id)
+        session.add(convo)
+        session.flush()
+        session.add(Message(conversation_id=convo.id, role=role, content="x", created_at=created_at))
+
+    with budgets_db.get_session() as session:
+        count = budgets.chat_turns_today(session, DEFAULT_USER_ID)
+    assert count == expected_count
+
+
+@pytest.mark.parametrize(
+    "model,key_source,when,expected_count",
+    [
+        (GROUNDING_MODEL, "app", "today", 1),
+        ("some-other-model", "app", "today", 0),
+        (GROUNDING_MODEL, "byok", "today", 0),
+        (GROUNDING_MODEL, "app", "yesterday", 0),
+    ],
+    ids=["matching-row-counts", "wrong-model-excluded", "byok-key-source-excluded", "yesterdays-row-excluded"],
+)
+def test_grounded_calls_today_filters(budgets_db, model, key_source, when, expected_count):
+    created_at = TODAY if when == "today" else YESTERDAY
+    with budgets_db.get_session() as session:
+        session.add(
+            Usage(
+                user_id=DEFAULT_USER_ID,
+                key_source=key_source,
+                vendor="gemini",
+                model=model,
+                input_tokens=1,
+                output_tokens=1,
+                created_at=created_at,
+            )
+        )
+
+    with budgets_db.get_session() as session:
+        count = budgets.grounded_calls_today(session, DEFAULT_USER_ID)
+    assert count == expected_count
+
+
+def test_grounded_calls_today_per_user_vs_global(budgets_db):
+    """user_id=None is the global governor — it must see BOTH users' rows; a specific
+    user_id must see only that user's."""
+    with budgets_db.get_session() as session:
+        session.merge(User(id=OTHER_USER, email="other@example.com"))
+        session.add_all(
+            [
+                Usage(
+                    user_id=DEFAULT_USER_ID,
+                    key_source="app",
+                    vendor="gemini",
+                    model=GROUNDING_MODEL,
+                    input_tokens=1,
+                    output_tokens=1,
+                    created_at=TODAY,
+                ),
+                Usage(
+                    user_id=OTHER_USER,
+                    key_source="app",
+                    vendor="gemini",
+                    model=GROUNDING_MODEL,
+                    input_tokens=1,
+                    output_tokens=1,
+                    created_at=TODAY + timedelta(minutes=1),
+                ),
+            ]
+        )
+
+    with budgets_db.get_session() as session:
+        mine = budgets.grounded_calls_today(session, DEFAULT_USER_ID)
+        theirs = budgets.grounded_calls_today(session, OTHER_USER)
+        everyone = budgets.grounded_calls_today(session, None)
+    assert mine == 1
+    assert theirs == 1
+    assert everyone == 2
+
+
+@pytest.mark.parametrize(
+    "days_from_now,has_cred,expected",
+    [
+        (None, False, "free"),
+        (30, False, "supporter"),
+        (None, True, "byok"),
+    ],
+    ids=["plain-user-is-free", "future-subscriber-until-is-supporter", "gemini-credential-is-byok"],
+)
+def test_effective_tier_db_wrapper(budgets_db, days_from_now, has_cred, expected):
+    subscriber_until = TODAY + timedelta(days=days_from_now) if days_from_now is not None else None
+    with budgets_db.get_session() as session:
+        user = session.get(User, DEFAULT_USER_ID)
+        user.subscriber_until = subscriber_until
+        if has_cred:
+            session.add(
+                UserCredential(
+                    user_id=DEFAULT_USER_ID,
+                    vendor="gemini",
+                    encrypted_key=b"ciphertext",
+                    kms_key_name="projects/test/keyRings/test/cryptoKeys/test",
+                )
+            )
+
+    with budgets_db.get_session() as session:
+        tier = tiers.effective_tier(session, DEFAULT_USER_ID)
+    assert tier == expected

--- a/test/integration/test_budgets_db.py
+++ b/test/integration/test_budgets_db.py
@@ -57,6 +57,7 @@ def test_chat_turns_today(budgets_db, role, owner, when, expected_count):
     with budgets_db.get_session() as session:
         if owner == "other":
             session.merge(User(id=OTHER_USER, email="other@example.com"))
+            session.flush()  # OTHER_USER's row must exist before the FK-referencing insert below
         convo = Conversation(user_id=user_id)
         session.add(convo)
         session.flush()
@@ -102,6 +103,7 @@ def test_grounded_calls_today_per_user_vs_global(budgets_db):
     user_id must see only that user's."""
     with budgets_db.get_session() as session:
         session.merge(User(id=OTHER_USER, email="other@example.com"))
+        session.flush()  # OTHER_USER's row must exist before the FK-referencing Usage rows below
         session.add_all(
             [
                 Usage(

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -1,11 +1,15 @@
+from datetime import UTC, datetime
+
 import pytest
 from fastapi.testclient import TestClient
 
 from agentic_librarian.api import auth
 from agentic_librarian.api import main as api_main
 from agentic_librarian.chat import transcript
+from agentic_librarian.core import budgets
 from agentic_librarian.core import usage as usage_mod
 from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import Conversation, Message
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -17,6 +21,7 @@ def client(db_url, monkeypatch):
     monkeypatch.setattr(api_main, "db_manager", manager)
     monkeypatch.setattr(transcript, "db_manager", manager)  # chat endpoints use the store's manager
     monkeypatch.setattr(usage_mod, "db_manager", manager)  # usage recorder writes to the test DB
+    monkeypatch.setattr(budgets, "db_manager", manager)  # chat quota check reads the store's manager
     # Endpoints wrap store calls in as_user(user.id), so a plain user object suffices.
     monkeypatch.setitem(
         api_main.app.dependency_overrides,
@@ -104,3 +109,39 @@ def test_conversations_current_payload_is_capped(client, monkeypatch):
     messages = resp.json()["messages"]
     assert len(messages) == 3
     assert [m["content"] for m in messages] == ["m3", "m4", "m5"]
+
+
+def test_chat_message_over_length_returns_422(client, monkeypatch):
+    # #100: cheap-string cap check — no need for a real 4000-char default here.
+    monkeypatch.setenv("CHAT_MESSAGE_MAX_CHARS", "50")
+    resp = client.post("/api/chat", json={"message": "x" * 51})
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "message_too_long"
+
+
+@pytest.mark.parametrize(
+    "seeded_today,expect_quota_blocked",
+    [
+        pytest.param(2, True, id="at_daily_limit_blocked"),
+        pytest.param(1, False, id="under_daily_limit_allowed"),
+    ],
+)
+def test_chat_quota_enforced_at_daily_limit(client, db_url, monkeypatch, seeded_today, expect_quota_blocked):
+    # #100 / #147 lesson: seed with an explicit, real "today" created_at rather than
+    # relying on the row default (avoids the same-timestamp/tie-break flake).
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", "2")
+    today = datetime.now(UTC)
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        convo = Conversation(user_id=DEFAULT_USER_ID)
+        session.add(convo)
+        session.flush()
+        for i in range(seeded_today):
+            session.add(Message(conversation_id=convo.id, role="user", content=f"seed-{i}", created_at=today))
+
+    resp = client.post("/api/chat", json={"message": "one more, please"})
+    if expect_quota_blocked:
+        assert resp.status_code == 429
+        assert resp.json()["detail"]["code"] == "chat_quota"
+    else:
+        assert resp.status_code != 429

--- a/test/integration/test_chat_api.py
+++ b/test/integration/test_chat_api.py
@@ -119,6 +119,22 @@ def test_chat_message_over_length_returns_422(client, monkeypatch):
     assert resp.json()["detail"]["code"] == "message_too_long"
 
 
+def test_chat_byok_key_error_returns_409_pre_stream(client, monkeypatch):
+    # arc 3/3: a decrypt/config failure at resolution time must surface as a 409 before
+    # any streaming starts — never a silent fallback to the app key. The client fixture
+    # already points api_main.db_manager at the test DB, so this exercises the real
+    # resolve_gemini_key seam (patched only at the KMS-decrypt boundary).
+    from agentic_librarian.core import byok
+
+    def _raise(session, user_id):
+        raise byok.ByokKeyError("decrypt failed")
+
+    monkeypatch.setattr(byok, "resolve_gemini_key", _raise)
+    resp = client.post("/api/chat", json={"message": "hi"})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "byok_key_error"
+
+
 @pytest.mark.parametrize(
     "seeded_today,expect_quota_blocked",
     [

--- a/test/integration/test_cli_invite.py
+++ b/test/integration/test_cli_invite.py
@@ -128,6 +128,23 @@ def test_subscribe_rejects_non_email(_cli_db, capsys):
     assert "error" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "extra_args",
+    [["--days", "0"], ["--days", "-30"], ["--months", "0"], ["--months", "-5"]],
+    ids=["days-zero", "days-negative", "months-zero", "months-negative"],
+)
+def test_subscribe_rejects_non_positive_grants(_cli_db, capsys, extra_args):
+    """Fat-finger guardrail: a negative/zero grant must not silently shrink paid time —
+    reducing/revoking is deliberate-only via the absolute --until."""
+    email = "guard@example.com"
+    horizon = datetime.now(UTC) + timedelta(days=200)
+    user_id = _seed_user(_cli_db, email, subscriber_until=horizon)
+    assert main(["user", "subscribe", email, *extra_args]) == 2
+    assert "--until" in capsys.readouterr().err
+    with _cli_db.get_session() as session:
+        assert session.get(User, user_id).subscriber_until == horizon
+
+
 def test_payments_list_unmatched_filters_out_matched_rows(_cli_db, capsys):
     user_id = _seed_user(_cli_db, "matched@example.com")
     _seed_payment(

--- a/test/integration/test_cli_invite.py
+++ b/test/integration/test_cli_invite.py
@@ -1,12 +1,19 @@
-"""Operator invite tooling (Lift 1, ADR-048): adding a friend is a command, not psql."""
+"""Operator account tooling (Lift 1, ADR-048; monetization arc 2/3 task 3): adding a
+friend, comping/correcting a supporter entitlement, and reconciling a Ko-fi payment
+that couldn't be auto-matched to a user are all commands, not psql."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
 from agentic_librarian.cli import main
-from agentic_librarian.db.models import User
+from agentic_librarian.db.models import Payment, User
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
+
+SLACK = timedelta(minutes=5)
 
 
 @pytest.fixture(autouse=True)
@@ -14,6 +21,45 @@ def _cli_db(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr("agentic_librarian.cli._invite_db_manager", lambda: manager)
     yield manager
+
+
+def _seed_user(db, email, subscriber_until=None, created_at=None):
+    """Returns the new user's id only — never a live ORM object across a closed session
+    boundary (expire-on-commit + session close = DetachedInstanceError on later attribute
+    access, CI-only since local runs never hit a real Postgres to exercise this path).
+    Flushes immediately so later FK-dependent inserts (Payment.matched_user_id) in the
+    SAME test see the row (PR #155 lesson)."""
+    with db.get_session() as session:
+        user = User(
+            email=email,
+            subscriber_until=subscriber_until,
+            created_at=created_at or (datetime.now(UTC) - timedelta(days=1)),
+        )
+        session.add(user)
+        session.flush()
+        return user.id
+
+
+def _seed_payment(db, **overrides):
+    fields = {
+        "kofi_transaction_id": "txn-1",
+        "kofi_type": "Subscription",
+        "email": "payer@example.com",
+        "amount": Decimal("5.00"),
+        "currency": "USD",
+        "tier_name": None,
+        "is_subscription_payment": True,
+        "payload": {},
+        "matched_user_id": None,
+        "entitlement_days": 0,
+        "created_at": datetime.now(UTC) - timedelta(days=1),
+        **overrides,
+    }
+    with db.get_session() as session:
+        payment = Payment(**fields)
+        session.add(payment)
+        session.flush()
+        return payment.id
 
 
 def test_invite_creates_lowercased_row(_cli_db, capsys):
@@ -36,3 +82,145 @@ def test_invite_existing_email_is_idempotent(_cli_db, capsys):
 
 def test_invite_rejects_non_email(capsys):
     assert main(["user", "invite", "not-an-email"]) == 2
+
+
+@pytest.mark.parametrize(
+    "extra_args,expected_days",
+    [
+        pytest.param([], 33, id="default-is-one-month-33-days"),
+        pytest.param(["--months", "3"], 99, id="months-3-times-33"),
+        pytest.param(["--days", "45"], 45, id="days-exact"),
+    ],
+)
+def test_subscribe_grants_expected_days(_cli_db, capsys, extra_args, expected_days):
+    email = "comp@example.com"
+    user_id = _seed_user(_cli_db, email)
+    before = datetime.now(UTC)
+    assert main(["user", "subscribe", email, *extra_args]) == 0
+    with _cli_db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        expected_min = before + timedelta(days=expected_days) - SLACK
+        expected_max = before + timedelta(days=expected_days) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+    assert email in capsys.readouterr().out
+
+
+def test_subscribe_until_sets_absolute_not_extend(_cli_db, capsys):
+    """--until SETS subscriber_until to the given date at UTC midnight, even when an
+    existing (still-active) horizon is further out than that date — proving it's an
+    absolute set, not entitlements.extend()'s stack-if-active behavior."""
+    email = "comp-until@example.com"
+    user_id = _seed_user(_cli_db, email, subscriber_until=datetime.now(UTC) + timedelta(days=500))
+    assert main(["user", "subscribe", email, "--until", "2027-01-01"]) == 0
+    with _cli_db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        assert refreshed.subscriber_until == datetime(2027, 1, 1, tzinfo=UTC)
+    assert "2027-01-01" in capsys.readouterr().out
+
+
+def test_subscribe_unknown_email_exits_2(_cli_db, capsys):
+    assert main(["user", "subscribe", "nobody@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_subscribe_rejects_non_email(_cli_db, capsys):
+    assert main(["user", "subscribe", "not-an-email"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_list_unmatched_filters_out_matched_rows(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "matched@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-matched",
+        email="matched@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    _seed_payment(_cli_db, kofi_transaction_id="txn-unmatched", email="nobody@example.com")
+    assert main(["payments", "list", "--unmatched"]) == 0
+    out = capsys.readouterr().out
+    assert "txn-unmatched" in out
+    assert "txn-matched" not in out
+
+
+def test_payments_list_without_filter_shows_matched_and_unmatched(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "matched2@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-m2",
+        email="matched2@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    _seed_payment(_cli_db, kofi_transaction_id="txn-u2", email="nobody2@example.com")
+    assert main(["payments", "list"]) == 0
+    out = capsys.readouterr().out
+    assert "txn-m2" in out
+    assert "txn-u2" in out
+    assert "nobody2@example.com" in out
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected_kind,expected_days",
+    [
+        pytest.param("Subscription", True, None, Decimal("5.00"), "monthly", 33, id="monthly"),
+        pytest.param("Shop Order", False, "Annual", Decimal("25.00"), "annual", 370, id="annual"),
+        pytest.param("Donation", False, None, Decimal("3.00"), "tip", 0, id="tip-no-entitlement"),
+    ],
+)
+def test_payments_match_recomputes_entitlement_from_stored_row(
+    _cli_db, capsys, kofi_type, is_sub, tier_name, amount, expected_kind, expected_days
+):
+    """match must recompute classify()/grant_days() from the STORED payment fields
+    (not anything on the command line) so CLI and webhook grant identically."""
+    email = f"match-{expected_kind}@example.com"
+    txn_id = f"txn-{expected_kind}"
+    user_id = _seed_user(_cli_db, email)
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id=txn_id,
+        kofi_type=kofi_type,
+        email=email,
+        amount=amount,
+        tier_name=tier_name,
+        is_subscription_payment=is_sub,
+    )
+    before = datetime.now(UTC)
+    assert main(["payments", "match", txn_id, email]) == 0
+    with _cli_db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == txn_id).one()
+        refreshed = session.get(User, user_id)
+        assert payment.matched_user_id == user_id
+        assert payment.entitlement_days == expected_days
+        if expected_days > 0:
+            expected_min = before + timedelta(days=expected_days) - SLACK
+            expected_max = before + timedelta(days=expected_days) + SLACK
+            assert expected_min <= refreshed.subscriber_until <= expected_max
+        else:
+            assert refreshed.subscriber_until is None
+
+
+def test_payments_match_refuses_unknown_transaction(_cli_db, capsys):
+    _seed_user(_cli_db, "someone@example.com")
+    assert main(["payments", "match", "nope-txn", "someone@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_match_refuses_unknown_email(_cli_db, capsys):
+    _seed_payment(_cli_db, kofi_transaction_id="txn-orphan", email="payer@example.com")
+    assert main(["payments", "match", "txn-orphan", "nobody@example.com"]) == 2
+    assert "error" in capsys.readouterr().err
+
+
+def test_payments_match_refuses_already_matched(_cli_db, capsys):
+    user_id = _seed_user(_cli_db, "already@example.com")
+    _seed_payment(
+        _cli_db,
+        kofi_transaction_id="txn-already",
+        email="already@example.com",
+        matched_user_id=user_id,
+        entitlement_days=33,
+    )
+    assert main(["payments", "match", "txn-already", "already@example.com"]) == 2
+    assert "already matched" in capsys.readouterr().err

--- a/test/integration/test_credentials_db.py
+++ b/test/integration/test_credentials_db.py
@@ -8,6 +8,7 @@ tiers.effective_tier is the single source of truth this exercises end to end."""
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -86,6 +87,33 @@ def test_put_stores_ciphertext_only_never_plaintext(client, db_url):
         assert row.encrypted_key != PLAINTEXT_KEY.encode("utf-8")
         assert PLAINTEXT_KEY.encode("utf-8") not in row.encrypted_key
         assert row.kms_key_name == KEY_NAME
+
+
+def test_put_again_replaces_ciphertext_and_bumps_updated_at(client, db_url):
+    """The upsert's UPDATE branch (re-PUT on an existing row): the stored ciphertext
+    changes to reflect the NEW key, kms_key_name still reflects the current env value,
+    and updated_at (the model's onupdate) strictly advances."""
+    first_resp = client.put("/api/me/credentials", json={"api_key": PLAINTEXT_KEY})
+    assert first_resp.status_code == 200
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        row = session.get(UserCredential, (DEFAULT_USER_ID, "gemini"))
+        first_ciphertext = row.encrypted_key
+        first_updated_at = row.updated_at
+
+    time.sleep(0.01)  # ensure onupdate's datetime.now(UTC) strictly advances
+    new_key = "AIzaADifferentReplacementGeminiKeyValue"
+    second_resp = client.put("/api/me/credentials", json={"api_key": new_key})
+    assert second_resp.status_code == 200
+    assert second_resp.json() == {"configured": True}
+
+    with manager.get_session() as session:
+        row = session.get(UserCredential, (DEFAULT_USER_ID, "gemini"))
+        assert row.encrypted_key == new_key.encode("utf-8")[::-1]
+        assert row.encrypted_key != first_ciphertext
+        assert row.kms_key_name == KEY_NAME
+        assert row.updated_at > first_updated_at
 
 
 def test_delete_removes_the_row(client, db_url):

--- a/test/integration/test_credentials_db.py
+++ b/test/integration/test_credentials_db.py
@@ -1,0 +1,121 @@
+"""BYOK credentials endpoint against a real Postgres (db_integration — executed locally,
+Postgres up; CI-only otherwise, see test/conftest.py). Follows test_account_api.py's
+client-fixture pattern; additionally patches api/credentials.py's live-validation seam
+and core/byok.py's KMS client seam (monetization arc 3/3) so no real Gemini/KMS call
+happens. Asserts the row is ciphertext-only (the plaintext key appears nowhere in the
+stored bytes) and that tier flips free->byok->free across PUT/DELETE via /api/account —
+tiers.effective_tier is the single source of truth this exercises end to end."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import auth
+from agentic_librarian.api import credentials as credentials_mod
+from agentic_librarian.api import main as api_main
+from agentic_librarian.core import byok
+from agentic_librarian.core.user_context import DEFAULT_USER_EMAIL, DEFAULT_USER_ID
+from agentic_librarian.db.models import UserCredential
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+KEY_NAME = "projects/p/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials"
+PLAINTEXT_KEY = "AIzaSuperSecretGeminiKeyThatMustNeverBeStored"
+
+
+class _FakeKmsClient:
+    """Reversible stand-in ciphertext (never the real algorithm) — enough to prove the
+    endpoint stores/round-trips whatever encrypt_key hands back, and never the
+    plaintext, without a real KMS call."""
+
+    def encrypt(self, request):
+        return SimpleNamespace(ciphertext=request["plaintext"][::-1])
+
+    def decrypt(self, request):
+        return SimpleNamespace(plaintext=request["ciphertext"][::-1])
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(api_main, "db_manager", manager)
+    monkeypatch.setattr(credentials_mod, "db_manager", manager)
+    monkeypatch.setitem(
+        api_main.app.dependency_overrides,
+        auth.get_current_user,
+        lambda: auth.AuthenticatedUser(id=DEFAULT_USER_ID, email=DEFAULT_USER_EMAIL),
+    )
+    monkeypatch.setattr(credentials_mod, "_validate_key", lambda k: True)
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    yield TestClient(api_main.app)
+    byok.set_kms_client(None)
+
+
+def test_get_credentials_unconfigured_before_any_put(client):
+    resp = client.get("/api/me/credentials")
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": False, "updated_at": None}
+
+
+def test_put_then_get_flips_configured_true(client):
+    put_resp = client.put("/api/me/credentials", json={"api_key": PLAINTEXT_KEY})
+    assert put_resp.status_code == 200
+    assert put_resp.json() == {"configured": True}
+
+    get_resp = client.get("/api/me/credentials")
+    assert get_resp.status_code == 200
+    body = get_resp.json()
+    assert body["configured"] is True
+    assert body["updated_at"] is not None
+
+
+def test_put_stores_ciphertext_only_never_plaintext(client, db_url):
+    resp = client.put("/api/me/credentials", json={"api_key": PLAINTEXT_KEY})
+    assert resp.status_code == 200
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        row = session.get(UserCredential, (DEFAULT_USER_ID, "gemini"))
+        assert row is not None
+        assert row.encrypted_key == PLAINTEXT_KEY.encode("utf-8")[::-1]  # the fake KMS "ciphertext"
+        assert row.encrypted_key != PLAINTEXT_KEY.encode("utf-8")
+        assert PLAINTEXT_KEY.encode("utf-8") not in row.encrypted_key
+        assert row.kms_key_name == KEY_NAME
+
+
+def test_delete_removes_the_row(client, db_url):
+    client.put("/api/me/credentials", json={"api_key": PLAINTEXT_KEY})
+
+    del_resp = client.delete("/api/me/credentials")
+    assert del_resp.status_code == 200
+    assert del_resp.json() == {"configured": False}
+
+    manager = DatabaseManager(db_url)
+    with manager.get_session() as session:
+        assert session.get(UserCredential, (DEFAULT_USER_ID, "gemini")) is None
+
+    get_resp = client.get("/api/me/credentials")
+    assert get_resp.json() == {"configured": False, "updated_at": None}
+
+
+def test_delete_is_idempotent_when_no_row_exists(client):
+    resp = client.delete("/api/me/credentials")
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": False}
+
+
+def test_tier_flips_free_byok_free_across_put_and_delete(client):
+    assert client.get("/api/account").json()["tier"] == "free"
+
+    put_resp = client.put("/api/me/credentials", json={"api_key": PLAINTEXT_KEY})
+    assert put_resp.status_code == 200
+    assert client.get("/api/account").json()["tier"] == "byok"
+
+    del_resp = client.delete("/api/me/credentials")
+    assert del_resp.status_code == 200
+    assert client.get("/api/account").json()["tier"] == "free"

--- a/test/integration/test_import_worker.py
+++ b/test/integration/test_import_worker.py
@@ -29,7 +29,7 @@ def wired(db_url, monkeypatch):
     monkeypatch.setattr(worker, "db_manager", manager)
     two_phase.set_db_manager(manager)
     # Never enqueue real Cloud Tasks from the worker in tests.
-    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id: True)
+    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id, user_id=None: True)
     return manager
 
 
@@ -84,14 +84,21 @@ def test_dedup_links_existing_catalog_work_without_scouts(wired, monkeypatch):
 def test_miss_creates_work_and_enqueues_deep(wired, monkeypatch):
     # Fake the fast scouts so a miss resolves to a created Work deterministically.
     monkeypatch.setattr(two_phase, "enrich_fast", lambda t, a, f="ebook": (_seed_work(wired, t, a), True))
-    enq = {"n": 0}
-    monkeypatch.setattr(worker, "enqueue_enrichment", lambda work_id: enq.__setitem__("n", enq["n"] + 1) or True)
+    enq = {"n": 0, "user_id": None}
+
+    def _fake_enqueue(work_id, user_id=None):
+        enq["n"] += 1
+        enq["user_id"] = user_id
+        return True
+
+    monkeypatch.setattr(worker, "enqueue_enrichment", _fake_enqueue)
     row_id = _make_row(wired, raw_title="New Title", raw_author="New Author")
 
     assert worker.process_import_row(row_id) == "done"
     with wired.get_session() as s:
         assert s.get(ImportRow, row_id).outcome == "created"
     assert enq["n"] == 1
+    assert enq["user_id"] == str(DEFAULT_USER_ID)  # attributed to the row's user (#100)
 
 
 def test_not_found_marks_failed_and_does_not_retry(wired, monkeypatch):

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -322,3 +322,98 @@ def test_byok_key_error_returns_200_byok_key_error_and_never_calls_complete_edit
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "byok_key_error"}
     assert ran_complete["called"] is False
+
+
+# --- task-2 review: key resolution must run BEFORE the budget gate, and a byok pass must
+# never be deferred by the tier-blind app-key governor (spec AC#2) ---
+
+
+def test_byok_credentialed_user_bypasses_budget_gate_and_still_runs(client, db_url, monkeypatch):
+    """Even with the app-key governor exhausted, a byok user's completion task must run on
+    their own key — never deferred by a budget that their usage rows are excluded from."""
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    _seed_credential(db_url, user_id=DEFAULT_USER_ID, plaintext_key="sk-users-real-gemini-key")
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+
+    captured = {}
+
+    def _fake_complete(wid, fmt, api_key=None, key_source="app"):
+        captured["args"] = (wid, fmt, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", _fake_complete)
+    enqueue_calls = []
+    monkeypatch.setattr(
+        internal_mod, "enqueue_edition_completion", lambda *a, **k: enqueue_calls.append((a, k)) or True
+    )
+
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert captured["args"] == (wid, "audiobook", "sk-users-real-gemini-key", "byok")
+    assert enqueue_calls == []  # never deferred
+
+
+def test_app_key_user_still_defers_when_over_budget(client, monkeypatch):
+    """An app-key user (no byok credential) is unaffected by the reorder: the budget gate
+    still fires and defers exactly as before."""
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_complete = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase,
+        "complete_edition",
+        lambda wid, fmt, **k: ran_complete.__setitem__("called", True) or "done",
+    )
+    calls = []
+    monkeypatch.setattr(
+        internal_mod,
+        "enqueue_edition_completion",
+        lambda wid, fmt, user_id=None, schedule_time=None: calls.append((wid, fmt)) or True,
+    )
+
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deferred"
+    assert ran_complete["called"] is False
+    assert calls == [(str(wid), "audiobook")]
+
+
+def test_byok_key_error_never_reaches_the_budget_gate(client, db_url, monkeypatch):
+    """The ByokKeyError early-return must fire BEFORE any budget logic — a revoked/broken
+    byok key must not even consult the (irrelevant) app-key governor."""
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    _seed_credential(db_url, user_id=DEFAULT_USER_ID, plaintext_key="sk-doesnt-matter")
+
+    budget_calls = {"called": False}
+
+    def _fail_if_called(uid):
+        budget_calls["called"] = True
+        return False, "global grounded-call governor reached"
+
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", _fail_if_called)
+
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "byok_key_error"}
+    assert budget_calls["called"] is False

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.core.user_context import current_user_id, get_required_user_id
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
@@ -88,7 +88,15 @@ def test_valid_queue_token_without_user_id_completion_unattributed(client, monke
 
     monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
     wid = uuid4()
-    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    # Neutralize the autouse _default_user_context fixture's ambient DEFAULT_USER_ID for
+    # this request only. TestClient copies the current contextvars into the ASGI call, so
+    # without this the probe would see an ambient user and never observe the "no user in
+    # context" path a real requeue-sweep task (no ?user_id=) actually exercises in prod.
+    token = current_user_id.set(None)
+    try:
+        resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    finally:
+        current_user_id.reset(token)
     assert resp.status_code == 200
     assert seen["raised"] is True
 

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -4,6 +4,7 @@ Mirrors test_internal_enrich_api.py: db_integration because the FastAPI app impo
 chain needs real settings, but complete_edition itself is monkeypatched — the pass's
 own behavior is covered by test/unit/test_edition_completion.py."""
 
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -12,6 +13,7 @@ from fastapi.testclient import TestClient
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
 from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
 
@@ -21,6 +23,9 @@ QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
 
 @pytest.fixture
 def client(db_url, monkeypatch):
+    # #100: point the budget gate at the isolated test DB, same reasoning as
+    # test_internal_enrich_api.py's client fixture.
+    monkeypatch.setattr(internal_mod.budgets, "db_manager", DatabaseManager(db_url))
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
@@ -119,3 +124,88 @@ def test_missing_format_param_is_422(client, monkeypatch):
     _as_queue(monkeypatch)
     resp = client.post(f"/internal/complete-edition/{uuid4()}", headers={"Authorization": "Bearer ok"})
     assert resp.status_code == 422
+
+
+def test_over_budget_defers_with_new_scheduled_task_and_never_calls_complete_edition(client, monkeypatch):
+    """#100: mirrors test_internal_enrich_api.py's deferral tests for the completion pass."""
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_complete = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase,
+        "complete_edition",
+        lambda wid, fmt: ran_complete.__setitem__("called", True) or "done",
+    )
+    calls = []
+
+    def fake_enqueue(wid, fmt, user_id=None, schedule_time=None):
+        calls.append((wid, fmt, user_id, schedule_time))
+        return True
+
+    monkeypatch.setattr(internal_mod, "enqueue_edition_completion", fake_enqueue)
+
+    wid = uuid4()
+    caller_id = uuid4()
+    before = datetime.now(UTC)
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={caller_id}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["work_id"] == str(wid)
+    assert body["format"] == "audiobook"
+    assert body["status"] == "deferred"
+    assert "until" in body
+    assert ran_complete["called"] is False
+    assert len(calls) == 1
+    call_wid, call_fmt, call_uid, when = calls[0]
+    assert call_wid == str(wid)
+    assert call_fmt == "audiobook"
+    assert call_uid == str(caller_id)
+    assert when > before
+
+
+def test_under_budget_runs_the_normal_completion_path_unchanged(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (True, ""))
+    called = {}
+
+    def fake_complete(wid, fmt):
+        called["args"] = (wid, fmt)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert called["args"] == (wid, "audiobook")
+
+
+def test_over_budget_and_enqueue_returns_false_is_deferred_enqueue_failed(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+    monkeypatch.setattr(
+        internal_mod, "enqueue_edition_completion", lambda wid, fmt, user_id=None, schedule_time=None: False
+    )
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "ebook", "status": "deferred_enqueue_failed"}
+
+
+def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, monkeypatch):
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+
+    def _boom(wid, fmt, user_id=None, schedule_time=None):
+        raise RuntimeError("cloud tasks unavailable")
+
+    monkeypatch.setattr(internal_mod, "enqueue_edition_completion", _boom)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=ebook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "ebook", "status": "deferred_enqueue_failed"}

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -5,6 +5,7 @@ chain needs real settings, but complete_edition itself is monkeypatched — the 
 own behavior is covered by test/unit/test_edition_completion.py."""
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -12,23 +13,31 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import current_user_id, get_required_user_id
+from agentic_librarian.core import byok
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, current_user_id, get_required_user_id
+from agentic_librarian.db.models import UserCredential
 from agentic_librarian.db.session import DatabaseManager
 
 pytestmark = pytest.mark.db_integration
 
 VALID_AUD = "https://librarian.example.run.app/internal/enrich/x"
 QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
+KMS_KEY_NAME = "projects/p/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials"
 
 
 @pytest.fixture
 def client(db_url, monkeypatch):
     # #100: point the budget gate at the isolated test DB, same reasoning as
     # test_internal_enrich_api.py's client fixture.
-    monkeypatch.setattr(internal_mod.budgets, "db_manager", DatabaseManager(db_url))
+    manager = DatabaseManager(db_url)
+    monkeypatch.setattr(internal_mod.budgets, "db_manager", manager)
+    # arc 3/3 BYOK: the completion handler resolves keys via two_phase.db_manager (the same
+    # shared DB-access pattern _has_real_trope already uses) — point it at the test DB too.
+    monkeypatch.setattr(internal_mod.two_phase, "db_manager", manager)
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
+    byok.set_kms_client(None)  # never leak a fake KMS client into a later test
 
 
 def _as_queue(monkeypatch):
@@ -217,3 +226,99 @@ def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, monke
     resp = client.post(f"/internal/complete-edition/{wid}?format=ebook", headers={"Authorization": "Bearer ok"})
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(wid), "format": "ebook", "status": "deferred_enqueue_failed"}
+
+
+# --- arc 3/3 BYOK: /internal/complete-edition resolves the requesting user's Gemini key ---
+
+
+class _FakeKmsClient:
+    """Reversible stand-in ciphertext (mirrors test_credentials_db.py) — no real KMS call."""
+
+    def __init__(self, decrypt_error: Exception | None = None):
+        self._decrypt_error = decrypt_error
+
+    def encrypt(self, request):
+        return SimpleNamespace(ciphertext=request["plaintext"][::-1])
+
+    def decrypt(self, request):
+        if self._decrypt_error is not None:
+            raise self._decrypt_error
+        return SimpleNamespace(plaintext=request["ciphertext"][::-1])
+
+
+def _seed_credential(db_url, *, user_id, plaintext_key):
+    """Seed a UserCredential row with real (fake-KMS) ciphertext for `user_id` — the byok
+    caller must already be a real `users` row (DEFAULT_USER_ID, autoseeded by conftest)."""
+    manager = DatabaseManager(db_url)
+    ciphertext = byok.encrypt_key(plaintext_key)
+    with manager.get_session() as s:
+        s.add(UserCredential(user_id=user_id, vendor="gemini", encrypted_key=ciphertext, kms_key_name=KMS_KEY_NAME))
+        s.flush()
+
+
+def test_byok_credentialed_user_completion_passes_key_and_byok_source(client, db_url, monkeypatch):
+    """The completion handler resolves DEFAULT_USER_ID's stored key and threads it into
+    two_phase.complete_edition as api_key/key_source='byok' (probe seam)."""
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    _seed_credential(db_url, user_id=DEFAULT_USER_ID, plaintext_key="sk-users-real-gemini-key")
+
+    captured = {}
+
+    def _fake_complete(wid, fmt, api_key=None, key_source="app"):
+        captured["args"] = (wid, fmt, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", _fake_complete)
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
+    assert captured["args"] == (wid, "audiobook", "sk-users-real-gemini-key", "byok")
+
+
+def test_user_without_byok_credential_completion_stays_app_keyed(client, db_url, monkeypatch):
+    """No stored credential -> resolution returns (None, 'app') and the handler's call is
+    byte-identical to pre-BYOK behavior (no extra kwargs)."""
+    _as_queue(monkeypatch)
+
+    captured = {}
+
+    def _fake_complete(wid, fmt, api_key=None, key_source="app"):
+        captured["args"] = (wid, fmt, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", _fake_complete)
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert captured["args"] == (wid, "audiobook", None, "app")
+
+
+def test_byok_key_error_returns_200_byok_key_error_and_never_calls_complete_edition(client, db_url, monkeypatch):
+    """Spec error table: decrypt failure -> task consumed with 200 byok_key_error, never a
+    silent fallback to the app key, and the paid completion pass never runs."""
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    _seed_credential(db_url, user_id=DEFAULT_USER_ID, plaintext_key="sk-doesnt-matter")
+
+    ran_complete = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase, "complete_edition", lambda *a, **k: ran_complete.__setitem__("called", True) or "done"
+    )
+    wid = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={DEFAULT_USER_ID}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "byok_key_error"}
+    assert ran_complete["called"] is False

--- a/test/integration/test_internal_complete_edition_api.py
+++ b/test/integration/test_internal_complete_edition_api.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import get_required_user_id
 
 pytestmark = pytest.mark.db_integration
 
@@ -45,6 +46,46 @@ def test_valid_queue_token_runs_completion(client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(wid), "format": "audiobook", "status": "done"}
     assert called["args"] == (wid, "audiobook")
+
+
+def test_valid_queue_token_with_user_id_attributes_completion(client, monkeypatch):
+    """#100: ?user_id=<uuid> attributes the completion pass's LLM usage to the requester."""
+    _as_queue(monkeypatch)
+    seen = {}
+
+    def fake_complete(wid, fmt):
+        seen["user_id"] = get_required_user_id()
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    caller_id = uuid4()
+    resp = client.post(
+        f"/internal/complete-edition/{wid}?format=audiobook&user_id={caller_id}",
+        headers={"Authorization": "Bearer ok"},
+    )
+    assert resp.status_code == 200
+    assert seen["user_id"] == caller_id
+
+
+def test_valid_queue_token_without_user_id_completion_unattributed(client, monkeypatch):
+    """Back-compat: no user_id -> no user in context, and the pass still succeeds."""
+    _as_queue(monkeypatch)
+    seen = {}
+
+    def fake_complete(wid, fmt):
+        seen["raised"] = False
+        try:
+            get_required_user_id()
+        except RuntimeError:
+            seen["raised"] = True
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "complete_edition", fake_complete)
+    wid = uuid4()
+    resp = client.post(f"/internal/complete-edition/{wid}?format=audiobook", headers={"Authorization": "Bearer ok"})
+    assert resp.status_code == 200
+    assert seen["raised"] is True
 
 
 def test_missing_work_is_404_non_retryable(client, monkeypatch):

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -20,6 +21,10 @@ QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
 def client(db_url, monkeypatch):
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(two_phase, "db_manager", manager)
+    # #100: point the budget gate at the isolated test DB too, so enrichment_allowed's
+    # global-governor query sees the empty test Usage table (allowed) rather than
+    # whatever DATABASE_URL a fail-open real connection would otherwise hit.
+    monkeypatch.setattr(internal_mod.budgets, "db_manager", manager)
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
@@ -251,3 +256,95 @@ def test_unconfigured_audience_is_forbidden(client, monkeypatch):
     )
     resp = client.post(f"/internal/enrich/{uuid4()}", headers={"Authorization": "Bearer x"})
     assert resp.status_code == 403
+
+
+def _as_queue(monkeypatch):
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+
+
+def test_over_budget_defers_with_new_scheduled_task_and_never_calls_enrich_deep(client, db_url, monkeypatch):
+    """#100: over budget -> 200 'deferred', a NEW task is enqueued with schedule_time strictly
+    after now (so the #97 give-up retry count never sees this attempt), and the paid deep pass
+    itself must NOT run."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_enrich_deep = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase, "enrich_deep", lambda wid: ran_enrich_deep.__setitem__("called", True) or "done"
+    )
+    calls = []
+
+    def fake_enqueue(wid, user_id=None, schedule_time=None):
+        calls.append((wid, user_id, schedule_time))
+        return True
+
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", fake_enqueue)
+
+    caller_id = uuid4()
+    before = datetime.now(UTC)
+    resp = client.post(f"/internal/enrich/{work_id}?user_id={caller_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "deferred"
+    assert body["work_id"] == str(work_id)
+    assert ran_enrich_deep["called"] is False
+    assert len(calls) == 1
+    wid, uid, when = calls[0]
+    assert wid == str(work_id)
+    assert uid == str(caller_id)
+    assert when > before
+
+
+def test_under_budget_runs_the_normal_enrich_path_unchanged(client, db_url, monkeypatch):
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (True, ""))
+    called = {}
+
+    def _fake_enrich_deep(wid):
+        called["wid"] = wid
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
+    assert str(called["wid"]) == str(work_id)
+
+
+def test_over_budget_and_enqueue_returns_false_is_deferred_enqueue_failed(client, db_url, monkeypatch):
+    """No retry storm: a failed re-enqueue must not raise/503 — the requeue sweep is the backstop."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "per-user grounded budget reached (tier free)")
+    )
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", lambda wid, user_id=None, schedule_time=None: False)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+
+
+def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, db_url, monkeypatch):
+    """The re-enqueue is best-effort — an exception (e.g. Cloud Tasks outage) must be caught,
+    not propagate as a 500."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global governor reached"))
+
+    def _boom(wid, user_id=None, schedule_time=None):
+        raise RuntimeError("cloud tasks unavailable")
+
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", _boom)
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "deferred_enqueue_failed"}

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import get_required_user_id
+from agentic_librarian.core.user_context import current_user_id, get_required_user_id
 from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
@@ -114,7 +114,15 @@ def test_valid_queue_token_without_user_id_runs_deep_enrich_unattributed(client,
 
     monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
 
-    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    # Neutralize the autouse _default_user_context fixture's ambient DEFAULT_USER_ID for
+    # this request only. TestClient copies the current contextvars into the ASGI call, so
+    # without this the probe would see an ambient user and never observe the "no user in
+    # context" path a real requeue-sweep task (no ?user_id=) actually exercises in prod.
+    token = current_user_id.set(None)
+    try:
+        resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    finally:
+        current_user_id.reset(token)
     assert resp.status_code == 200
     assert seen["raised"] is True  # no user in context, exactly as before #100
 

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
+from agentic_librarian.core.user_context import get_required_user_id
 from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
@@ -63,6 +64,54 @@ def test_valid_queue_token_runs_deep_enrich(client, db_url, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
     assert str(called["wid"]) == str(work_id)
+
+
+def test_valid_queue_token_with_user_id_runs_deep_enrich_attributed(client, db_url, monkeypatch):
+    """#100: the queue may pass ?user_id=<uuid> so the deep pass's LLM usage bills the
+    requesting user. as_user(...) wraps the call, so get_required_user_id() resolves inside
+    enrich_deep — this is the probe (patched at the handler's call site, per house pattern)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    seen = {}
+
+    def _fake_enrich_deep(wid):
+        seen["user_id"] = get_required_user_id()
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+    caller_id = uuid4()
+
+    resp = client.post(f"/internal/enrich/{work_id}?user_id={caller_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert seen["user_id"] == caller_id
+
+
+def test_valid_queue_token_without_user_id_runs_deep_enrich_unattributed(client, db_url, monkeypatch):
+    """Back-compat guarantee: pre-#100 (or requeue-sweep) tasks carry no user_id and must
+    still succeed, with no user identity in context (metering skips, nothing crashes)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    monkeypatch.setattr(
+        internal_mod, "_verify_oidc", lambda token, audience: {"email": QUEUE_SA, "email_verified": True}
+    )
+    seen = {}
+
+    def _fake_enrich_deep(wid):
+        seen["raised"] = False
+        try:
+            get_required_user_id()
+        except RuntimeError:
+            seen["raised"] = True
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+
+    resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert seen["raised"] is True  # no user in context, exactly as before #100
 
 
 def test_missing_token_is_rejected(client):

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -461,3 +461,92 @@ def test_byok_key_error_returns_200_byok_key_error_and_never_calls_enrich_deep(c
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(work_id), "status": "byok_key_error"}
     assert ran_enrich_deep["called"] is False
+
+
+# --- task-2 review: key resolution must run BEFORE the budget gate, and a byok pass must
+# never be deferred by the tier-blind app-key governor (spec AC#2) ---
+
+
+def test_byok_credentialed_user_bypasses_budget_gate_and_still_runs(client, db_url, monkeypatch):
+    """Even with the app-key governor exhausted, a byok user's task must run on their own
+    key — never deferred by a budget that their usage rows are excluded from."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    _seed_credential(manager, user_id=DEFAULT_USER_ID, plaintext_key="sk-users-real-gemini-key")
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+
+    captured = {}
+
+    def _fake_enrich_deep(wid, api_key=None, key_source="app"):
+        captured["args"] = (wid, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+    enqueue_calls = []
+    monkeypatch.setattr(internal_mod, "enqueue_enrichment", lambda *a, **k: enqueue_calls.append((a, k)) or True)
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
+    assert captured["args"] == (work_id, "sk-users-real-gemini-key", "byok")
+    assert enqueue_calls == []  # never deferred
+
+
+def test_app_key_user_still_defers_when_over_budget(client, db_url, monkeypatch):
+    """An app-key user (no byok credential) is unaffected by the reorder: the budget gate
+    still fires and defers exactly as before."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setattr(
+        internal_mod.budgets, "enrichment_allowed", lambda uid: (False, "global grounded-call governor reached")
+    )
+    ran_enrich_deep = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase, "enrich_deep", lambda *a, **k: ran_enrich_deep.__setitem__("called", True) or "done"
+    )
+    calls = []
+    monkeypatch.setattr(
+        internal_mod, "enqueue_enrichment", lambda wid, user_id=None, schedule_time=None: calls.append(wid) or True
+    )
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deferred"
+    assert ran_enrich_deep["called"] is False
+    assert calls == [str(work_id)]
+
+
+def test_byok_key_error_never_reaches_the_budget_gate(client, db_url, monkeypatch):
+    """The ByokKeyError early-return must fire BEFORE any budget logic — a revoked/broken
+    byok key must not even consult the (irrelevant) app-key governor."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    _seed_credential(manager, user_id=DEFAULT_USER_ID, plaintext_key="sk-doesnt-matter")
+
+    budget_calls = {"called": False}
+
+    def _fail_if_called(uid):
+        budget_calls["called"] = True
+        return False, "global grounded-call governor reached"
+
+    monkeypatch.setattr(internal_mod.budgets, "enrichment_allowed", _fail_if_called)
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "byok_key_error"}
+    assert budget_calls["called"] is False

--- a/test/integration/test_internal_enrich_api.py
+++ b/test/integration/test_internal_enrich_api.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -6,8 +7,9 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import internal as internal_mod
 from agentic_librarian.api import main as api_main
-from agentic_librarian.core.user_context import current_user_id, get_required_user_id
-from agentic_librarian.db.models import Author, Edition, Trope, Work, WorkContributor, WorkTrope
+from agentic_librarian.core import byok
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, current_user_id, get_required_user_id
+from agentic_librarian.db.models import Author, Edition, Trope, UserCredential, Work, WorkContributor, WorkTrope
 from agentic_librarian.db.session import DatabaseManager
 from agentic_librarian.enrichment import two_phase
 
@@ -15,6 +17,7 @@ pytestmark = pytest.mark.db_integration
 
 VALID_AUD = "https://librarian.example.run.app/internal/enrich/x"
 QUEUE_SA = "queue-invoker@p.iam.gserviceaccount.com"
+KMS_KEY_NAME = "projects/p/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials"
 
 
 @pytest.fixture
@@ -28,6 +31,7 @@ def client(db_url, monkeypatch):
     monkeypatch.setenv("ENRICH_INVOKER_SA", QUEUE_SA)
     monkeypatch.setenv("ENRICH_OIDC_AUDIENCE", VALID_AUD)
     yield TestClient(api_main.app)
+    byok.set_kms_client(None)  # never leak a fake KMS client into a later test
 
 
 def _seed_work(manager, *, with_real_trope=False):
@@ -356,3 +360,104 @@ def test_over_budget_and_enqueue_raises_is_deferred_enqueue_failed(client, db_ur
     resp = client.post(f"/internal/enrich/{work_id}", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 200
     assert resp.json() == {"work_id": str(work_id), "status": "deferred_enqueue_failed"}
+
+
+# --- arc 3/3 BYOK: /internal/enrich resolves the requesting user's Gemini key ---
+
+
+class _FakeKmsClient:
+    """Reversible stand-in ciphertext (mirrors test_credentials_db.py) — no real KMS call."""
+
+    def __init__(self, decrypt_error: Exception | None = None):
+        self._decrypt_error = decrypt_error
+
+    def encrypt(self, request):
+        return SimpleNamespace(ciphertext=request["plaintext"][::-1])
+
+    def decrypt(self, request):
+        if self._decrypt_error is not None:
+            raise self._decrypt_error
+        return SimpleNamespace(plaintext=request["ciphertext"][::-1])
+
+
+def _seed_credential(manager, *, user_id, plaintext_key):
+    """Seed a UserCredential row with real (fake-KMS) ciphertext for `user_id` — the byok
+    caller must already be a real `users` row (DEFAULT_USER_ID, autoseeded by conftest)."""
+    ciphertext = byok.encrypt_key(plaintext_key)
+    with manager.get_session() as s:
+        s.add(UserCredential(user_id=user_id, vendor="gemini", encrypted_key=ciphertext, kms_key_name=KMS_KEY_NAME))
+        s.flush()
+
+
+def test_byok_credentialed_user_enrich_passes_key_and_byok_source(client, db_url, monkeypatch):
+    """The enrich handler resolves DEFAULT_USER_ID's stored key and threads it into
+    two_phase.enrich_deep as api_key/key_source='byok' (probe seam) — proving the deep
+    pass would actually run on the user's own key, not the app key."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    _seed_credential(manager, user_id=DEFAULT_USER_ID, plaintext_key="sk-users-real-gemini-key")
+
+    captured = {}
+
+    def _fake_enrich_deep(wid, api_key=None, key_source="app"):
+        captured["args"] = (wid, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "enriched"}
+    assert captured["args"] == (work_id, "sk-users-real-gemini-key", "byok")
+
+
+def test_user_without_byok_credential_enrich_stays_app_keyed(client, db_url, monkeypatch):
+    """No stored credential (the common case) -> resolution returns (None, 'app') and the
+    handler's call to enrich_deep is byte-identical to pre-BYOK behavior (no extra kwargs)."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+
+    captured = {}
+
+    def _fake_enrich_deep(wid, api_key=None, key_source="app"):
+        captured["args"] = (wid, api_key, key_source)
+        return "done"
+
+    monkeypatch.setattr(internal_mod.two_phase, "enrich_deep", _fake_enrich_deep)
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert captured["args"] == (work_id, None, "app")
+
+
+def test_byok_key_error_returns_200_byok_key_error_and_never_calls_enrich_deep(client, db_url, monkeypatch):
+    """Spec error table: a decrypt failure (KMS outage / corrupted ciphertext / revoked key)
+    must never fall back to the app key. The task is consumed with 200 byok_key_error —
+    retrying can't fix a revoked key; the requeue sweep is the backstop — and the paid
+    deep-enrichment pass must NEVER run."""
+    manager = DatabaseManager(db_url)
+    work_id = _seed_work(manager)
+    _as_queue(monkeypatch)
+    monkeypatch.setenv("KMS_KEY_NAME", KMS_KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    _seed_credential(manager, user_id=DEFAULT_USER_ID, plaintext_key="sk-doesnt-matter")
+
+    ran_enrich_deep = {"called": False}
+    monkeypatch.setattr(
+        internal_mod.two_phase, "enrich_deep", lambda *a, **k: ran_enrich_deep.__setitem__("called", True) or "done"
+    )
+
+    resp = client.post(
+        f"/internal/enrich/{work_id}?user_id={DEFAULT_USER_ID}", headers={"Authorization": "Bearer good"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"work_id": str(work_id), "status": "byok_key_error"}
+    assert ran_enrich_deep["called"] is False

--- a/test/integration/test_kofi_webhook_db.py
+++ b/test/integration/test_kofi_webhook_db.py
@@ -1,0 +1,178 @@
+"""End-to-end Ko-fi webhook matrix against a real Postgres (db_integration — CI-only,
+see test/conftest.py). Follows test_internal_complete_edition_api.py's pattern: full
+FastAPI app via TestClient (no lifespan, since it's used without a `with` block),
+module's db_manager monkeypatched to the isolated test DB.
+
+Exact subscriber_until timestamps aren't assertable through HTTP (no way to freeze the
+webhook's internal `now`), so the matrix asserts a slack range around each grant instead.
+Rows are seeded with EXPLICIT, distinct created_at values (the #147 same-timestamp
+flake lesson)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import kofi as kofi_mod
+from agentic_librarian.api import main as api_main
+from agentic_librarian.db.models import Payment, User
+from agentic_librarian.db.session import DatabaseManager
+
+pytestmark = pytest.mark.db_integration
+
+VALID_TOKEN = "test-kofi-verification-token"
+SLACK = timedelta(minutes=5)
+
+
+@pytest.fixture
+def client(db_url, monkeypatch):
+    monkeypatch.setattr(kofi_mod, "db_manager", DatabaseManager(db_url))
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    yield TestClient(api_main.app)
+
+
+def _seed_user(db, email: str, subscriber_until: datetime | None, created_at: datetime):
+    """Returns the new user's id only — never a live ORM object across a closed
+    session boundary (the #11 CLAUDE.md pitfall: expire-on-commit + session.close()
+    turns any later attribute access into DetachedInstanceError, CI-only since local
+    runs never reach a real Postgres to exercise this path)."""
+    with db.get_session() as session:
+        user = User(email=email, subscriber_until=subscriber_until, created_at=created_at)
+        session.add(user)
+        session.flush()
+        return user.id
+
+
+def _post(client, **event_overrides):
+    event = {
+        "verification_token": VALID_TOKEN,
+        "kofi_transaction_id": "txn-1",
+        "email": "Subscriber@Example.com",
+        "amount": "5.00",
+        "currency": "USD",
+        "type": "Subscription",
+        "is_subscription_payment": True,
+        "tier_name": None,
+        **event_overrides,
+    }
+    return client.post("/webhooks/kofi", data={"data": json.dumps(event)})
+
+
+@pytest.mark.parametrize(
+    "prior_offset_days,expected_days",
+    [
+        pytest.param(-10, 33, id="lapsed-subscriber-restarts-from-now"),
+        pytest.param(20, 33, id="active-subscriber-stacks-from-existing-expiry"),
+    ],
+)
+def test_membership_payment_matched_email_extends_subscriber_until(client, db_url, prior_offset_days, expected_days):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    prior = now + timedelta(days=prior_offset_days)
+    user_id = _seed_user(db, "subscriber@example.com", prior, now - timedelta(days=1))
+
+    before_call = datetime.now(UTC)
+    resp = _post(client, kofi_transaction_id="membership-txn", email="Subscriber@Example.com")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "applied", "kind": "monthly"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "membership-txn").first()
+        base = prior if prior > before_call else before_call
+        expected_min = base + timedelta(days=expected_days) - SLACK
+        expected_max = base + timedelta(days=expected_days) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+        assert payment is not None
+        assert payment.email == "subscriber@example.com"  # lowercased at ingest
+        assert payment.matched_user_id == user_id
+        assert payment.entitlement_days == 33
+        assert payment.is_subscription_payment is True
+
+
+def test_annual_tier_name_grants_370_days(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "annual@example.com", None, now - timedelta(days=1))
+
+    before_call = datetime.now(UTC)
+    resp = _post(
+        client,
+        kofi_transaction_id="annual-txn",
+        email="annual@example.com",
+        tier_name="Annual",
+        is_subscription_payment=True,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "applied", "kind": "annual"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "annual-txn").first()
+        expected_min = before_call + timedelta(days=370) - SLACK
+        expected_max = before_call + timedelta(days=370) + SLACK
+        assert expected_min <= refreshed.subscriber_until <= expected_max
+        assert payment.entitlement_days == 370
+
+
+def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "tipper@example.com", None, now - timedelta(days=1))
+
+    resp = _post(
+        client,
+        kofi_transaction_id="tip-txn",
+        email="tipper@example.com",
+        amount="3.00",
+        type="Donation",
+        is_subscription_payment=False,
+        tier_name=None,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "recorded", "kind": "tip"}
+
+    with db.get_session() as session:
+        refreshed = session.get(User, user_id)
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "tip-txn").first()
+        assert refreshed.subscriber_until is None
+        assert payment.entitlement_days == 0
+        assert payment.amount == Decimal("3.00")
+
+
+def test_unknown_email_is_unmatched(client):
+    resp = _post(
+        client,
+        kofi_transaction_id="unmatched-txn",
+        email="nobody-here@example.com",
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "unmatched", "kind": "monthly"}
+
+
+def test_same_txn_replay_is_duplicate_no_second_row_no_double_extend(client, db_url):
+    db = DatabaseManager(db_url)
+    now = datetime.now(UTC)
+    user_id = _seed_user(db, "replay@example.com", None, now - timedelta(days=1))
+
+    first = _post(client, kofi_transaction_id="replay-txn", email="replay@example.com")
+    assert first.status_code == 200
+    assert first.json()["status"] == "applied"
+
+    with db.get_session() as session:
+        after_first = session.get(User, user_id).subscriber_until
+
+    second = _post(client, kofi_transaction_id="replay-txn", email="replay@example.com")
+    assert second.status_code == 200
+    assert second.json() == {"status": "duplicate"}
+
+    with db.get_session() as session:
+        after_second = session.get(User, user_id).subscriber_until
+        rows = session.query(Payment).filter(Payment.kofi_transaction_id == "replay-txn").all()
+
+    assert after_second == after_first
+    assert len(rows) == 1

--- a/test/integration/test_kofi_webhook_db.py
+++ b/test/integration/test_kofi_webhook_db.py
@@ -117,6 +117,8 @@ def test_annual_tier_name_grants_370_days(client, db_url):
         expected_max = before_call + timedelta(days=370) + SLACK
         assert expected_min <= refreshed.subscriber_until <= expected_max
         assert payment.entitlement_days == 370
+        assert payment.tier_name == "Annual"
+        assert payment.is_subscription_payment is True
 
 
 def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
@@ -144,14 +146,25 @@ def test_tip_below_threshold_is_recorded_without_entitlement(client, db_url):
         assert payment.amount == Decimal("3.00")
 
 
-def test_unknown_email_is_unmatched(client):
+def test_unknown_email_is_unmatched(client, db_url):
+    """The JSON response is only the delivery ack; the payments row is the durable
+    evidence the operator's `payments match` fallback actually depends on (CLAUDE.md
+    assertion-completeness rule #1) — assert the row directly, not just the ack body."""
+    db = DatabaseManager(db_url)
     resp = _post(
         client,
         kofi_transaction_id="unmatched-txn",
-        email="nobody-here@example.com",
+        email="Nobody-Here@Example.com",
     )
     assert resp.status_code == 200
     assert resp.json() == {"status": "unmatched", "kind": "monthly"}
+
+    with db.get_session() as session:
+        payment = session.query(Payment).filter(Payment.kofi_transaction_id == "unmatched-txn").first()
+        assert payment is not None
+        assert payment.matched_user_id is None
+        assert payment.entitlement_days == 0
+        assert payment.email == "nobody-here@example.com"  # lowercased at ingest
 
 
 def test_same_txn_replay_is_duplicate_no_second_row_no_double_extend(client, db_url):

--- a/test/integration/test_two_phase_deep.py
+++ b/test/integration/test_two_phase_deep.py
@@ -51,7 +51,7 @@ def test_enrich_deep_updates_same_work_idempotently(db_url, monkeypatch):
             {"name": "Kevin J. Anderson", "role": "Author"},  # deep pass discovers a co-author
         ],
     }
-    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda *a, **k: _FakeManager(deep))
 
     work_id = _seed_work(manager, title="Dune", author="Frank Herbert")
 
@@ -101,7 +101,7 @@ def test_enrich_deep_returns_missing_not_done_when_nothing_was_persisted(db_url,
         "narrator_names": [],
         "contributors": [{"name": None, "role": "Author"}],
     }
-    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda *a, **k: _FakeManager(deep))
 
     work_id = _seed_work(manager, title="Vanishing Work", author="Some Author")
 
@@ -164,7 +164,7 @@ def test_enrich_deep_redirect_pins_invoked_work_and_records_detection(db_url, mo
         "narrator_names": [],
         "contributors": [{"name": "Casualfarmer, CasualFarmer", "role": "Author"}],
     }
-    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda *a, **k: _FakeManager(deep))
 
     twin_id, invoked_id = _seed_duplicate_identity_pair(
         manager, title="Beware of Chicken", author="Casualfarmer, CasualFarmer"
@@ -253,7 +253,7 @@ def test_enrich_deep_redirect_missing_invoked_row_leaves_twin_data_intact_no_det
     monkeypatch.setattr(
         two_phase,
         "create_deep_scout_manager",
-        lambda: _DeletingFakeManager(deep, manager=manager, invoked_id=invoked_id),
+        lambda *a, **k: _DeletingFakeManager(deep, manager=manager, invoked_id=invoked_id),
     )
 
     assert two_phase.enrich_deep(invoked_id) == "missing"
@@ -291,7 +291,7 @@ def test_enrich_deep_redirect_is_idempotent_on_redelivery(db_url, monkeypatch):
         "narrator_names": [],
         "contributors": [{"name": "Casualfarmer, CasualFarmer", "role": "Author"}],
     }
-    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(deep))
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda *a, **k: _FakeManager(deep))
 
     twin_id, invoked_id = _seed_duplicate_identity_pair(
         manager, title="Beware of Chicken", author="Casualfarmer, CasualFarmer"
@@ -321,7 +321,7 @@ def test_enrich_deep_empty_pass_still_stamps_deep_enriched_at(db_url, monkeypatc
     treat this work as never-attempted."""
     from agentic_librarian.enrichment import two_phase
 
-    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda: _FakeManager(None))
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", lambda *a, **k: _FakeManager(None))
 
     manager = DatabaseManager(db_url)
     monkeypatch.setattr(two_phase, "db_manager", manager)

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -258,6 +258,48 @@ def test_gemini_with_api_key_binds_a_client_to_that_key():
     assert model.api_client.models._api_client.api_key == "user-secret-key"
 
 
+def test_gemini_byok_generate_content_async_actually_uses_the_byok_client(monkeypatch):
+    """Behavioral canary (task-3 review): the construction-level test above proves
+    `.api_client` is BOUND to the byok key, but that alone doesn't prove ADK's REAL call
+    path reads `self.api_client` at call time — a future google-adk (pinned
+    `>=2.1.0`, unbounded — CI resolves fresh) could route `generate_content_async`
+    through a different attribute or a module-level client, and this would silently
+    fall back to the app key while the construction test above kept passing. This drives
+    the actual entry point the mesh calls (`generate_content_async`), mocking only the
+    network boundary (`AsyncModels.generate_content`), and fails loudly the moment a
+    future ADK version stops consulting `self.api_client` for the real call."""
+    from google.adk.models.llm_request import LlmRequest
+    from google.genai import types as genai_types
+
+    model = services._gemini("model-x", api_key="canary-byok-key")
+    client = model.api_client  # forces construction; api_client is cached, so the real
+    # call below reuses this exact instance — not a fresh one.
+    assert client.models._api_client.api_key == "canary-byok-key"
+
+    captured: dict = {}
+
+    async def fake_generate_content(*, model, contents, config):
+        # The real network boundary. Read the key off the client instance that is
+        # actually executing the call — not off `model`/`_gemini`'s return value — so
+        # this fails if a future ADK routes the call through some OTHER client.
+        captured["key"] = client.models._api_client.api_key
+        return genai_types.GenerateContentResponse()
+
+    monkeypatch.setattr(client.aio.models, "generate_content", fake_generate_content)
+
+    llm_request = LlmRequest(
+        model="model-x", contents=[genai_types.Content(role="user", parts=[genai_types.Part(text="hi")])]
+    )
+
+    async def _drive():
+        return [r async for r in model.generate_content_async(llm_request)]
+
+    responses = asyncio.run(_drive())
+
+    assert captured.get("key") == "canary-byok-key"
+    assert responses  # the fake response was consumed all the way to an LlmResponse
+
+
 @pytest.mark.parametrize(
     "api_key",
     [pytest.param("user-secret-key", id="byok_key_threaded"), pytest.param(None, id="app_key_default")],

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -1,9 +1,10 @@
+import asyncio
 import os
 
 import pytest
 from google.genai import types
 
-from agentic_librarian.agents import runtime
+from agentic_librarian.agents import runtime, services
 from agentic_librarian.agents.services import create_agent_mesh
 
 
@@ -232,3 +233,92 @@ def test_explorer_discovers_real_books():
     response = conv.send("Find grimdark fantasy novels published in 2024. List each title and author.")
     assert isinstance(response, str)
     assert len(response.strip()) > 30
+
+
+# --- arc 3/3 BYOK: key threading through the chat mesh ---
+
+
+def test_gemini_without_api_key_constructs_a_plain_gemini():
+    # Unchanged from before this arc: no api_key kwarg means the model reads the app's
+    # process-wide GOOGLE_API_KEY (set by the autouse _adk_key fixture in tests).
+    model = services._gemini("model-x")
+    assert type(model) is services.Gemini
+    assert model.model == "model-x"
+
+
+def test_gemini_with_api_key_binds_a_client_to_that_key():
+    # ADK's Gemini (google-adk 2.2.0) has no api_key field of its own — a plain
+    # `Gemini(api_key=...)` kwarg is silently dropped. _gemini must route through the
+    # documented api_client-override extension point (_ByokGemini) instead, or the byok
+    # key never actually reaches google.genai.Client.
+    model = services._gemini("model-x", api_key="user-secret-key")
+    assert isinstance(model, services._ByokGemini)
+    assert model.model == "model-x"
+    assert model.byok_api_key == "user-secret-key"
+    assert model.api_client.models._api_client.api_key == "user-secret-key"
+
+
+@pytest.mark.parametrize(
+    "api_key",
+    [pytest.param("user-secret-key", id="byok_key_threaded"), pytest.param(None, id="app_key_default")],
+)
+def test_create_agent_mesh_threads_api_key_to_every_agent(monkeypatch, api_key):
+    calls = []
+
+    def fake_gemini(model_name, key=None):
+        calls.append((model_name, key))
+        return services.Gemini(model=model_name)
+
+    monkeypatch.setattr(services, "_gemini", fake_gemini)
+    services.create_agent_mesh(api_key=api_key)
+    # Analyst, Explorer (the grounding model too), Critic, Librarian.
+    assert len(calls) == 4
+    assert all(key == api_key for _, key in calls)
+
+
+def test_build_runner_threads_api_key_into_create_agent_mesh(monkeypatch):
+    captured = {}
+
+    def fake_create_agent_mesh(api_key=None):
+        captured["api_key"] = api_key
+        return create_agent_mesh()
+
+    monkeypatch.setattr(runtime, "create_agent_mesh", fake_create_agent_mesh)
+    runtime.build_runner(api_key="byok-key")
+    assert captured["api_key"] == "byok-key"
+
+
+def test_astart_conversation_threads_api_key_into_build_runner_when_no_runner_given(monkeypatch):
+    captured = {}
+
+    def fake_build_runner(api_key=None):
+        captured["api_key"] = api_key
+        return _FakeRunner()
+
+    monkeypatch.setattr(runtime, "build_runner", fake_build_runner)
+    asyncio.run(runtime.astart_conversation(user_id="u", session_id="s", api_key="byok-key"))
+    assert captured["api_key"] == "byok-key"
+
+
+def test_astart_conversation_does_not_rebuild_an_explicitly_passed_runner(monkeypatch):
+    # A caller-supplied runner's mesh is already fixed — api_key threading only applies
+    # when astart_conversation builds the runner itself.
+    def fail_build_runner(api_key=None):
+        raise AssertionError("build_runner must not be called when a runner is passed")
+
+    monkeypatch.setattr(runtime, "build_runner", fail_build_runner)
+    fake = _FakeRunner()
+    conv = asyncio.run(runtime.astart_conversation(user_id="u", runner=fake, session_id="s", api_key="byok-key"))
+    assert conv is not None
+
+
+def test_astart_conversation_carries_key_source_onto_the_conversation():
+    fake = _FakeRunner()
+    conv = asyncio.run(runtime.astart_conversation(user_id="u", runner=fake, session_id="s", key_source="byok"))
+    assert conv.key_source == "byok"
+
+
+def test_astart_conversation_key_source_defaults_to_app():
+    fake = _FakeRunner()
+    conv = asyncio.run(runtime.astart_conversation(user_id="u", runner=fake, session_id="s"))
+    assert conv.key_source == "app"

--- a/test/unit/test_agent_runtime.py
+++ b/test/unit/test_agent_runtime.py
@@ -258,6 +258,19 @@ def test_gemini_with_api_key_binds_a_client_to_that_key():
     assert model.api_client.models._api_client.api_key == "user-secret-key"
 
 
+def test_byok_gemini_never_exposes_the_key_in_repr_or_dumps():
+    # Leak-surface guard (arc 3/3 branch review I-1): the plaintext key must not appear
+    # in any serialized/printable form of the model — a future debug log or error
+    # reporter that reprs/dumps the agent tree must not print user secrets.
+    model = services._gemini("model-x", api_key="user-secret-key")
+    assert "user-secret-key" not in repr(model)
+    assert "user-secret-key" not in str(model)
+    assert "user-secret-key" not in str(model.model_dump())
+    assert "user-secret-key" not in model.model_dump_json()
+    # The key still WORKS (excluded from serialization, not from the attribute).
+    assert model.byok_api_key == "user-secret-key"
+
+
 def test_gemini_byok_generate_content_async_actually_uses_the_byok_client(monkeypatch):
     """Behavioral canary (task-3 review): the construction-level test above proves
     `.api_client` is BOUND to the byok key, but that alone doesn't prove ADK's REAL call

--- a/test/unit/test_api_import_commit.py
+++ b/test/unit/test_api_import_commit.py
@@ -32,14 +32,42 @@ _GOODREADS_MAP = {
 }
 
 
+class _NullQuery:
+    """Chainable no-op ORM query stub. `.first()` returns whatever `result` was configured
+    with — the commit-cap unit tests only need to control that one value; the real
+    join/filter correctness is proven against Postgres in test_api_import_caps.py."""
+
+    def __init__(self, result=None):
+        self._result = result
+
+    def join(self, *a, **k):
+        return self
+
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._result
+
+
 class _Recorder:
-    def __init__(self):
+    def __init__(self, in_flight=None):
         self.jobs = []
         self.rows = []
+        # Configurable first()-result for any session.query(...) call made inside commit
+        # (the #100 in-flight check; effective_tier's own UserCredential query is bypassed
+        # in tests that need this by monkeypatching tiers.effective_tier directly instead).
+        self.in_flight = in_flight
 
     def add(self, obj):
         name = type(obj).__name__
         (self.jobs if name == "ImportJob" else self.rows).append(obj)
+
+    def get(self, model, obj_id):
+        return None  # no User row -> tiers.effective_tier resolves 'free' (subscriber_until None)
+
+    def query(self, *entities):
+        return _NullQuery(self.in_flight)
 
     def __enter__(self):
         return self
@@ -66,8 +94,8 @@ def _fake_manager(rec):
     return _M()
 
 
-def _commit(monkeypatch, *, to_read=True):
-    rec = _Recorder()
+def _commit(monkeypatch, *, to_read=True, in_flight=None):
+    rec = _Recorder(in_flight=in_flight)
     monkeypatch.setattr(imports_mod, "db_manager", _fake_manager(rec))
     enq = []
     monkeypatch.setattr(imports_mod, "enqueue_import_row", lambda row_id: enq.append(row_id) or True)
@@ -109,3 +137,26 @@ def test_commit_422_when_required_mapping_missing(monkeypatch):
         data={"mapping": json.dumps(bad), "import_to_read": "true", "import_currently_reading": "true"},
     )
     assert r.status_code == 422
+
+
+def test_commit_413_when_over_tier_row_limit(monkeypatch):
+    """#100: wiring check only — the real free/supporter/DB-driven cap resolution is
+    covered end-to-end against Postgres in test_api_import_caps.py."""
+    monkeypatch.setattr(imports_mod.tiers, "import_max_rows", lambda tier: 1)
+    r, rec, enq = _commit(monkeypatch)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert rec.jobs == []  # rejected before anything was written
+    assert enq == []
+
+
+def test_commit_409_when_import_already_in_flight(monkeypatch):
+    """#100: wiring check only — real pending/processing-row detection against Postgres is
+    covered in test_api_import_caps.py."""
+    monkeypatch.setattr(imports_mod.tiers, "effective_tier", lambda session, user_id: "free")
+    r, rec, enq = _commit(monkeypatch, in_flight="some-row-id")
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "import_in_flight"
+    assert rec.jobs == []
+    assert enq == []

--- a/test/unit/test_api_import_commit.py
+++ b/test/unit/test_api_import_commit.py
@@ -141,13 +141,34 @@ def test_commit_422_when_required_mapping_missing(monkeypatch):
 
 def test_commit_413_when_over_tier_row_limit(monkeypatch):
     """#100: wiring check only — the real free/supporter/DB-driven cap resolution is
-    covered end-to-end against Postgres in test_api_import_caps.py."""
-    monkeypatch.setattr(imports_mod.tiers, "import_max_rows", lambda tier: 1)
+    covered end-to-end against Postgres in test_api_import_caps.py. Uses the real env
+    knob (not a stubbed tiers.import_max_rows) so the message's interpolated numbers stay
+    honest: the free limit shown must be the small override, and the supporter upsell
+    figure must be the real (untouched) env-tunable ceiling — not hardcoded text (#100
+    review fix)."""
+    monkeypatch.setenv("IMPORT_MAX_ROWS_FREE", "1")
     r, rec, enq = _commit(monkeypatch)
     assert r.status_code == 413
     body = r.json()["detail"]
     assert body["code"] == "import_rows_limit"
+    assert "your current limit is 1" in body["message"]
+    assert "support Shelfwright for the full 2,000-row limit" in body["message"]
     assert rec.jobs == []  # rejected before anything was written
+    assert enq == []
+
+
+def test_commit_413_over_supporter_cap_has_no_upsell_pitch(monkeypatch):
+    """#100 review fix: a supporter already at their own ceiling shouldn't be told to
+    'support Shelfwright' for a limit they already have."""
+    monkeypatch.setattr(imports_mod.tiers, "effective_tier", lambda session, user_id: "supporter")
+    monkeypatch.setenv("IMPORT_MAX_ROWS_SUPPORTER", "1")
+    r, rec, enq = _commit(monkeypatch)
+    assert r.status_code == 413
+    body = r.json()["detail"]
+    assert body["code"] == "import_rows_limit"
+    assert "your current limit is 1" in body["message"]
+    assert "support Shelfwright" not in body["message"]
+    assert rec.jobs == []
     assert enq == []
 
 

--- a/test/unit/test_budgets_allowed.py
+++ b/test/unit/test_budgets_allowed.py
@@ -1,0 +1,136 @@
+"""DB-free unit tests for the two fail-open budget wrappers in core/budgets.py —
+chat_turn_allowed and enrichment_allowed (#100 Task 1 review carry-forward). No Postgres:
+the limit-reached/under-limit branches use a db_manager stub whose get_session() yields a
+sentinel (never queried directly — the counting/tier functions that would touch it are
+monkeypatched), and the fail-open branch points db_manager at an unreachable host
+(mirrors test/unit/test_usage_recorder.py)."""
+
+import logging
+from contextlib import contextmanager
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+from agentic_librarian.db.session import DatabaseManager
+
+
+class _StubManager:
+    """A db_manager stand-in that never touches a real database — get_session() yields a
+    sentinel object. Only safe when every function that would query the session is
+    monkeypatched out by the test."""
+
+    @contextmanager
+    def get_session(self):
+        yield object()
+
+
+@pytest.fixture
+def stub_db_manager():
+    """Point budgets.db_manager at the DB-free stub, restoring the real one after."""
+    original = budgets.db_manager
+    budgets.set_db_manager(_StubManager())
+    yield
+    budgets.set_db_manager(original)
+
+
+@pytest.fixture
+def unreachable_db_manager():
+    """Point budgets.db_manager at a host that can never resolve, restoring after."""
+    original = budgets.db_manager
+    budgets.set_db_manager(DatabaseManager("postgresql://x:x@nohost-never-resolves:1/x"))
+    yield
+    budgets.set_db_manager(original)
+
+
+@pytest.mark.parametrize(
+    "used,limit,expect_allowed",
+    [
+        pytest.param(0, 2, True, id="under_limit"),
+        pytest.param(1, 2, True, id="just_under_limit"),
+        pytest.param(2, 2, False, id="at_limit"),
+        pytest.param(5, 2, False, id="over_limit"),
+    ],
+)
+def test_chat_turn_allowed_limit_branches(monkeypatch, stub_db_manager, used, limit, expect_allowed):
+    monkeypatch.setattr(tiers, "effective_tier", lambda session, user_id: "free")
+    monkeypatch.setattr(tiers, "chat_turns_per_day", lambda tier: limit)
+    monkeypatch.setattr(budgets, "chat_turns_today", lambda session, user_id: used)
+
+    allowed, message = budgets.chat_turn_allowed(uuid4())
+
+    assert allowed is expect_allowed
+    if expect_allowed:
+        assert message == ""
+    else:
+        assert str(limit) in message
+
+
+def test_chat_turn_allowed_fails_open_on_db_error(caplog, unreachable_db_manager):
+    with caplog.at_level(logging.WARNING):
+        allowed, message = budgets.chat_turn_allowed(uuid4())
+    assert allowed is True
+    assert message == ""
+    assert "chat budget check failed open" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "global_used,global_limit,user_used,user_limit,expect_allowed,message_contains",
+    [
+        pytest.param(0, 100, 0, 5, True, None, id="under_both_budgets"),
+        pytest.param(0, 100, 4, 5, True, None, id="under_per_user_budget"),
+        pytest.param(100, 100, 0, 5, False, "governor", id="global_governor_reached"),
+        pytest.param(0, 100, 5, 5, False, "tier", id="per_user_budget_reached"),
+    ],
+)
+def test_enrichment_allowed_limit_branches(
+    monkeypatch,
+    stub_db_manager,
+    global_used,
+    global_limit,
+    user_used,
+    user_limit,
+    expect_allowed,
+    message_contains,
+):
+    monkeypatch.setattr(tiers, "grounded_calls_per_day_global", lambda: global_limit)
+    monkeypatch.setattr(tiers, "grounded_calls_per_day", lambda tier: user_limit)
+    monkeypatch.setattr(tiers, "effective_tier", lambda session, user_id: "free")
+
+    def _fake_grounded_calls_today(session, user_id):
+        return global_used if user_id is None else user_used
+
+    monkeypatch.setattr(budgets, "grounded_calls_today", _fake_grounded_calls_today)
+
+    allowed, message = budgets.enrichment_allowed(uuid4())
+
+    assert allowed is expect_allowed
+    if expect_allowed:
+        assert message == ""
+    else:
+        assert message_contains in message
+
+
+def test_enrichment_allowed_under_limit_with_no_user_checks_only_governor(monkeypatch, stub_db_manager):
+    """user_id=None (pre-attribution tasks) must check only the global governor — the
+    per-user branch is never reached (tier lookup would need a real user row)."""
+    monkeypatch.setattr(tiers, "grounded_calls_per_day_global", lambda: 100)
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("per-user tier lookup must not run when user_id is None")
+
+    monkeypatch.setattr(tiers, "effective_tier", _fail_if_called)
+    monkeypatch.setattr(budgets, "grounded_calls_today", lambda session, user_id: 0)
+
+    allowed, message = budgets.enrichment_allowed(None)
+
+    assert allowed is True
+    assert message == ""
+
+
+def test_enrichment_allowed_fails_open_on_db_error(caplog, unreachable_db_manager):
+    with caplog.at_level(logging.WARNING):
+        allowed, message = budgets.enrichment_allowed(uuid4())
+    assert allowed is True
+    assert message == ""
+    assert "enrichment budget check failed open" in caplog.text

--- a/test/unit/test_byok_crypto.py
+++ b/test/unit/test_byok_crypto.py
@@ -1,0 +1,126 @@
+"""Unit tests for core/byok.py's KMS crypto seam (monetization arc 3/3). The fake-KMS-
+client pattern here mirrors enrichment/tasks.py's `_client()` lazy-import seam:
+`set_kms_client` injects a fake client so no real `google-cloud-kms` network call ever
+happens in these tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.core import byok
+
+KEY_NAME = "projects/p/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials"
+
+
+class _FakeKmsClient:
+    """Records encrypt/decrypt request dicts and returns SimpleNamespace responses
+    shaped like the real KMS EncryptResponse/DecryptResponse (.ciphertext/.plaintext)."""
+
+    def __init__(self, decrypt_error: Exception | None = None):
+        self.encrypt_calls: list[dict] = []
+        self.decrypt_calls: list[dict] = []
+        self._decrypt_error = decrypt_error
+
+    def encrypt(self, request):
+        self.encrypt_calls.append(request)
+        return SimpleNamespace(ciphertext=request["plaintext"][::-1])  # trivial reversible stand-in
+
+    def decrypt(self, request):
+        self.decrypt_calls.append(request)
+        if self._decrypt_error is not None:
+            raise self._decrypt_error
+        return SimpleNamespace(plaintext=request["ciphertext"][::-1])
+
+
+class _FakeCredentialSession:
+    """Stands in for a SQLAlchemy Session: session.get(Model, pk) returns whatever row
+    was configured, and records the (model, pk) it was called with."""
+
+    def __init__(self, row=None):
+        self._row = row
+        self.get_calls: list[tuple] = []
+
+    def get(self, model, pk):
+        self.get_calls.append((model, pk))
+        return self._row
+
+
+class _FakeCredentialRow:
+    def __init__(self, encrypted_key: bytes):
+        self.encrypted_key = encrypted_key
+
+
+@pytest.fixture(autouse=True)
+def _reset_kms_client():
+    """set_kms_client caches a module global — reset after every test so a fake client
+    never leaks into a later, unrelated test."""
+    yield
+    byok.set_kms_client(None)
+
+
+def test_encrypt_then_decrypt_round_trips(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    fake = _FakeKmsClient()
+    byok.set_kms_client(fake)
+
+    ciphertext = byok.encrypt_key("sk-real-secret")
+    assert ciphertext != b"sk-real-secret"  # never store the plaintext bytes verbatim
+    plaintext = byok.decrypt_key(ciphertext)
+
+    assert plaintext == "sk-real-secret"
+    assert fake.encrypt_calls[0]["name"] == KEY_NAME
+    assert fake.encrypt_calls[0]["plaintext"] == b"sk-real-secret"
+    assert fake.decrypt_calls[0]["name"] == KEY_NAME
+    assert fake.decrypt_calls[0]["ciphertext"] == ciphertext
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda: byok.encrypt_key("secret"), id="encrypt"),
+        pytest.param(lambda: byok.decrypt_key(b"some-ciphertext"), id="decrypt"),
+    ],
+)
+def test_kms_key_name_unset_raises_not_configured(monkeypatch, call):
+    monkeypatch.delenv("KMS_KEY_NAME", raising=False)
+    byok.set_kms_client(_FakeKmsClient())
+    with pytest.raises(byok.ByokNotConfigured):
+        call()
+
+
+def test_decrypt_kms_exception_raises_byok_key_error(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    with pytest.raises(byok.ByokKeyError):
+        byok.decrypt_key(b"some-ciphertext")
+
+
+def test_resolve_gemini_key_returns_none_when_no_row(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    user_id = uuid4()
+    session = _FakeCredentialSession(row=None)
+
+    assert byok.resolve_gemini_key(session, user_id) is None
+    assert session.get_calls[0][1] == (user_id, "gemini")
+
+
+def test_resolve_gemini_key_decrypts_existing_row(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient())
+    ciphertext = byok.encrypt_key("sk-real-secret")
+    session = _FakeCredentialSession(row=_FakeCredentialRow(encrypted_key=ciphertext))
+
+    assert byok.resolve_gemini_key(session, uuid4()) == "sk-real-secret"
+
+
+def test_resolve_gemini_key_propagates_decrypt_failure(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    byok.set_kms_client(_FakeKmsClient(decrypt_error=RuntimeError("kms unavailable")))
+    session = _FakeCredentialSession(row=_FakeCredentialRow(encrypted_key=b"ciphertext"))
+
+    with pytest.raises(byok.ByokKeyError):
+        byok.resolve_gemini_key(session, uuid4())

--- a/test/unit/test_chat_byok_routing.py
+++ b/test/unit/test_chat_byok_routing.py
@@ -1,0 +1,92 @@
+"""Chat mesh byok key routing (arc 3/3): the handler resolves the caller's Gemini key
+once per turn, BEFORE the StreamingResponse exists (SSE cannot carry an HTTP error status
+once streaming has started — the same reason the 429 quota check above it is pre-stream).
+A decrypt/config failure must surface as a 409, never a silent fallback to the app key."""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from agentic_librarian.api import main as api_main
+from agentic_librarian.api.auth import AuthenticatedUser
+from agentic_librarian.core import byok
+
+
+class _FakeCtx:
+    """Stand-in for transcript.ConversationContext — chat() only reads these two fields
+    before returning (the StreamingResponse body is never iterated by a direct call)."""
+
+    def __init__(self):
+        self.conversation_id = uuid4()
+        self.history = []
+
+
+@pytest.fixture(autouse=True)
+def _allow_chat_turn(monkeypatch):
+    """Bypass the (DB-backed) daily quota check — irrelevant to byok key resolution."""
+    monkeypatch.setattr(api_main.budgets, "chat_turn_allowed", lambda user_id: (True, None))
+
+
+@pytest.fixture
+def _user():
+    return AuthenticatedUser(id=uuid4(), email="reader@example.com")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(byok.ByokKeyError("decrypt failed"), id="decrypt_failure"),
+        pytest.param(byok.ByokNotConfigured("KMS_KEY_NAME unset"), id="kms_not_configured"),
+    ],
+)
+def test_chat_byok_resolution_failure_maps_to_409_pre_stream(monkeypatch, _user, error):
+    def _raise(user_id):
+        raise error
+
+    monkeypatch.setattr(api_main, "_resolve_byok_chat_key", _raise)
+
+    with pytest.raises(HTTPException) as exc_info:
+        api_main.chat(user=_user, message="hi")
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {
+        "code": "byok_key_error",
+        "message": "Your API key failed — check Settings.",
+    }
+
+
+def test_chat_without_byok_credential_behaves_as_before(monkeypatch, _user):
+    """No credential row -> (None, "app"), same as pre-arc-3 behavior: the handler
+    proceeds to build the streaming chat response instead of raising."""
+    monkeypatch.setattr(api_main, "_resolve_byok_chat_key", lambda user_id: (None, "app"))
+    monkeypatch.setattr(api_main.transcript, "get_or_create_active_conversation", lambda: _FakeCtx())
+
+    response = api_main.chat(user=_user, message="hi")
+
+    assert isinstance(response, StreamingResponse)
+
+
+def test_chat_with_byok_credential_threads_key_into_the_sync_opener(monkeypatch, _user):
+    """A resolved byok key reaches _SyncOpener (and, from there, astart_conversation) —
+    verified via the conversation factory sse_turn would call, not by draining the
+    stream (draining requires the async event loop; that's covered by the runtime and
+    integration tests)."""
+    monkeypatch.setattr(api_main, "_resolve_byok_chat_key", lambda user_id: ("user-secret-key", "byok"))
+    monkeypatch.setattr(api_main.transcript, "get_or_create_active_conversation", lambda: _FakeCtx())
+
+    captured = {}
+    real_sse_turn = api_main.stream.sse_turn
+
+    def _capturing_sse_turn(*, message, conversation, on_persist, user_id):
+        opener = conversation(on_event=None)
+        captured["api_key"] = opener._api_key
+        captured["key_source"] = opener._key_source
+        return real_sse_turn(message=message, conversation=conversation, on_persist=on_persist, user_id=user_id)
+
+    monkeypatch.setattr(api_main.stream, "sse_turn", _capturing_sse_turn)
+
+    api_main.chat(user=_user, message="hi")
+
+    assert captured == {"api_key": "user-secret-key", "key_source": "byok"}

--- a/test/unit/test_chat_enrich_reroute.py
+++ b/test/unit/test_chat_enrich_reroute.py
@@ -4,10 +4,14 @@ pass; the user-facing message says the Librarian is still investigating."""
 import uuid
 from unittest.mock import patch
 
+from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user
 from agentic_librarian.mcp import server as mcp_server
 
 
 def test_enrich_tool_routes_through_two_phase_and_enqueues():
+    # test/conftest.py's autouse _default_user_context fixture puts every test in
+    # as_user(DEFAULT_USER_ID) unless overridden -> that's the ambient attribution here
+    # (see test_enrich_tool_enqueue_attributed_to_ambient_user below for an explicit user).
     wid = uuid.uuid4()
     with (
         patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)) as fast,
@@ -16,7 +20,24 @@ def test_enrich_tool_routes_through_two_phase_and_enqueues():
         result = mcp_server.enrich_and_persist_work(title="Dune", author="Frank Herbert")
     assert result == str(wid)
     fast.assert_called_once()
-    enq.assert_called_once_with(str(wid))
+    enq.assert_called_once_with(str(wid), user_id=str(DEFAULT_USER_ID))
+
+
+def test_enrich_tool_enqueue_attributed_to_ambient_user():
+    """#100: enrich_and_persist_work is a chat tool that runs inside the turn's
+    as_user(...) scope (chat/stream.py sets it around the driver; make_async_tool's
+    asyncio.to_thread copies contextvars) — the deep-enrichment enqueue must carry that
+    user's id so the eventual /internal/enrich metering bills the requester, not nobody."""
+    wid = uuid.uuid4()
+    uid = uuid.uuid4()
+    with (
+        patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)),
+        patch.object(mcp_server, "enqueue_enrichment", return_value=True) as enq,
+        as_user(uid),
+    ):
+        result = mcp_server.enrich_and_persist_work(title="Dune", author="Frank Herbert")
+    assert result == str(wid)
+    enq.assert_called_once_with(str(wid), user_id=str(uid))
 
 
 def test_enrich_tool_dedup_hit_does_not_reenqueue():
@@ -59,6 +80,21 @@ def test_add_book_enqueue_failure_omits_background_note(monkeypatch):
         msg = mcp_server.add_book_to_history(title="Dune", author="Frank Herbert")
     assert "background" not in msg.lower()
     assert "Added" in msg
+
+
+def test_add_book_enqueue_attributed_to_ambient_user():
+    """#100: same attribution guarantee as enrich_and_persist_work, for the other
+    enqueue_enrichment call site (add_book_to_history)."""
+    wid = uuid.uuid4()
+    uid = uuid.uuid4()
+    with (
+        patch.object(mcp_server.two_phase, "enrich_fast", return_value=(wid, True)),
+        patch.object(mcp_server, "enqueue_enrichment", return_value=True) as enq,
+        patch.object(mcp_server.two_phase, "add_read_event", return_value={"read_number": 1, "already_logged": False}),
+        as_user(uid),
+    ):
+        mcp_server.add_book_to_history(title="Dune", author="Frank Herbert")
+    enq.assert_called_once_with(str(wid), user_id=str(uid))
 
 
 def test_add_book_existing_work_has_no_background_note(monkeypatch):

--- a/test/unit/test_credentials_api.py
+++ b/test/unit/test_credentials_api.py
@@ -1,0 +1,123 @@
+"""Unit tests for api/credentials.py's DB-free guards (monetization arc 3/3, BYOK):
+shape validation, live-validation-seam failure mapping, and the byok_unavailable 503
+when KMS_KEY_NAME is unset. Mirrors test_kofi_webhook.py's tiny-app-with-just-the-router
+pattern, plus test_api_history.py's get_current_user dependency-override seam."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import credentials
+from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
+from agentic_librarian.api.credentials import router
+from agentic_librarian.core import byok
+
+USER = AuthenticatedUser(id=uuid4(), email="reader@example.com")
+KEY_NAME = "projects/p/locations/us-central1/keyRings/librarian/cryptoKeys/byok-credentials"
+
+
+class _FakeKmsClient:
+    def __init__(self):
+        self.encrypt_calls: list[dict] = []
+
+    def encrypt(self, request):
+        self.encrypt_calls.append(request)
+        return SimpleNamespace(ciphertext=b"ciphertext-bytes")
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: USER
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_seams():
+    """db_manager and the KMS client are module/global caches mutated by tests below —
+    reset both after every test so nothing leaks (kofi test's _reset_db_manager pattern,
+    extended for byok's client seam)."""
+    original_db = credentials.db_manager
+    yield
+    credentials.set_db_manager(original_db)
+    byok.set_kms_client(None)
+
+
+def _mock_db(get_return=None) -> MagicMock:
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_db.get_session.return_value.__enter__.return_value = mock_session
+    mock_session.get.return_value = get_return
+    return mock_db
+
+
+@pytest.mark.parametrize(
+    "api_key",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param("x" * 201, id="oversize"),
+    ],
+)
+def test_put_credentials_shape_guard_is_422(api_key):
+    resp = _client().put("/me/credentials", json={"api_key": api_key})
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "invalid_api_key"
+
+
+def test_put_credentials_failed_live_validation_is_422(monkeypatch):
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: False)
+    resp = _client().put("/me/credentials", json={"api_key": "AIzaLooksLikeAKeyButIsNot"})
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "invalid_api_key"
+
+
+def test_put_credentials_kms_unset_is_503(monkeypatch):
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: True)
+    monkeypatch.delenv("KMS_KEY_NAME", raising=False)
+    resp = _client().put("/me/credentials", json={"api_key": "AIzaLooksLikeARealKey"})
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["code"] == "byok_unavailable"
+
+
+def test_put_credentials_success_stores_ciphertext_never_plaintext(monkeypatch):
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: True)
+    fake_kms = _FakeKmsClient()
+    byok.set_kms_client(fake_kms)
+    mock_db = _mock_db(get_return=None)  # no existing row -> insert path
+    credentials.set_db_manager(mock_db)
+
+    plaintext = "AIzaSomeRealSecretLookingKey"
+    resp = _client().put("/me/credentials", json={"api_key": plaintext})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": True}
+    added_row = mock_db.get_session.return_value.__enter__.return_value.add.call_args[0][0]
+    assert added_row.vendor == "gemini"
+    assert added_row.encrypted_key == b"ciphertext-bytes"
+    assert added_row.kms_key_name == KEY_NAME
+    # The plaintext key must never end up inside anything handed to session.add().
+    assert plaintext.encode() not in added_row.encrypted_key
+
+
+def test_get_credentials_unconfigured_is_false():
+    credentials.set_db_manager(_mock_db(get_return=None))
+    resp = _client().get("/me/credentials")
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": False, "updated_at": None}
+
+
+def test_delete_credentials_is_idempotent_when_no_row_exists():
+    mock_db = _mock_db(get_return=None)
+    credentials.set_db_manager(mock_db)
+    resp = _client().delete("/me/credentials")
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": False}
+    mock_db.get_session.return_value.__enter__.return_value.delete.assert_not_called()

--- a/test/unit/test_credentials_api.py
+++ b/test/unit/test_credentials_api.py
@@ -1,10 +1,14 @@
 """Unit tests for api/credentials.py's DB-free guards (monetization arc 3/3, BYOK):
-shape validation, live-validation-seam failure mapping, and the byok_unavailable 503
-when KMS_KEY_NAME is unset. Mirrors test_kofi_webhook.py's tiny-app-with-just-the-router
-pattern, plus test_api_history.py's get_current_user dependency-override seam."""
+shape validation, live-validation-seam failure mapping, the byok_unavailable 503 when
+KMS_KEY_NAME is unset or KMS itself fails, the upsert's update branch, and the
+concurrent-first-PUT insert race (IntegrityError -> re-query -> update, per
+get_or_create.py's SAVEPOINT pattern). Mirrors test_kofi_webhook.py's
+tiny-app-with-just-the-router pattern, plus test_api_history.py's get_current_user
+dependency-override seam."""
 
 from __future__ import annotations
 
+import contextlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -12,6 +16,7 @@ from uuid import uuid4
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 
 from agentic_librarian.api import credentials
 from agentic_librarian.api.auth import AuthenticatedUser, get_current_user
@@ -29,6 +34,51 @@ class _FakeKmsClient:
     def encrypt(self, request):
         self.encrypt_calls.append(request)
         return SimpleNamespace(ciphertext=b"ciphertext-bytes")
+
+
+class _RaisingKmsClient:
+    """Simulates a KMS-side outage (not a config problem) at encrypt time."""
+
+    def encrypt(self, request):
+        raise RuntimeError("kms unavailable")
+
+
+class _RacingSession:
+    """First flush() (inside the nested first-insert attempt) raises IntegrityError,
+    simulating a concurrent PUT that won the (user_id, vendor) primary-key race.
+    Every later flush() succeeds. get() returns None until the race has "happened"
+    (mirroring the real DB: nothing to find before the concurrent writer commits),
+    then returns the row the concurrent writer inserted."""
+
+    def __init__(self, existing_row):
+        self._existing_row = existing_row
+        self.flush_calls = 0
+        self.get_calls: list[tuple] = []
+        self.add_calls: list[object] = []
+
+    def get(self, model, pk):
+        self.get_calls.append((model, pk))
+        return None if self.flush_calls == 0 else self._existing_row
+
+    def add(self, obj):
+        self.add_calls.append(obj)
+
+    def begin_nested(self):
+        return contextlib.nullcontext()
+
+    def flush(self):
+        self.flush_calls += 1
+        if self.flush_calls == 1:
+            raise IntegrityError("insert", {}, Exception("duplicate key"))
+
+
+class _FakeDbManager:
+    def __init__(self, session):
+        self._session = session
+
+    @contextlib.contextmanager
+    def get_session(self):
+        yield self._session
 
 
 def _client() -> TestClient:
@@ -105,6 +155,65 @@ def test_put_credentials_success_stores_ciphertext_never_plaintext(monkeypatch):
     assert added_row.kms_key_name == KEY_NAME
     # The plaintext key must never end up inside anything handed to session.add().
     assert plaintext.encode() not in added_row.encrypted_key
+
+
+def test_put_credentials_kms_encrypt_failure_is_503(monkeypatch):
+    """A KMS outage at encrypt time (not a config problem — KMS_KEY_NAME IS set) must
+    map to the same byok_unavailable 503 shape, not a raw 500."""
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: True)
+    byok.set_kms_client(_RaisingKmsClient())
+
+    resp = _client().put("/me/credentials", json={"api_key": "AIzaSomeRealLookingKey"})
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == {
+        "code": "byok_unavailable",
+        "message": "Key storage is temporarily unavailable — try again.",
+    }
+
+
+def test_put_credentials_update_path_mutates_existing_row_not_add(monkeypatch):
+    """A re-PUT (row already exists) must mutate the existing row in place, never call
+    session.add() a second time."""
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: True)
+    byok.set_kms_client(_FakeKmsClient())
+
+    existing_row = MagicMock()
+    mock_db = _mock_db(get_return=existing_row)
+    credentials.set_db_manager(mock_db)
+
+    resp = _client().put("/me/credentials", json={"api_key": "AIzaUpdatedReplacementKey"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": True}
+    session = mock_db.get_session.return_value.__enter__.return_value
+    session.add.assert_not_called()
+    assert existing_row.encrypted_key == b"ciphertext-bytes"
+    assert existing_row.kms_key_name == KEY_NAME
+
+
+def test_put_credentials_concurrent_insert_race_falls_through_to_update(monkeypatch):
+    """Two concurrent first-time PUTs: this request's insert loses the (user_id, vendor)
+    primary-key race (IntegrityError on flush) -> re-query finds the winner's row ->
+    fall through to the update path with THIS request's (newer) ciphertext, and still
+    respond 200 rather than a spurious 500."""
+    monkeypatch.setenv("KMS_KEY_NAME", KEY_NAME)
+    monkeypatch.setattr(credentials, "_validate_key", lambda k: True)
+    byok.set_kms_client(_FakeKmsClient())
+
+    existing_row = MagicMock()
+    fake_session = _RacingSession(existing_row)
+    credentials.set_db_manager(_FakeDbManager(fake_session))
+
+    resp = _client().put("/me/credentials", json={"api_key": "AIzaConcurrentWinnerKey"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"configured": True}
+    assert existing_row.encrypted_key == b"ciphertext-bytes"
+    assert existing_row.kms_key_name == KEY_NAME
+    assert fake_session.flush_calls == 2  # the losing insert attempt, then the recovery update
 
 
 def test_get_credentials_unconfigured_is_false():

--- a/test/unit/test_db_pool_consolidation.py
+++ b/test/unit/test_db_pool_consolidation.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import analysis as analysis_mod
 from agentic_librarian.api import auth as auth_mod
+from agentic_librarian.api import credentials as credentials_mod
 from agentic_librarian.api import kofi as kofi_mod
 from agentic_librarian.api import main as main_mod
 from agentic_librarian.api import recommendations as recommendations_mod
@@ -26,6 +27,7 @@ def _restore_db_managers():
         analysis_mod.db_manager,
         budgets_mod.db_manager,
         kofi_mod.db_manager,
+        credentials_mod.db_manager,
     )
     yield
     (
@@ -37,6 +39,7 @@ def _restore_db_managers():
         analysis_mod.db_manager,
         budgets_mod.db_manager,
         kofi_mod.db_manager,
+        credentials_mod.db_manager,
     ) = saved
 
 
@@ -53,3 +56,4 @@ def test_startup_consolidates_api_pools(_restore_db_managers):
         assert analysis_mod.db_manager is shared
         assert budgets_mod.db_manager is shared
         assert kofi_mod.db_manager is shared
+        assert credentials_mod.db_manager is shared

--- a/test/unit/test_db_pool_consolidation.py
+++ b/test/unit/test_db_pool_consolidation.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 
 from agentic_librarian.api import analysis as analysis_mod
 from agentic_librarian.api import auth as auth_mod
+from agentic_librarian.api import kofi as kofi_mod
 from agentic_librarian.api import main as main_mod
 from agentic_librarian.api import recommendations as recommendations_mod
 from agentic_librarian.chat import transcript as transcript_mod
@@ -24,6 +25,7 @@ def _restore_db_managers():
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
         budgets_mod.db_manager,
+        kofi_mod.db_manager,
     )
     yield
     (
@@ -34,6 +36,7 @@ def _restore_db_managers():
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
         budgets_mod.db_manager,
+        kofi_mod.db_manager,
     ) = saved
 
 
@@ -49,3 +52,4 @@ def test_startup_consolidates_api_pools(_restore_db_managers):
         assert recommendations_mod.db_manager is shared
         assert analysis_mod.db_manager is shared
         assert budgets_mod.db_manager is shared
+        assert kofi_mod.db_manager is shared

--- a/test/unit/test_db_pool_consolidation.py
+++ b/test/unit/test_db_pool_consolidation.py
@@ -9,6 +9,7 @@ from agentic_librarian.api import auth as auth_mod
 from agentic_librarian.api import main as main_mod
 from agentic_librarian.api import recommendations as recommendations_mod
 from agentic_librarian.chat import transcript as transcript_mod
+from agentic_librarian.core import budgets as budgets_mod
 from agentic_librarian.core import usage as usage_mod
 
 
@@ -22,6 +23,7 @@ def _restore_db_managers():
         usage_mod.db_manager,
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
+        budgets_mod.db_manager,
     )
     yield
     (
@@ -31,6 +33,7 @@ def _restore_db_managers():
         usage_mod.db_manager,
         recommendations_mod.db_manager,
         analysis_mod.db_manager,
+        budgets_mod.db_manager,
     ) = saved
 
 
@@ -45,3 +48,4 @@ def test_startup_consolidates_api_pools(_restore_db_managers):
         assert usage_mod.db_manager is shared
         assert recommendations_mod.db_manager is shared
         assert analysis_mod.db_manager is shared
+        assert budgets_mod.db_manager is shared

--- a/test/unit/test_edition_completion.py
+++ b/test/unit/test_edition_completion.py
@@ -48,7 +48,7 @@ def _wire(monkeypatch, *, work, edition, enriched, state=None):
     monkeypatch.setattr(two_phase, "db_manager", fake_manager)
     scout_mgr = MagicMock()
     scout_mgr.enrich.return_value = enriched
-    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda *a, **k: scout_mgr)
     return state, scout_mgr
 
 
@@ -91,7 +91,7 @@ def test_done_merges_scouted_values_for_audiobook(monkeypatch):
     monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
     style_scout = MagicMock()
     style_scout.scout_narrator_style.return_value = {"pacing": "brisk"}
-    monkeypatch.setattr(two_phase, "StyleScout", lambda: style_scout)
+    monkeypatch.setattr(two_phase, "StyleScout", lambda *a, **k: style_scout)
     merged = {}
 
     def fake_merge(session, **kwargs):
@@ -124,7 +124,7 @@ def test_style_scout_failure_degrades_to_no_styles(monkeypatch):
     monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
     broken = MagicMock()
     broken.scout_narrator_style.side_effect = RuntimeError("LLM down")
-    monkeypatch.setattr(two_phase, "StyleScout", lambda: broken)
+    monkeypatch.setattr(two_phase, "StyleScout", lambda *a, **k: broken)
     merged = {}
     monkeypatch.setattr(
         two_phase, "merge_edition_and_narrators", lambda session, **kw: merged.update(kw) or MagicMock()
@@ -155,7 +155,7 @@ def test_work_deleted_mid_pass_returns_missing(monkeypatch):
     monkeypatch.setattr(two_phase, "db_manager", fake_manager)
     scout_mgr = MagicMock()
     scout_mgr.enrich.return_value = enriched
-    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda *a, **k: scout_mgr)
     assert two_phase.complete_edition(uuid4(), "ebook") == "missing"
 
 
@@ -183,7 +183,7 @@ def test_edition_deleted_mid_pass_returns_missing_without_merge(monkeypatch):
     monkeypatch.setattr(two_phase, "db_manager", fake_manager)
     scout_mgr = MagicMock()
     scout_mgr.enrich.return_value = enriched
-    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda: scout_mgr)
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", lambda *a, **k: scout_mgr)
     merge_calls = []
     monkeypatch.setattr(
         two_phase, "merge_edition_and_narrators", lambda session, **kw: merge_calls.append(kw) or MagicMock()

--- a/test/unit/test_enqueue_enrichment.py
+++ b/test/unit/test_enqueue_enrichment.py
@@ -1,3 +1,7 @@
+from datetime import UTC, datetime
+
+import pytest
+
 from agentic_librarian.enrichment import tasks
 
 
@@ -68,3 +72,91 @@ def test_enqueue_edition_completion_skips_when_not_configured(monkeypatch):
 
     assert tasks.enqueue_edition_completion("abc", "audiobook") is False
     assert called["n"] == 0
+
+
+@pytest.mark.parametrize(
+    "user_id,expected_url",
+    [
+        (
+            "22222222-2222-4222-8222-222222222222",
+            "https://librarian.example.run.app/internal/enrich/"
+            "11111111-1111-4111-8111-111111111111?user_id=22222222-2222-4222-8222-222222222222",
+        ),
+        (None, "https://librarian.example.run.app/internal/enrich/11111111-1111-4111-8111-111111111111"),
+    ],
+)
+def test_enqueue_enrichment_appends_user_id_query_when_given(monkeypatch, user_id, expected_url):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert tasks.enqueue_enrichment("11111111-1111-4111-8111-111111111111", user_id=user_id) is True
+
+    _parent, task = fake.created[0]
+    http = task["http_request"]
+    assert http["url"] == expected_url
+    # Audience is the bare path url regardless of user_id — a per-user audience would never
+    # match the receiver's single fixed ENRICH_OIDC_AUDIENCE.
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/enrich/11111111-1111-4111-8111-111111111111"
+    )
+
+
+@pytest.mark.parametrize(
+    "user_id,expected_url",
+    [
+        (
+            "22222222-2222-4222-8222-222222222222",
+            "https://librarian.example.run.app/internal/complete-edition/"
+            "11111111-1111-4111-8111-111111111111?format=audiobook"
+            "&user_id=22222222-2222-4222-8222-222222222222",
+        ),
+        (
+            None,
+            "https://librarian.example.run.app/internal/complete-edition/"
+            "11111111-1111-4111-8111-111111111111?format=audiobook",
+        ),
+    ],
+)
+def test_enqueue_edition_completion_appends_user_id_query_when_given(monkeypatch, user_id, expected_url):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+
+    assert (
+        tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook", user_id=user_id) is True
+    )
+
+    _parent, task = fake.created[0]
+    http = task["http_request"]
+    assert http["url"] == expected_url
+    assert http["oidc_token"]["audience"] == (
+        "https://librarian.example.run.app/internal/complete-edition/11111111-1111-4111-8111-111111111111"
+    )
+
+
+def test_enqueue_enrichment_sets_schedule_time_on_task(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+    when = datetime(2026, 8, 1, tzinfo=UTC)
+
+    assert tasks.enqueue_enrichment("11111111-1111-4111-8111-111111111111", schedule_time=when) is True
+
+    _parent, task = fake.created[0]
+    assert task["schedule_time"] == when
+
+
+def test_enqueue_edition_completion_sets_schedule_time_on_task(monkeypatch):
+    _set_env(monkeypatch)
+    fake = _FakeClient()
+    monkeypatch.setattr(tasks, "_client", lambda: fake)
+    when = datetime(2026, 8, 1, tzinfo=UTC)
+
+    assert (
+        tasks.enqueue_edition_completion("11111111-1111-4111-8111-111111111111", "audiobook", schedule_time=when)
+        is True
+    )
+
+    _parent, task = fake.created[0]
+    assert task["schedule_time"] == when

--- a/test/unit/test_entitlements.py
+++ b/test/unit/test_entitlements.py
@@ -1,0 +1,57 @@
+"""Monetization arc 2/3: entitlement classification is pure and DB-free."""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from agentic_librarian.core import entitlements
+
+NOW = datetime(2026, 7, 26, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "kofi_type,is_sub,tier_name,amount,expected",
+    [
+        ("Subscription", True, "Supporter", Decimal("3.00"), "monthly"),
+        ("Subscription", True, None, Decimal("3.00"), "monthly"),
+        ("Shop Order", False, "Annual", Decimal("25.00"), "annual"),
+        ("Shop Order", False, "ANNUAL", Decimal("25.00"), "annual"),  # case-insensitive
+        # "Annual Supporter" != "annual" under exact case-folded match, so tier_name does
+        # NOT win here; falls through to is_sub=True -> monthly. See NOTE in task-1-brief.md.
+        ("Subscription", True, "Annual Supporter", Decimal("25.00"), "monthly"),
+        ("Donation", False, None, Decimal("25.00"), "annual"),  # one-off >= threshold
+        ("Donation", False, None, Decimal("30.00"), "annual"),
+        ("Donation", False, None, Decimal("24.99"), "tip"),
+        ("Donation", False, None, Decimal("3.00"), "tip"),
+        ("Commission", False, None, Decimal("10.00"), "tip"),
+    ],
+)
+def test_classify_defaults(monkeypatch, kofi_type, is_sub, tier_name, amount, expected):
+    monkeypatch.delenv("KOFI_ANNUAL_TIER_NAMES", raising=False)
+    monkeypatch.delenv("KOFI_ANNUAL_MIN_AMOUNT", raising=False)
+    assert entitlements.classify(kofi_type, is_sub, tier_name, amount) == expected
+
+
+def test_classify_env_tier_names(monkeypatch):
+    monkeypatch.setenv("KOFI_ANNUAL_TIER_NAMES", "yearly, gold ")
+    assert entitlements.classify("Shop Order", False, "Gold", Decimal("25.00")) == "annual"
+    assert entitlements.classify("Shop Order", False, "Annual", Decimal("10.00")) == "tip"
+
+
+@pytest.mark.parametrize("kind,days", [("monthly", 33), ("annual", 370), ("tip", 0)])
+def test_grant_days(kind, days):
+    assert entitlements.grant_days(kind) == days
+
+
+@pytest.mark.parametrize(
+    "current,days,expected",
+    [
+        (None, 33, NOW + timedelta(days=33)),  # first sub
+        (NOW - timedelta(days=10), 33, NOW + timedelta(days=33)),  # lapsed: restart from now
+        (NOW + timedelta(days=5), 33, NOW + timedelta(days=38)),  # active: stack
+        (NOW + timedelta(days=100), 370, NOW + timedelta(days=470)),  # annual stacks too
+    ],
+)
+def test_extend(current, days, expected):
+    assert entitlements.extend(current, days, now=NOW) == expected

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -5,6 +5,9 @@ tiny-app-with-just-the-router pattern — no real DB, no real app lifespan."""
 
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -27,6 +30,39 @@ class _RaisingSessionManager:
 
     def get_session(self):
         raise RuntimeError("db unavailable")
+
+
+class _FakeQuery:
+    """Minimal chainable stand-in for a SQLAlchemy Query: every filter() no-ops, first()
+    always reports 'nothing found' (no duplicate row, no matched user)."""
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+
+class _FakeSession:
+    def query(self, *args, **kwargs):
+        return _FakeQuery()
+
+    def add(self, obj):
+        pass
+
+    def flush(self):
+        pass
+
+
+class _WorkingSessionManager:
+    """Stands in for DatabaseManager: get_session() yields a working fake session (the
+    _RaisingSessionManager's pattern inverted) so a handler run can reach a 2xx without a
+    real DB — used for the non-finite-amount guard, which must survive all the way to the
+    DB-write branch rather than crash in entitlements.classify() first."""
+
+    @contextmanager
+    def get_session(self):
+        yield _FakeSession()
 
 
 def _client() -> TestClient:
@@ -74,3 +110,38 @@ def test_db_layer_error_after_valid_token_is_500(monkeypatch):
     payload = f'{{"verification_token": "{VALID_TOKEN}", "kofi_transaction_id": "t1"}}'
     resp = _client().post("/webhooks/kofi", data={"data": payload})
     assert resp.status_code == 500
+
+
+@pytest.mark.parametrize(
+    "amount_str",
+    [
+        pytest.param("nan", id="amount-nan"),
+        pytest.param("-nan", id="amount-negative-nan"),
+        pytest.param("Infinity", id="amount-infinity"),
+    ],
+)
+def test_non_finite_amount_does_not_crash_classify(monkeypatch, amount_str):
+    """Decimal("nan")/Decimal("-nan")/Decimal("Infinity") all parse WITHOUT raising
+    InvalidOperation, so the handler's own try/except around Decimal(...) never catches
+    them. Without an explicit is_finite() guard, entitlements.classify()'s
+    `amount >= threshold` ordering comparison raises decimal.InvalidOperation on a
+    non-finite operand -> an uncaught 500 BEFORE the event is durably stored, and since
+    Ko-fi retries non-2xx responses with the SAME payload, that crash would repeat
+    forever. Uses a working fake session (not the 500 test's raising one) so the request
+    reaches the DB-write branch and actually returns 2xx."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_WorkingSessionManager())
+    payload = json.dumps(
+        {
+            "verification_token": VALID_TOKEN,
+            "kofi_transaction_id": f"txn-{amount_str}",
+            "amount": amount_str,
+            # No email -> no User lookup needed from the fake session; the payment still
+            # goes through the add()/flush() write path and lands on "unmatched".
+        }
+    )
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 200
+    # Non-finite amount is clamped to 0 -> classifies as a tip (amount 0 < the annual
+    # threshold, no tier_name, not a subscription payment).
+    assert resp.json() == {"status": "unmatched", "kind": "tip"}

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -1,0 +1,76 @@
+"""Unit tests for the Ko-fi webhook's DB-free guards (monetization arc 2/3): malformed
+payload, verification-token fail-closed posture, and the 500-on-DB-error path Ko-fi's
+retry logic relies on for idempotent recovery. Mirrors test_firebase_auth_proxy.py's
+tiny-app-with-just-the-router pattern — no real DB, no real app lifespan."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentic_librarian.api import kofi
+from agentic_librarian.api.kofi import router
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_manager():
+    """Reset the module-global db_manager after each test so a stub never leaks."""
+    original = kofi.db_manager
+    yield
+    kofi.set_db_manager(original)
+
+
+class _RaisingSessionManager:
+    """Stands in for DatabaseManager: get_session() raises before yielding, simulating
+    a DB outage — the webhook must surface it as 500 so Ko-fi retries."""
+
+    def get_session(self):
+        raise RuntimeError("db unavailable")
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+VALID_TOKEN = "the-shared-secret"
+
+
+@pytest.mark.parametrize(
+    "form,expected_status",
+    [
+        pytest.param({}, 422, id="no-data-field-is-422-fastapi-validation"),
+        pytest.param({"data": "not json"}, 400, id="data-not-json-is-400"),
+        pytest.param({"data": "[1, 2, 3]"}, 400, id="data-not-an-object-is-400"),
+    ],
+)
+def test_malformed_payload_guards(monkeypatch, form, expected_status):
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    resp = _client().post("/webhooks/kofi", data=form)
+    assert resp.status_code == expected_status
+
+
+def test_verification_token_unset_fails_closed_even_with_token_in_payload(monkeypatch):
+    monkeypatch.delenv("KOFI_VERIFICATION_TOKEN", raising=False)
+    payload = '{"verification_token": "anything", "kofi_transaction_id": "t1"}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 403
+
+
+def test_verification_token_mismatch_is_403(monkeypatch):
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    payload = '{"verification_token": "wrong-token", "kofi_transaction_id": "t1"}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 403
+
+
+def test_db_layer_error_after_valid_token_is_500(monkeypatch):
+    """Token OK but the DB layer raises -> 500, not a swallowed/misreported error. Ko-fi
+    retries non-2xx and kofi_transaction_id idempotency makes the retry safe."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_RaisingSessionManager())
+    payload = f'{{"verification_token": "{VALID_TOKEN}", "kofi_transaction_id": "t1"}}'
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 500

--- a/test/unit/test_kofi_webhook.py
+++ b/test/unit/test_kofi_webhook.py
@@ -145,3 +145,31 @@ def test_non_finite_amount_does_not_crash_classify(monkeypatch, amount_str):
     # Non-finite amount is clamped to 0 -> classifies as a tip (amount 0 < the annual
     # threshold, no tier_name, not a subscription payment).
     assert resp.json() == {"status": "unmatched", "kind": "tip"}
+
+
+@pytest.mark.parametrize(
+    "raw_tier,expected_kind",
+    [
+        pytest.param(123, "tip", id="tier-name-int"),
+        pytest.param(["annual"], "tip", id="tier-name-list"),
+        pytest.param("Annual", "annual", id="tier-name-string-still-classifies"),
+    ],
+)
+def test_non_string_tier_name_does_not_crash_classify(monkeypatch, raw_tier, expected_kind):
+    """Same failure class as the non-finite amount: an attacker-shaped non-string
+    tier_name would crash classify()'s .strip().casefold() before the event is
+    persisted -> deterministic 500 retried forever. The handler str-coerces it like
+    the sibling fields (a coerced "123" simply matches no annual tier name)."""
+    monkeypatch.setenv("KOFI_VERIFICATION_TOKEN", VALID_TOKEN)
+    kofi.set_db_manager(_WorkingSessionManager())
+    payload = json.dumps(
+        {
+            "verification_token": VALID_TOKEN,
+            "kofi_transaction_id": f"txn-tier-{expected_kind}-{type(raw_tier).__name__}",
+            "amount": "5.00",
+            "tier_name": raw_tier,
+        }
+    )
+    resp = _client().post("/webhooks/kofi", data={"data": payload})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "unmatched", "kind": expected_kind}

--- a/test/unit/test_scout_factories.py
+++ b/test/unit/test_scout_factories.py
@@ -1,3 +1,7 @@
+from unittest.mock import MagicMock
+
+import pytest
+
 from agentic_librarian.orchestration.definitions import (
     create_completion_scout_manager,
     create_deep_scout_manager,
@@ -40,3 +44,62 @@ def test_completion_manager_composition(monkeypatch):
         AudiobookScout,
         DirectKnowledgeScout,
     ]
+
+
+@pytest.fixture
+def _no_network_gemini_client(monkeypatch):
+    """GeminiGroundedLLM's __init__ builds a real genai.Client — stub it so constructing
+    LLM scouts in these threading tests never attempts a network call. Also pins
+    AGENT_BACKEND to the default Gemini provider regardless of the ambient env."""
+    from agentic_librarian.scouts import grounded_llm
+
+    monkeypatch.setattr(grounded_llm.genai, "Client", lambda *a, **k: MagicMock())
+    monkeypatch.delenv("AGENT_BACKEND", raising=False)
+
+
+@pytest.mark.parametrize(
+    ("factory", "llm_scout_types"),
+    [
+        pytest.param(
+            create_deep_scout_manager, {AudiobookScout, DirectKnowledgeScout, StyleScout, LLMTropeScout}, id="deep"
+        ),
+        pytest.param(create_completion_scout_manager, {AudiobookScout, DirectKnowledgeScout}, id="completion"),
+    ],
+)
+def test_factory_threads_byok_key_into_every_llm_scout(
+    monkeypatch, _no_network_gemini_client, factory, llm_scout_types
+):
+    """arc 3/3: a byok user's api_key/key_source must reach every LLM scout's underlying
+    GeminiGroundedLLM (so its usage rows record key_source='byok'), never the non-LLM
+    API scouts (Hardcover/GoogleBooks, which use their own unrelated keys)."""
+    monkeypatch.delenv("GOOGLE_SEARCH_API_KEY", raising=False)
+    manager = factory("byok-users-gemini-key", "byok")
+
+    seen_llm_scouts = [s for s, _priority in manager.scouts if type(s) in llm_scout_types]
+    assert len(seen_llm_scouts) == len(llm_scout_types)
+    for scout in seen_llm_scouts:
+        assert scout.api_key == "byok-users-gemini-key"
+        assert scout._llm.api_key == "byok-users-gemini-key"
+        assert scout._llm.key_source == "byok"
+
+    non_llm_scouts = [s for s, _priority in manager.scouts if type(s) not in llm_scout_types]
+    for scout in non_llm_scouts:
+        assert type(scout) in (HardcoverScout, GoogleBooksScout)
+        # HardcoverScout/GoogleBooksScout read their OWN env-keyed credentials — the byok
+        # Gemini key must never leak into them.
+        assert scout.api_key != "byok-users-gemini-key"
+
+
+def test_factory_defaults_are_app_keyed(monkeypatch, _no_network_gemini_client):
+    """No api_key/key_source passed -> every LLM scout stays on the app key, byte-identical
+    to pre-BYOK behavior."""
+    monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "dummy-key-for-construction")
+    manager = create_deep_scout_manager()
+    llm_scouts = [
+        s
+        for s, _priority in manager.scouts
+        if isinstance(s, AudiobookScout | DirectKnowledgeScout | StyleScout | LLMTropeScout)
+    ]
+    assert len(llm_scouts) == 4
+    for scout in llm_scouts:
+        assert scout._llm.key_source == "app"

--- a/test/unit/test_scout_metering.py
+++ b/test/unit/test_scout_metering.py
@@ -1,0 +1,48 @@
+"""#100: grounded-scout + embedding metering. Fake response objects — no network, no DB
+(record_llm_call is monkeypatched to a recorder)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentic_librarian.scouts import grounded_llm
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None):
+        self.calls.append((vendor, model, input_tokens, output_tokens))
+
+
+@pytest.mark.parametrize(
+    "usage,expected",
+    [
+        (SimpleNamespace(prompt_token_count=120, candidates_token_count=45), [("gemini", "gemini-2.5-flash", 120, 45)]),
+        (SimpleNamespace(prompt_token_count=None, candidates_token_count=None), [("gemini", "gemini-2.5-flash", 0, 0)]),
+        (None, []),  # no usage_metadata -> no row, no crash
+    ],
+)
+def test_record_gemini_usage(monkeypatch, usage, expected):
+    rec = _Recorder()
+    monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
+    response = SimpleNamespace(text="ok", usage_metadata=usage)
+    grounded_llm._record_gemini_usage("gemini-2.5-flash", response)
+    assert rec.calls == expected
+
+
+def test_embed_metering_records_only_on_cache_miss(monkeypatch):
+    from agentic_librarian.scouts import utils
+
+    rec = _Recorder()
+    monkeypatch.setattr(utils, "record_llm_call", rec)
+
+    fake_resp = SimpleNamespace(embeddings=[SimpleNamespace(values=[0.0] * 4)])
+    client = SimpleNamespace(models=SimpleNamespace(embed_content=lambda **kw: fake_resp))
+    monkeypatch.setattr(utils, "get_shared_genai_client", lambda: client)
+
+    utils.get_cached_embedding.cache_clear()
+    utils.get_cached_embedding("m", "some tag text!!")  # miss -> one row
+    utils.get_cached_embedding("m", "some tag text!!")  # hit -> no new row
+    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0)]

--- a/test/unit/test_scout_metering.py
+++ b/test/unit/test_scout_metering.py
@@ -12,23 +12,48 @@ class _Recorder:
     def __init__(self):
         self.calls = []
 
-    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None):
-        self.calls.append((vendor, model, input_tokens, output_tokens))
+    def __call__(self, vendor, model, input_tokens, output_tokens, conversation_id=None, key_source="app"):
+        self.calls.append((vendor, model, input_tokens, output_tokens, key_source))
 
 
 @pytest.mark.parametrize(
     "usage,expected",
     [
-        (SimpleNamespace(prompt_token_count=120, candidates_token_count=45), [("gemini", "gemini-2.5-flash", 120, 45)]),
-        (SimpleNamespace(prompt_token_count=None, candidates_token_count=None), [("gemini", "gemini-2.5-flash", 0, 0)]),
+        (
+            SimpleNamespace(prompt_token_count=120, candidates_token_count=45),
+            [("gemini", "gemini-2.5-flash", 120, 45, "app")],
+        ),
+        (
+            SimpleNamespace(prompt_token_count=None, candidates_token_count=None),
+            [("gemini", "gemini-2.5-flash", 0, 0, "app")],
+        ),
         (None, []),  # no usage_metadata -> no row, no crash
     ],
 )
-def test_record_gemini_usage(monkeypatch, usage, expected):
+def test_record_gemini_usage_defaults_to_app(monkeypatch, usage, expected):
     rec = _Recorder()
     monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
     response = SimpleNamespace(text="ok", usage_metadata=usage)
     grounded_llm._record_gemini_usage("gemini-2.5-flash", response)
+    assert rec.calls == expected
+
+
+@pytest.mark.parametrize(
+    "usage,expected",
+    [
+        (
+            SimpleNamespace(prompt_token_count=120, candidates_token_count=45),
+            [("gemini", "gemini-2.5-flash", 120, 45, "byok")],
+        ),
+        (None, []),  # no usage_metadata -> no row, no crash, regardless of key_source
+    ],
+)
+def test_record_gemini_usage_threads_byok_key_source(monkeypatch, usage, expected):
+    """arc 3/3: a byok-constructed scout's key_source reaches the recorded Usage row."""
+    rec = _Recorder()
+    monkeypatch.setattr(grounded_llm, "record_llm_call", rec)
+    response = SimpleNamespace(text="ok", usage_metadata=usage)
+    grounded_llm._record_gemini_usage("gemini-2.5-flash", response, key_source="byok")
     assert rec.calls == expected
 
 
@@ -45,4 +70,5 @@ def test_embed_metering_records_only_on_cache_miss(monkeypatch):
     utils.get_cached_embedding.cache_clear()
     utils.get_cached_embedding("m", "some tag text!!")  # miss -> one row
     utils.get_cached_embedding("m", "some tag text!!")  # hit -> no new row
-    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0)]
+    # Embeddings stay app-keyed by design (spec scope boundary #1) — never routed per-user.
+    assert rec.calls == [("gemini", "m", len("some tag text!!") // 4, 0, "app")]

--- a/test/unit/test_tiers.py
+++ b/test/unit/test_tiers.py
@@ -1,0 +1,78 @@
+"""#100: tier decision + env-tunable budget knobs are DB-free and unit-testable
+(the un-gate-DB-free-paths lesson)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentic_librarian.core import budgets, tiers
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    "subscriber_until,has_cred,expected",
+    [
+        (None, False, "free"),
+        (NOW - timedelta(days=1), False, "free"),  # lapsed
+        (NOW + timedelta(days=1), False, "supporter"),
+        (None, True, "byok"),
+        (NOW + timedelta(days=1), True, "byok"),  # byok wins over supporter
+    ],
+)
+def test_tier_for(subscriber_until, has_cred, expected):
+    assert tiers.tier_for(subscriber_until, has_cred, now=NOW) == expected
+
+
+@pytest.mark.parametrize(
+    "fn,tier,expected",
+    [
+        (tiers.chat_turns_per_day, "free", 20),
+        (tiers.chat_turns_per_day, "supporter", 200),
+        (tiers.chat_turns_per_day, "byok", 2000),
+        (tiers.import_max_rows, "free", 300),
+        (tiers.import_max_rows, "supporter", 2000),
+        (tiers.grounded_calls_per_day, "free", 300),
+        (tiers.grounded_calls_per_day, "supporter", 1500),
+        (tiers.grounded_calls_per_day, "byok", 15000),
+    ],
+)
+def test_default_budgets(monkeypatch, fn, tier, expected):
+    for var in tiers._DEFAULTS:
+        monkeypatch.delenv(var, raising=False)
+    assert fn(tier) == expected
+
+
+def test_global_governor_default(monkeypatch):
+    monkeypatch.delenv("GROUNDED_CALLS_PER_DAY_GLOBAL", raising=False)
+    assert tiers.grounded_calls_per_day_global() == 1400
+
+
+@pytest.mark.parametrize("raw,expected", [("50", 50), ("abc", 20), ("", 20), ("-5", 20), ("0", 20)])
+def test_env_override_and_fallback(monkeypatch, raw, expected):
+    monkeypatch.setenv("CHAT_TURNS_PER_DAY_FREE", raw)
+    assert tiers.chat_turns_per_day("free") == expected
+
+
+def test_chat_message_max_chars_default(monkeypatch):
+    monkeypatch.delenv("CHAT_MESSAGE_MAX_CHARS", raising=False)
+    assert tiers.chat_message_max_chars() == 4000
+
+
+def test_grounding_model_name_default(monkeypatch):
+    monkeypatch.delenv("GROUNDING_MODEL", raising=False)
+    monkeypatch.delenv("EXPLORER_MODEL", raising=False)
+    assert tiers.grounding_model_name() == "gemini-2.5-flash"
+
+
+def test_next_utc_day_start_is_next_midnight_plus_jitter():
+    now = datetime(2026, 7, 25, 23, 50, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now, jitter_seconds=600)
+    assert when == datetime(2026, 7, 26, 0, 10, tzinfo=UTC)
+
+
+def test_next_utc_day_start_jitter_bounds():
+    now = datetime(2026, 7, 25, 3, 0, tzinfo=UTC)
+    when = budgets.next_utc_day_start_with_jitter(now=now)
+    midnight = datetime(2026, 7, 26, tzinfo=UTC)
+    assert midnight <= when <= midnight + timedelta(seconds=1800)

--- a/test/unit/test_two_phase_byok_threading.py
+++ b/test/unit/test_two_phase_byok_threading.py
@@ -1,0 +1,123 @@
+"""arc 3/3 BYOK: two_phase.enrich_deep / complete_edition thread api_key/key_source into
+the scout factories they call (and complete_edition's bare narrator-style StyleScout call),
+so a byok user's deep-enrichment pass genuinely runs on their own Gemini key. Session
+doubles follow the house #94 pattern (test_two_phase_sessions.py / test_edition_completion.py)
+— no real DB, no real scout network calls."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from agentic_librarian.enrichment import two_phase
+
+
+class _Session:
+    """Stands in for both the read and write `with db_manager.get_session()` blocks."""
+
+    def __init__(self, work=None, edition=None):
+        self._work = work
+        self._edition = edition
+
+    def __enter__(self):
+        m = MagicMock()
+        m.get.return_value = self._work
+        m.query.return_value.filter_by.return_value.first.return_value = self._edition
+        return m
+
+    def __exit__(self, *a):
+        return False
+
+
+def _work_double(title="T", author="A", editions=None):
+    work = MagicMock()
+    work.title = title
+    contrib = MagicMock(role="Author")
+    contrib.author.name = author
+    work.contributors = [contrib]
+    work.editions = editions or []
+    return work
+
+
+@pytest.mark.parametrize(
+    ("api_key", "key_source", "call_with_kwargs"),
+    [
+        pytest.param("users-gemini-key", "byok", True, id="byok"),
+        pytest.param(None, "app", False, id="app-default"),
+    ],
+)
+def test_enrich_deep_threads_key_into_deep_scout_factory(monkeypatch, api_key, key_source, call_with_kwargs):
+    work = _work_double()
+    sessions = [_Session(work=work), _Session(work=work)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+
+    captured = {}
+
+    def fake_factory(factory_api_key=None, factory_key_source="app"):
+        captured["args"] = (factory_api_key, factory_key_source)
+        mgr = MagicMock()
+        mgr.enrich.return_value = None  # scouts found nothing -> "empty" path, no persist needed
+        return mgr
+
+    monkeypatch.setattr(two_phase, "create_deep_scout_manager", fake_factory)
+
+    work_id = uuid4()
+    if call_with_kwargs:
+        result = two_phase.enrich_deep(work_id, api_key=api_key, key_source=key_source)
+    else:
+        result = two_phase.enrich_deep(work_id)
+
+    assert result == "empty"
+    assert captured["args"] == (api_key, key_source)
+
+
+@pytest.mark.parametrize(
+    ("api_key", "key_source", "call_with_kwargs"),
+    [
+        pytest.param("users-gemini-key", "byok", True, id="byok"),
+        pytest.param(None, "app", False, id="app-default"),
+    ],
+)
+def test_complete_edition_threads_key_into_completion_factory_and_style_scout(
+    monkeypatch, api_key, key_source, call_with_kwargs
+):
+    work = _work_double()
+    edition = MagicMock()
+    sessions = [_Session(work=work, edition=edition), _Session(work=work, edition=edition)]
+    fake_manager = MagicMock()
+    fake_manager.get_session = lambda: sessions.pop(0)
+    monkeypatch.setattr(two_phase, "db_manager", fake_manager)
+
+    captured = {}
+    scout_mgr = MagicMock()
+    scout_mgr.enrich.return_value = {"narrator_names": ["Ray Porter"], "source_priority": ["Hardcover"]}
+
+    def fake_completion_factory(factory_api_key=None, factory_key_source="app"):
+        captured["factory_args"] = (factory_api_key, factory_key_source)
+        return scout_mgr
+
+    monkeypatch.setattr(two_phase, "create_completion_scout_manager", fake_completion_factory)
+
+    style_scout = MagicMock()
+    style_scout.scout_narrator_style.return_value = {}
+
+    def fake_style_scout(style_api_key=None, key_source="app"):
+        captured["style_scout_args"] = (style_api_key, key_source)
+        return style_scout
+
+    monkeypatch.setattr(two_phase, "StyleScout", fake_style_scout)
+    monkeypatch.setattr(two_phase, "get_cached_embedding", lambda *a, **k: [0.0])
+    monkeypatch.setattr(two_phase, "merge_edition_and_narrators", lambda session, **kw: MagicMock())
+
+    work_id = uuid4()
+    if call_with_kwargs:
+        result = two_phase.complete_edition(work_id, "audiobook", api_key=api_key, key_source=key_source)
+    else:
+        result = two_phase.complete_edition(work_id, "audiobook")
+
+    assert result == "done"
+    assert captured["factory_args"] == (api_key, key_source)
+    assert captured["style_scout_args"] == (api_key, key_source)
+    style_scout.scout_narrator_style.assert_called_once_with("Ray Porter")

--- a/test/unit/test_usage_recording_backends.py
+++ b/test/unit/test_usage_recording_backends.py
@@ -12,7 +12,14 @@ import pytest
 from agentic_librarian.core.user_context import DEFAULT_USER_ID, as_user, get_required_user_id
 
 
-def test_adk_conversation_records_usage(monkeypatch):
+@pytest.mark.parametrize(
+    "key_source",
+    [pytest.param("app", id="app_key_default"), pytest.param("byok", id="byok_key_threaded")],
+)
+def test_adk_conversation_records_usage(monkeypatch, key_source):
+    # arc 3/3: LibrarianConversation carries key_source as an instance attribute (never
+    # module-global state — concurrent turns from different users can be in flight at
+    # once) and _record_event_usage must thread it into the recorded row.
     calls = []
     monkeypatch.setattr("agentic_librarian.agents.runtime.record_llm_call", lambda **kw: calls.append(kw))
 
@@ -31,7 +38,7 @@ def test_adk_conversation_records_usage(monkeypatch):
 
     from agentic_librarian.agents.runtime import LibrarianConversation
 
-    convo = LibrarianConversation(FakeRunner(), "local", uuid4().hex)
+    convo = LibrarianConversation(FakeRunner(), "local", uuid4().hex, key_source=key_source)
     assert convo.send("hi") == "(no response)"
     assert calls == [
         {
@@ -40,6 +47,7 @@ def test_adk_conversation_records_usage(monkeypatch):
             "input_tokens": 10,
             "output_tokens": 4,
             "conversation_id": convo.conversation_id,
+            "key_source": key_source,
         }
     ]
 


### PR DESCRIPTION
Final PR of the three-PR monetization stack. **Base is PR #156's branch** — merge order: #155 → #156 → this; GitHub retargets automatically as each base merges.

## What

**Key storage** — the Lift-1 `user_credentials` table finally gets its writer: `PUT /api/me/credentials` validates the pasted key with a real `count_tokens` probe (bounded by the shared retry/timeout options), encrypts via **Cloud KMS**, and stores ciphertext only. GET returns configured/updated_at (never key material); DELETE revokes. Concurrent-PUT race handled with the house SAVEPOINT pattern; KMS-down maps to a clean 503. The user's tier auto-flips to `byok` (PR 1's `effective_tier` reads row existence).

**Key routing (parameters, never env mutation)** —
- *Chat mesh:* the key threads `chat handler → astart_conversation → build_runner → create_agent_mesh → _gemini`. ADK 2.2.0's `Gemini` silently drops an `api_key` kwarg, so `_ByokGemini` overrides the **documented** `api_client` extension point (byte-exact mirror of the stock construction + the user key), guarded by a **behavioral canary test** that drives the real `generate_content_async` and fails loudly if a future ADK stops consulting the override. The key field is `repr=False, exclude=True` with a leak-surface test (never appears in repr/dumps).
- *Deep-enrichment scouts:* the internal handlers resolve the key inside the user scope and thread it through `two_phase` into every LLM scout. **Byok tasks skip the app-key budget gate** — their usage rows (`key_source='byok'`) never count against the global governor, so they can't be deferred by other users' app-key spend.
- *Embeddings stay app-keyed by design* (the shared cache has no key identity; routing them would misattribute pennies for no benefit).

**No silent fallback, every path:** 503 `byok_unavailable` (KMS unconfigured), 422 `invalid_api_key` (save), 409 `byok_key_error` pre-stream (chat), task-consumed 200 `byok_key_error` (enrich). A byok user's failing key is always surfaced, never quietly billed to the app key.

**Frontend** — Settings gains the guided walkthrough (create a free AI Studio key → paste → live-validated Save; configured state + Remove; optimistic save state decoupled from the status refetch), and the avatar menu shows "Using your own key" + an "API key settings" link.

## Review

Four task reviews (each with review-driven fix rounds: upsert coverage, KMS-down mapping, SAVEPOINT race, probe timeout, governor-bypass ordering, ADK canary, optimistic save) + opus whole-branch adversarial pass: **Ready to merge YES, 0 Critical**. The one Important finding (plaintext key visible in the model's pydantic repr/dump — latent, no active sink) is fixed in `e67e9c0`. All 7 residuals triaged RIDE. Runtime-verified against local Postgres: tier flip free→byok→free, ciphertext-only storage, byok budget-gate bypass, canary.

## Verification

Backend unit **972 passed / 0 failed**; frontend **170 tests** + tsc + eslint clean; db_integration **executed locally against real Postgres** (credentials 7, internal-enrich 24, complete-edition 18, chat 8, plus Task-2 suites) — and runs again as CI's first gate.

## Ops at rollout (operator)

1. Run `infra/10-kms.sh` **before deploy** (creates keyring `librarian` + key `byok-credentials`, grants the runtime SA `cryptoKeyEncrypterDecrypter`). Note: numbered 10 because slot 09 was taken.
2. `KMS_KEY_NAME` is wired via deploy.yml (a resource name, not a secret).
3. **Standing constraint:** KMS key *version* rotation is safe (ciphertext embeds its version), but never repoint `KMS_KEY_NAME` at a *different* CryptoKey resource once credentials exist — decrypt resolves the resource from env, and a resource change would brick stored keys (users would re-add via Settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hyNHf8LCF6Gs8gUeKfxh3